### PR TITLE
fix: add `onError` within SupabaseAuth.dart to listen to auth errors

### DIFF
--- a/lib/src/supabase_auth.dart
+++ b/lib/src/supabase_auth.dart
@@ -74,9 +74,13 @@ class SupabaseAuth with WidgetsBindingObserver {
       _instance._authCallbackUrlHostname = authCallbackUrlHostname;
 
       _instance._authSubscription =
-          Supabase.instance.client.auth.onAuthStateChange.listen((data) {
-        _instance._onAuthStateChange(data.event, data.session);
-      });
+          Supabase.instance.client.auth.onAuthStateChange.listen(
+        (data) {
+          _instance._onAuthStateChange(data.event, data.session);
+        },
+      )..onError((error, stackTrace) {
+              Supabase.instance.log(error.toString(), stackTrace);
+            });
 
       await _instance._localStorage.initialize();
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR adds `onError` on the `onAuthStateChanged` within SupabaseAuth.dart to listen to auth errors and logs it.