### PR TITLE
Make readme clearer around native sign in progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ class _MyWidgetState extends State<MyWidget> {
 ```
 
 #### Native Sign in with Apple example
-##### The `signInWithIdToken` method is currently experimental and is subject to change.
+##### The `signInWithIdToken` method is currently experimental and is subject to change. Apple sign in on iOS is working, as shown in the code below, but other combinations of Apple/Google sign in on iOS/Android may not be. Follow [this issue](https://github.com/supabase/supabase-flutter/issues/399) for platform support progress.
 
 ```dart
 import 'dart:convert';


### PR DESCRIPTION
## What kind of change does this PR introduce?

Readme update.

## What is the current behavior?

The verbage on the readme is a but unclear, and might lead users to assume that native sign in is now supported cross-platform.

## What is the new behavior?

Adds text explaining the state of native auth, and links a relevant issue.

