### PR TITLE
fix: reformat Provider type to be ordered alphabetically

### DIFF
--- a/packages/gotrue/lib/src/types/provider.dart
+++ b/packages/gotrue/lib/src/types/provider.dart
@@ -7,6 +7,7 @@ enum Provider {
   github,
   gitlab,
   google,
+  kakao,
   keycloak,
   linkedin,
   notion,
@@ -15,7 +16,6 @@ enum Provider {
   twitch,
   twitter,
   workos,
-  kakao
 }
 
 extension ProviderName on Provider {

--- a/packages/gotrue/lib/src/types/provider.dart
+++ b/packages/gotrue/lib/src/types/provider.dart
@@ -16,7 +16,6 @@ enum Provider {
   twitch,
   twitter,
   workos,
-  kakao
 }
 
 extension ProviderName on Provider {

--- a/packages/gotrue/lib/src/types/provider.dart
+++ b/packages/gotrue/lib/src/types/provider.dart
@@ -15,6 +15,7 @@ enum Provider {
   twitch,
   twitter,
   workos,
+  kakao
 }
 
 extension ProviderName on Provider {


### PR DESCRIPTION
## What kind of change does this PR introduce?
A quick reformat Provider type to be ordered alphabetically.
I forgot to order Provider type alphabetically in the previous PR #470 .

