### PR TITLE
fix(realtime): use access token from headers

### DIFF
--- a/packages/realtime_client/lib/src/realtime_client.dart
+++ b/packages/realtime_client/lib/src/realtime_client.dart
@@ -91,6 +91,8 @@ class RealtimeClient {
       eventsPerSecondLimitMs = (1000 / int.parse(eventsPerSecond)).floor();
     }
 
+    accessToken = this.headers['Authorization']?.split(' ').last;
+
     this.reconnectAfterMs =
         reconnectAfterMs ?? RetryTimer.createRetryFunction();
     this.encode = encode ??


### PR DESCRIPTION
Use authorization header to set initial access token. That's necessary, when passing custom jwt on Supabase initialization.

close #557