### PR TITLE
Move Auth implementation to a separated class

### DIFF
--- a/lib/src/supabase.dart
+++ b/lib/src/supabase.dart
@@ -1,138 +1,7 @@
 import 'package:flutter/foundation.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 import 'package:supabase/supabase.dart';
-import 'package:url_launcher/url_launcher.dart';
 
-const supabasePersistSessionKey = 'SUPABASE_PERSIST_SESSION_KEY';
-
-Future<bool> _defHasAccessToken() async {
-  final prefs = await SharedPreferences.getInstance();
-  final exist = prefs.containsKey(supabasePersistSessionKey);
-  return exist;
-}
-
-Future<String?> _defAccessToken() async {
-  final prefs = await SharedPreferences.getInstance();
-  final jsonStr = prefs.getString(supabasePersistSessionKey);
-  return jsonStr;
-}
-
-Future<void> _defRemovePersistedSession() async {
-  final SharedPreferences prefs = await SharedPreferences.getInstance();
-  await prefs.remove(supabasePersistSessionKey);
-}
-
-Future<void> _defPersistSession(String persistSessionString) async {
-  final prefs = await SharedPreferences.getInstance();
-  await prefs.setString(supabasePersistSessionKey, persistSessionString);
-}
-
-/// LocalStorage is used to persist the user session in the device.
-///
-/// By default, the package `shared_preferences` is used to save the
-/// user info on the device. However, you can use any other plugin to
-/// do so.
-///
-/// For example, we can use `flutter_secure_storage` plugin to store
-/// user session in secure storage.
-///
-/// ```dart
-/// final localStorage = LocalStorage(
-///   hasAccessToken: () {
-///     const storage = FlutterSecureStorage();
-///     return storage.containsKey(key: supabasePersistSessionKey);
-///   }, accessToken: () {
-///     const storage = FlutterSecureStorage();
-///     return storage.read(key: supabasePersistSessionKey);
-///   }, removePersistedSession: () {
-///     const storage = FlutterSecureStorage();
-///     return storage.delete(key: supabasePersistSessionKey);
-///   }, persistSession: (String value) {
-///     const storage = FlutterSecureStorage();
-///     return storage.write(key: supabasePersistSessionKey, value: value);
-///   });
-/// ```
-///
-/// To use the `LocalStorage` instance, pass it to `localStorage` when initializing
-/// the [Supabase] instance:
-///
-/// ```dart
-/// Supabase.initialize(
-///  ...
-///  localStorage: localStorage,
-/// );
-/// ```
-///
-/// See also:
-///
-///   * [Supabase], the instance used to manage authentication
-class LocalStorage {
-  /// Creates a `LocalStorage` instance
-  const LocalStorage({
-    this.hasAccessToken = _defHasAccessToken,
-    this.accessToken = _defAccessToken,
-    this.removePersistedSession = _defRemovePersistedSession,
-    this.persistSession = _defPersistSession,
-  });
-
-  /// {@template supabase.localstorage.hasAccessToken}
-  /// Check if there is a persisted session.
-  ///
-  /// Here's an example of how to do it using the shared_preferences
-  /// package:
-  ///
-  /// ```dart
-  /// Future<bool> hasAccessToken() async {
-  ///   final prefs = await SharedPreferences.getInstance();
-  ///   final exist = prefs.containsKey(supabasePersistSessionKey);
-  ///   return exist;
-  /// }
-  /// ```
-  /// {@endTemplate}
-  final Future<bool> Function() hasAccessToken;
-
-  /// {@template supabase.localstorage.accessToken}
-  /// Get the access token from the current persisted session.
-  ///
-  /// Here's an example of how to do it using the shared_preferences
-  /// package:
-  ///
-  /// ```dart
-  /// Future<String?> accessToken() async {
-  ///   final prefs = await SharedPreferences.getInstance();
-  ///   final jsonStr = prefs.getString(supabasePersistSessionKey);
-  ///   return jsonStr;
-  /// }
-  /// ```
-  /// {@endTemplate}
-  final Future<String?> Function() accessToken;
-
-  /// Remove the current persisted session.
-  ///
-  /// Here's an example of how to do it using the shared_preferences
-  /// package:
-  ///
-  /// ```dart
-  /// Future<void> removePersistedSession() async {
-  ///   final SharedPreferences prefs = await SharedPreferences.getInstance();
-  ///   return prefs.remove(supabasePersistSessionKey);
-  /// }
-  /// ```
-  final Future<void> Function() removePersistedSession;
-
-  /// Persist a session in the device.
-  ///
-  /// Here's an example of how to do it using the shared_preferences
-  /// package:
-  ///
-  /// ```dart
-  /// Future<void> persistSession(String persistSessionString) async {
-  ///   final prefs = await SharedPreferences.getInstance();
-  ///   return prefs.setString(supabasePersistSessionKey, persistSessionString);
-  /// }
-  /// ```
-  final Future<void> Function(String) persistSession;
-}
+import 'supabase_auth.dart';
 
 /// Supabase instance. It must be initialized before used:
 ///
@@ -179,10 +48,13 @@ class Supabase {
     );
     if (url != null && anonKey != null) {
       _instance._init(url, anonKey);
-      _instance._authCallbackUrlHostname = authCallbackUrlHostname;
       _instance._debugEnable = debug ?? kDebugMode;
-      _instance._localStorage = localStorage ?? const LocalStorage();
       _instance.log('***** Supabase init completed $_instance');
+
+      SupabaseAuth.initialize(
+        localStorage: localStorage ?? const LocalStorage(),
+        authCallbackUrlHostname: authCallbackUrlHostname,
+      );
     }
 
     return _instance;
@@ -197,111 +69,21 @@ class Supabase {
   ///
   /// Throws an error if [Supabase.initialize] was not called.
   late final SupabaseClient client;
-  GotrueSubscription? _initialClientSubscription;
-  bool _initialDeeplinkIsHandled = false;
   bool _debugEnable = false;
-
-  String? _authCallbackUrlHostname;
-  LocalStorage _localStorage = const LocalStorage();
 
   /// Dispose the instance to free up resources.
   void dispose() {
-    if (_initialClientSubscription != null) {
-      _initialClientSubscription!.data!.unsubscribe();
-    }
     _initialized = false;
   }
 
   void _init(String supabaseUrl, String supabaseAnonKey) {
     client = SupabaseClient(supabaseUrl, supabaseAnonKey);
-    _initialClientSubscription =
-        client.auth.onAuthStateChange(_onAuthStateChange);
     _initialized = true;
-  }
-
-  /// The [LocalStorage] instance used to persist the user session.
-  LocalStorage get localStorage => _localStorage;
-
-  /// {@macro supabase.localstorage.hasAccessToken}
-  Future<bool> get hasAccessToken => _localStorage.hasAccessToken();
-
-  /// {@macro supabase.localstorage.accessToken}
-  Future<String?> get accessToken => _localStorage.accessToken();
-
-  void _onAuthStateChange(AuthChangeEvent event, Session? session) {
-    log('**** onAuthStateChange: $event');
-    if (event == AuthChangeEvent.signedIn && session != null) {
-      log(session.persistSessionString);
-      _localStorage.persistSession(session.persistSessionString);
-    } else if (event == AuthChangeEvent.signedOut) {
-      _localStorage.removePersistedSession();
-    }
   }
 
   void log(String msg) {
     if (_debugEnable) {
       debugPrint(msg);
     }
-  }
-
-  /// Parse Uri parameters from redirect url/deeplink
-  Map<String, String> parseUriParameters(Uri uri) {
-    Uri _uri = uri;
-    if (_uri.hasQuery) {
-      final decoded = _uri.toString().replaceAll('#', '&');
-      _uri = Uri.parse(decoded);
-    } else {
-      final uriStr = _uri.toString();
-      String decoded;
-      // %23 is the encoded of #hash
-      // support custom redirect to on flutter web
-      if (uriStr.contains('/#%23')) {
-        decoded = uriStr.replaceAll('/#%23', '/?');
-      } else if (uriStr.contains('/#/')) {
-        decoded = uriStr.replaceAll('/#/', '/').replaceAll('%23', '?');
-      } else {
-        decoded = uriStr.replaceAll('#', '?');
-      }
-      _uri = Uri.parse(decoded);
-    }
-    return _uri.queryParameters;
-  }
-
-  /// **ATTENTION**: `getInitialLink`/`getInitialUri` should be handled
-  /// ONLY ONCE in your app's lifetime, since it is not meant to change
-  /// throughout your app's life.
-  bool shouldHandleInitialDeeplink() {
-    if (_initialDeeplinkIsHandled) {
-      return false;
-    } else {
-      _initialDeeplinkIsHandled = true;
-      return true;
-    }
-  }
-
-  /// if _authCallbackUrlHost not init, we treat all deeplink as auth callback
-  bool isAuthCallbackDeeplink(Uri uri) {
-    if (_authCallbackUrlHostname == null) {
-      return true;
-    } else {
-      return _authCallbackUrlHostname == uri.host;
-    }
-  }
-}
-
-extension GoTrueClientSignInProvider on GoTrueClient {
-  /// Signs the user in using a thrid parties providers.
-  ///
-  /// See also:
-  ///
-  ///   * <https://supabase.io/docs/guides/auth#third-party-logins>
-  Future<bool> signInWithProvider(Provider provider,
-      {AuthOptions? options}) async {
-    final res = await signIn(
-      provider: provider,
-      options: options,
-    );
-    final result = await launch(res.url!, webOnlyWindowName: '_self');
-    return result;
   }
 }

--- a/lib/src/supabase.dart
+++ b/lib/src/supabase.dart
@@ -35,13 +35,13 @@ class Supabase {
   ///
   /// This must be called only once. If called more than once, an
   /// [AssertionError] is thrown
-  factory Supabase.initialize({
+  static Future<Supabase> initialize({
     String? url,
     String? anonKey,
     String? authCallbackUrlHostname,
     bool? debug,
     LocalStorage? localStorage,
-  }) {
+  }) async {
     assert(
       !_instance._initialized,
       'This instance is already initialized',
@@ -51,7 +51,7 @@ class Supabase {
       _instance._debugEnable = debug ?? kDebugMode;
       _instance.log('***** Supabase init completed $_instance');
 
-      SupabaseAuth.initialize(
+      await SupabaseAuth.initialize(
         localStorage: localStorage ?? const LocalStorage(),
         authCallbackUrlHostname: authCallbackUrlHostname,
       );

--- a/lib/src/supabase.dart
+++ b/lib/src/supabase.dart
@@ -17,7 +17,7 @@ import 'supabase_auth.dart';
 ///
 /// See also:
 ///
-///   * [LocalStorage], used to persist the user session.
+///   * [SupabaseAuth]
 class Supabase {
   /// Gets the current supabase instance.
   ///

--- a/lib/src/supabase_auth.dart
+++ b/lib/src/supabase_auth.dart
@@ -1,0 +1,264 @@
+import 'dart:async';
+
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:supabase/supabase.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import '../supabase_flutter.dart';
+
+const supabasePersistSessionKey = 'SUPABASE_PERSIST_SESSION_KEY';
+
+Future<bool> _defHasAccessToken() async {
+  final prefs = await SharedPreferences.getInstance();
+  final exist = prefs.containsKey(supabasePersistSessionKey);
+  return exist;
+}
+
+Future<String?> _defAccessToken() async {
+  final prefs = await SharedPreferences.getInstance();
+  final jsonStr = prefs.getString(supabasePersistSessionKey);
+  return jsonStr;
+}
+
+Future<void> _defRemovePersistedSession() async {
+  final SharedPreferences prefs = await SharedPreferences.getInstance();
+  await prefs.remove(supabasePersistSessionKey);
+}
+
+Future<void> _defPersistSession(String persistSessionString) async {
+  final prefs = await SharedPreferences.getInstance();
+  await prefs.setString(supabasePersistSessionKey, persistSessionString);
+}
+
+/// LocalStorage is used to persist the user session in the device.
+///
+/// By default, the package `shared_preferences` is used to save the
+/// user info on the device. However, you can use any other plugin to
+/// do so.
+///
+/// For example, we can use `flutter_secure_storage` plugin to store
+/// user session in secure storage.
+///
+/// ```dart
+/// final localStorage = LocalStorage(
+///   hasAccessToken: () {
+///     const storage = FlutterSecureStorage();
+///     return storage.containsKey(key: supabasePersistSessionKey);
+///   }, accessToken: () {
+///     const storage = FlutterSecureStorage();
+///     return storage.read(key: supabasePersistSessionKey);
+///   }, removePersistedSession: () {
+///     const storage = FlutterSecureStorage();
+///     return storage.delete(key: supabasePersistSessionKey);
+///   }, persistSession: (String value) {
+///     const storage = FlutterSecureStorage();
+///     return storage.write(key: supabasePersistSessionKey, value: value);
+///   });
+/// ```
+///
+/// To use the `LocalStorage` instance, pass it to `localStorage` when initializing
+/// the [Supabase] instance:
+///
+/// ```dart
+/// Supabase.initialize(
+///  ...
+///  localStorage: localStorage,
+/// );
+/// ```
+///
+/// See also:
+///
+///   * [Supabase], the instance used to manage authentication
+class LocalStorage {
+  /// Creates a `LocalStorage` instance
+  const LocalStorage({
+    this.hasAccessToken = _defHasAccessToken,
+    this.accessToken = _defAccessToken,
+    this.removePersistedSession = _defRemovePersistedSession,
+    this.persistSession = _defPersistSession,
+  });
+
+  /// {@template supabase.localstorage.hasAccessToken}
+  /// Check if there is a persisted session.
+  ///
+  /// Here's an example of how to do it using the shared_preferences
+  /// package:
+  ///
+  /// ```dart
+  /// Future<bool> hasAccessToken() async {
+  ///   final prefs = await SharedPreferences.getInstance();
+  ///   final exist = prefs.containsKey(supabasePersistSessionKey);
+  ///   return exist;
+  /// }
+  /// ```
+  /// {@endTemplate}
+  final Future<bool> Function() hasAccessToken;
+
+  /// {@template supabase.localstorage.accessToken}
+  /// Get the access token from the current persisted session.
+  ///
+  /// Here's an example of how to do it using the shared_preferences
+  /// package:
+  ///
+  /// ```dart
+  /// Future<String?> accessToken() async {
+  ///   final prefs = await SharedPreferences.getInstance();
+  ///   final jsonStr = prefs.getString(supabasePersistSessionKey);
+  ///   return jsonStr;
+  /// }
+  /// ```
+  /// {@endTemplate}
+  final Future<String?> Function() accessToken;
+
+  /// Remove the current persisted session.
+  ///
+  /// Here's an example of how to do it using the shared_preferences
+  /// package:
+  ///
+  /// ```dart
+  /// Future<void> removePersistedSession() async {
+  ///   final SharedPreferences prefs = await SharedPreferences.getInstance();
+  ///   return prefs.remove(supabasePersistSessionKey);
+  /// }
+  /// ```
+  final Future<void> Function() removePersistedSession;
+
+  /// Persist a session in the device.
+  ///
+  /// Here's an example of how to do it using the shared_preferences
+  /// package:
+  ///
+  /// ```dart
+  /// Future<void> persistSession(String persistSessionString) async {
+  ///   final prefs = await SharedPreferences.getInstance();
+  ///   return prefs.setString(supabasePersistSessionKey, persistSessionString);
+  /// }
+  /// ```
+  final Future<void> Function(String) persistSession;
+}
+
+class SupabaseAuth {
+  SupabaseAuth._();
+  static final SupabaseAuth _instance = SupabaseAuth._();
+
+  bool _initialized = false;
+  late LocalStorage _localStorage;
+
+  /// The [LocalStorage] instance used to persist the user session.
+  LocalStorage get localStorage => _localStorage;
+
+  /// {@macro supabase.localstorage.hasAccessToken}
+  Future<bool> get hasAccessToken => _localStorage.hasAccessToken();
+
+  /// {@macro supabase.localstorage.accessToken}
+  Future<String?> get accessToken => _localStorage.accessToken();
+
+  bool _initialDeeplinkIsHandled = false;
+  String? _authCallbackUrlHostname;
+
+  final _listenerController = StreamController<AuthChangeEvent>.broadcast();
+
+  Stream<AuthChangeEvent> get onAuthChange => _listenerController.stream;
+
+  static SupabaseAuth get instance {
+    assert(
+      _instance._initialized,
+      'You must initialize the supabase instance before calling Supabase.instance',
+    );
+
+    Supabase.instance.client.auth.onAuthStateChange((event, session) {
+      _instance._onAuthStateChange(event, session);
+      if (!_instance._listenerController.isClosed) {
+        _instance._listenerController.add(event);
+      }
+    });
+
+    return _instance;
+  }
+
+  factory SupabaseAuth.initialize({
+    LocalStorage localStorage = const LocalStorage(),
+    String? authCallbackUrlHostname,
+  }) {
+    _instance._initialized = true;
+    _instance._localStorage = localStorage;
+    _instance._authCallbackUrlHostname = authCallbackUrlHostname;
+
+    return _instance;
+  }
+
+  void dispose() {
+    _listenerController.close();
+  }
+
+  void _onAuthStateChange(AuthChangeEvent event, Session? session) {
+    Supabase.instance.log('**** onAuthStateChange: $event');
+    if (event == AuthChangeEvent.signedIn && session != null) {
+      Supabase.instance.log(session.persistSessionString);
+      _localStorage.persistSession(session.persistSessionString);
+    } else if (event == AuthChangeEvent.signedOut) {
+      _localStorage.removePersistedSession();
+    }
+  }
+
+  /// Parse Uri parameters from redirect url/deeplink
+  Map<String, String> parseUriParameters(Uri uri) {
+    Uri _uri = uri;
+    if (_uri.hasQuery) {
+      final decoded = _uri.toString().replaceAll('#', '&');
+      _uri = Uri.parse(decoded);
+    } else {
+      final uriStr = _uri.toString();
+      String decoded;
+      // %23 is the encoded of #hash
+      // support custom redirect to on flutter web
+      if (uriStr.contains('/#%23')) {
+        decoded = uriStr.replaceAll('/#%23', '/?');
+      } else if (uriStr.contains('/#/')) {
+        decoded = uriStr.replaceAll('/#/', '/').replaceAll('%23', '?');
+      } else {
+        decoded = uriStr.replaceAll('#', '?');
+      }
+      _uri = Uri.parse(decoded);
+    }
+    return _uri.queryParameters;
+  }
+
+  /// **ATTENTION**: `getInitialLink`/`getInitialUri` should be handled
+  /// ONLY ONCE in your app's lifetime, since it is not meant to change
+  /// throughout your app's life.
+  bool shouldHandleInitialDeeplink() {
+    if (_initialDeeplinkIsHandled) {
+      return false;
+    } else {
+      _initialDeeplinkIsHandled = true;
+      return true;
+    }
+  }
+
+  /// if _authCallbackUrlHost not init, we treat all deeplink as auth callback
+  bool isAuthCallbackDeeplink(Uri uri) {
+    if (_authCallbackUrlHostname == null) {
+      return true;
+    } else {
+      return _authCallbackUrlHostname == uri.host;
+    }
+  }
+}
+
+extension GoTrueClientSignInProvider on GoTrueClient {
+  /// Signs the user in using a thrid parties providers.
+  ///
+  /// See also:
+  ///
+  ///   * <https://supabase.io/docs/guides/auth#third-party-logins>
+  Future<bool> signInWithProvider(Provider provider,
+      {AuthOptions? options}) async {
+    final res = await signIn(
+      provider: provider,
+      options: options,
+    );
+    final result = await launch(res.url!, webOnlyWindowName: '_self');
+    return result;
+  }
+}

--- a/lib/src/supabase_auth_required_state.dart
+++ b/lib/src/supabase_auth_required_state.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/widgets.dart';
 import 'package:supabase/supabase.dart';
-import 'package:supabase_flutter/src/supabase.dart';
-import 'package:supabase_flutter/src/supabase_state.dart';
+
+import '../supabase_flutter.dart';
+import 'supabase_state.dart';
 
 /// Interface for screen that requires an authenticated user
 abstract class SupabaseAuthRequiredState<T extends StatefulWidget>
@@ -50,13 +51,15 @@ abstract class SupabaseAuthRequiredState<T extends StatefulWidget>
   }
 
   Future<bool> _recoverSupabaseSession() async {
-    final bool exist = await Supabase.instance.localStorage.hasAccessToken();
+    final bool exist =
+        await SupabaseAuth.instance.localStorage.hasAccessToken();
     if (!exist) {
       onUnauthenticated();
       return false;
     }
 
-    final String? jsonStr = await Supabase.instance.localStorage.accessToken();
+    final String? jsonStr =
+        await SupabaseAuth.instance.localStorage.accessToken();
     if (jsonStr == null) {
       onUnauthenticated();
       return false;
@@ -65,7 +68,7 @@ abstract class SupabaseAuthRequiredState<T extends StatefulWidget>
     final response =
         await Supabase.instance.client.auth.recoverSession(jsonStr);
     if (response.error != null) {
-      Supabase.instance.localStorage.removePersistedSession();
+      SupabaseAuth.instance.localStorage.removePersistedSession();
       onUnauthenticated();
       return false;
     } else {

--- a/lib/src/supabase_auth_state.dart
+++ b/lib/src/supabase_auth_state.dart
@@ -60,13 +60,15 @@ abstract class SupabaseAuthState<T extends StatefulWidget>
   /// Recover/refresh session if it's available
   /// e.g. called on a Splash screen when app starts.
   Future<bool> recoverSupabaseSession() async {
-    final bool exist = await SupabaseAuth.instance.localStorage.hasAccessToken();
+    final bool exist =
+        await SupabaseAuth.instance.localStorage.hasAccessToken();
     if (!exist) {
       onUnauthenticated();
       return false;
     }
 
-    final String? jsonStr = await SupabaseAuth.instance.localStorage.accessToken();
+    final String? jsonStr =
+        await SupabaseAuth.instance.localStorage.accessToken();
     if (jsonStr == null) {
       onUnauthenticated();
       return false;

--- a/lib/src/supabase_auth_state.dart
+++ b/lib/src/supabase_auth_state.dart
@@ -4,6 +4,8 @@ import 'package:supabase_flutter/src/supabase.dart';
 import 'package:supabase_flutter/src/supabase_state.dart';
 import 'package:supabase_flutter/src/supabase_deep_linking_mixin.dart';
 
+import '../supabase_flutter.dart';
+
 /// Interface for user authentication screen
 /// It supports deeplink authentication
 abstract class SupabaseAuthState<T extends StatefulWidget>
@@ -22,7 +24,7 @@ abstract class SupabaseAuthState<T extends StatefulWidget>
 
   @override
   Future<bool> handleDeeplink(Uri uri) async {
-    if (!Supabase.instance.isAuthCallbackDeeplink(uri)) return false;
+    if (!SupabaseAuth.instance.isAuthCallbackDeeplink(uri)) return false;
 
     Supabase.instance.log('***** SupabaseAuthState handleDeeplink $uri');
 
@@ -38,7 +40,7 @@ abstract class SupabaseAuthState<T extends StatefulWidget>
   }
 
   Future<bool> recoverSessionFromUrl(Uri uri) async {
-    final uriParameters = Supabase.instance.parseUriParameters(uri);
+    final uriParameters = SupabaseAuth.instance.parseUriParameters(uri);
     final type = uriParameters['type'] ?? '';
 
     // recover session from deeplink
@@ -58,13 +60,13 @@ abstract class SupabaseAuthState<T extends StatefulWidget>
   /// Recover/refresh session if it's available
   /// e.g. called on a Splash screen when app starts.
   Future<bool> recoverSupabaseSession() async {
-    final bool exist = await Supabase.instance.localStorage.hasAccessToken();
+    final bool exist = await SupabaseAuth.instance.localStorage.hasAccessToken();
     if (!exist) {
       onUnauthenticated();
       return false;
     }
 
-    final String? jsonStr = await Supabase.instance.localStorage.accessToken();
+    final String? jsonStr = await SupabaseAuth.instance.localStorage.accessToken();
     if (jsonStr == null) {
       onUnauthenticated();
       return false;
@@ -73,7 +75,7 @@ abstract class SupabaseAuthState<T extends StatefulWidget>
     final response =
         await Supabase.instance.client.auth.recoverSession(jsonStr);
     if (response.error != null) {
-      Supabase.instance.localStorage.removePersistedSession();
+      SupabaseAuth.instance.localStorage.removePersistedSession();
       onUnauthenticated();
       return false;
     } else {

--- a/lib/src/supabase_deep_linking_mixin.dart
+++ b/lib/src/supabase_deep_linking_mixin.dart
@@ -3,8 +3,9 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter/services.dart';
-import 'package:supabase_flutter/src/supabase.dart';
 import 'package:uni_links/uni_links.dart';
+
+import '../supabase_flutter.dart';
 
 mixin SupabaseDeepLinkingMixin<T extends StatefulWidget> on State<T> {
   StreamSubscription? _sub;
@@ -45,7 +46,7 @@ mixin SupabaseDeepLinkingMixin<T extends StatefulWidget> on State<T> {
   ///
   /// We handle all exceptions, since it is called from initState.
   Future<void> _handleInitialUri() async {
-    if (!Supabase.instance.shouldHandleInitialDeeplink()) return;
+    if (!SupabaseAuth.instance.shouldHandleInitialDeeplink()) return;
 
     try {
       final uri = await getInitialUri();

--- a/lib/supabase_flutter.dart
+++ b/lib/supabase_flutter.dart
@@ -4,5 +4,6 @@
 library supabase_flutter;
 
 export 'src/supabase.dart';
+export 'src/supabase_auth.dart';
 export 'src/supabase_auth_required_state.dart';
 export 'src/supabase_auth_state.dart';

--- a/test/supabase_flutter_test.dart
+++ b/test/supabase_flutter_test.dart
@@ -19,7 +19,7 @@ void main() {
   test('can parse deeplink', () async {
     final uri = Uri.parse(
         "io.supabase.flutterdemo://login-callback#access_token=aaa&expires_in=3600&refresh_token=bbb&token_type=bearer&type=recovery");
-    final uriParams = Supabase.instance.parseUriParameters(uri);
+    final uriParams = SupabaseAuth.instance.parseUriParameters(uri);
     expect(uriParams.length, equals(5));
     expect(uriParams['access_token'], equals('aaa'));
     expect(uriParams['refresh_token'], equals('bbb'));
@@ -28,7 +28,7 @@ void main() {
   test('can parse flutter web redirect link', () async {
     final uri = Uri.parse(
         "http://localhost:55510/#access_token=aaa&expires_in=3600&refresh_token=bbb&token_type=bearer&type=magiclink");
-    final uriParams = Supabase.instance.parseUriParameters(uri);
+    final uriParams = SupabaseAuth.instance.parseUriParameters(uri);
     expect(uriParams.length, equals(5));
     expect(uriParams['access_token'], equals('aaa'));
     expect(uriParams['refresh_token'], equals('bbb'));
@@ -37,7 +37,7 @@ void main() {
   test('can parse flutter web custom page redirect link', () async {
     final uri = Uri.parse(
         "http://localhost:55510/#/webAuth%23access_token=aaa&expires_in=3600&refresh_token=bbb&token_type=bearer&type=magiclink");
-    final uriParams = Supabase.instance.parseUriParameters(uri);
+    final uriParams = SupabaseAuth.instance.parseUriParameters(uri);
     expect(uriParams.length, equals(5));
     expect(uriParams['access_token'], equals('aaa'));
     expect(uriParams['refresh_token'], equals('bbb'));

--- a/test/supabase_flutter_test.dart
+++ b/test/supabase_flutter_test.dart
@@ -6,9 +6,9 @@ void main() {
   const supabaseUrl = '';
   const supabaseKey = '';
 
-  setUpAll(() {
-    // initial Supabase singleton
-    Supabase.initialize(url: supabaseUrl, anonKey: supabaseKey);
+  setUpAll(() async {
+    // Initialize the Supabase singleton
+    await Supabase.initialize(url: supabaseUrl, anonKey: supabaseKey);
   });
 
   test('can access Supabase singleton', () async {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature and bug fix

## What is the current behavior?

Currently, the user session is not recovered from storage when the app is initialized.

## What is the new behavior?

Fetch the user session from storage when recovered

Fix for #11

## Additional context

This pull request also separates the auth logic into a separate singleton (`SupabaseAuth`), in order to make things easier for future PRs (for #8)
