### PR TITLE
fix: Format the files to adjust to Flutter 3.10.1

### DIFF
--- a/.github/workflows/functions_client_ci.yml
+++ b/.github/workflows/functions_client_ci.yml
@@ -2,6 +2,8 @@ name: functions_client
 
 on:
   push:
+    branches:
+      - main
     paths:
       - 'packages/functions_client/**'
       - '.github/workflows/functions_client.yaml'

--- a/.github/workflows/gotrue_ci.yml
+++ b/.github/workflows/gotrue_ci.yml
@@ -2,6 +2,8 @@ name: gotrue
 
 on:
   push:
+    branches:
+      - main
     paths:
       - 'packages/gotrue/**'
       - '.github/workflows/gotrue.yaml'

--- a/.github/workflows/postgrest_ci.yml
+++ b/.github/workflows/postgrest_ci.yml
@@ -2,6 +2,8 @@ name: postgrest
 
 on:
   push:
+    branches:
+      - main
     paths:
       - 'packages/postgrest/**'
       - '.github/workflows/postgrest.yaml'

--- a/.github/workflows/realtime_client_ci.yml
+++ b/.github/workflows/realtime_client_ci.yml
@@ -2,6 +2,8 @@ name: realtime_client
 
 on:
   push:
+    branches:
+      - main
     paths:
       - 'packages/realtime_client/**'
       - '.github/workflows/realtime_client.yaml'

--- a/.github/workflows/storage_client_ci.yml
+++ b/.github/workflows/storage_client_ci.yml
@@ -2,6 +2,8 @@ name: storage_client
 
 on:
   push:
+    branches:
+      - main
     paths:
       - 'packages/storage_client/**'
       - '.github/workflows/storage_client.yaml'

--- a/.github/workflows/supabase_ci.yml
+++ b/.github/workflows/supabase_ci.yml
@@ -2,6 +2,8 @@ name: supabase
 
 on:
   push:
+    branches:
+      - main
     paths:
       - 'packages/supabase/**'
       - '.github/workflows/supabase.yaml'

--- a/.github/workflows/supabase_flutter_ci.yml
+++ b/.github/workflows/supabase_flutter_ci.yml
@@ -2,6 +2,8 @@ name: supabase_flutter
 
 on:
   push:
+    branches:
+      - main
     paths:
       - 'packages/supabase_flutter/**'
       - '.github/workflows/supabase_flutter.yaml'

--- a/.github/workflows/yet_another_json_isolate_ci.yml
+++ b/.github/workflows/yet_another_json_isolate_ci.yml
@@ -2,6 +2,8 @@ name: yet_another_json_isolate
 
 on:
   push:
+    branches:
+      - main
     paths:
       - 'packages/yet_another_json_isolate/**'
       - '.github/workflows/yet_another_json_isolate.yaml'

--- a/packages/postgrest/lib/src/postgrest_query_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_query_builder.dart
@@ -215,7 +215,7 @@ class PostgrestQueryBuilder<T> extends PostgrestBuilder<T, T> {
   /// ```
   PostgrestFilterBuilder<T> delete({
     @Deprecated('Append `.select()` on the query instead')
-        ReturningOption returning = ReturningOption.representation,
+    ReturningOption returning = ReturningOption.representation,
     FetchOptions options = const FetchOptions(),
   }) {
     _method = METHOD_DELETE;

--- a/packages/realtime_client/lib/src/transformers.dart
+++ b/packages/realtime_client/lib/src/transformers.dart
@@ -167,7 +167,7 @@ dynamic convertCell(String type, dynamic value) {
     case PostgresTypes.text:
     case PostgresTypes.time: // To allow users to cast it based on Timezone
     case PostgresTypes
-        .timestamptz: // To allow users to cast it based on Timezone
+          .timestamptz: // To allow users to cast it based on Timezone
     case PostgresTypes.timetz: // To allow users to cast it based on Timezone
     case PostgresTypes.tsrange:
     case PostgresTypes.tstzrange:

--- a/packages/supabase_flutter/test/widget_test_stubs.dart
+++ b/packages/supabase_flutter/test/widget_test_stubs.dart
@@ -90,9 +90,11 @@ void mockAppLink({String? initialLink}) {
 
   TestWidgetsFlutterBinding.ensureInitialized();
 
+  // ignore: invalid_null_aware_operator
   TestDefaultBinaryMessengerBinding.instance?.defaultBinaryMessenger
       .setMockMethodCallHandler(channel, (call) async => initialLink);
 
+  // ignore: invalid_null_aware_operator
   TestDefaultBinaryMessengerBinding.instance?.defaultBinaryMessenger
       .setMockMethodCallHandler(anotherChannel, (message) async => null);
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

- Format the files so that `melos run lint:all` passes on the most recent stable version of Flutter, which is v3.10.1.
- Add branch filter on the `push` action for CI actions to not run on pull request pushes. 

@Vinzent03 I apologize. I think I misunderstood something [here](https://github.com/supabase/supabase-flutter/pull/469#issuecomment-1550367300), and yes each test running twice makes it hard to grasp what is going on. Hopefully this PR fixes it.