### PR TITLE
Update documentation to reflect correct code for Apple auth login

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,8 +117,9 @@ final AuthorizationCredentialAppleID credential = await SignInWithApple.getApple
 );
 
 return supabase.auth.signInWithIdToken(
-  provider: Provider.google, 
+  provider: Provider.apple, 
   idToken: credential.identityToken,
+  nonce: nonce
 );
 ```
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Doc update

## What is the current behavior?

The current doc code for Apple native auth is not correct.

## What is the new behavior?

The new behavior changes the provider from Google to Apple, and critically includes the nonce, non-hashed, in the constructor. 

## Additional context

Add any other context or screenshots.
