### PR TITLE
chore: improve version reporting in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -24,7 +24,11 @@ A clear and concise description of what you expected to happen.
 If applicable, add screenshots to help explain your problem.
 
 **Version (please complete the following information):**
- - [e.g. 1.2.2]
+On Linux/macOS
+Please run `dart pub deps | grep -E "supabase|gotrue|postgrest|storage_client|realtime_client|functions_client"` in your project directory and paste the output here.
+
+On Windows
+Please run `dart pub deps | findstr "supabase gotrue postgrest storage_client realtime_client functions_client"` in your project directory and paste the output here.
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
         run: flutter pub get
 
       - name: flutterfmt
-        run: flutter format lib test -l 80 --set-exit-if-changed
+        run: dart format lib test -l 80 --set-exit-if-changed
 
       - name: analyzer
         run: flutter analyze --fatal-warnings --fatal-infos .


### PR DESCRIPTION
It's helpful to know the version of the sub libraries, so I added this oneliner to get these versions. I outputs the following for this repo:
```bash
supabase_flutter 1.6.0
├── supabase 1.6.1
│   ├── functions_client 1.1.1
│   ├── gotrue 1.5.2
│   ├── postgrest 1.2.2
│   ├── realtime_client 1.0.3
│   ├── storage_client 1.2.3
```

`flutter format` is deprecated, so I'm switching to `dart format`