### PR TITLE
fix: show web support on pub.dev

### DIFF
--- a/lib/src/supabase_auth.dart
+++ b/lib/src/supabase_auth.dart
@@ -1,13 +1,12 @@
 import 'dart:async';
 
 import 'package:app_links/app_links.dart';
-import 'package:flutter/foundation.dart';
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:universal_io/io.dart' show Platform;
 import 'package:url_launcher/url_launcher.dart';
-import 'dart:io' show Platform;
-import 'package:flutter/foundation.dart' show kIsWeb;
 
 // ignore_for_file: invalid_null_aware_operator
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
   http: ^0.13.4
   supabase: ^1.5.0
   url_launcher: ^6.1.2
+  universal_io: ^2.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Currently [pub.dev](https://pub.dev/packages/supabase_flutter/score) states that this package doesn't support web, because of the `dart:io` import. I've changed it to `universal_io`, which should fix the issue. This doesn't add a new dependency, as the sub libraries are already using it.