### PR TITLE
Rework the LocalStorage implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,9 +127,19 @@ class SecureLocalStorage extends LocalStorage {
   );
 }
 
+// use it when initializing
 Supabase.initialize(
   ...
   localStorage: SecureLocalStorage(),
+);
+```
+
+You can use `EmptyLocalStorage` to disable session persistance:
+
+```dart
+Supabase.initialize(
+  ...
+  localStorage: const EmptyLocalStorage(),
 );
 ```
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,6 @@ As default `supabase_flutter` uses [`hive`](https://pub.dev/packages/hive) plugi
 For example, we can use `flutter_secure_storage` plugin to store the user session in a secure storage.
 
 ```dart
-
 // Define the custom LocalStorage implementation
 class SecureLocalStorage extends LocalStorage {
   SecureLocalStorage() : super(

--- a/README.md
+++ b/README.md
@@ -101,28 +101,35 @@ Supabase.instance.client.auth.signInWithProvider(
 
 ### Custom LocalStorage
 
-As default `supabase_flutter` uses `shared_preferences` plugin to persist user session. However you can use any other plugins by providing a **LocalStorage**.
-For example, we can use `flutter_secure_storage` plugin to store user session in secure storage.
+As default `supabase_flutter` uses [`hive`](https://pub.dev/packages/hive) plugin to persist user session. However you can use any other plugins by creating a `LocalStorage` impl.
+
+For example, we can use `flutter_secure_storage` plugin to store the user session in a secure storage.
 
 ```dart
-final localStorage = LocalStorage(
-  hasAccessToken: () {
-    const storage = FlutterSecureStorage();
-    return storage.containsKey(key: supabasePersistSessionKey);
-  }, accessToken: () {
-    const storage = FlutterSecureStorage();
-    return storage.read(key: supabasePersistSessionKey);
-  }, removePersistedSession: () {
-    const storage = FlutterSecureStorage();
-    return storage.delete(key: supabasePersistSessionKey);
-  }, persistSession: (String value) {
-    const storage = FlutterSecureStorage();
-    return storage.write(key: supabasePersistSessionKey, value: value);
-  });
+
+// Define the custom LocalStorage implementation
+class SecureLocalStorage extends LocalStorage {
+  SecureLocalStorage() : super(
+    initialize: () async {},
+    hasAccessToken: () {
+      const storage = FlutterSecureStorage();
+      return storage.containsKey(key: supabasePersistSessionKey);
+    }, accessToken: () {
+      const storage = FlutterSecureStorage();
+      return storage.read(key: supabasePersistSessionKey);
+    }, removePersistedSession: () {
+      const storage = FlutterSecureStorage();
+      return storage.delete(key: supabasePersistSessionKey);
+    }, persistSession: (String value) {
+      const storage = FlutterSecureStorage();
+      return storage.write(key: supabasePersistSessionKey, value: value);
+    },
+  );
+}
 
 Supabase.initialize(
   ...
-  localStorage: localStorage,
+  localStorage: SecureLocalStorage(),
 );
 ```
 

--- a/lib/src/local_storage.dart
+++ b/lib/src/local_storage.dart
@@ -71,7 +71,7 @@ class HiveLocalStorage extends LocalStorage {
         );
 
   /// The encryption key used by Hive. If null, the box is not encrypted
-  /// 
+  ///
   /// This value should not be redefined in runtime, otherwise the user may
   /// not be fetched correctly
   ///

--- a/lib/src/local_storage.dart
+++ b/lib/src/local_storage.dart
@@ -32,36 +32,6 @@ Future<void> _defPersistSession(String persistSessionString) {
 /// By default, the package `hive` is used to save the user info on
 /// the device. However, you can use any other plugin to do so.
 ///
-/// For example, we can use `flutter_secure_storage` plugin to store
-/// user session in a secure storage.
-///
-/// ```dart
-/// final localStorage = LocalStorage(
-///   hasAccessToken: () {
-///     const storage = FlutterSecureStorage();
-///     return storage.containsKey(key: supabasePersistSessionKey);
-///   }, accessToken: () {
-///     const storage = FlutterSecureStorage();
-///     return storage.read(key: supabasePersistSessionKey);
-///   }, removePersistedSession: () {
-///     const storage = FlutterSecureStorage();
-///     return storage.delete(key: supabasePersistSessionKey);
-///   }, persistSession: (String value) {
-///     const storage = FlutterSecureStorage();
-///     return storage.write(key: supabasePersistSessionKey, value: value);
-///   });
-/// ```
-///
-/// To use the `LocalStorage` instance, pass it to `localStorage` when initializing
-/// the [Supabase] instance:
-///
-/// ```dart
-/// Supabase.initialize(
-///  ...
-///  localStorage: localStorage,
-/// );
-/// ```
-///
 /// See also:
 ///
 ///   * [SupabaseAuth], the instance used to manage authentication

--- a/lib/src/local_storage.dart
+++ b/lib/src/local_storage.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:hive_flutter/hive_flutter.dart';
 
 const _hiveBoxName = 'supabase_authentication';
@@ -68,9 +70,23 @@ class HiveLocalStorage extends LocalStorage {
           persistSession: _persistSession,
         );
 
+  /// The encryption key used by Hive. If null, the box is not encrypted
+  /// 
+  /// This value should not be redefined in runtime, otherwise the user may
+  /// not be fetched correctly
+  ///
+  /// See also:
+  ///
+  ///   * <https://docs.hivedb.dev/#/advanced/encrypted_box?id=encrypted-box>
+  static String? encryptionKey;
+
   static Future<void> _initialize() async {
+    HiveCipher? encryptionCipher;
+    if (encryptionKey != null) {
+      encryptionCipher = HiveAesCipher(base64Url.decode(encryptionKey!));
+    }
     await Hive.initFlutter('auth');
-    await Hive.openBox(_hiveBoxName);
+    await Hive.openBox(_hiveBoxName, encryptionCipher: encryptionCipher);
   }
 
   static Future<bool> _hasAccessToken() {

--- a/lib/src/local_storage.dart
+++ b/lib/src/local_storage.dart
@@ -1,0 +1,103 @@
+import 'package:hive_flutter/hive_flutter.dart';
+
+const _hiveBoxName = 'supabase_authentication';
+const supabasePersistSessionKey = 'SUPABASE_PERSIST_SESSION_KEY';
+
+Future<void> _defInitialize() async {
+  await Hive.initFlutter('auth');
+  await Hive.openBox(_hiveBoxName);
+}
+
+Future<bool> _defHasAccessToken() {
+  return Future.value(
+      Hive.box(_hiveBoxName).containsKey(supabasePersistSessionKey));
+}
+
+Future<String?> _defAccessToken() {
+  return Future.value(
+      Hive.box(_hiveBoxName).get(supabasePersistSessionKey) as String?);
+}
+
+Future<void> _defRemovePersistedSession() {
+  return Hive.box(_hiveBoxName).delete(supabasePersistSessionKey);
+}
+
+Future<void> _defPersistSession(String persistSessionString) {
+  return Hive.box(_hiveBoxName)
+      .put(supabasePersistSessionKey, persistSessionString);
+}
+
+/// LocalStorage is used to persist the user session in the device.
+///
+/// By default, the package `hive` is used to save the user info on
+/// the device. However, you can use any other plugin to do so.
+///
+/// For example, we can use `flutter_secure_storage` plugin to store
+/// user session in a secure storage.
+///
+/// ```dart
+/// final localStorage = LocalStorage(
+///   hasAccessToken: () {
+///     const storage = FlutterSecureStorage();
+///     return storage.containsKey(key: supabasePersistSessionKey);
+///   }, accessToken: () {
+///     const storage = FlutterSecureStorage();
+///     return storage.read(key: supabasePersistSessionKey);
+///   }, removePersistedSession: () {
+///     const storage = FlutterSecureStorage();
+///     return storage.delete(key: supabasePersistSessionKey);
+///   }, persistSession: (String value) {
+///     const storage = FlutterSecureStorage();
+///     return storage.write(key: supabasePersistSessionKey, value: value);
+///   });
+/// ```
+///
+/// To use the `LocalStorage` instance, pass it to `localStorage` when initializing
+/// the [Supabase] instance:
+///
+/// ```dart
+/// Supabase.initialize(
+///  ...
+///  localStorage: localStorage,
+/// );
+/// ```
+///
+/// See also:
+///
+///   * [SupabaseAuth], the instance used to manage authentication
+abstract class LocalStorage {
+  const LocalStorage({
+    required this.initialize,
+    required this.hasAccessToken,
+    required this.accessToken,
+    required this.persistSession,
+    required this.removePersistedSession,
+  });
+
+  /// Initialize the storage to persist session.
+  final Future<void> Function() initialize;
+
+  /// Check if there is a persisted session.
+  final Future<bool> Function() hasAccessToken;
+
+  /// Get the access token from the current persisted session.
+  final Future<String?> Function() accessToken;
+
+  /// Remove the current persisted session.
+  final Future<void> Function() removePersistedSession;
+
+  /// Persist a session in the device.
+  final Future<void> Function(String) persistSession;
+}
+
+class HiveLocalStorage extends LocalStorage {
+  /// Creates a LocalStorage instance that implements the Hive Database
+  const HiveLocalStorage()
+      : super(
+          initialize: _defInitialize,
+          hasAccessToken: _defHasAccessToken,
+          accessToken: _defAccessToken,
+          removePersistedSession: _defRemovePersistedSession,
+          persistSession: _defPersistSession,
+        );
+}

--- a/lib/src/supabase.dart
+++ b/lib/src/supabase.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:supabase/supabase.dart';
 
+import 'local_storage.dart';
 import 'supabase_auth.dart';
 
 /// Supabase instance. It must be initialized before used:
@@ -52,7 +53,7 @@ class Supabase {
       _instance.log('***** Supabase init completed $_instance');
 
       await SupabaseAuth.initialize(
-        localStorage: localStorage ?? const LocalStorage(),
+        localStorage: localStorage ?? const HiveLocalStorage(),
         authCallbackUrlHostname: authCallbackUrlHostname,
       );
     }

--- a/lib/src/supabase_auth.dart
+++ b/lib/src/supabase_auth.dart
@@ -1,146 +1,10 @@
 import 'dart:async';
 
-import 'package:hive_flutter/hive_flutter.dart';
 import 'package:supabase/supabase.dart';
 import 'package:url_launcher/url_launcher.dart';
 
+import 'local_storage.dart';
 import '../supabase_flutter.dart';
-
-const _hiveBoxName = 'supabase_authentication';
-const supabasePersistSessionKey = 'SUPABASE_PERSIST_SESSION_KEY';
-
-Future<void> _defInitialize() async {
-  await Hive.initFlutter('auth');
-  await Hive.openBox(_hiveBoxName);
-}
-
-Future<bool> _defHasAccessToken() {
-  return Future.value(
-      Hive.box(_hiveBoxName).containsKey(supabasePersistSessionKey));
-}
-
-Future<String?> _defAccessToken() {
-  return Future.value(Hive.box(_hiveBoxName).get(supabasePersistSessionKey) as String?);
-}
-
-Future<void> _defRemovePersistedSession() {
-  return Hive.box(_hiveBoxName).delete(supabasePersistSessionKey);
-}
-
-Future<void> _defPersistSession(String persistSessionString) {
-  return Hive.box(_hiveBoxName).put(supabasePersistSessionKey, persistSessionString);
-}
-
-/// LocalStorage is used to persist the user session in the device.
-///
-/// By default, the package `shared_preferences` is used to save the
-/// user info on the device. However, you can use any other plugin to
-/// do so.
-///
-/// For example, we can use `flutter_secure_storage` plugin to store
-/// user session in secure storage.
-///
-/// ```dart
-/// final localStorage = LocalStorage(
-///   hasAccessToken: () {
-///     const storage = FlutterSecureStorage();
-///     return storage.containsKey(key: supabasePersistSessionKey);
-///   }, accessToken: () {
-///     const storage = FlutterSecureStorage();
-///     return storage.read(key: supabasePersistSessionKey);
-///   }, removePersistedSession: () {
-///     const storage = FlutterSecureStorage();
-///     return storage.delete(key: supabasePersistSessionKey);
-///   }, persistSession: (String value) {
-///     const storage = FlutterSecureStorage();
-///     return storage.write(key: supabasePersistSessionKey, value: value);
-///   });
-/// ```
-///
-/// To use the `LocalStorage` instance, pass it to `localStorage` when initializing
-/// the [Supabase] instance:
-///
-/// ```dart
-/// Supabase.initialize(
-///  ...
-///  localStorage: localStorage,
-/// );
-/// ```
-///
-/// See also:
-///
-///   * [Supabase], the instance used to manage authentication
-class LocalStorage {
-  /// Creates a `LocalStorage` instance
-  const LocalStorage({
-    this.initialize = _defInitialize,
-    this.hasAccessToken = _defHasAccessToken,
-    this.accessToken = _defAccessToken,
-    this.removePersistedSession = _defRemovePersistedSession,
-    this.persistSession = _defPersistSession,
-  });
-
-  /// Initialize the storage to persist session.
-  final Future<void> Function() initialize;
-
-  /// {@template supabase.localstorage.hasAccessToken}
-  /// Check if there is a persisted session.
-  ///
-  /// Here's an example of how to do it using the shared_preferences
-  /// package:
-  ///
-  /// ```dart
-  /// Future<bool> hasAccessToken() async {
-  ///   final prefs = await SharedPreferences.getInstance();
-  ///   final exist = prefs.containsKey(supabasePersistSessionKey);
-  ///   return exist;
-  /// }
-  /// ```
-  /// {@endTemplate}
-  final Future<bool> Function() hasAccessToken;
-
-  /// {@template supabase.localstorage.accessToken}
-  /// Get the access token from the current persisted session.
-  ///
-  /// Here's an example of how to do it using the shared_preferences
-  /// package:
-  ///
-  /// ```dart
-  /// Future<String?> accessToken() async {
-  ///   final prefs = await SharedPreferences.getInstance();
-  ///   final jsonStr = prefs.getString(supabasePersistSessionKey);
-  ///   return jsonStr;
-  /// }
-  /// ```
-  /// {@endTemplate}
-  final Future<String?> Function() accessToken;
-
-  /// Remove the current persisted session.
-  ///
-  /// Here's an example of how to do it using the shared_preferences
-  /// package:
-  ///
-  /// ```dart
-  /// Future<void> removePersistedSession() async {
-  ///   final SharedPreferences prefs = await SharedPreferences.getInstance();
-  ///   return prefs.remove(supabasePersistSessionKey);
-  /// }
-  /// ```
-  final Future<void> Function() removePersistedSession;
-
-  /// Persist a session in the device.
-  ///
-  /// Here's an example of how to do it using the shared_preferences
-  /// package:
-  ///
-  /// ```dart
-  /// Future<void> persistSession(String persistSessionString) async {
-  ///   final prefs = await SharedPreferences.getInstance();
-  ///   return prefs.setString(supabasePersistSessionKey, persistSessionString);
-  /// }
-  /// ```
-  final Future<void> Function(String) persistSession;
-}
 
 /// SupabaseAuth
 class SupabaseAuth {
@@ -197,7 +61,7 @@ class SupabaseAuth {
   ///
   /// It's necessary to initialize before calling [SupabaseAuth.instance]
   static Future<SupabaseAuth> initialize({
-    LocalStorage localStorage = const LocalStorage(),
+    LocalStorage localStorage = const HiveLocalStorage(),
     String? authCallbackUrlHostname,
   }) async {
     _instance._initialized = true;

--- a/lib/src/supabase_auth.dart
+++ b/lib/src/supabase_auth.dart
@@ -4,7 +4,6 @@ import 'package:supabase/supabase.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import 'local_storage.dart';
-import '../supabase_flutter.dart';
 
 /// SupabaseAuth
 class SupabaseAuth {

--- a/lib/src/supabase_auth.dart
+++ b/lib/src/supabase_auth.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:supabase/supabase.dart';
 import 'package:url_launcher/url_launcher.dart';
 
+import '../supabase_flutter.dart';
 import 'local_storage.dart';
 
 /// SupabaseAuth

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -93,6 +93,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.0.7"
+  hive:
+    dependency: "direct main"
+    description:
+      name: hive
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.4"
+  hive_flutter:
+    dependency: "direct main"
+    description:
+      name: hive_flutter
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.0"
   http:
     dependency: transitive
     description:
@@ -156,6 +170,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.8.0"
+  path_provider:
+    dependency: transitive
+    description:
+      name: path_provider
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.2"
   path_provider_linux:
     dependency: transitive
     description:
@@ -163,6 +184,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.0"
+  path_provider_macos:
+    dependency: transitive
+    description:
+      name: path_provider_macos
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.2"
   path_provider_platform_interface:
     dependency: transitive
     description:
@@ -219,48 +247,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.1.7"
-  shared_preferences:
-    dependency: "direct main"
-    description:
-      name: shared_preferences
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.0.6"
-  shared_preferences_linux:
-    dependency: transitive
-    description:
-      name: shared_preferences_linux
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.0.0"
-  shared_preferences_macos:
-    dependency: transitive
-    description:
-      name: shared_preferences_macos
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.0.0"
-  shared_preferences_platform_interface:
-    dependency: transitive
-    description:
-      name: shared_preferences_platform_interface
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.0.0"
-  shared_preferences_web:
-    dependency: transitive
-    description:
-      name: shared_preferences_web
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.0.0"
-  shared_preferences_windows:
-    dependency: transitive
-    description:
-      name: shared_preferences_windows
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.0.0"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  shared_preferences: ^2.0.6
+  hive: ^2.0.4
+  hive_flutter: ^1.1.0
   supabase: ^0.0.7
   uni_links: ^0.5.1
   url_launcher: ^6.0.9


### PR DESCRIPTION
## What is the current behavior?

`shared_preferences` is currently used to store the user session

## What is the new behavior?

`hive` is now used.

## Aditional information

Fix for #8

Reworked the LocalStorage implementation. `LocalStorage` is now an abstract class that can be extended by others. Some classes are already built-in: 

- `HiveLocalStorage`, that implements Hive as the storage solution to persist the session on the device.
- `EmptyLocalStorage`, that disabled persistence.

An example of how to extend LocalStorage:

```dart
class EmptyLocalStorage extends LocalStorage {
  /// Creates a [LocalStorage] instance that disables persistance
  const EmptyLocalStorage()
      : super(
          initialize: _initialize,
          hasAccessToken: _hasAccessToken,
          accessToken: _accessToken,
          removePersistedSession: _removePersistedSession,
          persistSession: _persistSession,
        );

  static Future<void> _initialize() async {}
  static Future<bool> _hasAccessToken() => Future.value(false);
  static Future<String?> _accessToken() => Future.value(null);
  static Future<void> _removePersistedSession() async {}
  static Future<void> _persistSession(_) async {}
}
```

I also added a new function to `LocalStorage`: `initialize`. There you can initialize anything you need before performing any search operation. On the `HiveLocalStorage` implementation, it is used to open the box:

```dart
  static Future<void> _initialize() async {
    HiveCipher? encryptionCipher;
    if (encryptionKey != null) {
      encryptionCipher = HiveAesCipher(base64Url.decode(encryptionKey!));
    }
    await Hive.initFlutter('auth');
    await Hive.openBox(_hiveBoxName, encryptionCipher: encryptionCipher);
  }
```

It could be useful to improve fetching time for a lot of packages. We can take `shared_preferences` as an example:

```dart

late SharedPreferences _sharedPreferencesInstance;

class SharedPreferencesLocalStorage extends LocalStorage {
  const SharedPreferencesLocalStorage ()
      : super(
          initialize: _initialize,
          hasAccessToken: _hasAccessToken,
          accessToken: _accessToken,
          removePersistedSession: _removePersistedSession,
          persistSession: _persistSession,
        );

  static Future<void> _initialize() async {
    _sharedPreferencesInstance = await SharedPreferences.getInstance();
  }
  static Future<bool> _hasAccessToken() async {
    return _sharedPreferencesInstance.containsKey(...);
  }
  static Future<String?> _accessToken() {...}
  static Future<void> _removePersistedSession() async {...}
  static Future<void> _persistSession(_) async {...}
}
```

PS.: this was NOT tested in any app in production.