### PR TITLE
fix: declare web support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ Flutter Client library for [Supabase](https://supabase.com/).
 
 - Documentation: https://supabase.com/docs/reference/dart/introduction
 
+## Platform Support
+
+Except Linux, all platforms are fully supported. Linux only doesn't support deeplinks, because of our dependency [app_links](https://pub.dev/packages/app_links). All other features are supported.
+
 ## Getting Started
 
 Import the package:

--- a/lib/src/supabase_auth.dart
+++ b/lib/src/supabase_auth.dart
@@ -1,12 +1,13 @@
 import 'dart:async';
 
 import 'package:app_links/app_links.dart';
-import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
-import 'package:universal_io/io.dart' show Platform;
 import 'package:url_launcher/url_launcher.dart';
+import 'dart:io' show Platform;
+import 'package:flutter/foundation.dart' show kIsWeb;
 
 // ignore_for_file: invalid_null_aware_operator
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,4 +23,11 @@ dev_dependencies:
     sdk: flutter
   lints: ^1.0.1
 
+platforms:
+  android:
+  ios:
+  macos:
+  web:
+  windows:
+
 flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,6 @@ dependencies:
   http: ^0.13.4
   supabase: ^1.5.0
   url_launcher: ^6.1.2
-  universal_io: ^2.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
The previous fix didn't work, because universal_io is still listed as not supported. I'm now hard coding the supported platforms as described [here](https://dart.dev/tools/pub/pubspec#platforms). Hopefully it works this time.

I added a section about linux support in the readme, because one might think we don't support linux at all. 
