### PR TITLE
fix(gotrue): catch some errors in signOut

### DIFF
--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -613,9 +613,8 @@ class GoTrueClient {
       try {
         await admin.signOut(accessToken);
       } on AuthException catch (error) {
-        // ignore 401s since an invalid or expired JWT should sign out the         
+        // ignore 401s since an invalid or expired JWT should sign out the current session
         // ignore 404s since user might not exist anymore
-current session
         if (error.statusCode != '401' && error.statusCode != '404') {
           rethrow;
         }

--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -610,7 +610,17 @@ class GoTrueClient {
     _removeSession();
     _notifyAllSubscribers(AuthChangeEvent.signedOut);
     if (accessToken != null) {
-      return admin.signOut(accessToken);
+      try {
+        return await admin.signOut(accessToken);
+      } on AuthException catch (error) {
+        // ignore 404s since user might not exist anymore
+        // ignore 401s since an invalid or expired JWT should sign out the current session
+        if (error.statusCode == '401' || error.statusCode == '404') {
+          return;
+        } else {
+          rethrow;
+        }
+      }
     }
   }
 

--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -611,13 +611,12 @@ class GoTrueClient {
     _notifyAllSubscribers(AuthChangeEvent.signedOut);
     if (accessToken != null) {
       try {
-        return await admin.signOut(accessToken);
+        await admin.signOut(accessToken);
       } on AuthException catch (error) {
+        // ignore 401s since an invalid or expired JWT should sign out the         
         // ignore 404s since user might not exist anymore
-        // ignore 401s since an invalid or expired JWT should sign out the current session
-        if (error.statusCode == '401' || error.statusCode == '404') {
-          return;
-        } else {
+current session
+        if (error.statusCode != '401' && error.statusCode != '404') {
           rethrow;
         }
       }

--- a/packages/gotrue/test/admin_test.dart
+++ b/packages/gotrue/test/admin_test.dart
@@ -1,6 +1,5 @@
 import 'dart:math';
 
-import 'package:dart_jsonwebtoken/dart_jsonwebtoken.dart';
 import 'package:dotenv/dotenv.dart' show env, load;
 import 'package:gotrue/gotrue.dart';
 import 'package:http/http.dart' as http;
@@ -12,15 +11,6 @@ void main() {
   load(); // Load env variables from .env file
 
   final gotrueUrl = env['GOTRUE_URL'] ?? 'http://localhost:9998';
-
-  final serviceRoleToken = JWT(
-    {
-      'role': 'service_role',
-    },
-  ).sign(
-    SecretKey(
-        env['GOTRUE_JWT_SECRET'] ?? '37c304f8-51aa-419a-a1af-06154e63707a'),
-  );
 
   late GoTrueClient client;
 
@@ -34,8 +24,8 @@ void main() {
     client = GoTrueClient(
       url: gotrueUrl,
       headers: {
-        'Authorization': 'Bearer $serviceRoleToken',
-        'apikey': serviceRoleToken,
+        'Authorization': 'Bearer ${getServiceRoleToken()}',
+        'apikey': getServiceRoleToken(),
       },
     );
   });

--- a/packages/gotrue/test/client_test.dart
+++ b/packages/gotrue/test/client_test.dart
@@ -19,6 +19,7 @@ void main() {
 
   group('Client with default http client', () {
     late GoTrueClient client;
+    late GoTrueClient adminClient;
     late GoTrueClient clientWithAuthConfirmOff;
 
     setUp(() async {
@@ -37,6 +38,15 @@ void main() {
         headers: {
           'Authorization': 'Bearer $anonToken',
           'apikey': anonToken,
+        },
+        asyncStorage: asyncStorage,
+      );
+
+      adminClient = client = GoTrueClient(
+        url: gotrueUrl,
+        headers: {
+          'Authorization': 'Bearer ${getServiceRoleToken()}',
+          'apikey': getServiceRoleToken(),
         },
         asyncStorage: asyncStorage,
       );
@@ -251,6 +261,15 @@ void main() {
     test('signOut', () async {
       await client.signInWithPassword(email: email1, password: password);
       expect(client.currentUser, isNotNull);
+      await client.signOut();
+      expect(client.currentUser, isNull);
+      expect(client.currentSession, isNull);
+    });
+
+    test('signOut of deleted user', () async {
+      await client.signInWithPassword(email: email1, password: password);
+      expect(client.currentUser, isNotNull);
+      await adminClient.admin.deleteUser(userId1);
       await client.signOut();
       expect(client.currentUser, isNull);
       expect(client.currentSession, isNull);

--- a/packages/gotrue/test/utils.dart
+++ b/packages/gotrue/test/utils.dart
@@ -1,3 +1,5 @@
+import 'package:dart_jsonwebtoken/dart_jsonwebtoken.dart';
+import 'package:dotenv/dotenv.dart';
 import 'package:gotrue/gotrue.dart';
 
 /// Email of a user with unverified factor
@@ -33,6 +35,17 @@ String getNewPhone() {
   final timestamp =
       (DateTime.now().microsecondsSinceEpoch / (1000 * 1000)).round();
   return '$timestamp';
+}
+
+String getServiceRoleToken() {
+  return JWT(
+    {
+      'role': 'service_role',
+    },
+  ).sign(
+    SecretKey(
+        env['GOTRUE_JWT_SECRET'] ?? '37c304f8-51aa-419a-a1af-06154e63707a'),
+  );
 }
 
 class TestAsyncStorage extends GotrueAsyncStorage {


### PR DESCRIPTION
close #500
I'm catching specifc errors on sign out like in [gotrue-js](https://github.com/supabase/gotrue-js/blob/master/src/GoTrueClient.ts#L1059) to prevent errors being thrown in `signOut()`.