### PR TITLE
fix: google login on android will always open external browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.8.1]
+
+- fix: ensure that Google login on Android always opens in external browser [#455](https://github.com/supabase/supabase-flutter/pull/455)
+
 ## [1.8.0]
 
 - feat: allow `signInWithOAuth` with `platformDefault` option to open in app webview for iOS [#431](https://github.com/supabase/supabase-flutter/pull/431)

--- a/lib/src/supabase_auth.dart
+++ b/lib/src/supabase_auth.dart
@@ -306,9 +306,11 @@ extension GoTrueClientSignInProvider on GoTrueClient {
   ///   Provider.google,
   ///   // Use deep link to bring the user back to the app
   ///   redirectTo: 'my-scheme://my-host/login-callback',
-  ///   // Pass the context to open the OAuth screen in webview for iOS apps as recommended by Apple.
-  ///   // For other platforms it will launch the OAuth screen in external browser.
+  ///   // Pass the context and set `authScreenLaunchMode` to `platformDefault`
+  ///   // to open the OAuth screen in webview for iOS apps as recommended by Apple.
+  ///   // For other platforms it will launch the OAuth screen in whatever the platform default is.
   ///   context: context,
+  ///   authScreenLaunchMode: LaunchMode.platformDefault
   /// );
   /// ```
   ///
@@ -348,9 +350,18 @@ extension GoTrueClientSignInProvider on GoTrueClient {
       }));
       return true;
     } else {
+      LaunchMode launchMode = authScreenLaunchMode;
+
+      // `Platform.isAndroid` throws on web, so adding a guard for web here.
+      final isAndroid = !kIsWeb && Platform.isAndroid;
+
+      if (provider == Provider.google && isAndroid) {
+        launchMode = LaunchMode.externalApplication;
+      }
+
       final result = await launchUrl(
         uri,
-        mode: authScreenLaunchMode,
+        mode: launchMode,
         webOnlyWindowName: '_self',
       );
       return result;

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,1 +1,1 @@
-const version = '1.8.0';
+const version = '1.8.1';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: supabase_flutter
 description: Flutter integration for Supabase. This package makes it simple for developers to build secure and scalable products.
-version: 1.8.0
+version: 1.8.1
 homepage: 'https://supabase.io'
 repository: 'https://github.com/supabase/supabase-flutter'
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Opening in app browser with Google OAuth login on Android will fail because of [Google's policy](https://developers.googleblog.com/2016/08/modernizing-oauth-interactions-in-native-apps.html). This PR ensures that Google login on Android always opens external browser.

Fixes https://github.com/supabase/supabase-flutter/issues/357