### PR TITLE
feat: Add kakao provider enum type

### DIFF
--- a/packages/gotrue/lib/src/types/provider.dart
+++ b/packages/gotrue/lib/src/types/provider.dart
@@ -15,6 +15,7 @@ enum Provider {
   twitch,
   twitter,
   workos,
+  kakao
 }
 
 extension ProviderName on Provider {


### PR DESCRIPTION
## What kind of change does this PR introduce?
Kakao auth provider sign in method has been added by this PR & doc
[Kakao Auth PR](https://github.com/supabase/gotrue/pull/834)
[Kakao Auth docs PR](https://github.com/supabase/supabase/pull/14287)
To support Kakao provider in the future releases in supabase-flutter, I have come up with this PR.

## What is the current behavior?
No kakao provider option for Provider enum type
Please link any relevant issues here.

## What is the new behavior?
Kakao provider option for Provider enum type

## Additional context
If there's other changes needed, please let me know.
