### PR TITLE
refactor(realtime_client): Add docs on `.subscribe()` and give callback parameters names

### DIFF
--- a/packages/realtime_client/lib/src/realtime_channel.dart
+++ b/packages/realtime_client/lib/src/realtime_channel.dart
@@ -180,7 +180,7 @@ class RealtimeChannel {
     }
   }
 
-  /// Subscribe registers your client with the server
+  /// Subscribes to receive real-time changes
   ///
   /// Pass a [callback] to react to different status changes. Values of `status`
   /// can be `SUBSCRIBED`, `CHANNEL_ERROR`, `CLOSED`, or `TIMED_OUT`.

--- a/packages/realtime_client/lib/src/realtime_channel.dart
+++ b/packages/realtime_client/lib/src/realtime_channel.dart
@@ -180,8 +180,16 @@ class RealtimeChannel {
     }
   }
 
-  void subscribe(
-      [void Function(String, [Object?])? callback, Duration? timeout]) {
+  /// Subscribe registers your client with the server
+  ///
+  /// Pass a [callback] to react to different status changes. Values of `status`
+  /// can be `SUBSCRIBED`, `CHANNEL_ERROR`, `CLOSED`, or `TIMED_OUT`.
+  ///
+  /// [timeout] parameter can be used to override the default timeout set on `RealtimeClient`.
+  void subscribe([
+    void Function(String status, [Object? error])? callback,
+    Duration? timeout,
+  ]) {
     if (joinedOnce == true) {
       throw "tried to subscribe multiple times. 'subscribe' can only be called a single time per channel instance";
     } else {


### PR DESCRIPTION
## What kind of change does this PR introduce?

- Add some basic docs on `.subscribe()` method
- Give names to the parameters of `callback` on `.subscribe()`