### PR TITLE
feat: Add `signInWithApple` method

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        flutter-version: ['2.8.0', '3.x']
+        flutter-version: ['3.0.0', '3.x']
 
     runs-on: ${{ matrix.os }}
 

--- a/README.md
+++ b/README.md
@@ -96,32 +96,21 @@ class _MyWidgetState extends State<MyWidget> {
 ```
 
 #### Native Sign in with Apple example
-##### The `signInWithIdToken` method is currently experimental and is subject to change. Apple sign in on iOS is working, as shown in the code below, but other combinations of Apple/Google sign in on iOS/Android may not be. Follow [this issue](https://github.com/supabase/supabase-flutter/issues/399) for platform support progress.
+
+Before you run the code, you need to [register your app ID with Apple](https://developer.apple.com/help/account/manage-identifiers/register-an-app-id/) with the `Sign In with Apple` capability selected. 
 
 ```dart
-import 'dart:convert';
-import 'package:crypto/crypto.dart';
-import 'package:sign_in_with_apple/sign_in_with_apple.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 final supabase = Supabase.instance.client;
-final String nonce = uuidV4();
-final String hashedNonce = sha256.convert(utf8.encode(nonce)).toString();
-const String clientId = 'com.app';
 
-final AuthorizationCredentialAppleID credential = await SignInWithApple.getAppleIDCredential(
-  scopes: [
-    AppleIDAuthorizationScopes.email,
-  ],
-  nonce: hashedNonce,
-);
-
-return supabase.auth.signInWithIdToken(
-  provider: Provider.apple, 
-  idToken: credential.identityToken,
-  nonce: nonce
-);
+return supabase.auth.signInWithApple();
 ```
+
+`signInWithApple()` is only supported on iOS. Other platforms can use the `signInWithOAuth()` method to perform Apple login.
+
+The `signInWithApple` method is currently experimental and is subject to change. Follow [this issue](https://github.com/supabase/supabase-flutter/issues/399) for platform support progress.
+
 
 ### [Database](https://supabase.com/docs/guides/database)
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ final supabase = Supabase.instance.client;
 return supabase.auth.signInWithApple();
 ```
 
-`signInWithApple()` is only supported on iOS. Other platforms can use the `signInWithOAuth()` method to perform Apple login.
+`signInWithApple()` is only supported on iOS and on macOS. Other platforms can use the `signInWithOAuth()` method to perform Apple login.
 
 The `signInWithApple` method is currently experimental and is subject to change. Follow [this issue](https://github.com/supabase/supabase-flutter/issues/399) for platform support progress.
 

--- a/example/analysis_options.yaml
+++ b/example/analysis_options.yaml
@@ -25,5 +25,9 @@ linter:
     # avoid_print: false  # Uncomment to disable the `avoid_print` rule
     # prefer_single_quotes: true  # Uncomment to enable the `prefer_single_quotes` rule
 
+analyzer:
+  exclude: 
+    - lib/generated_plugin_registrant.dart
+
 # Additional information about this file can be found at
 # https://dart.dev/guides/language/analysis-options

--- a/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -7,10 +7,12 @@ import Foundation
 
 import app_links
 import path_provider_foundation
+import sign_in_with_apple
 import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AppLinksMacosPlugin.register(with: registry.registrar(forPlugin: "AppLinksMacosPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
+  SignInWithApplePlugin.register(with: registry.registrar(forPlugin: "SignInWithApplePlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/lib/src/supabase_auth.dart
+++ b/lib/src/supabase_auth.dart
@@ -355,7 +355,12 @@ extension GoTrueClientSignInProvider on GoTrueClient {
     }
   }
 
+  /// Signs a user in using native Apple Login.
+  ///
+  /// This method only works on iOS. If you want to sign in a user using Apple
+  /// on other platforms, please use the `signInWithOAuth` method.
   Future<AuthResponse> signInWithApple() async {
+    assert(Platform.isIOS, 'Please use signInWithOAuth for non-iOS platforms');
     final rawNonce = _generateRandomString();
     final hashedNonce = sha256.convert(utf8.encode(rawNonce)).toString();
 

--- a/lib/src/supabase_auth.dart
+++ b/lib/src/supabase_auth.dart
@@ -364,7 +364,7 @@ extension GoTrueClientSignInProvider on GoTrueClient {
   /// This method is experimental as the underlying `signInWithIdToken` method is experimental.
   @experimental
   Future<AuthResponse> signInWithApple() async {
-    assert(Platform.isIOS, 'Please use signInWithOAuth for non-iOS platforms');
+    assert(!kIsWeb && Platform.isIOS, 'Please use signInWithOAuth for non-iOS platforms');
     final rawNonce = _generateRandomString();
     final hashedNonce = sha256.convert(utf8.encode(rawNonce)).toString();
 

--- a/lib/src/supabase_auth.dart
+++ b/lib/src/supabase_auth.dart
@@ -364,7 +364,8 @@ extension GoTrueClientSignInProvider on GoTrueClient {
   /// This method is experimental as the underlying `signInWithIdToken` method is experimental.
   @experimental
   Future<AuthResponse> signInWithApple() async {
-    assert(!kIsWeb && Platform.isIOS, 'Please use signInWithOAuth for non-iOS platforms');
+    assert(!kIsWeb && Platform.isIOS,
+        'Please use signInWithOAuth for non-iOS platforms');
     final rawNonce = _generateRandomString();
     final hashedNonce = sha256.convert(utf8.encode(rawNonce)).toString();
 

--- a/lib/src/supabase_auth.dart
+++ b/lib/src/supabase_auth.dart
@@ -8,6 +8,7 @@ import 'package:crypto/crypto.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:meta/meta.dart';
 import 'package:sign_in_with_apple/sign_in_with_apple.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -359,6 +360,9 @@ extension GoTrueClientSignInProvider on GoTrueClient {
   ///
   /// This method only works on iOS. If you want to sign in a user using Apple
   /// on other platforms, please use the `signInWithOAuth` method.
+  ///
+  /// This method is experimental as the underlying `signInWithIdToken` method is experimental.
+  @experimental
   Future<AuthResponse> signInWithApple() async {
     assert(Platform.isIOS, 'Please use signInWithOAuth for non-iOS platforms');
     final rawNonce = _generateRandomString();

--- a/lib/src/supabase_auth.dart
+++ b/lib/src/supabase_auth.dart
@@ -358,13 +358,13 @@ extension GoTrueClientSignInProvider on GoTrueClient {
 
   /// Signs a user in using native Apple Login.
   ///
-  /// This method only works on iOS. If you want to sign in a user using Apple
+  /// This method only works on iOS and MacOS. If you want to sign in a user using Apple
   /// on other platforms, please use the `signInWithOAuth` method.
   ///
   /// This method is experimental as the underlying `signInWithIdToken` method is experimental.
   @experimental
   Future<AuthResponse> signInWithApple() async {
-    assert(!kIsWeb && Platform.isIOS,
+    assert(!kIsWeb && (Platform.isIOS || Platform.isMacOS),
         'Please use signInWithOAuth for non-iOS platforms');
     final rawNonce = _generateRandomString();
     final hashedNonce = sha256.convert(utf8.encode(rawNonce)).toString();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,7 +22,6 @@ dependencies:
   url_launcher: ^6.1.2
   webview_flutter: ^4.0.0
 
-
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,11 +10,13 @@ environment:
 
 dependencies:
   app_links: ^3.4.1
+  crypto: ^3.0.2
   flutter:
     sdk: flutter
   hive: ^2.2.1
   hive_flutter: ^1.1.0
   http: ^0.13.4
+  sign_in_with_apple: ^4.3.0
   supabase: ^1.6.1
   url_launcher: ^6.1.2
   webview_flutter: ^4.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,10 +16,12 @@ dependencies:
   hive: ^2.2.1
   hive_flutter: ^1.1.0
   http: ^0.13.4
+  meta: ^1.7.0
   sign_in_with_apple: ^4.3.0
   supabase: ^1.6.1
   url_launcher: ^6.1.2
   webview_flutter: ^4.0.0
+
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## What kind of change does this PR introduce?

After the very long wait, Supabase is bringing proper native mobile auth! There is a `bundleId` field within the Supabase dashboard that you can add your iOS bundle ID to start using Apple login for both iOS and other platforms. This only allows a single iOS app to be used with a single Supabase instance, but we will take care of that in the later times. 

In the mean while, implementing Apple login could be kind of complicated. We have had the `signInWithIdToken` method thanks to @DanMossa for a while, but the process of signing a user in requires generating nonce and verifying it, and just a whole bunch of stuff that the developers don't really need to worry about. 

I propose to add a `signInWithApple()` method that allows supabase_flutter user to implement Apple login with just one line.

```dart
final AuthResponse response = await supabase.auth.signInWithApple();
```

Pros and cons of adding this method instead of allowing developers to import Apple login package themselves and add the login from scratch.

Pros:
- Simple developer experience. Literally one line to start using Apple Login.

Cons:
- Adds unnecessary extra dependencies for those that don't use Apple login

Would love to hear comments/ feedback about this approach! 

## What about other providers?

If we go this path, the plan is to add `signInWithGoogle` method next, and create each individual sign-in methods for different native auth providers. I don't think we will ever get to supporting every single OAuth providers that we support currently, and quite frankly, I think supporting Apple and Google login will be good enough for 90% of the use cases, but we will see and hear what the community wants after Google login.

To implement Google login, we will use the [AppAuth ](https://pub.dev/packages/flutter_appauth) package, because the official Google login package does not allow us to specify the nonce, and after talking with the auth team, we have decided that for security reasons, we have to make nonce a required parameter. With any other providers that we may support in the future, we will see if we can implement it using the AppAuth package as well to minimize the extra dependencies of supabase_flutter.