### PR TITLE
Update supabase_auth.dart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [1.6.2]
 
-- fix: Update supabase_auth.dart [#422](https://github.com/supabase/supabase-flutter/pull/422)
+- fix: persist session to local storage on `onAuthStateChanged` event with a session [#422](https://github.com/supabase/supabase-flutter/pull/422)
 
 ## [1.6.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.6.2]
+
+- fix: persist session to local storage on `onAuthStateChanged` event with a session [#422](https://github.com/supabase/supabase-flutter/pull/422)
+
 ## [1.6.1]
 
 - fix: log errors from `onAuthStateChange` [#416](https://github.com/supabase/supabase-flutter/pull/416)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.6.2]
+
+- fix: Update supabase_auth.dart [#422](https://github.com/supabase/supabase-flutter/pull/422)
+
 ## [1.6.1]
 
 - fix: log errors from `onAuthStateChange` [#416](https://github.com/supabase/supabase-flutter/pull/416)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,3 @@
-## [1.6.2]
-
-- fix: persist session to local storage on `onAuthStateChanged` event with a session [#422](https://github.com/supabase/supabase-flutter/pull/422)
-
 ## [1.6.1]
 
 - fix: log errors from `onAuthStateChange` [#416](https://github.com/supabase/supabase-flutter/pull/416)

--- a/lib/src/supabase_auth.dart
+++ b/lib/src/supabase_auth.dart
@@ -186,7 +186,7 @@ class SupabaseAuth with WidgetsBindingObserver {
 
   void _onAuthStateChange(AuthChangeEvent event, Session? session) {
     Supabase.instance.log('**** onAuthStateChange: $event');
-    if (event == AuthChangeEvent.signedIn && session != null) {
+    if (((event == AuthChangeEvent.signedIn) || (event == AuthChangeEvent.tokenRefreshed) )&& session != null) {
       Supabase.instance.log(session.persistSessionString);
       _localStorage.persistSession(session.persistSessionString);
     } else if (event == AuthChangeEvent.signedOut) {

--- a/lib/src/supabase_auth.dart
+++ b/lib/src/supabase_auth.dart
@@ -186,7 +186,7 @@ class SupabaseAuth with WidgetsBindingObserver {
 
   void _onAuthStateChange(AuthChangeEvent event, Session? session) {
     Supabase.instance.log('**** onAuthStateChange: $event');
-    if (((event == AuthChangeEvent.signedIn) || (event == AuthChangeEvent.tokenRefreshed) )&& session != null) {
+    if (session != null) {
       Supabase.instance.log(session.persistSessionString);
       _localStorage.persistSession(session.persistSessionString);
     } else if (event == AuthChangeEvent.signedOut) {

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,1 +1,1 @@
-const version = '1.6.1';
+const version = '1.6.2';

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,1 +1,1 @@
-const version = '1.6.2';
+const version = '1.6.1';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: supabase_flutter
 description: Flutter integration for Supabase. This package makes it simple for developers to build secure and scalable products.
-version: 1.6.2
+version: 1.6.1
 homepage: 'https://supabase.io'
 repository: 'https://github.com/supabase/supabase-flutter'
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: supabase_flutter
 description: Flutter integration for Supabase. This package makes it simple for developers to build secure and scalable products.
-version: 1.6.1
+version: 1.6.2
 homepage: 'https://supabase.io'
 repository: 'https://github.com/supabase/supabase-flutter'
 


### PR DESCRIPTION
_onAuthStateChange now persists the session on AuthChangeEvent .signedIn AND .tokenRefreshed

## What kind of change does this PR introduce?
See #421 - It persists the token to localStorage on auth.refreshSession() which generates AuthChangeEvent.tokenRefreshed. 

Bug fix, feature, docs update, ...

## What is the current behavior?
The current behavior is that only persists to localStorage on AuthChangeEvent.signedIn.

Please link any relevant issues here.
See #421 

## What is the new behavior?
It persists the session to localStorage on BOTH AuthChangeEvent.signedIn AND AuthChangeEvent.tokenRefreshed
