### PR TITLE
fix(supabase): get jwt on http call

### DIFF
--- a/packages/gotrue/lib/src/types/session.dart
+++ b/packages/gotrue/lib/src/types/session.dart
@@ -68,10 +68,14 @@ class Session {
     }
   }
 
-  bool get expired {
+  /// Returns 'true` if the token is expired or will expire in the next 5 seconds.
+  ///
+  /// The 5 second buffer is to account for latency issues.
+  bool get isExpired {
     if (expiresAt == null) return false;
-    return DateTime.now()
-        .isAfter(DateTime.fromMillisecondsSinceEpoch(expiresAt! * 1000));
+    return DateTime.now().add(Duration(seconds: 5)).isAfter(
+          DateTime.fromMillisecondsSinceEpoch(expiresAt! * 1000),
+        );
   }
 
   String get persistSessionString {

--- a/packages/gotrue/lib/src/types/session.dart
+++ b/packages/gotrue/lib/src/types/session.dart
@@ -16,7 +16,7 @@ class Session {
   final String tokenType;
   final User user;
 
-  const Session({
+  Session({
     required this.accessToken,
     this.expiresIn,
     this.refreshToken,
@@ -57,13 +57,21 @@ class Session {
 
   /// A timestamp of when the token will expire. Returned when a login is
   /// confirmed.
-  int? get expiresAt {
+  late int? expiresAt = _expiresAt;
+
+  int? get _expiresAt {
     try {
       final payload = Jwt.parseJwt(accessToken);
       return payload['exp'] as int;
     } catch (_) {
       return null;
     }
+  }
+
+  bool get expired {
+    if (expiresAt == null) return false;
+    return DateTime.now()
+        .isAfter(DateTime.fromMillisecondsSinceEpoch(expiresAt! * 1000));
   }
 
   String get persistSessionString {

--- a/packages/supabase/lib/src/auth_http_client.dart
+++ b/packages/supabase/lib/src/auth_http_client.dart
@@ -1,0 +1,22 @@
+import 'package:http/http.dart';
+import 'package:supabase/supabase.dart';
+
+class AuthHttpClient extends BaseClient {
+  final Client _inner;
+  final GoTrueClient _auth;
+  final String _supabaseKey;
+
+  AuthHttpClient(this._supabaseKey, this._inner, this._auth);
+
+  @override
+  Future<StreamedResponse> send(BaseRequest request) async {
+    if (_auth.currentSession?.expired ?? false) {
+      await _auth.refreshSession();
+    }
+    final authBearer = _auth.currentSession?.accessToken ?? _supabaseKey;
+
+    request.headers.putIfAbsent("Authorization", () => 'Bearer $authBearer');
+    request.headers.putIfAbsent("apikey", () => _supabaseKey);
+    return _inner.send(request);
+  }
+}

--- a/packages/supabase/lib/src/auth_http_client.dart
+++ b/packages/supabase/lib/src/auth_http_client.dart
@@ -10,7 +10,7 @@ class AuthHttpClient extends BaseClient {
 
   @override
   Future<StreamedResponse> send(BaseRequest request) async {
-    if (_auth.currentSession?.expired ?? false) {
+    if (_auth.currentSession?.isExpired ?? false) {
       await _auth.refreshSession();
     }
     final authBearer = _auth.currentSession?.accessToken ?? _supabaseKey;

--- a/packages/supabase/lib/src/supabase_client.dart
+++ b/packages/supabase/lib/src/supabase_client.dart
@@ -11,6 +11,8 @@ import 'package:supabase/src/realtime_client_options.dart';
 import 'package:supabase/src/supabase_query_builder.dart';
 import 'package:yet_another_json_isolate/yet_another_json_isolate.dart';
 
+import 'auth_http_client.dart';
+
 /// {@template supabase_client}
 /// Creates a Supabase client to interact with your Supabase instance.
 ///
@@ -43,7 +45,8 @@ class SupabaseClient {
   final String storageUrl;
   final String functionsUrl;
   final Map<String, String> _headers;
-  final Client? _httpClient;
+  late final Client _authHttpClient;
+  late final Client? _httpClient;
 
   late final GoTrueClient auth;
 
@@ -61,9 +64,6 @@ class SupabaseClient {
   /// Increment ID of the stream to create different realtime topic for each stream
   int _incrementId = 0;
 
-  /// Number of retries storage client should do on file failed file uploads.
-  final int _storageRetryAttempts;
-
   /// Getter for the HTTP headers
   Map<String, String> get headers {
     return _headers;
@@ -74,7 +74,6 @@ class SupabaseClient {
     _headers.clear();
     _headers.addAll({
       ...Constants.defaultHeaders,
-      ..._getAuthHeaders(),
       ...headers,
     });
 
@@ -92,7 +91,11 @@ class SupabaseClient {
 
     auth.headers
       ..clear()
-      ..addAll(_headers);
+      ..addAll({
+        ...Constants.defaultHeaders,
+        ..._getAuthHeaders(),
+        ...headers,
+      });
 
     // To apply the new headers in the realtime client,
     // manually unsubscribe and resubscribe to all channels.
@@ -141,23 +144,18 @@ class SupabaseClient {
           ...Constants.defaultHeaders,
           if (headers != null) ...headers
         },
-        _httpClient = httpClient,
-        _storageRetryAttempts = storageRetryAttempts,
         _isolate = isolate ?? (YAJsonIsolate()..initialize()) {
+    _httpClient = httpClient;
     auth = _initSupabaseAuthClient(
       autoRefreshToken: autoRefreshToken,
-      headers: _headers,
       gotrueAsyncStorage: gotrueAsyncStorage,
       authFlowType: authFlowType,
     );
+    _authHttpClient = AuthHttpClient(supabaseKey, httpClient ?? Client(), auth);
     rest = _initRestClient();
     functions = _initFunctionsClient();
-    storage = _initStorageClient();
-    realtime = _initRealtimeClient(
-      headers: _headers,
-      options: realtimeClientOptions,
-    );
-
+    storage = _initStorageClient(storageRetryAttempts);
+    realtime = _initRealtimeClient(options: realtimeClientOptions);
     _listenForAuthEvents();
   }
 
@@ -168,13 +166,10 @@ class SupabaseClient {
     return SupabaseQueryBuilder(
       url,
       realtime,
-      headers: {
-        ...rest.headers,
-        ..._getAuthHeaders(),
-      },
+      headers: {...rest.headers, ...headers},
       schema: schema,
       table: table,
-      httpClient: _httpClient,
+      httpClient: _authHttpClient,
       incrementId: _incrementId,
       isolate: _isolate,
     );
@@ -186,7 +181,7 @@ class SupabaseClient {
     Map<String, dynamic>? params,
     FetchOptions options = const FetchOptions(),
   }) {
-    rest.headers.addAll({...rest.headers, ..._getAuthHeaders()});
+    rest.headers.addAll({...rest.headers, ...headers});
     return rest.rpc(fn, params: params, options: options);
   }
 
@@ -220,7 +215,6 @@ class SupabaseClient {
 
   GoTrueClient _initSupabaseAuthClient({
     bool? autoRefreshToken,
-    required Map<String, String> headers,
     required GotrueAsyncStorage? gotrueAsyncStorage,
     required AuthFlowType authFlowType,
   }) {
@@ -241,9 +235,9 @@ class SupabaseClient {
   PostgrestClient _initRestClient() {
     return PostgrestClient(
       restUrl,
-      headers: _getAuthHeaders(),
+      headers: {...headers},
       schema: schema,
-      httpClient: _httpClient,
+      httpClient: _authHttpClient,
       isolate: _isolate,
     );
   }
@@ -251,23 +245,22 @@ class SupabaseClient {
   FunctionsClient _initFunctionsClient() {
     return FunctionsClient(
       functionsUrl,
-      _getAuthHeaders(),
-      httpClient: _httpClient,
+      {...headers},
+      httpClient: _authHttpClient,
       isolate: _isolate,
     );
   }
 
-  SupabaseStorageClient _initStorageClient() {
+  SupabaseStorageClient _initStorageClient(int storageRetryAttempts) {
     return SupabaseStorageClient(
       storageUrl,
-      _getAuthHeaders(),
-      httpClient: _httpClient,
-      retryAttempts: _storageRetryAttempts,
+      {...headers},
+      httpClient: _authHttpClient,
+      retryAttempts: storageRetryAttempts,
     );
   }
 
   RealtimeClient _initRealtimeClient({
-    required Map<String, String> headers,
     required RealtimeClientOptions options,
   }) {
     final eventsPerSecond = options.eventsPerSecond;
@@ -306,16 +299,12 @@ class SupabaseClient {
         event == AuthChangeEvent.signedIn && _changedAccessToken != token) {
       // Token has changed
       _changedAccessToken = token;
-      rest.setAuth(token);
-      storage.setAuth(token!);
-      functions.setAuth(token);
+
       realtime.setAuth(token);
     } else if (event == AuthChangeEvent.signedOut ||
         event == AuthChangeEvent.userDeleted) {
       // Token is removed
-      rest.setAuth(supabaseKey);
-      storage.setAuth(supabaseKey);
-      functions.setAuth(supabaseKey);
+
       realtime.setAuth(supabaseKey);
     }
   }

--- a/packages/supabase/lib/src/supabase_client.dart
+++ b/packages/supabase/lib/src/supabase_client.dart
@@ -45,8 +45,8 @@ class SupabaseClient {
   final String storageUrl;
   final String functionsUrl;
   final Map<String, String> _headers;
+  final Client? _httpClient;
   late final Client _authHttpClient;
-  late final Client? _httpClient;
 
   late final GoTrueClient auth;
 
@@ -144,8 +144,8 @@ class SupabaseClient {
           ...Constants.defaultHeaders,
           if (headers != null) ...headers
         },
+        _httpClient = httpClient,
         _isolate = isolate ?? (YAJsonIsolate()..initialize()) {
-    _httpClient = httpClient;
     auth = _initSupabaseAuthClient(
       autoRefreshToken: autoRefreshToken,
       gotrueAsyncStorage: gotrueAsyncStorage,

--- a/packages/supabase/test/client_test.dart
+++ b/packages/supabase/test/client_test.dart
@@ -1,3 +1,6 @@
+import 'dart:convert';
+import 'dart:io';
+
 import 'package:supabase/supabase.dart';
 import 'package:test/test.dart';
 
@@ -25,6 +28,46 @@ void main() {
       final xClientHeaderBeforeSlash =
           client.storage.headers['X-Client-Info']!.split('/').first;
       expect(xClientHeaderBeforeSlash, 'supabase-dart');
+    });
+  });
+
+  group('auth', () {
+    test('properly set Authorization header', () async {
+      final expiresAt =
+          DateTime.now().add(Duration(hours: 1)).millisecondsSinceEpoch ~/ 1000;
+      final accessToken = base64.encode(utf8.encode(json.encode(
+          {"exp": expiresAt, "sub": "1234567890", "role": "authenticated"})));
+
+      final sessionString =
+          '{"currentSession":{"access_token":"$accessToken","expires_in":3600,"refresh_token":"-yeS4omysFs9tpUYBws9Rg","token_type":"bearer","provider_token":null,"provider_refresh_token":null,"user":{"id":"4d2583da-8de4-49d3-9cd1-37a9a74f55bd","app_metadata":{"provider":"email","providers":["email"]},"user_metadata":{"Hello":"World"},"aud":"","email":"fake1680338105@email.com","phone":"","created_at":"2023-04-01T08:35:05.208586Z","confirmed_at":null,"email_confirmed_at":"2023-04-01T08:35:05.220096086Z","phone_confirmed_at":null,"last_sign_in_at":"2023-04-01T08:35:05.222755878Z","role":"","updated_at":"2023-04-01T08:35:05.226938Z"}},"expiresAt":$expiresAt}';
+
+      final mockServer = await HttpServer.bind('localhost', 0);
+      final client = SupabaseClient(
+        'http://${mockServer.address.host}:${mockServer.port}',
+        "supabaseKey",
+        autoRefreshToken: false,
+      );
+      await client.auth.recoverSession(sessionString);
+
+      // Make some requests
+      client.from("test").select().then((value) => null);
+      client.rpc("test").select().then((value) => null);
+      client.functions.invoke("test").then((value) => null);
+      client.storage.from("test").list().then((value) => null);
+
+      var count = 0;
+
+      // Check for every request if the Authorization header is set properly
+      await for (final req in mockServer) {
+        expect(
+            req.headers.value('Authorization')?.split(" ").last, accessToken);
+        count++;
+        if (count == 4) {
+          break;
+        }
+      }
+
+      mockServer.close();
     });
   });
 

--- a/packages/supabase/test/utils.dart
+++ b/packages/supabase/test/utils.dart
@@ -1,0 +1,14 @@
+import 'dart:convert';
+
+/// Construct session data for a given expiration date
+List<String> getSessionData(DateTime dateTime) {
+  final expiresAt = dateTime.millisecondsSinceEpoch ~/ 1000;
+  final accessTokenMid = base64.encode(utf8.encode(json.encode(
+      {"exp": expiresAt, "sub": "1234567890", "role": "authenticated"})));
+  final accessToken = "any." + accessTokenMid + ".any";
+  final currentSession =
+      '{"access_token":"$accessToken","expires_in":${dateTime.difference(DateTime.now()).inSeconds},"refresh_token":"-yeS4omysFs9tpUYBws9Rg","token_type":"bearer","provider_token":null,"provider_refresh_token":null,"user":{"id":"4d2583da-8de4-49d3-9cd1-37a9a74f55bd","app_metadata":{"provider":"email","providers":["email"]},"user_metadata":{"Hello":"World"},"aud":"","email":"fake1680338105@email.com","phone":"","created_at":"2023-04-01T08:35:05.208586Z","confirmed_at":null,"email_confirmed_at":"2023-04-01T08:35:05.220096086Z","phone_confirmed_at":null,"last_sign_in_at":"2023-04-01T08:35:05.222755878Z","role":"","updated_at":"2023-04-01T08:35:05.226938Z"}}';
+  final sessionString =
+      '{"currentSession":$currentSession,"expiresAt":$expiresAt}';
+  return [accessToken, currentSession, sessionString];
+}


### PR DESCRIPTION
## What is the new behavior?

I'm now getting the latest access token when the actual request is done by wrapping the http client with another client, which gets the newest from `gotrue` and sets the headers correctly.

Additionally I made `expiresAt` a late variable to avoid reparsing the jwt each time. And I added `expired`, because I think its a nice addition to easy check the validity of a session. But I'm not sure if some additional padding could be useful. So that a session is maybe 5 seconds before actual expiration, marked as expired.

## Additional context
That technique is inspired from supabase-js
