### PR TITLE
ci: fix publishing supabase_flutter

### DIFF
--- a/.github/workflows/supabase_flutter_publish.yml
+++ b/.github/workflows/supabase_flutter_publish.yml
@@ -9,7 +9,8 @@ jobs:
   publish:
     name: Publish on pub.dev
     runs-on: ubuntu-latest
-
+    permissions:
+      id-token: write # This is required for requesting the JWT
     defaults:
       run:
         working-directory: packages/supabase_flutter

--- a/.github/workflows/supabase_flutter_publish.yml
+++ b/.github/workflows/supabase_flutter_publish.yml
@@ -7,6 +7,33 @@ on:
 
 jobs:
   publish:
-    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
-    with:
-      working-directory: packages/supabase_flutter
+    name: Publish on pub.dev
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: packages/supabase_flutter
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v3
+
+      # This step adds the auth token for pub.dev
+      - name: Set up Dart
+        uses: dart-lang/setup-dart@v1
+        with:
+          sdk: stable
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - name: Install dependencies
+        run: flutter pub get
+      - name: Publish - dry run
+        run: flutter pub publish --dry-run
+      # Publishing...
+      - name: Publish to pub.dev
+        run: flutter pub publish -f


### PR DESCRIPTION
I pushed the tag for release, but the associated workflow failed. This should hopefully fix that.
https://github.com/supabase/supabase-flutter/actions/runs/5000004116/jobs/8956914310

It's a combination of the following:
https://github.com/leancodepl/patrol/blob/master/.github/workflows/patrol-publish.yaml
https://github.com/leancodepl/mobile-tools/blob/master/.github/actions/pub-release/action.yaml