### PR TITLE
fix(supabase_flutter): prevent Platform.environment use on web

### DIFF
--- a/packages/supabase_flutter/lib/src/supabase_auth.dart
+++ b/packages/supabase_flutter/lib/src/supabase_auth.dart
@@ -149,7 +149,7 @@ class SupabaseAuth with WidgetsBindingObserver {
 
   /// Dispose the instance to free up resources
   void dispose() {
-    if (Platform.environment.containsKey('FLUTTER_TEST')) {
+    if (!kIsWeb && Platform.environment.containsKey('FLUTTER_TEST')) {
       _initialDeeplinkIsHandled = false;
     }
     _authSubscription?.cancel();


### PR DESCRIPTION
Fixes https://github.com/supabase/supabase-flutter/issues/466

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

https://github.com/supabase/supabase-flutter/issues/466

## What is the new behavior?

It works without throwing.

