### PR TITLE
chore(release): publish packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,68 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 2023-05-22
+
+### Changes
+
+---
+
+Packages with breaking changes:
+
+ - There are no breaking changes in this release.
+
+Packages with other changes:
+
+ - [`functions_client` - `v1.3.0`](#functions_client---v130)
+ - [`gotrue` - `v1.8.0`](#gotrue---v180)
+ - [`postgrest` - `v1.3.0`](#postgrest---v130)
+ - [`realtime_client` - `v1.1.0`](#realtime_client---v110)
+ - [`storage_client` - `v1.4.0`](#storage_client---v140)
+ - [`supabase` - `v1.9.0`](#supabase---v190)
+ - [`supabase_flutter` - `v1.10.0`](#supabase_flutter---v1100)
+ - [`yet_another_json_isolate` - `v1.1.0`](#yet_another_json_isolate---v110)
+
+---
+
+#### `functions_client` - `v1.3.0`
+
+ - **FEAT**: update dependency constraints to sdk < 4.0.0 ([#474](https://github.com/supabase/supabase-flutter/issues/474)). ([7894bc70](https://github.com/supabase/supabase-flutter/commit/7894bc70a154b68cb62507262470504188f32c06))
+
+#### `gotrue` - `v1.8.0`
+
+ - **FIX**: reformat Provider type to be ordered alphabetically ([#471](https://github.com/supabase/supabase-flutter/issues/471)). ([c3a1dbb3](https://github.com/supabase/supabase-flutter/commit/c3a1dbb3974bcb7d95160d6412810c69122f2755))
+ - **FEAT**: update dependency constraints to sdk < 4.0.0 ([#474](https://github.com/supabase/supabase-flutter/issues/474)). ([7894bc70](https://github.com/supabase/supabase-flutter/commit/7894bc70a154b68cb62507262470504188f32c06))
+ - **FEAT**: Add kakao provider enum type ([#470](https://github.com/supabase/supabase-flutter/issues/470)). ([9a1bb334](https://github.com/supabase/supabase-flutter/commit/9a1bb33453a08f3f74838b9624d4e7a709e60859))
+
+#### `postgrest` - `v1.3.0`
+
+ - **FIX**(postgrest): Remove qoutations on foreign table transforms on 'or' ([#477](https://github.com/supabase/supabase-flutter/issues/477)). ([c2c6982a](https://github.com/supabase/supabase-flutter/commit/c2c6982a5f3343368c8721b0e80cb656dee10d60))
+ - **FIX**: Format the files to adjust to Flutter 3.10.1 ([#475](https://github.com/supabase/supabase-flutter/issues/475)). ([eb0bcd95](https://github.com/supabase/supabase-flutter/commit/eb0bcd954d1691a28a659dc367c4562c7f16b301))
+ - **FEAT**: update dependency constraints to sdk < 4.0.0 ([#474](https://github.com/supabase/supabase-flutter/issues/474)). ([7894bc70](https://github.com/supabase/supabase-flutter/commit/7894bc70a154b68cb62507262470504188f32c06))
+
+#### `realtime_client` - `v1.1.0`
+
+ - **FIX**: Format the files to adjust to Flutter 3.10.1 ([#475](https://github.com/supabase/supabase-flutter/issues/475)). ([eb0bcd95](https://github.com/supabase/supabase-flutter/commit/eb0bcd954d1691a28a659dc367c4562c7f16b301))
+ - **FEAT**: update dependency constraints to sdk < 4.0.0 ([#474](https://github.com/supabase/supabase-flutter/issues/474)). ([7894bc70](https://github.com/supabase/supabase-flutter/commit/7894bc70a154b68cb62507262470504188f32c06))
+
+#### `storage_client` - `v1.4.0`
+
+ - **FEAT**: update dependency constraints to sdk < 4.0.0 ([#474](https://github.com/supabase/supabase-flutter/issues/474)). ([7894bc70](https://github.com/supabase/supabase-flutter/commit/7894bc70a154b68cb62507262470504188f32c06))
+
+#### `supabase` - `v1.9.0`
+
+ - **FEAT**: update dependency constraints to sdk < 4.0.0 ([#474](https://github.com/supabase/supabase-flutter/issues/474)). ([7894bc70](https://github.com/supabase/supabase-flutter/commit/7894bc70a154b68cb62507262470504188f32c06))
+
+#### `supabase_flutter` - `v1.10.0`
+
+ - **FIX**: Format the files to adjust to Flutter 3.10.1 ([#475](https://github.com/supabase/supabase-flutter/issues/475)). ([eb0bcd95](https://github.com/supabase/supabase-flutter/commit/eb0bcd954d1691a28a659dc367c4562c7f16b301))
+ - **FEAT**: update dependency constraints to sdk < 4.0.0 ([#474](https://github.com/supabase/supabase-flutter/issues/474)). ([7894bc70](https://github.com/supabase/supabase-flutter/commit/7894bc70a154b68cb62507262470504188f32c06))
+
+#### `yet_another_json_isolate` - `v1.1.0`
+
+ - **FEAT**: update dependency constraints to sdk < 4.0.0 ([#474](https://github.com/supabase/supabase-flutter/issues/474)). ([7894bc70](https://github.com/supabase/supabase-flutter/commit/7894bc70a154b68cb62507262470504188f32c06))
+
+
 ## 2023-05-16
 
 ### Changes

--- a/packages/functions_client/CHANGELOG.md
+++ b/packages/functions_client/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.0
+
+ - **FEAT**: update dependency constraints to sdk < 4.0.0 ([#474](https://github.com/supabase/supabase-flutter/issues/474)). ([7894bc70](https://github.com/supabase/supabase-flutter/commit/7894bc70a154b68cb62507262470504188f32c06))
+
 ## 1.2.1
 
  - chore: move the repo into supabase-flutter monorepo

--- a/packages/functions_client/lib/src/version.dart
+++ b/packages/functions_client/lib/src/version.dart
@@ -1,1 +1,1 @@
-const version = '1.2.1';
+const version = '1.3.0';

--- a/packages/functions_client/pubspec.yaml
+++ b/packages/functions_client/pubspec.yaml
@@ -1,6 +1,6 @@
 name: functions_client
 description: A dart client library for the Supabase functions.
-version: 1.2.1
+version: 1.3.0
 homepage: 'https://supabase.com'
 repository: 'https://github.com/supabase/supabase-flutter/tree/main/packages/functions_client'
 documentation: 'https://supabase.com/docs/reference/dart/functions-invoke'
@@ -10,7 +10,7 @@ environment:
 
 dependencies:
   http: ^0.13.4
-  yet_another_json_isolate: ^1.0.4
+  yet_another_json_isolate: ^1.1.0
 
 dev_dependencies:
   lints: ^1.0.1

--- a/packages/gotrue/CHANGELOG.md
+++ b/packages/gotrue/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.8.0
+
+ - **FIX**: reformat Provider type to be ordered alphabetically ([#471](https://github.com/supabase/supabase-flutter/issues/471)). ([c3a1dbb3](https://github.com/supabase/supabase-flutter/commit/c3a1dbb3974bcb7d95160d6412810c69122f2755))
+ - **FEAT**: update dependency constraints to sdk < 4.0.0 ([#474](https://github.com/supabase/supabase-flutter/issues/474)). ([7894bc70](https://github.com/supabase/supabase-flutter/commit/7894bc70a154b68cb62507262470504188f32c06))
+ - **FEAT**: Add kakao provider enum type ([#470](https://github.com/supabase/supabase-flutter/issues/470)). ([9a1bb334](https://github.com/supabase/supabase-flutter/commit/9a1bb33453a08f3f74838b9624d4e7a709e60859))
+
 ## 1.7.1
 
  - chore: move the repo into supabase-flutter monorepo

--- a/packages/gotrue/lib/src/version.dart
+++ b/packages/gotrue/lib/src/version.dart
@@ -1,1 +1,1 @@
-const version = '1.7.1';
+const version = '1.8.0';

--- a/packages/gotrue/pubspec.yaml
+++ b/packages/gotrue/pubspec.yaml
@@ -1,6 +1,6 @@
 name: gotrue
 description: A dart client library for the GoTrue API.
-version: 1.7.1
+version: 1.8.0
 homepage: 'https://supabase.com'
 repository: 'https://github.com/supabase/supabase-flutter/tree/main/packages/gotrue'
 documentation: 'https://supabase.com/docs/reference/dart/auth-signup'

--- a/packages/postgrest/CHANGELOG.md
+++ b/packages/postgrest/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.3.0
+
+ - **FIX**(postgrest): Remove qoutations on foreign table transforms on 'or' ([#477](https://github.com/supabase/supabase-flutter/issues/477)). ([c2c6982a](https://github.com/supabase/supabase-flutter/commit/c2c6982a5f3343368c8721b0e80cb656dee10d60))
+ - **FIX**: Format the files to adjust to Flutter 3.10.1 ([#475](https://github.com/supabase/supabase-flutter/issues/475)). ([eb0bcd95](https://github.com/supabase/supabase-flutter/commit/eb0bcd954d1691a28a659dc367c4562c7f16b301))
+ - **FEAT**: update dependency constraints to sdk < 4.0.0 ([#474](https://github.com/supabase/supabase-flutter/issues/474)). ([7894bc70](https://github.com/supabase/supabase-flutter/commit/7894bc70a154b68cb62507262470504188f32c06))
+
 ## 1.2.4
 
  - chore: move the repo into supabase-flutter monorepo

--- a/packages/postgrest/lib/src/version.dart
+++ b/packages/postgrest/lib/src/version.dart
@@ -1,1 +1,1 @@
-const version = '1.2.4';
+const version = '1.3.0';

--- a/packages/postgrest/pubspec.yaml
+++ b/packages/postgrest/pubspec.yaml
@@ -1,6 +1,6 @@
 name: postgrest
 description: PostgREST client for Dart. This library provides an ORM interface to PostgREST.
-version: 1.2.4
+version: 1.3.0
 homepage: 'https://supabase.com'
 repository: 'https://github.com/supabase/supabase-flutter/tree/main/packages/postgrest'
 documentation: 'https://supabase.com/docs/reference/dart/select'
@@ -10,7 +10,7 @@ environment:
 
 dependencies:
   http: ^0.13.0
-  yet_another_json_isolate: ^1.0.4
+  yet_another_json_isolate: ^1.1.0
 
 dev_dependencies:
   collection: ^1.16.0

--- a/packages/realtime_client/CHANGELOG.md
+++ b/packages/realtime_client/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.1.0
+
+ - **FIX**: Format the files to adjust to Flutter 3.10.1 ([#475](https://github.com/supabase/supabase-flutter/issues/475)). ([eb0bcd95](https://github.com/supabase/supabase-flutter/commit/eb0bcd954d1691a28a659dc367c4562c7f16b301))
+ - **FEAT**: update dependency constraints to sdk < 4.0.0 ([#474](https://github.com/supabase/supabase-flutter/issues/474)). ([7894bc70](https://github.com/supabase/supabase-flutter/commit/7894bc70a154b68cb62507262470504188f32c06))
+
 ## 1.0.4
 
  - chore: move the repo into supabase-flutter monorepo

--- a/packages/realtime_client/lib/src/version.dart
+++ b/packages/realtime_client/lib/src/version.dart
@@ -1,1 +1,1 @@
-const version = '1.0.4';
+const version = '1.1.0';

--- a/packages/realtime_client/pubspec.yaml
+++ b/packages/realtime_client/pubspec.yaml
@@ -1,6 +1,6 @@
 name: realtime_client
 description: Listens to changes in a PostgreSQL Database and via websockets. This is for usage with Supabase Realtime server.
-version: 1.0.4
+version: 1.1.0
 homepage: 'https://supabase.com'
 repository: 'https://github.com/supabase/supabase-flutter/tree/main/packages/realtime_client'
 documentation: 'https://supabase.com/docs/reference/dart/subscribe'

--- a/packages/storage_client/CHANGELOG.md
+++ b/packages/storage_client/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.4.0
+
+ - **FEAT**: update dependency constraints to sdk < 4.0.0 ([#474](https://github.com/supabase/supabase-flutter/issues/474)). ([7894bc70](https://github.com/supabase/supabase-flutter/commit/7894bc70a154b68cb62507262470504188f32c06))
+
 ## 1.3.1
 
  - chore: move the repo into supabase-flutter monorepo

--- a/packages/storage_client/lib/src/version.dart
+++ b/packages/storage_client/lib/src/version.dart
@@ -1,1 +1,1 @@
-const version = '1.3.1';
+const version = '1.4.0';

--- a/packages/storage_client/pubspec.yaml
+++ b/packages/storage_client/pubspec.yaml
@@ -1,6 +1,6 @@
 name: storage_client
 description: Dart client library to interact with Supabase Storage. Supabase Storage provides an interface for managing Files stored in S3, using Postgres to manage permissions.
-version: 1.3.1
+version: 1.4.0
 homepage: 'https://supabase.com'
 repository: 'https://github.com/supabase/supabase-flutter/tree/main/packages/storage_client'
 documentation: 'https://supabase.com/docs/reference/dart/storage-createbucket'

--- a/packages/supabase/CHANGELOG.md
+++ b/packages/supabase/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.9.0
+
+ - **FEAT**: update dependency constraints to sdk < 4.0.0 ([#474](https://github.com/supabase/supabase-flutter/issues/474)). ([7894bc70](https://github.com/supabase/supabase-flutter/commit/7894bc70a154b68cb62507262470504188f32c06))
+
 ## 1.8.1
 
  - chore: move the repo into supabase-flutter monorepo

--- a/packages/supabase/lib/src/version.dart
+++ b/packages/supabase/lib/src/version.dart
@@ -1,1 +1,1 @@
-const version = '1.8.1';
+const version = '1.9.0';

--- a/packages/supabase/pubspec.yaml
+++ b/packages/supabase/pubspec.yaml
@@ -1,6 +1,6 @@
 name: supabase
 description: A dart client for Supabase. This client makes it simple for developers to build secure and scalable products.
-version: 1.8.1
+version: 1.9.0
 homepage: 'https://supabase.com'
 repository: 'https://github.com/supabase/supabase-flutter/tree/main/packages/supabase'
 documentation: 'https://supabase.com/docs/reference/dart/introduction'
@@ -9,14 +9,14 @@ environment:
   sdk: '>=2.15.0 <4.0.0'
 
 dependencies:
-  functions_client: ^1.2.1
-  gotrue: ^1.7.1
+  functions_client: ^1.3.0
+  gotrue: ^1.8.0
   http: ^0.13.4
-  postgrest: ^1.2.4
-  realtime_client: ^1.0.4
-  storage_client: ^1.3.1
+  postgrest: ^1.3.0
+  realtime_client: ^1.1.0
+  storage_client: ^1.4.0
   rxdart: ^0.27.5
-  yet_another_json_isolate: ^1.0.4
+  yet_another_json_isolate: ^1.1.0
 
 dev_dependencies:
   lints: ^1.0.1

--- a/packages/supabase_flutter/CHANGELOG.md
+++ b/packages/supabase_flutter/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.10.0
+
+ - **FIX**: Format the files to adjust to Flutter 3.10.1 ([#475](https://github.com/supabase/supabase-flutter/issues/475)). ([eb0bcd95](https://github.com/supabase/supabase-flutter/commit/eb0bcd954d1691a28a659dc367c4562c7f16b301))
+ - **FEAT**: update dependency constraints to sdk < 4.0.0 ([#474](https://github.com/supabase/supabase-flutter/issues/474)). ([7894bc70](https://github.com/supabase/supabase-flutter/commit/7894bc70a154b68cb62507262470504188f32c06))
+
 ## 1.9.2
 
  - **FIX**(supabase_flutter): prevent Platform.environment use on web ([#468](https://github.com/supabase/supabase-flutter/issues/468)). ([de5a6300](https://github.com/supabase/supabase-flutter/commit/de5a6300d75f8951f1b75b73d8e6db5f31f581a1))

--- a/packages/supabase_flutter/lib/src/version.dart
+++ b/packages/supabase_flutter/lib/src/version.dart
@@ -1,1 +1,1 @@
-const version = '1.9.2';
+const version = '1.10.0';

--- a/packages/supabase_flutter/pubspec.yaml
+++ b/packages/supabase_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: supabase_flutter
 description: Flutter integration for Supabase. This package makes it simple for developers to build secure and scalable products.
-version: 1.9.2
+version: 1.10.0
 homepage: 'https://supabase.com'
 repository: 'https://github.com/supabase/supabase-flutter/tree/main/packages/supabase_flutter'
 documentation: 'https://supabase.com/docs/reference/dart/introduction'
@@ -19,7 +19,7 @@ dependencies:
   http: ^0.13.4
   meta: ^1.7.0
   sign_in_with_apple: ^4.3.0
-  supabase: ^1.8.1
+  supabase: ^1.9.0
   url_launcher: ^6.1.2
   webview_flutter: ^4.0.0
   path_provider: ^2.0.0

--- a/packages/yet_another_json_isolate/CHANGELOG.md
+++ b/packages/yet_another_json_isolate/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.0
+
+ - **FEAT**: update dependency constraints to sdk < 4.0.0 ([#474](https://github.com/supabase/supabase-flutter/issues/474)). ([7894bc70](https://github.com/supabase/supabase-flutter/commit/7894bc70a154b68cb62507262470504188f32c06))
+
 ## 1.0.4
 
  - chore: move the repo into supabase-flutter monorepo

--- a/packages/yet_another_json_isolate/pubspec.yaml
+++ b/packages/yet_another_json_isolate/pubspec.yaml
@@ -1,6 +1,6 @@
 name: yet_another_json_isolate
 description: Package to simplify and improve JSON parsing in isolates by keeping one isolate running per instance.
-version: 1.0.4
+version: 1.1.0
 homepage: https://github.com/supabase-community/json-isolate-dart
 
 environment:


### PR DESCRIPTION
All packages are being updated, because we updated the Dart SDK constraints here https://github.com/supabase/supabase-flutter/pull/474

 - functions_client@1.3.0
 - gotrue@1.8.0
 - postgrest@1.3.0
 - realtime_client@1.1.0
 - storage_client@1.4.0
 - supabase@1.9.0
 - supabase_flutter@1.10.0
 - yet_another_json_isolate@1.1.0

