### PR TITLE
refactor: bump minimum Dart SDK version to 2.17.0

### DIFF
--- a/.github/workflows/functions_client_ci.yml
+++ b/.github/workflows/functions_client_ci.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         node: ['12']
-        sdk: [2.15.0, stable, beta, dev]
+        sdk: [2.17.0, stable, beta, dev]
 
     defaults:
       run:
@@ -48,7 +48,7 @@ jobs:
           melos bootstrap --ignore="supabase_flutter"
 
       - name: dartfmt
-        if: ${{ matrix.sdk == 'stable'}} 
+        if: ${{ matrix.sdk == 'stable'}}
         run: dart format lib test -l 80 --set-exit-if-changed
 
       - name: analyzer

--- a/.github/workflows/gotrue_ci.yml
+++ b/.github/workflows/gotrue_ci.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         node: ['12']
-        sdk: [2.15.0, stable, beta, dev]
+        sdk: [2.17.0, stable, beta, dev]
 
     defaults:
       run:
@@ -45,7 +45,7 @@ jobs:
           melos bootstrap --ignore="supabase_flutter"
 
       - name: dartfmt
-        if: ${{ matrix.sdk == 'stable'}} 
+        if: ${{ matrix.sdk == 'stable'}}
         run: dart format lib test -l 80 --set-exit-if-changed
 
       - name: analyzer

--- a/.github/workflows/postgrest_ci.yml
+++ b/.github/workflows/postgrest_ci.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         node: ['12']
-        sdk: [2.15.0, stable, beta, dev]
+        sdk: [2.17.0, stable, beta, dev]
 
     defaults:
       run:
@@ -47,7 +47,7 @@ jobs:
           melos bootstrap --ignore="supabase_flutter"
 
       - name: dartfmt
-        if: ${{ matrix.sdk == 'stable'}} 
+        if: ${{ matrix.sdk == 'stable'}}
         run: dart format lib test -l 80 --set-exit-if-changed
 
       - name: analyzer

--- a/.github/workflows/realtime_client_ci.yml
+++ b/.github/workflows/realtime_client_ci.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         node: ['12']
-        sdk: [2.15.0, stable, beta, dev]
+        sdk: [2.17.0, stable, beta, dev]
 
     defaults:
       run:
@@ -45,7 +45,7 @@ jobs:
           melos bootstrap --ignore="supabase_flutter"
 
       - name: dartfmt
-        if: ${{ matrix.sdk == 'stable'}} 
+        if: ${{ matrix.sdk == 'stable'}}
         run: dart format lib test -l 80 --set-exit-if-changed
 
       - name: analyzer

--- a/.github/workflows/storage_client_ci.yml
+++ b/.github/workflows/storage_client_ci.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         node: ['12']
-        sdk: [2.15.0, stable, beta, dev]
+        sdk: [2.17.0, stable, beta, dev]
 
     defaults:
       run:
@@ -44,7 +44,7 @@ jobs:
           melos bootstrap --ignore="supabase_flutter"
 
       - name: dartfmt
-        if: ${{ matrix.sdk == 'stable'}} 
+        if: ${{ matrix.sdk == 'stable'}}
         run: dart format lib test -l 80 --set-exit-if-changed
 
       - name: analyzer

--- a/.github/workflows/supabase_ci.yml
+++ b/.github/workflows/supabase_ci.yml
@@ -31,7 +31,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         node: ['12']
-        sdk: [2.15.0, stable, beta, dev]
+        sdk: [2.17.0, stable, beta, dev]
 
     defaults:
       run:
@@ -55,7 +55,7 @@ jobs:
           melos bootstrap --ignore="supabase_flutter"
 
       - name: dartfmt
-        if: ${{ matrix.sdk == 'stable'}} 
+        if: ${{ matrix.sdk == 'stable'}}
         run: dart format lib test -l 80 --set-exit-if-changed
 
       - name: analyzer

--- a/.github/workflows/yet_another_json_isolate_ci.yml
+++ b/.github/workflows/yet_another_json_isolate_ci.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         node: ['12']
-        sdk: [2.15.0, stable, beta, dev]
+        sdk: [2.17.0, stable, beta, dev]
 
     defaults:
       run:
@@ -45,7 +45,7 @@ jobs:
           melos bootstrap --ignore="supabase_flutter"
 
       - name: dartfmt
-        if: ${{ matrix.sdk == 'stable'}} 
+        if: ${{ matrix.sdk == 'stable'}}
         run: dart format lib test -l 80 --set-exit-if-changed
 
       - name: analyzer

--- a/packages/functions_client/pubspec.yaml
+++ b/packages/functions_client/pubspec.yaml
@@ -6,7 +6,7 @@ repository: 'https://github.com/supabase/supabase-flutter/tree/main/packages/fun
 documentation: 'https://supabase.com/docs/reference/dart/functions-invoke'
 
 environment:
-  sdk: '>=2.15.0 <4.0.0'
+  sdk: '>=2.17.0 <4.0.0'
 
 dependencies:
   http: '>=0.13.4 <2.0.0'

--- a/packages/gotrue/lib/src/constants.dart
+++ b/packages/gotrue/lib/src/constants.dart
@@ -56,9 +56,3 @@ enum OtpType {
   recovery,
   emailChange
 }
-
-extension EnumName on Enum {
-  String get name {
-    return toString().split('.').last;
-  }
-}

--- a/packages/gotrue/lib/src/types/mfa.dart
+++ b/packages/gotrue/lib/src/types/mfa.dart
@@ -1,5 +1,4 @@
 import 'package:gotrue/gotrue.dart';
-import 'package:gotrue/src/constants.dart';
 
 class AuthMFAEnrollResponse {
   /// ID of the factor that was just enrolled (in an unverified state).

--- a/packages/gotrue/pubspec.yaml
+++ b/packages/gotrue/pubspec.yaml
@@ -6,7 +6,7 @@ repository: 'https://github.com/supabase/supabase-flutter/tree/main/packages/got
 documentation: 'https://supabase.com/docs/reference/dart/auth-signup'
 
 environment:
-  sdk: '>=2.14.0 <4.0.0'
+  sdk: '>=2.17.0 <4.0.0'
 
 dependencies:
   collection: ^1.15.0

--- a/packages/postgrest/pubspec.yaml
+++ b/packages/postgrest/pubspec.yaml
@@ -6,7 +6,7 @@ repository: 'https://github.com/supabase/supabase-flutter/tree/main/packages/pos
 documentation: 'https://supabase.com/docs/reference/dart/select'
 
 environment:
-  sdk: '>=2.15.0 <4.0.0'
+  sdk: '>=2.17.0 <4.0.0'
 
 dependencies:
   http: '>=0.13.0 <2.0.0'

--- a/packages/realtime_client/lib/src/constants.dart
+++ b/packages/realtime_client/lib/src/constants.dart
@@ -50,12 +50,6 @@ extension ChannelEventsExtended on ChannelEvents {
   }
 }
 
-extension EnumName on Enum {
-  String get name {
-    return toString().split('.').last;
-  }
-}
-
 class Transports {
   static const String websocket = 'websocket';
 }

--- a/packages/realtime_client/pubspec.yaml
+++ b/packages/realtime_client/pubspec.yaml
@@ -6,7 +6,7 @@ repository: 'https://github.com/supabase/supabase-flutter/tree/main/packages/rea
 documentation: 'https://supabase.com/docs/reference/dart/subscribe'
 
 environment:
-  sdk: '>=2.14.0 <4.0.0'
+  sdk: '>=2.17.0 <4.0.0'
 
 dependencies:
   collection: ^1.15.0

--- a/packages/storage_client/pubspec.yaml
+++ b/packages/storage_client/pubspec.yaml
@@ -6,7 +6,7 @@ repository: 'https://github.com/supabase/supabase-flutter/tree/main/packages/sto
 documentation: 'https://supabase.com/docs/reference/dart/storage-createbucket'
 
 environment:
-  sdk: '>=2.15.0 <4.0.0'
+  sdk: '>=2.17.0 <4.0.0'
 
 dependencies:
   http: '>=0.13.4 <2.0.0'

--- a/packages/supabase/pubspec.yaml
+++ b/packages/supabase/pubspec.yaml
@@ -6,7 +6,7 @@ repository: 'https://github.com/supabase/supabase-flutter/tree/main/packages/sup
 documentation: 'https://supabase.com/docs/reference/dart/introduction'
 
 environment:
-  sdk: '>=2.15.0 <4.0.0'
+  sdk: '>=2.17.0 <4.0.0'
 
 dependencies:
   functions_client: ^1.3.1

--- a/packages/yet_another_json_isolate/pubspec.yaml
+++ b/packages/yet_another_json_isolate/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.1.0
 homepage: https://github.com/supabase-community/json-isolate-dart
 
 environment:
-  sdk: '>=2.15.0 <4.0.0'
+  sdk: '>=2.17.0 <4.0.0'
 
 dependencies:
   async: ^2.8.0


### PR DESCRIPTION
## What kind of change does this PR introduce?

- Bumps the minimum Dart SDK version to 2.17.0 across all packages
- Also removed the extension methods on Enums to add `name` getter.