### PR TITLE
Export the LocalStorage class

### DIFF
--- a/lib/supabase_flutter.dart
+++ b/lib/supabase_flutter.dart
@@ -3,6 +3,7 @@
 /// See <https://github.com/supabase/supabase-flutter> to learn more
 library supabase_flutter;
 
+export 'src/local_storage.dart';
 export 'src/supabase.dart';
 export 'src/supabase_auth.dart';
 export 'src/supabase_auth_required_state.dart';


### PR DESCRIPTION
Many projects use the analyzer's option of avoiding 'implementation_imports'.
This rule needs to be explicitly ignored for importing LocalStorage.

Also Flutter in vscode doesn't automatically suggest imports for classes which aren't exported / in the src directory. I first looked at the documentation for the right import, and after not finding it, I had to look into the code.

