### PR TITLE
chore: publish version 0.2.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [0.2.9]
+
+- feat: signing out now triggers `onUnauthenticated()`
+- feat: export supabase package so that underlying symbols can be imported
+- fix: update code samples to reflect breaking change from v0.0.3
+- fix: typos on code samples on readme.md
+
 ## [0.2.8]
 
 - chore: update supabase to v0.2.7

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: supabase_flutter
 description: Flutter integration for Supabase. This package makes it simple for developers to build secure and scalable products.
-version: 0.2.8
+version: 0.2.9
 homepage: "https://supabase.io"
 repository: "https://github.com/supabase/supabase-flutter"
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Publishes a new version of `supabase_flutter` which includes
- feat: signing out now triggers `onUnauthenticated()`
- feat: export supabase package so that underlying symbols can be imported
- fix: update code samples to reflect breaking change from v0.0.3
- fix: typos on code samples on readme.md