### PR TITLE
feat(storage_client): upload signed URL

### DIFF
--- a/infra/storage_client/docker-compose.yml
+++ b/infra/storage_client/docker-compose.yml
@@ -12,19 +12,6 @@ services:
     ports:
       - 8000:8000/tcp
       - 8443:8443/tcp
-  rest:
-    image: postgrest/postgrest:latest
-    ports:
-      - '3000:3000'
-    depends_on:
-      storage:
-        condition: service_healthy
-    restart: always
-    environment:
-      PGRST_DB_URI: postgres://postgres:postgres@db:5432/postgres
-      PGRST_DB_SCHEMA: public, storage
-      PGRST_DB_ANON_ROLE: postgres
-      PGRST_JWT_SECRET: super-secret-jwt-token-with-at-least-32-characters-long
   storage:
     build:
       context: ./storage

--- a/infra/storage_client/postgres/dummy-data.sql
+++ b/infra/storage_client/postgres/dummy-data.sql
@@ -38,6 +38,8 @@ INSERT INTO "storage"."objects" ("id", "bucket_id", "name", "owner", "created_at
 -- add policies
 -- allows user to CRUD all buckets
 CREATE POLICY crud_buckets ON storage.buckets for all USING (auth.uid() = '317eadce-631a-4429-a0bb-f19a7a517b4a');
+CREATE POLICY crud_objects ON storage.objects for all USING (auth.uid() = '317eadce-631a-4429-a0bb-f19a7a517b4a');
+
 -- allow public CRUD acccess to the public folder in bucket2
 CREATE POLICY crud_public_folder ON storage.objects for all USING (bucket_id='bucket2' and (storage.foldername(name))[1] = 'public');
 -- allow public CRUD acccess to a particular file in bucket2

--- a/infra/storage_client/storage/Dockerfile
+++ b/infra/storage_client/storage/Dockerfile
@@ -1,3 +1,3 @@
-FROM supabase/storage-api:v0.29.1
+FROM supabase/storage-api:v0.35.1
 
 RUN apk add curl --no-cache

--- a/packages/storage_client/lib/src/storage_file_api.dart
+++ b/packages/storage_client/lib/src/storage_file_api.dart
@@ -127,36 +127,6 @@ class StorageFileApi {
     return cleanPath;
   }
 
-  /// Upload a file with a token generated from `createUploadSignedUrl`.
-  ///
-  /// [path] The file path, including the file name. Should be of the format `folder/subfolder/filename.png`. The bucket must already exist before attempting to upload.
-  ///
-  /// [token] The token generated from `createUploadSignedUrl`
-  ///
-  /// [data] The body of the file to be stored in the bucket.
-  Future<String> uploadToSignedUrlBinary(
-    String path,
-    String token,
-    Uint8List data, [
-    FileOptions fileOptions = const FileOptions(),
-    int? retryAttempts,
-    StorageRetryController? retryController,
-  ]) async {
-    assert(retryAttempts == null || retryAttempts >= 0,
-        'retryAttempts has to be greater or equal to 0');
-
-    final cleanPath = _removeEmptyFolders(path);
-    final _path = _getFinalPath(cleanPath);
-    var url = Uri.parse('${this.url}/object/upload/sign/$_path');
-    url = url.replace(queryParameters: {'token': token});
-
-    await storageFetch.putBinaryFile(url.toString(), data, fileOptions,
-        retryAttempts: retryAttempts ?? _retryAttempts,
-        retryController: retryController);
-
-    return cleanPath;
-  }
-
   /// Creates a signed upload URL.
   ///
   /// Signed upload URLs can be used upload files to the bucket without further authentication.

--- a/packages/storage_client/lib/src/storage_file_api.dart
+++ b/packages/storage_client/lib/src/storage_file_api.dart
@@ -56,6 +56,32 @@ class StorageFileApi {
     return (response as Map)['Key'] as String;
   }
 
+  /// Upload a file with a token generated from `createUploadSignedUrl`.
+  ///
+  /// [path] The file path, including the file name. Should be of the format `folder/subfolder/filename.png`. The bucket must already exist before attempting to upload.
+  ///
+  /// [token] The token generated from `createUploadSignedUrl`
+  ///
+  /// [file] The body of the file to be stored in the bucket.
+  Future<String> uploadToSignedUrl(
+    String path,
+    String token,
+    File file, [
+    FileOptions? fileOptions,
+  ]) async {
+    throw UnimplementedError();
+  }
+
+  /// Creates a signed upload URL.
+  ///
+  /// Signed upload URLs can be used upload files to the bucket without further authentication.
+  /// They are valid for one minute.
+  ///
+  /// [path] The file path, including the current file name. For example `folder/image.png`.
+  Future<SignedUploadURLResponse> createSignedUploadUrl(String path) async {
+    throw UnimplementedError();
+  }
+
   /// Uploads a binary file to an existing bucket. Can be used on the web.
   ///
   /// [path] is the relative file path without the bucket ID. Should be of the

--- a/packages/storage_client/lib/src/storage_file_api.dart
+++ b/packages/storage_client/lib/src/storage_file_api.dart
@@ -62,46 +62,6 @@ class StorageFileApi {
     return (response as Map)['Key'] as String;
   }
 
-  /// Upload a file with a token generated from `createUploadSignedUrl`.
-  ///
-  /// [path] The file path, including the file name. Should be of the format `folder/subfolder/filename.png`. The bucket must already exist before attempting to upload.
-  ///
-  /// [token] The token generated from `createUploadSignedUrl`
-  ///
-  /// [file] The body of the file to be stored in the bucket.
-  Future<String> uploadToSignedUrl(
-    String path,
-    String token,
-    File file, [
-    FileOptions fileOptions = const FileOptions(),
-    int? retryAttempts,
-    StorageRetryController? retryController,
-  ]) async {
-    assert(retryAttempts == null || retryAttempts >= 0,
-        'retryAttempts has to be greater or equal to 0');
-
-    final cleanPath = _removeEmptyFolders(path);
-    final _path = _getFinalPath(cleanPath);
-    var url = Uri.parse('${this.url}/object/upload/sign/$_path');
-    url = url.replace(queryParameters: {'token': token});
-
-    await storageFetch.putFile(url.toString(), file, fileOptions,
-        retryAttempts: retryAttempts ?? _retryAttempts,
-        retryController: retryController);
-
-    return cleanPath;
-  }
-
-  /// Creates a signed upload URL.
-  ///
-  /// Signed upload URLs can be used upload files to the bucket without further authentication.
-  /// They are valid for one minute.
-  ///
-  /// [path] The file path, including the current file name. For example `folder/image.png`.
-  Future<SignedUploadURLResponse> createSignedUploadUrl(String path) async {
-    throw UnimplementedError();
-  }
-
   /// Uploads a binary file to an existing bucket. Can be used on the web.
   ///
   /// [path] is the relative file path without the bucket ID. Should be of the
@@ -135,6 +95,98 @@ class StorageFileApi {
     );
 
     return (response as Map)['Key'] as String;
+  }
+
+  /// Upload a file with a token generated from `createUploadSignedUrl`.
+  ///
+  /// [path] The file path, including the file name. Should be of the format `folder/subfolder/filename.png`. The bucket must already exist before attempting to upload.
+  ///
+  /// [token] The token generated from `createUploadSignedUrl`
+  ///
+  /// [file] The body of the file to be stored in the bucket.
+  Future<String> uploadToSignedUrl(
+    String path,
+    String token,
+    File file, [
+    FileOptions fileOptions = const FileOptions(),
+    int? retryAttempts,
+    StorageRetryController? retryController,
+  ]) async {
+    assert(retryAttempts == null || retryAttempts >= 0,
+        'retryAttempts has to be greater or equal to 0');
+
+    final cleanPath = _removeEmptyFolders(path);
+    final _path = _getFinalPath(cleanPath);
+    var url = Uri.parse('${this.url}/object/upload/sign/$_path');
+    url = url.replace(queryParameters: {'token': token});
+
+    await storageFetch.putFile(url.toString(), file, fileOptions,
+        retryAttempts: retryAttempts ?? _retryAttempts,
+        retryController: retryController);
+
+    return cleanPath;
+  }
+
+  /// Upload a file with a token generated from `createUploadSignedUrl`.
+  ///
+  /// [path] The file path, including the file name. Should be of the format `folder/subfolder/filename.png`. The bucket must already exist before attempting to upload.
+  ///
+  /// [token] The token generated from `createUploadSignedUrl`
+  ///
+  /// [data] The body of the file to be stored in the bucket.
+  Future<String> uploadToSignedUrlBinary(
+    String path,
+    String token,
+    Uint8List data, [
+    FileOptions fileOptions = const FileOptions(),
+    int? retryAttempts,
+    StorageRetryController? retryController,
+  ]) async {
+    assert(retryAttempts == null || retryAttempts >= 0,
+        'retryAttempts has to be greater or equal to 0');
+
+    final cleanPath = _removeEmptyFolders(path);
+    final _path = _getFinalPath(cleanPath);
+    var url = Uri.parse('${this.url}/object/upload/sign/$_path');
+    url = url.replace(queryParameters: {'token': token});
+
+    await storageFetch.putBinaryFile(url.toString(), data, fileOptions,
+        retryAttempts: retryAttempts ?? _retryAttempts,
+        retryController: retryController);
+
+    return cleanPath;
+  }
+
+  /// Creates a signed upload URL.
+  ///
+  /// Signed upload URLs can be used upload files to the bucket without further authentication.
+  /// They are valid for one minute.
+  ///
+  /// [path] The file path, including the current file name. For example `folder/image.png`.
+  Future<SignedUploadURLResponse> createSignedUploadUrl(String path) async {
+    final finalPath = _getFinalPath(path);
+
+    final data = await storageFetch.post(
+      '$url/object/upload/sign/$finalPath',
+      {},
+      options: FetchOptions(headers: headers),
+    );
+
+    final signedUrl = Uri.parse('$url${data['url']}');
+
+    final token = signedUrl.queryParameters['token'];
+
+    if (token == null || token.isEmpty) {
+      throw StorageException('No token returned by API');
+    }
+
+    return SignedUploadURLResponse(
+      signedUrl: signedUrl.toString(),
+      path: path,
+      token: token,
+    );
+
+    //   return { data: { signedUrl: url.toString(), path, token }, error: null }
   }
 
   /// Replaces an existing file at the specified path with a new one.

--- a/packages/storage_client/lib/src/types.dart
+++ b/packages/storage_client/lib/src/types.dart
@@ -160,10 +160,13 @@ class SortBy {
 }
 
 class SignedUrl {
-  final String? path;
-  final String? signedUrl;
+  final String path;
+  final String signedUrl;
 
-  const SignedUrl({this.path, this.signedUrl});
+  const SignedUrl({
+    required this.path,
+    required this.signedUrl,
+  });
 
   @override
   String toString() => 'SignedUrl(path: $path, signedUrl: $signedUrl)';
@@ -189,6 +192,19 @@ class SignedUrl {
       signedUrl: signedUrl ?? this.signedUrl,
     );
   }
+}
+
+class SignedUploadURLResponse extends SignedUrl {
+  final String token;
+
+  const SignedUploadURLResponse({
+    required String signedUrl,
+    required String path,
+    required this.token,
+  }) : super(
+          signedUrl: signedUrl,
+          path: path,
+        );
 }
 
 class StorageException implements Exception {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Implements signed upload URL by adding Expose the `createUploadSignedUrl`, and `uploadToSignedUrl` methods. This allows developers to first upload the file to their own server while attaching the token from `createSignedUploadUrl()` method, and then complete the upload process from their server to Supabase. 

```dart
final response =
    await storage.from(newBucketName).createSignedUploadUrl(uploadPath);

// Uploads the file to their own server, and call the following to complete the upload to Supabase

await storage
    .from(newBucketName)
    .uploadToSignedUrl(response.path, response.token, file);
```

I didn't add the binary version of `uploadToSignedUrl` method, as it is intended to be used in a server environment.

Related https://github.com/supabase/storage-js/pull/158, https://github.com/supabase/storage-api/pull/282#issue-1600162612