### PR TITLE
refactor(gotrue): add email otptype

### DIFF
--- a/packages/gotrue/lib/src/constants.dart
+++ b/packages/gotrue/lib/src/constants.dart
@@ -50,11 +50,14 @@ extension GenerateLinkTypeExtended on GenerateLinkType {
 enum OtpType {
   sms,
   phoneChange,
+  @Deprecated('Use OtpType.email instead')
   signup,
   invite,
+  @Deprecated('Use OtpType.email instead')
   magiclink,
   recovery,
-  emailChange
+  emailChange,
+  email
 }
 
 ///Determines which sessions should be logged out.


### PR DESCRIPTION
Add new `OtpType.email` and deprecate `OtpType.signup` and `OtpType.magiclink`.

[gotrue pr](https://github.com/supabase/gotrue/pull/885)

[gotrue-js pr](https://github.com/supabase/gotrue-js/pull/642)