### PR TITLE
fix: auth callback not properly parsing callback URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.2.2]
+
+- fix: bug where auth callback URL is not correctly parsed
+
 ## [1.2.1]
 
 - fix: Only parse deep links if it contains access_token [#284](https://github.com/supabase/supabase-flutter/pull/284)

--- a/lib/src/supabase_auth.dart
+++ b/lib/src/supabase_auth.dart
@@ -178,7 +178,7 @@ class SupabaseAuth with WidgetsBindingObserver {
   /// if _authCallbackUrlHost not init, we treat all deeplink as auth callback
   bool _isAuthCallbackDeeplink(Uri uri) {
     if (_authCallbackUrlHostname == null) {
-      return uri.queryParameters.containsKey('access_token');
+      return uri.toString().contains('access_token');
     } else {
       return _authCallbackUrlHostname == uri.host;
     }

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,1 +1,1 @@
-const version = '1.2.1';
+const version = '1.2.2';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: supabase_flutter
 description: Flutter integration for Supabase. This package makes it simple for developers to build secure and scalable products.
-version: 1.2.1
+version: 1.2.2
 homepage: 'https://supabase.io'
 repository: 'https://github.com/supabase/supabase-flutter'
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

There was a bug with logic inside `_isAuthCallbackDeeplink`, where the link from Supabase does not contain query parameters, but rather passes parameters after `#`, and yet the library looks for `access_token` parameter resulting in no auth callback URL being parsed. 