### PR TITLE
feat(postgrest, supabase): add `useSchema()` method for making rest API calls on custom schema.

### DIFF
--- a/packages/postgrest/lib/src/postgrest.dart
+++ b/packages/postgrest/lib/src/postgrest.dart
@@ -50,12 +50,25 @@ class PostgrestClient {
   }
 
   /// Perform a table operation.
-  PostgrestQueryBuilder<void> from(String table, {String? schema}) {
+  PostgrestQueryBuilder<void> from(String table) {
     final url = '${this.url}/$table';
     return PostgrestQueryBuilder<void>(
       url,
       headers: {...headers},
-      schema: schema ?? this.schema,
+      schema: schema,
+      httpClient: httpClient,
+      isolate: _isolate,
+    );
+  }
+
+  /// Select a schema to query or perform an function (rpc) call.
+  ///
+  /// The schema needs to be on the list of exposed schemas inside Supabase.
+  PostgrestClient setSchema(String schema) {
+    return PostgrestClient(
+      url,
+      headers: {...headers},
+      schema: schema,
       httpClient: httpClient,
       isolate: _isolate,
     );

--- a/packages/postgrest/lib/src/postgrest.dart
+++ b/packages/postgrest/lib/src/postgrest.dart
@@ -50,12 +50,12 @@ class PostgrestClient {
   }
 
   /// Perform a table operation.
-  PostgrestQueryBuilder<void> from(String table) {
+  PostgrestQueryBuilder<void> from(String table, {String? schema}) {
     final url = '${this.url}/$table';
     return PostgrestQueryBuilder<void>(
       url,
       headers: {...headers},
-      schema: schema,
+      schema: schema ?? this.schema,
       httpClient: httpClient,
       isolate: _isolate,
     );

--- a/packages/postgrest/lib/src/postgrest.dart
+++ b/packages/postgrest/lib/src/postgrest.dart
@@ -64,7 +64,7 @@ class PostgrestClient {
   /// Select a schema to query or perform an function (rpc) call.
   ///
   /// The schema needs to be on the list of exposed schemas inside Supabase.
-  PostgrestClient setSchema(String schema) {
+  PostgrestClient useSchema(String schema) {
     return PostgrestClient(
       url,
       headers: {...headers},

--- a/packages/postgrest/test/basic_test.dart
+++ b/packages/postgrest/test/basic_test.dart
@@ -91,7 +91,7 @@ void main() {
     test('query non-public schema dynamically', () async {
       final postgrest = PostgrestClient(rootUrl);
       final personalData = await postgrest
-          .setSchema('personal')
+          .useSchema('personal')
           .from('users')
           .select<PostgrestList>();
       expect(personalData.length, 5);

--- a/packages/postgrest/test/basic_test.dart
+++ b/packages/postgrest/test/basic_test.dart
@@ -88,7 +88,7 @@ void main() {
       expect(res.length, 5);
     });
 
-    test('specify schema within from', () async {
+    test('query non-public schema dynamically', () async {
       final postgrest = PostgrestClient(rootUrl);
       final personalData = await postgrest
           .setSchema('personal')

--- a/packages/postgrest/test/basic_test.dart
+++ b/packages/postgrest/test/basic_test.dart
@@ -88,6 +88,18 @@ void main() {
       expect(res.length, 5);
     });
 
+    test('specify schema within from', () async {
+      final postgrest = PostgrestClient(rootUrl);
+      final personalData = await postgrest
+          .from('users', schema: 'personal')
+          .select<PostgrestList>();
+      expect(personalData.length, 5);
+
+      // confirm that the client defaults to its initialized schema by default.
+      final publicData = await postgrest.from('users').select<PostgrestList>();
+      expect(publicData.length, 4);
+    });
+
     test('on_conflict upsert', () async {
       final res = await postgrest.from('users').upsert(
         {'username': 'dragarcia', 'status': 'OFFLINE'},

--- a/packages/postgrest/test/basic_test.dart
+++ b/packages/postgrest/test/basic_test.dart
@@ -91,7 +91,8 @@ void main() {
     test('specify schema within from', () async {
       final postgrest = PostgrestClient(rootUrl);
       final personalData = await postgrest
-          .from('users', schema: 'personal')
+          .setSchema('personal')
+          .from('users')
           .select<PostgrestList>();
       expect(personalData.length, 5);
 

--- a/packages/supabase/lib/src/supabase_client.dart
+++ b/packages/supabase/lib/src/supabase_client.dart
@@ -184,16 +184,7 @@ class SupabaseClient {
   ///
   /// The schema needs to be on the list of exposed schemas inside Supabase.
   PostgrestClient setSchema(String schema) {
-    return PostgrestClient(
-      restUrl,
-      headers: {
-        ...rest.headers,
-        ..._getAuthHeaders(),
-      },
-      schema: schema,
-      httpClient: _httpClient,
-      isolate: _isolate,
-    );
+    return rest.setSchema(schema);
   }
 
   /// Perform a stored procedure call.

--- a/packages/supabase/lib/src/supabase_client.dart
+++ b/packages/supabase/lib/src/supabase_client.dart
@@ -162,7 +162,7 @@ class SupabaseClient {
   }
 
   /// Perform a table operation.
-  SupabaseQueryBuilder from(String table, {String? schema}) {
+  SupabaseQueryBuilder from(String table) {
     final url = '$restUrl/$table';
     _incrementId++;
     return SupabaseQueryBuilder(
@@ -172,10 +172,26 @@ class SupabaseClient {
         ...rest.headers,
         ..._getAuthHeaders(),
       },
-      schema: schema ?? this.schema,
+      schema: schema,
       table: table,
       httpClient: _httpClient,
       incrementId: _incrementId,
+      isolate: _isolate,
+    );
+  }
+
+  /// Select a schema to query or perform an function (rpc) call.
+  ///
+  /// The schema needs to be on the list of exposed schemas inside Supabase.
+  PostgrestClient setSchema(String schema) {
+    return PostgrestClient(
+      restUrl,
+      headers: {
+        ...rest.headers,
+        ..._getAuthHeaders(),
+      },
+      schema: schema,
+      httpClient: _httpClient,
       isolate: _isolate,
     );
   }

--- a/packages/supabase/lib/src/supabase_client.dart
+++ b/packages/supabase/lib/src/supabase_client.dart
@@ -162,7 +162,7 @@ class SupabaseClient {
   }
 
   /// Perform a table operation.
-  SupabaseQueryBuilder from(String table) {
+  SupabaseQueryBuilder from(String table, {String? schema}) {
     final url = '$restUrl/$table';
     _incrementId++;
     return SupabaseQueryBuilder(
@@ -172,7 +172,7 @@ class SupabaseClient {
         ...rest.headers,
         ..._getAuthHeaders(),
       },
-      schema: schema,
+      schema: schema ?? this.schema,
       table: table,
       httpClient: _httpClient,
       incrementId: _incrementId,

--- a/packages/supabase/lib/src/supabase_client.dart
+++ b/packages/supabase/lib/src/supabase_client.dart
@@ -183,8 +183,8 @@ class SupabaseClient {
   /// Select a schema to query or perform an function (rpc) call.
   ///
   /// The schema needs to be on the list of exposed schemas inside Supabase.
-  PostgrestClient setSchema(String schema) {
-    return rest.setSchema(schema);
+  PostgrestClient useSchema(String schema) {
+    return rest.useSchema(schema);
   }
 
   /// Perform a stored procedure call.


### PR DESCRIPTION
## What kind of change does this PR introduce?

Allows developers to easily query custom schema.
Fixes https://github.com/supabase/supabase-flutter/issues/314

## What is the current behavior?

There isn't a way to query other schemas once Supabase client is initialized. Some workarounds that I can think about right now would be
- Don't use custom schemas
- Create postgres views/ functions in the public schema for every custom schema table
- `dispose` and re-initialize the client every time when querying custom schema
All of them are kind of painful to implement.

## What is the new behavior?

Developers can query custom schema like this:
```dart
final data = await supabase.useSchema('custom_schema').from('table').select();
```

## Additional Context

Since `schema` name is already taken, we couldn't name the method `schema()` like how the js SDK does it. 