### PR TITLE
fix(supabase): add stackTrace on stream exception

### DIFF
--- a/packages/supabase/lib/src/supabase_stream_builder.dart
+++ b/packages/supabase/lib/src/supabase_stream_builder.dart
@@ -345,7 +345,7 @@ class SupabaseStreamBuilder extends Stream<SupabaseStreamEvent> {
       }
     }).subscribe((status, [error]) {
       if (error != null) {
-        _streamController?.addError(error);
+        _addException(error);
       }
     });
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

There is a handy method called `_addException` that adds the error on the streamController and passes a current stack trace if there are none provided. This PR uses the method instead of directly passing the error to the stream.