### PR TITLE
fix(postgrest): Remove qoutations on foreign table transforms on 'or'

### DIFF
--- a/packages/postgrest/lib/src/postgrest_filter_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_filter_builder.dart
@@ -48,7 +48,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   ///     .or('status.eq.OFFLINE,username.eq.supabot');
   /// ```
   PostgrestFilterBuilder<T> or(String filters, {String? foreignTable}) {
-    final key = foreignTable != null ? '"$foreignTable".or' : 'or';
+    final key = foreignTable != null ? '$foreignTable.or' : 'or';
     appendSearchParams(key, '($filters)');
     return this;
   }


### PR DESCRIPTION
small correction of an error similar to #104, where the character " generated a bug when converted to the url.
the previous bug fix fixed **Order**, **Limit** and **Range**, but had not fixed **Or**.