### PR TITLE
feat(postgrest): updates for postgREST 11

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Monorepo containing all [Supabase](https://supabase.com/) libraries for Flutter.
 - [supabase_flutter](https://github.com/supabase/supabase-flutter/tree/main/packages/supabase_flutter)
 - [yet_another_json_isolate](https://github.com/supabase/supabase-flutter/tree/main/packages/yet_another_json_isolate)
 
-- Documentation: https://supabase.com/docs/reference/dart/introduction
+Documentation: https://supabase.com/docs/reference/dart/introduction
 
 ---
 

--- a/infra/postgrest/docker-compose.yml
+++ b/infra/postgrest/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     depends_on:
       - db
   db:
-    image: supabase/postgres:14.1.0.34
+    image: supabase/postgres:15.1.0.37
     ports:
       - '5432:5432'
     volumes:

--- a/infra/postgrest/docker-compose.yml
+++ b/infra/postgrest/docker-compose.yml
@@ -3,7 +3,7 @@
 version: '3'
 services:
   rest:
-    image: postgrest/postgrest:v9.0.1.20220802
+    image: postgrest/postgrest:v11.0.0
     ports:
       - '3000:3000'
     environment:

--- a/packages/postgrest/lib/src/postgrest_filter_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_filter_builder.dart
@@ -152,6 +152,32 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
     return this;
   }
 
+  /// Match only rows where [column] matches all of [patterns] case-sensitively.
+  ///
+  /// ```dart
+  /// await supabase
+  ///     .from('users')
+  ///     .select()
+  ///     .likeAllOf('username', ['%supa%', '%bot%']);
+  /// ```
+  PostgrestFilterBuilder likeAllOf(String column, List<String> patterns) {
+    appendSearchParams(column, 'like(all).{${patterns.join(',')}}');
+    return this;
+  }
+
+  /// Match only rows where [column] matches any of [patterns] case-sensitively.
+  ///
+  /// ```dart
+  /// await supabase
+  ///     .from('users')
+  ///     .select()
+  ///     .likeAnyOf('username', ['%supa%', '%bot%']);
+  /// ```
+  PostgrestFilterBuilder likeAnyOf(String column, List<String> patterns) {
+    appendSearchParams(column, 'like(any).{${patterns.join(',')}}');
+    return this;
+  }
+
   /// Finds all rows whose value in the stated [column] matches the supplied [pattern] (case insensitive).
   ///
   /// ```dart
@@ -162,6 +188,32 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   /// ```
   PostgrestFilterBuilder<T> ilike(String column, String pattern) {
     appendSearchParams(column, 'ilike.$pattern');
+    return this;
+  }
+
+  /// Match only rows where [column] matches all of [patterns] case-insensitively.
+  ///
+  /// ```dart
+  /// await supabase
+  ///     .from('users')
+  ///     .select()
+  ///     .likeAllOf('username', ['%supa%', '%bot%']);
+  /// ```
+  PostgrestFilterBuilder ilikeAllOf(String column, List<String> patterns) {
+    appendSearchParams(column, 'ilike(all).{${patterns.join(',')}}');
+    return this;
+  }
+
+  /// Match only rows where [column] matches any of [patterns] case-insensitively.
+  ///
+  /// ```dart
+  /// await supabase
+  ///     .from('users')
+  ///     .select()
+  ///     .likeAnyOf('username', ['%supa%', '%bot%']);
+  /// ```
+  PostgrestFilterBuilder ilikeAnyOf(String column, List<String> patterns) {
+    appendSearchParams(column, 'ilike(any).{${patterns.join(',')}}');
     return this;
   }
 

--- a/packages/postgrest/lib/src/postgrest_filter_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_filter_builder.dart
@@ -197,7 +197,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   /// await supabase
   ///     .from('users')
   ///     .select()
-  ///     .likeAllOf('username', ['%supa%', '%bot%']);
+  ///     .ilikeAllOf('username', ['%supa%', '%bot%']);
   /// ```
   PostgrestFilterBuilder ilikeAllOf(String column, List<String> patterns) {
     appendSearchParams(column, 'ilike(all).{${patterns.join(',')}}');
@@ -210,7 +210,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   /// await supabase
   ///     .from('users')
   ///     .select()
-  ///     .likeAnyOf('username', ['%supa%', '%bot%']);
+  ///     .ilikeAnyOf('username', ['%supa%', '%bot%']);
   /// ```
   PostgrestFilterBuilder ilikeAnyOf(String column, List<String> patterns) {
     appendSearchParams(column, 'ilike(any).{${patterns.join(',')}}');

--- a/packages/postgrest/lib/src/postgrest_query_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_query_builder.dart
@@ -124,7 +124,7 @@ class PostgrestQueryBuilder<T> extends PostgrestBuilder<T, T> {
     _body = values;
 
     if (values is List) {
-      _setColumsSearchParam(values);
+      _setColumnsSearchParam(values);
     }
 
     return PostgrestFilterBuilder<T>(this);
@@ -182,7 +182,7 @@ class PostgrestQueryBuilder<T> extends PostgrestBuilder<T, T> {
     }
 
     if (values is List) {
-      _setColumsSearchParam(values);
+      _setColumnsSearchParam(values);
     }
 
     _body = values;
@@ -252,7 +252,7 @@ class PostgrestQueryBuilder<T> extends PostgrestBuilder<T, T> {
     return PostgrestFilterBuilder<T>(this);
   }
 
-  void _setColumsSearchParam(List values) {
+  void _setColumnsSearchParam(List values) {
     final newValues = PostgrestList.from(values);
     final columns = newValues.fold<List<String>>(
         [], (value, element) => value..addAll(element.keys));

--- a/packages/postgrest/lib/src/postgrest_query_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_query_builder.dart
@@ -122,6 +122,11 @@ class PostgrestQueryBuilder<T> extends PostgrestBuilder<T, T> {
     }
 
     _body = values;
+
+    if (values is List) {
+      _setColumsSearchParam(values);
+    }
+
     return PostgrestFilterBuilder<T>(this);
   }
 
@@ -175,6 +180,11 @@ class PostgrestQueryBuilder<T> extends PostgrestBuilder<T, T> {
         },
       );
     }
+
+    if (values is List) {
+      _setColumsSearchParam(values);
+    }
+
     _body = values;
     _options = options.ensureNotHead();
     return PostgrestFilterBuilder<T>(this);
@@ -240,5 +250,15 @@ class PostgrestQueryBuilder<T> extends PostgrestBuilder<T, T> {
     _headers['Prefer'] = '';
     _options = options.ensureNotHead();
     return PostgrestFilterBuilder<T>(this);
+  }
+
+  void _setColumsSearchParam(List values) {
+    final newValues = PostgrestList.from(values);
+    final columns = newValues.fold<List<String>>(
+        [], (value, element) => value..addAll(element.keys));
+    if (newValues.isNotEmpty) {
+      final uniqueColumns = {...columns}.map((e) => '"$e"').join(',');
+      appendSearchParams("columns", uniqueColumns);
+    }
   }
 }

--- a/packages/postgrest/lib/src/postgrest_query_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_query_builder.dart
@@ -94,7 +94,11 @@ class PostgrestQueryBuilder<T> extends PostgrestBuilder<T, T> {
   ///
   /// By default no data is returned. Use a trailing `select` to return data.
   ///
-  /// When inserting multiple rows in bulk, [defaultToNull] can be used to set the values of the missing fields to be either `null` or the default value for the column. For single row insertions, missing fields will be set to default values when applicable.
+  /// When inserting multiple rows in bulk, [defaultToNull] is used to set the values of fields missing in a proper subset of rows
+  /// to be either `NULL` or the default value of these columns.
+  /// Fields missing in all rows always use the default value of these columns.
+  ///
+  /// For single row insertions, missing fields will be set to default values when applicable.
   ///
   /// Default (not returning data):
   /// ```dart
@@ -137,7 +141,11 @@ class PostgrestQueryBuilder<T> extends PostgrestBuilder<T, T> {
   ///
   /// By default no data is returned. Use a trailing `select` to return data.
   ///
-  /// When inserting multiple rows in bulk, [defaultToNull] can be used to set the values of the missing fields to be either `null` or the default value for the column. For single row insertions, missing fields will be set to default values when applicable.
+  /// When inserting multiple rows in bulk, [defaultToNull] is used to set the values of fields missing in a proper subset of rows
+  /// to be either `NULL` or the default value of these columns.
+  /// Fields missing in all rows always use the default value of these columns.
+  ///
+  /// For single row insertions, missing fields will be set to default values when applicable.
   ///
   /// Default (not returning data):
   /// ```dart

--- a/packages/postgrest/lib/src/postgrest_query_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_query_builder.dart
@@ -94,7 +94,7 @@ class PostgrestQueryBuilder<T> extends PostgrestBuilder<T, T> {
   ///
   /// By default no data is returned. Use a trailing `select` to return data.
   ///
-  /// [defaultToNull] Make missing fields default to `null`. Otherwise, use the default value for the column.
+  /// When inserting multiple rows in bulk, [defaultToNull] can be used to set the values of the missing fields to be either `null` or the default value for the column. For single row insertions, missing fields will be set to default values when applicable.
   ///
   /// Default (not returning data):
   /// ```dart
@@ -137,7 +137,7 @@ class PostgrestQueryBuilder<T> extends PostgrestBuilder<T, T> {
   ///
   /// By default no data is returned. Use a trailing `select` to return data.
   ///
-  /// [defaultToNull] Make missing fields default to `null`. Otherwise, use the default value for the column. This only applies when inserting new rows, not when merging with existing rows under [ignoreDuplicates] = false.
+  /// When inserting multiple rows in bulk, [defaultToNull] can be used to set the values of the missing fields to be either `null` or the default value for the column. For single row insertions, missing fields will be set to default values when applicable.
   ///
   /// Default (not returning data):
   /// ```dart

--- a/packages/postgrest/lib/src/postgrest_query_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_query_builder.dart
@@ -94,6 +94,8 @@ class PostgrestQueryBuilder<T> extends PostgrestBuilder<T, T> {
   ///
   /// By default no data is returned. Use a trailing `select` to return data.
   ///
+  /// [defaultToNull] Make missing fields default to `null`. Otherwise, use the default value for the column.
+  ///
   /// Default (not returning data):
   /// ```dart
   /// await supabase.from('messages').insert(
@@ -108,9 +110,17 @@ class PostgrestQueryBuilder<T> extends PostgrestBuilder<T, T> {
   ///   'channel_id': 1
   /// }).select();
   /// ```
-  PostgrestFilterBuilder<T> insert(dynamic values) {
+  PostgrestFilterBuilder<T> insert(
+    dynamic values, {
+    bool defaultToNull = true,
+  }) {
     _method = METHOD_POST;
     _headers['Prefer'] = '';
+
+    if (!defaultToNull) {
+      _headers['Prefer'] = 'missing=default';
+    }
+
     _body = values;
     return PostgrestFilterBuilder<T>(this);
   }
@@ -121,6 +131,8 @@ class PostgrestQueryBuilder<T> extends PostgrestBuilder<T, T> {
   /// [ignoreDuplicates] Specifies if duplicate rows should be ignored and not inserted.
   ///
   /// By default no data is returned. Use a trailing `select` to return data.
+  ///
+  /// [defaultToNull] Make missing fields default to `null`. Otherwise, use the default value for the column. This only applies when inserting new rows, not when merging with existing rows under [ignoreDuplicates] = false.
   ///
   /// Default (not returning data):
   /// ```dart
@@ -144,11 +156,17 @@ class PostgrestQueryBuilder<T> extends PostgrestBuilder<T, T> {
     dynamic values, {
     String? onConflict,
     bool ignoreDuplicates = false,
+    bool defaultToNull = true,
     FetchOptions options = const FetchOptions(),
   }) {
     _method = METHOD_POST;
     _headers['Prefer'] =
         'resolution=${ignoreDuplicates ? 'ignore' : 'merge'}-duplicates';
+
+    if (!defaultToNull) {
+      _headers['Prefer'] = _headers['Prefer']! + ',missing=default';
+    }
+
     if (onConflict != null) {
       _url = _url.replace(
         queryParameters: {

--- a/packages/postgrest/test/basic_test.dart
+++ b/packages/postgrest/test/basic_test.dart
@@ -360,15 +360,6 @@ void main() {
       expect(res.count, 1);
     });
 
-    test('row level security error', () async {
-      try {
-        await postgrest.from('sample').update({'id': 2});
-        fail('Returned even with row level security');
-      } on PostgrestException catch (error) {
-        expect(error.code, '404');
-      }
-    });
-
     test('withConverter', () async {
       final res = await postgrest
           .from('users')

--- a/packages/postgrest/test/basic_test.dart
+++ b/packages/postgrest/test/basic_test.dart
@@ -133,6 +133,41 @@ void main() {
       expect(res.length, 2);
     });
 
+    test('bulk insert without column defaults', () async {
+      final res = await postgrest.from('users').insert(
+        [
+          {
+            'username': "bot",
+            'status': 'OFFLINE',
+          },
+          {
+            'username': "crazy bot",
+          },
+        ],
+      ).select<PostgrestList>();
+      expect(res.length, 2);
+      expect(res.first['status'], 'OFFLINE');
+      expect(res.last['status'], null);
+    });
+
+    test('bulk insert with column defaults', () async {
+      final res = await postgrest.from('users').insert(
+        [
+          {
+            'username': "bot",
+            'status': 'OFFLINE',
+          },
+          {
+            'username': "crazy bot",
+          },
+        ],
+        defaultToNull: false,
+      ).select<PostgrestList>();
+      expect(res.length, 2);
+      expect(res.first['status'], 'OFFLINE');
+      expect(res.last['status'], 'ONLINE');
+    });
+
     test('basic update', () async {
       final res = await postgrest
           .from('messages')

--- a/packages/postgrest/test/basic_test.dart
+++ b/packages/postgrest/test/basic_test.dart
@@ -125,6 +125,37 @@ void main() {
       expect(res, isEmpty);
     });
 
+    test('insert', () async {
+      final res = await postgrest.from('users').insert(
+        {
+          'username': "bot",
+          'status': 'OFFLINE',
+        },
+      ).select<PostgrestList>();
+      expect(res.length, 1);
+      expect(res.first['status'], 'OFFLINE');
+    });
+
+    test('insert uses default value', () async {
+      final res = await postgrest.from('users').insert(
+        {
+          'username': "bot",
+        },
+      ).select<PostgrestList>();
+      expect(res.length, 1);
+      expect(res.first['status'], 'ONLINE');
+    });
+
+    test('bulk insert with one row uses default value', () async {
+      final res = await postgrest.from('users').insert(
+        {
+          'username': "bot",
+        },
+      ).select<PostgrestList>();
+      expect(res.length, 1);
+      expect(res.first['status'], 'ONLINE');
+    });
+
     test('bulk insert', () async {
       final res = await postgrest.from('messages').insert([
         {'id': 4, 'message': 'foo', 'username': 'supabot', 'channel_id': 2},

--- a/packages/postgrest/test/basic_test.dart
+++ b/packages/postgrest/test/basic_test.dart
@@ -176,33 +176,8 @@ void main() {
           )
           .is_("data", null)
           .select<PostgrestList>();
-      expect(res, [
-        {
-          'id': 1,
-          'data': null,
-          'message': 'Hello World 👋',
-          'username': 'supabot',
-          'channel_id': 2,
-          'inserted_at': '2021-06-25T04:28:21.598+00:00'
-        },
-        {
-          'id': 2,
-          'data': null,
-          'message':
-              'Perfection is attained, not when there is nothing more to add, but when there is nothing left to take away.',
-          'username': 'supabot',
-          'channel_id': 2,
-          'inserted_at': '2021-06-29T04:28:21.598+00:00'
-        },
-        {
-          'id': 3,
-          'data': null,
-          'message': 'Supabase Launch Week is on fire',
-          'username': 'supabot',
-          'channel_id': 2,
-          'inserted_at': '2021-06-20T04:28:21.598+00:00'
-        }
-      ]);
+      expect(res, isNotEmpty);
+      expect(res, everyElement(containsPair("channel_id", 2)));
 
       final messages = await postgrest.from('messages').select<PostgrestList>();
       for (final rec in messages) {

--- a/packages/postgrest/test/filter_test.dart
+++ b/packages/postgrest/test/filter_test.dart
@@ -183,6 +183,31 @@ void main() {
     }
   });
 
+  test('likeAllOf', () async {
+    PostgrestList res = await postgrest
+        .from('users')
+        .select<PostgrestList>('username')
+        .likeAllOf('username', ['%supa%', '%bot%']);
+    expect(res, isNotEmpty);
+    for (final item in res) {
+      expect(item['username'], contains('supa'));
+      expect(item['username'], contains('bot'));
+    }
+  });
+
+  test('likeAnyOf', () async {
+    PostgrestList res = await postgrest
+        .from('users')
+        .select<PostgrestList>('username')
+        .likeAnyOf('username', ['%supa%', '%wai%']);
+    expect(res, isNotEmpty);
+    for (final item in res) {
+      expect(
+          item['username'].contains('supa') || item['username'].contains('wai'),
+          true);
+    }
+  });
+
   test('ilike', () async {
     final res = await postgrest
         .from('users')
@@ -192,6 +217,32 @@ void main() {
     for (final item in res) {
       final user = (item['username'] as String).toLowerCase();
       expect(user.contains('supa'), true);
+    }
+  });
+
+  test('ilikeAllOf', () async {
+    PostgrestList res = await postgrest
+        .from('users')
+        .select<PostgrestList>('username')
+        .ilikeAllOf('username', ['%SUPA%', '%bot%']);
+    expect(res, isNotEmpty);
+    for (final item in res) {
+      expect(item['username'].toLowerCase(), contains('supa'));
+      expect(item['username'].toLowerCase(), contains('bot'));
+    }
+  });
+
+  test('ilikeAnyOf', () async {
+    PostgrestList res = await postgrest
+        .from('users')
+        .select<PostgrestList>('username')
+        .ilikeAnyOf('username', ['%SUPA%', '%wai%']);
+    expect(res, isNotEmpty);
+    for (final item in res) {
+      expect(
+          item['username'].toLowerCase().contains('supa') ||
+              item['username'].toLowerCase().contains('wai'),
+          true);
     }
   });
 


### PR DESCRIPTION
# Changes
- add `any` and `all` version to `like` and `ilike`
- set columns search parameter in bulk insert/upsert to allow missing column in one row
- add `defaultToNull` to use default value instead of null for missing value in bulk insert/upsert

# Ressources
- [postgREST doc](https://postgrest.org/en/stable/references/api/tables_views.html#bulk-insert)
- [postgrest-js pr](https://github.com/supabase/postgrest-js/pull/417) for postgrest 11 changes
- [postgrest-js pr](https://github.com/supabase/postgrest-js/pull/176)  for columns for bulk insert