### PR TITLE
Feat/in app browser oauth

### DIFF
--- a/lib/src/supabase_auth.dart
+++ b/lib/src/supabase_auth.dart
@@ -283,6 +283,7 @@ extension GoTrueClientSignInProvider on GoTrueClient {
     Provider provider, {
     String? redirectTo,
     String? scopes,
+    LaunchMode mode = LaunchMode.externalApplication,
     Map<String, String>? queryParams,
   }) async {
     final res = await getOAuthSignInUrl(
@@ -294,7 +295,7 @@ extension GoTrueClientSignInProvider on GoTrueClient {
     final url = Uri.parse(res.url!);
     final result = await launchUrl(
       url,
-      mode: LaunchMode.externalApplication,
+      mode: mode,
       webOnlyWindowName: '_self',
     );
     return result;

--- a/lib/src/supabase_auth.dart
+++ b/lib/src/supabase_auth.dart
@@ -283,7 +283,7 @@ extension GoTrueClientSignInProvider on GoTrueClient {
     Provider provider, {
     String? redirectTo,
     String? scopes,
-    LaunchMode mode = LaunchMode.externalApplication,
+    LaunchMode authScreenLaunchMode = LaunchMode.externalApplication,
     Map<String, String>? queryParams,
   }) async {
     final res = await getOAuthSignInUrl(
@@ -295,7 +295,7 @@ extension GoTrueClientSignInProvider on GoTrueClient {
     final url = Uri.parse(res.url!);
     final result = await launchUrl(
       url,
-      mode: mode,
+      mode: authScreenLaunchMode,
       webOnlyWindowName: '_self',
     );
     return result;

--- a/lib/src/supabase_auth.dart
+++ b/lib/src/supabase_auth.dart
@@ -283,7 +283,7 @@ extension GoTrueClientSignInProvider on GoTrueClient {
     Provider provider, {
     String? redirectTo,
     String? scopes,
-    LaunchMode authScreenLaunchMode = LaunchMode.externalApplication,
+    LaunchMode authScreenLaunchMode = LaunchMode.inAppWebView,
     Map<String, String>? queryParams,
   }) async {
     final res = await getOAuthSignInUrl(

--- a/lib/src/supabase_auth.dart
+++ b/lib/src/supabase_auth.dart
@@ -283,7 +283,7 @@ extension GoTrueClientSignInProvider on GoTrueClient {
     Provider provider, {
     String? redirectTo,
     String? scopes,
-    LaunchMode authScreenLaunchMode = LaunchMode.inAppWebView,
+    LaunchMode authScreenLaunchMode = LaunchMode.externalApplication,
     Map<String, String>? queryParams,
   }) async {
     final res = await getOAuthSignInUrl(

--- a/lib/supabase_flutter.dart
+++ b/lib/supabase_flutter.dart
@@ -7,3 +7,4 @@ export 'package:supabase/supabase.dart';
 export 'src/local_storage.dart';
 export 'src/supabase.dart';
 export 'src/supabase_auth.dart';
+export 'package:url_launcher/url_launcher.dart' show LaunchMode;


### PR DESCRIPTION
## What kind of change does this PR introduce?

Added parameter `authScreenLaunchMode` to `signInWithOAuth` method because Apple explicitly asks for `LaunchMode.inAppWebView`, elsewhere they will not approve the app on App Store.

## What is the current behavior?

Actually, `LaunchMode.externalApplication` is the only way to launch auth screen browser.

## What is the new behavior?

Now developers can choose the launch mode for OAuth signin
