### PR TITLE
feat: SignInWithKakaoTalkApp

### DIFF
--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -300,7 +300,7 @@ class GoTrueClient {
 
   /// Allows signing in with an ID token issued by certain supported providers.
   /// The [idToken] is verified for validity and a new session is established.
-  /// This method of signing in only supports [Provider.google] or [Provider.apple].
+  /// This method of signing in only supports [Provider.google] or [Provider.apple] or [Provider.kakao].
   ///
   /// This method is experimental.
   @experimental
@@ -312,9 +312,9 @@ class GoTrueClient {
   }) async {
     _removeSession();
 
-    if (provider != Provider.google && provider != Provider.apple) {
+    if (provider != Provider.google && provider != Provider.apple && provider != Provider.kakao) {
       throw AuthException('Provider must either be '
-          '${Provider.google.name} or ${Provider.apple.name}.');
+          '${Provider.google.name} or ${Provider.apple.name} or ${Provider.kakao.name}.');
     }
 
     final response = await _fetch.request(

--- a/packages/gotrue/lib/src/types/provider.dart
+++ b/packages/gotrue/lib/src/types/provider.dart
@@ -7,6 +7,7 @@ enum Provider {
   github,
   gitlab,
   google,
+  kakao,
   keycloak,
   linkedin,
   notion,
@@ -15,7 +16,6 @@ enum Provider {
   twitch,
   twitter,
   workos,
-  kakao
 }
 
 extension ProviderName on Provider {

--- a/packages/gotrue/lib/src/types/provider.dart
+++ b/packages/gotrue/lib/src/types/provider.dart
@@ -16,7 +16,6 @@ enum Provider {
   twitch,
   twitter,
   workos,
-  kakao
 }
 
 extension ProviderName on Provider {

--- a/packages/gotrue/lib/src/types/provider.dart
+++ b/packages/gotrue/lib/src/types/provider.dart
@@ -15,6 +15,7 @@ enum Provider {
   twitch,
   twitter,
   workos,
+  kakao
 }
 
 extension ProviderName on Provider {

--- a/packages/supabase_flutter/pubspec.yaml
+++ b/packages/supabase_flutter/pubspec.yaml
@@ -24,6 +24,7 @@ dependencies:
   webview_flutter: ^4.0.0
   path_provider: ^2.0.0
   shared_preferences: ^2.0.0
+  kakao_flutter_sdk_user: ^1.4.1
 
 dev_dependencies:
   dart_jsonwebtoken: ^2.4.1


### PR DESCRIPTION
## What kind of change does this PR introduce?
Added `Sign In With Kakao Talk App` feature to make it possible signing in using Kakao talk application.
It will help many Korean developers when this  [PR](https://github.com/supabase/gotrue/pull/834) goes on production release since they almost always integrate their apps with Kakao talk sign in.

## What is the current behavior?
No option for Kakao Talk sign in.

## What is the new behavior?
Option for Kakao Talk sign in.

## Additional context
**Referece docs regarding Kakao Login implementation can be found [here](https://developers.kakao.com/docs/latest/en/kakaologin/flutter#login-with-kakao-talk)**
