### PR TITLE
feat(supabase_flutter): Add `signInWithGoogle()` method to perform native Google login

### DIFF
--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -309,6 +309,7 @@ class GoTrueClient {
     required String idToken,
     String? nonce,
     String? captchaToken,
+    String? accessToken,
   }) async {
     _removeSession();
 
@@ -327,6 +328,7 @@ class GoTrueClient {
           'id_token': idToken,
           'nonce': nonce,
           'gotrue_meta_security': {'captcha_token': captchaToken},
+          'access_token': accessToken,
         },
         query: {'grant_type': 'id_token'},
       ),

--- a/packages/supabase_flutter/README.md
+++ b/packages/supabase_flutter/README.md
@@ -41,10 +41,6 @@ void main() async {
 final supabase = Supabase.instance.client;
 ```
 
-> `authCallbackUrlHostname` is optional. It will be used to filter Supabase authentication redirect deeplink. You need to provide this param if you use deeplink for other features on the app.
-
-> `debug` is optional. It's enabled by default if you're running the app in debug mode (`flutter run --debug`).
-
 ## Usage example
 
 ### [Authentication](https://supabase.com/docs/guides/auth)
@@ -95,21 +91,33 @@ class _MyWidgetState extends State<MyWidget> {
 }
 ```
 
-#### Native Sign in with Apple example
+#### Native Apple Sign in
 
-Before you run the code, you need to [register your app ID with Apple](https://developer.apple.com/help/account/manage-identifiers/register-an-app-id/) with the `Sign In with Apple` capability selected, and add the bundle ID to your Supabase dashboard in `Authentication -> Providers -> Apple`. 
+You need to [register your app ID with Apple](https://developer.apple.com/help/account/manage-identifiers/register-an-app-id/) with the `Sign In with Apple` capability selected, and add the bundle ID to your Supabase dashboard in `Authentication -> Providers -> Apple` before performing native Apple sign in. 
 
 ```dart
-import 'package:supabase_flutter/supabase_flutter.dart';
-
-final supabase = Supabase.instance.client;
-
-return supabase.auth.signInWithApple();
+// Perform Apple login on iOS and macOS
+await supabase.auth.signInWithApple();
 ```
 
-`signInWithApple()` is only supported on iOS and on macOS. Other platforms can use the `signInWithOAuth()` method to perform Apple login.
+`signInWithApple()` is only supported on iOS and on macOS. Use the `signInWithOAuth()` method to perform web-based Apple sign in on other platforms.
 
-The `signInWithApple` method is currently experimental and is subject to change. Follow [this issue](https://github.com/supabase/supabase-flutter/issues/399) for platform support progress.
+#### Native Google sign in
+
+You need to obtain a client ID from your Google console and add them to your Supabase dashboard in `Authentication -> Providers -> Google`.
+
+Android guide [here](https://developers.google.com/identity/sign-in/android/start-integrating#configure_a_project), and iOS guide [here](https://developers.google.com/identity/sign-in/ios/start-integrating#get_an_oauth_client_id). In both platforms, you do **NOT** need to add any configuration files into your Flutter application.
+
+```dart
+// Perform Google login on Android and iOS
+// Pass the same client ID set on the Supabase dashboard to the sign in method
+await supabase.auth.signInWithGoogle(
+  iosClientId: 'IOS_CLIENT_ID',
+  androidClientId: 'ANDROID_CLIENT_ID',
+);
+```
+
+`signInWithGoogle()` is only supported on Android and iOS. Use the `signInWithOAuth()` method to perform web-based Google sign in on other platforms.
 
 
 ### [Database](https://supabase.com/docs/guides/database)

--- a/packages/supabase_flutter/README.md
+++ b/packages/supabase_flutter/README.md
@@ -46,49 +46,29 @@ final supabase = Supabase.instance.client;
 ### [Authentication](https://supabase.com/docs/guides/auth)
 
 ```dart
-import 'package:supabase_flutter/supabase_flutter.dart';
-
 final supabase = Supabase.instance.client;
 
-class MyWidget extends StatefulWidget {
-  const MyWidget({Key? key}) : super(key: key);
+// Email and password sign up
+await supabase.auth.signUp(
+  email: email,
+  password: password,
+);
 
-  @override
-  State<MyWidget> createState() => _MyWidgetState();
-}
+// Email and password login
+await supabase.auth.signInWithPassword(
+  email: email,
+  password: password,
+);
 
-class _MyWidgetState extends State<MyWidget> {
-  late final StreamSubscription<AuthState> _authSubscription;
-  User? _user;
+// Magic link login
+await supabase.auth.signInWithOtp(email: 'my_email@example.com');
 
-  @override
-  void initState() {
-    _authSubscription = supabase.auth.onAuthStateChange.listen((data) {
-      final AuthChangeEvent event = data.event;
-      final Session? session = data.session;
-      setState(() {
-        _user = session?.user;
-      });
-    });
-    super.initState();
-  }
-
-  @override
-  void dispose() {
-    _authSubscription.cancel();
-    super.dispose();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return ElevatedButton(
-      onPressed: () {
-        supabase.auth.signInWithOtp(email: 'my_email@example.com');
-      },
-      child: const Text('Login'),
-    );
-  }
-}
+// Listen to auth state changes
+supabase.auth.onAuthStateChange.listen((data) {
+  final AuthChangeEvent event = data.event;
+  final Session? session = data.session;
+  // Do something when there is an auth event
+});
 ```
 
 #### Native Apple Sign in
@@ -104,9 +84,10 @@ await supabase.auth.signInWithApple();
 
 #### Native Google sign in
 
-You need to obtain a client ID from your Google console and add them to your Supabase dashboard in `Authentication -> Providers -> Google`.
+You need to create a client ID in your Google Cloud console and add them to your Supabase dashboard in `Authentication -> Providers -> Google`. 
 
-Android guide [here](https://developers.google.com/identity/sign-in/android/start-integrating#configure_a_project), and iOS guide [here](https://developers.google.com/identity/sign-in/ios/start-integrating#get_an_oauth_client_id). In both platforms, you do **NOT** need to add any configuration files into your Flutter application.
+- [Obtain Android client ID](https://developers.google.com/identity/sign-in/android/start-integrating#configure_a_project)
+- [Obtain iOS client ID](https://developers.google.com/identity/sign-in/ios/start-integrating#get_an_oauth_client_id)
 
 ```dart
 // Perform Google login on Android and iOS

--- a/packages/supabase_flutter/pubspec.yaml
+++ b/packages/supabase_flutter/pubspec.yaml
@@ -14,10 +14,12 @@ dependencies:
   crypto: ^3.0.2
   flutter:
     sdk: flutter
+  flutter_appauth: ^4.2.1
   hive: ^2.2.1
   hive_flutter: ^1.1.0
   http: '>=0.13.4 <2.0.0'
   meta: ^1.7.0
+  package_info_plus: '>=3.0.0 <5.0.0'
   sign_in_with_apple: ^4.3.0
   supabase: ^1.9.1
   url_launcher: ^6.1.2


### PR DESCRIPTION
## What kind of change does this PR introduce?

- Adds native Google login support for iOS and Android via `signInWithGoogle()` method.
- Add instruction to setup native login on readme.md
- Some cleanups on the auth section of the readme
```dart
await supabase.auth.signInWithGoogle(
  iosClientId: 'IOS_CLIENT_ID',
  androidClientId: 'ANDROID_CLIENT_ID',
);
```

The `package_info_plus` dependency requires Android SDK version 19, and Flutter by default uses 16. This may be an issue, but since [Play store requires 19](https://developers.google.com/android/guides/setup#:~:text=A%20compatible%20Android%20device%20that,Google%20Play%20Store%20app%20installed.) anyway, I think it's fine.