### PR TITLE
Dont call recover session if deeplink is handled

### DIFF
--- a/lib/src/supabase_auth.dart
+++ b/lib/src/supabase_auth.dart
@@ -140,7 +140,9 @@ class SupabaseAuth with WidgetsBindingObserver {
   void didChangeAppLifecycleState(AppLifecycleState state) {
     switch (state) {
       case AppLifecycleState.resumed:
+        if (!_initialDeeplinkIsHandled) {
         _recoverSupabaseSession();
+        }
         break;
       case AppLifecycleState.inactive:
         break;


### PR DESCRIPTION
## What kind of change does this PR introduce?

fixes #365 #184 

## What is the current behavior?

Recover Session gets called when the deeplink was handled and the session
from the deeplink was saved. Resulting in emitting signIn when it should not have been emitted. 1. signedIn 2. recovery 3. signedIn

## What is the new behavior?

didChangeAppLifeCycle now checks if a deeplink is handled and if so it does not call recoverSupabaseSession when it should not. Resulting in  only 1. signedIn 2. recovery event beeing emitted.


