### PR TITLE
feat: Sining out triggers onUnauthenticated()

### DIFF
--- a/lib/src/supabase_auth_state.dart
+++ b/lib/src/supabase_auth_state.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/widgets.dart';
 import 'package:supabase/supabase.dart';
 import 'package:supabase_flutter/src/supabase.dart';
@@ -37,6 +39,24 @@ abstract class SupabaseAuthState<T extends StatefulWidget>
   @override
   void onErrorReceivingDeeplink(String message) {
     Supabase.instance.log('onErrorReceivingDeppLink message: $message');
+  }
+
+  late final StreamSubscription<AuthChangeEvent> _authStateListener;
+
+  @override
+  void initState() {
+    _authStateListener = SupabaseAuth.instance.onAuthChange.listen((event) {
+      if (event == AuthChangeEvent.signedOut) {
+        onUnauthenticated();
+      }
+    });
+    super.initState();
+  }
+
+  @override
+  void dispose() {
+    _authStateListener.cancel();
+    super.dispose();
   }
 
   Future<bool> recoverSessionFromUrl(Uri uri) async {

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import 'widget_test_stubs.dart';
+
+void main() {
+  const supabaseUrl = '';
+  const supabaseKey = '';
+
+  setUpAll(() async {
+    // Initialize the Supabase singleton
+    await Supabase.initialize(
+      url: supabaseUrl,
+      anonKey: supabaseKey,
+      localStorage: MockLocalStorage(),
+    );
+  });
+
+  testWidgets('Signing out triggers onUnauthenticated()', (tester) async {
+    await tester.pumpWidget(const MaterialApp(home: MockWidget()));
+    await tester.tap(find.text('Sign out'));
+    await tester.pump();
+    expect(find.text('You have signed out'), findsOneWidget);
+  });
+}

--- a/test/widget_test_stubs.dart
+++ b/test/widget_test_stubs.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+class MockWidget extends StatefulWidget {
+  const MockWidget({Key? key}) : super(key: key);
+
+  @override
+  _MockWidgetState createState() => _MockWidgetState();
+}
+
+class _MockWidgetState extends SupabaseAuthRequiredState<MockWidget> {
+  bool isSignedIn = true;
+
+  @override
+  void onUnauthenticated() {
+    setState(() {
+      isSignedIn = false;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return isSignedIn
+        ? TextButton(
+            onPressed: () {
+              Supabase.instance.client.auth.signOut();
+            },
+            child: const Text('Sign out'),
+          )
+        : const Text('You have signed out');
+  }
+}
+
+class MockLocalStorage extends LocalStorage {
+  MockLocalStorage()
+      : super(
+            initialize: () async {},
+
+            /// Session expires at is at its maximum value for unix timestamp
+            accessToken: () async =>
+                '{"currentSession":{"access_token":"","expires_in":3600,"refresh_token":"","user":{"id":"","aud":"","created_at":"","role":"authenticated","updated_at":""}},"expiresAt":2147483647}',
+            persistSession: (_) async {},
+            removePersistedSession: () async {},
+            hasAccessToken: () async => true);
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Currently, sining out from Supabase does not trigger `onUnauthenticated()`. This causes the user to manually update the navigator stack after a successful sign out. With this PR, users will no longer have to manually update the navigator stack upon a successful sign out. 

Closes https://github.com/supabase/supabase-flutter/issues/35

## What is the current behavior?

Calling `signout()` out does not trigger `onUnauthenticated()` on neither `SupabaseAuthState` nor `SupabaseAuthRequiredState`, so the user has to manually navigate out from the current page. 

## What is the new behavior?

Upon a successful sign out from Supabase, `onUnauthenticated()` is triggered on both `SupabaseAuthState` and `SupabaseAuthRequiredState`. 

## Additional context

N/A
