### PR TITLE
fix: Add errors from `.subscribe()` to `.stream()` streamController

### DIFF
--- a/packages/realtime_client/lib/src/realtime_channel.dart
+++ b/packages/realtime_client/lib/src/realtime_channel.dart
@@ -180,8 +180,10 @@ class RealtimeChannel {
     }
   }
 
-  void subscribe(
-      [void Function(String, [Object?])? callback, Duration? timeout]) {
+  void subscribe([
+    void Function(String status, [Object? error])? callback,
+    Duration? timeout,
+  ]) {
     if (joinedOnce == true) {
       throw "tried to subscribe multiple times. 'subscribe' can only be called a single time per channel instance";
     } else {

--- a/packages/realtime_client/lib/src/realtime_channel.dart
+++ b/packages/realtime_client/lib/src/realtime_channel.dart
@@ -180,10 +180,8 @@ class RealtimeChannel {
     }
   }
 
-  void subscribe([
-    void Function(String status, [Object? error])? callback,
-    Duration? timeout,
-  ]) {
+  void subscribe(
+      [void Function(String, [Object?])? callback, Duration? timeout]) {
     if (joinedOnce == true) {
       throw "tried to subscribe multiple times. 'subscribe' can only be called a single time per channel instance";
     } else {

--- a/packages/supabase/lib/src/supabase_stream_builder.dart
+++ b/packages/supabase/lib/src/supabase_stream_builder.dart
@@ -343,7 +343,11 @@ class SupabaseStreamBuilder extends Stream<SupabaseStreamEvent> {
         _streamData.removeAt(deletedIndex);
         _addStream();
       }
-    }).subscribe();
+    }).subscribe((status, [error]) {
+      if (error != null) {
+        _streamController?.addError(error);
+      }
+    });
 
     PostgrestFilterBuilder query = _queryBuilder.select();
     if (_streamFilter != null) {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Currently, the error caught in `.subscribe()` is not passed to the `.stream()` method, and therefore users using the `.stream()` method have no way to catch the errors on the realtime subscription. This PR adds the error on caught on the `.subscribe()` using the callback to pass it to the stream controller so that users can catch it using `.stream().listen().onError()`. 