### PR TITLE
feat(gotrue): add accessToken to `signInWithIdToken` method

### DIFF
--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -309,6 +309,7 @@ class GoTrueClient {
     required String idToken,
     String? nonce,
     String? captchaToken,
+    String? accessToken,
   }) async {
     _removeSession();
 
@@ -327,6 +328,7 @@ class GoTrueClient {
           'id_token': idToken,
           'nonce': nonce,
           'gotrue_meta_security': {'captcha_token': captchaToken},
+          'access_token': accessToken,
         },
         query: {'grant_type': 'id_token'},
       ),
@@ -437,9 +439,7 @@ class GoTrueClient {
     assert((email != null && phone == null) || (email == null && phone != null),
         '`email` or `phone` needs to be specified.');
 
-    if (type != OtpType.emailChange && type != OtpType.phoneChange) {
-      _removeSession();
-    }
+    _removeSession();
 
     final body = {
       if (email != null) 'email': email,
@@ -612,15 +612,7 @@ class GoTrueClient {
     _removeSession();
     _notifyAllSubscribers(AuthChangeEvent.signedOut);
     if (accessToken != null) {
-      try {
-        await admin.signOut(accessToken);
-      } on AuthException catch (error) {
-        // ignore 401s since an invalid or expired JWT should sign out the current session
-        // ignore 404s since user might not exist anymore
-        if (error.statusCode != '401' && error.statusCode != '404') {
-          rethrow;
-        }
-      }
+      return admin.signOut(accessToken);
     }
   }
 

--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -302,14 +302,23 @@ class GoTrueClient {
   /// The [idToken] is verified for validity and a new session is established.
   /// This method of signing in only supports [Provider.google] or [Provider.apple].
   ///
+  /// If the ID token contains an `at_hash` claim, then [accessToken] must be
+  /// provided to compare its hashthe hash with the value in the ID token.
+  ///
+  /// If the ID token contains a `nonce` claim, then [nonce] must be
+  /// provided to compare its hash with the value in the ID token.
+  ///
+  /// [captchaToken] is the verification token received when the user
+  /// completes the captcha on the app.
+  ///
   /// This method is experimental.
   @experimental
   Future<AuthResponse> signInWithIdToken({
     required Provider provider,
     required String idToken,
+    String? accessToken,
     String? nonce,
     String? captchaToken,
-    String? accessToken,
   }) async {
     _removeSession();
 

--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -303,7 +303,7 @@ class GoTrueClient {
   /// This method of signing in only supports [Provider.google] or [Provider.apple].
   ///
   /// If the ID token contains an `at_hash` claim, then [accessToken] must be
-  /// provided to compare its hashthe hash with the value in the ID token.
+  /// provided to compare its hash with the value in the ID token.
   ///
   /// If the ID token contains a `nonce` claim, then [nonce] must be
   /// provided to compare its hash with the value in the ID token.


### PR DESCRIPTION
## What kind of change does this PR introduce?

Adds `accessToken` parameter to `signInWithIdToken` method. 

Related https://github.com/supabase/gotrue-js/pull/690
Related https://github.com/supabase/supabase-flutter/issues/399