### PR TITLE
fix: only parse deep link if it has access token

### DIFF
--- a/lib/src/supabase_auth.dart
+++ b/lib/src/supabase_auth.dart
@@ -178,7 +178,7 @@ class SupabaseAuth with WidgetsBindingObserver {
   /// if _authCallbackUrlHost not init, we treat all deeplink as auth callback
   bool _isAuthCallbackDeeplink(Uri uri) {
     if (_authCallbackUrlHostname == null) {
-      return true;
+      return uri.queryParameters.containsKey('access_token');
     } else {
       return _authCallbackUrlHostname == uri.host;
     }


### PR DESCRIPTION
## What kind of change does this PR introduce?

With the current setup, Flutter web application will try to parse every URL as a auth call back URL, which results in `No access_token detected` error, causing confusion for developers getting started with Supabase and Flutter web. With this PR, the link will only be parsed, if it contains `access_token` in the query parameter. I remember @DanMossa suggesting implementing something like this, and I should have listened back then 😂

Fixes https://github.com/supabase/supabase-flutter/issues/274