### PR TITLE
fix: Update http dependency constraints

### DIFF
--- a/packages/functions_client/pubspec.yaml
+++ b/packages/functions_client/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: '>=2.15.0 <4.0.0'
 
 dependencies:
-  http: ^0.13.4
+  http: '>=0.13.4 <2.0.0'
   yet_another_json_isolate: ^1.1.0
 
 dev_dependencies:

--- a/packages/gotrue/pubspec.yaml
+++ b/packages/gotrue/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 dependencies:
   collection: ^1.15.0
   crypto: ^3.0.2
-  http: ^0.13.0
+  http: '>=0.13.0 <2.0.0'
   jwt_decode: ^0.3.1
   universal_io: ^2.0.4
   rxdart: ^0.27.7

--- a/packages/postgrest/pubspec.yaml
+++ b/packages/postgrest/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: '>=2.15.0 <4.0.0'
 
 dependencies:
-  http: ^0.13.0
+  http: '>=0.13.0 <2.0.0'
   yet_another_json_isolate: ^1.1.0
 
 dev_dependencies:

--- a/packages/storage_client/pubspec.yaml
+++ b/packages/storage_client/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: '>=2.15.0 <4.0.0'
 
 dependencies:
-  http: ^0.13.4
+  http: '>=0.13.4 <2.0.0'
   http_parser: ^4.0.1
   mime: ^1.0.2
   universal_io: ^2.0.4

--- a/packages/supabase/pubspec.yaml
+++ b/packages/supabase/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 dependencies:
   functions_client: ^1.3.0
   gotrue: ^1.8.0
-  http: ^0.13.4
+  http: '>=0.13.5 <2.0.0'
   postgrest: ^1.3.0
   realtime_client: ^1.1.0
   storage_client: ^1.4.0

--- a/packages/supabase_flutter/pubspec.yaml
+++ b/packages/supabase_flutter/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
     sdk: flutter
   hive: ^2.2.1
   hive_flutter: ^1.1.0
-  http: ^0.13.4
+  http: '>=0.13.4 <2.0.0'
   meta: ^1.7.0
   sign_in_with_apple: ^4.3.0
   supabase: ^1.9.0


### PR DESCRIPTION
## What kind of change does this PR introduce?

Updates http dependencies to include v1.0.0 while preserving the minimum required Dart version.

fixes https://github.com/supabase/supabase-flutter/issues/488