### PR TITLE
fix: `maybeSingle` no longer logs error on Postgrest API

### DIFF
--- a/packages/postgrest/lib/src/postgrest_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_builder.dart
@@ -79,7 +79,7 @@ class PostgrestBuilder<T, S> implements Future<T> {
       isolate: _isolate,
       httpClient: _httpClient,
       options: _options,
-      // maybeSingle: _maybeSingle,
+      maybeSingle: _maybeSingle,
       converter: converter,
     );
   }

--- a/packages/postgrest/lib/src/postgrest_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_builder.dart
@@ -420,9 +420,9 @@ class PostgrestBuilder<T, S> implements Future<T> {
       // Workaround for https://github.com/supabase/supabase-flutter/issues/560
       if (_maybeSingle && _method?.toUpperCase() == 'GET' && data is List) {
         if (data.length > 1) {
+          // https://github.com/PostgREST/postgrest/blob/a867d79c42419af16c18c3fb019eba8df992626f/src/PostgREST/Error.hs#L553
           throw PostgrestException(
-            // https://github.com/PostgREST/postgrest/blob/a867d79c42419af16c18c3fb019eba8df992626f/src/PostgREST/Error.hs#L553
-            code: 'PGRST116',
+            code: '406',
             details:
                 'Results contain ${data.length} rows, application/vnd.pgrst.object+json requires 1 row',
             hint: null,

--- a/packages/postgrest/lib/src/postgrest_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_builder.dart
@@ -415,25 +415,7 @@ class PostgrestBuilder<T, S> implements Future<T> {
 
     try {
       final response = await _execute();
-      var data = response.data;
-
-      // Workaround for https://github.com/supabase/supabase-flutter/issues/560
-      if (_maybeSingle && _method?.toUpperCase() == 'GET' && data is List) {
-        if (data.length > 1) {
-          // https://github.com/PostgREST/postgrest/blob/a867d79c42419af16c18c3fb019eba8df992626f/src/PostgREST/Error.hs#L553
-          throw PostgrestException(
-            code: '406',
-            details:
-                'Results contain ${data.length} rows, application/vnd.pgrst.object+json requires 1 row',
-            hint: null,
-            message: 'JSON object requested, multiple (or no) rows returned',
-          );
-        } else if (data.length == 1) {
-          data = data.first;
-        } else {
-          data = null;
-        }
-      }
+      final data = response.data;
 
       if (_converter != null) {
         assert(

--- a/packages/postgrest/lib/src/postgrest_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_builder.dart
@@ -28,11 +28,11 @@ class PostgrestBuilder<T, S> implements Future<T> {
   dynamic _body;
   late final Headers _headers;
   // ignore: prefer_final_fields
-  bool _maybeSingle = false;
+  bool _maybeSingle;
   String? _method;
   late final String? _schema;
   late Uri _url;
-  PostgrestConverter<T, S>? _converter;
+  final PostgrestConverter<T, S>? _converter;
   late final Client? _httpClient;
   late final YAJsonIsolate? _isolate;
   // ignore: prefer_final_fields
@@ -47,7 +47,10 @@ class PostgrestBuilder<T, S> implements Future<T> {
     Client? httpClient,
     YAJsonIsolate? isolate,
     FetchOptions? options,
-  }) {
+    bool maybeSingle = false,
+    PostgrestConverter<T, S>? converter,
+  })  : _maybeSingle = maybeSingle,
+        _converter = converter {
     _url = url;
     _headers = headers;
     _schema = schema;
@@ -76,7 +79,9 @@ class PostgrestBuilder<T, S> implements Future<T> {
       isolate: _isolate,
       httpClient: _httpClient,
       options: _options,
-    ).._converter = converter;
+      // maybeSingle: _maybeSingle,
+      converter: converter,
+    );
   }
 
   void _assertCorrectGeneric(Type R) {

--- a/packages/postgrest/lib/src/postgrest_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_builder.dart
@@ -227,7 +227,7 @@ class PostgrestBuilder<T, S> implements Future<T> {
         if (body.length > 1) {
           throw PostgrestException(
             // https://github.com/PostgREST/postgrest/blob/a867d79c42419af16c18c3fb019eba8df992626f/src/PostgREST/Error.hs#L553
-            code: 'PGRST116',
+            code: '406',
             details:
                 'Results contain ${body.length} rows, application/vnd.pgrst.object+json requires 1 row',
             hint: null,

--- a/packages/postgrest/lib/src/postgrest_transform_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_transform_builder.dart
@@ -175,7 +175,8 @@ class PostgrestTransformBuilder<T> extends PostgrestBuilder<T, T> {
   /// Retrieves at most one row from the result.
   ///
   /// Result must be at most one row or nullable
-  /// (e.g. using `eq` on a UNIQUE column), otherwise this will result in an error.
+  /// (e.g. using `eq` on a UNIQUE column or `limit(1)`),
+  /// otherwise this will result in an error.
   ///
   ///
   /// Data type is `Map<String, dynamic>?`.

--- a/packages/postgrest/lib/src/postgrest_transform_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_transform_builder.dart
@@ -182,8 +182,14 @@ class PostgrestTransformBuilder<T> extends PostgrestBuilder<T, T> {
   ///
   /// By specifying this type via `.select<Map<String,dynamic>?>()` you get more type safety.
   PostgrestTransformBuilder<T> maybeSingle() {
-    _headers['Accept'] = 'application/vnd.pgrst.object+json';
-    _maybeEmpty = true;
+    // Temporary fix for https://github.com/supabase/supabase-flutter/issues/560
+    // Issue persists e.g. for `.insert([...]).select().maybeSingle()`
+    if (_method?.toUpperCase() == 'GET') {
+      _headers['Accept'] = 'application/json';
+    } else {
+      _headers['Accept'] = 'application/vnd.pgrst.object+json';
+    }
+    _maybeSingle = true;
     return this;
   }
 

--- a/packages/postgrest/test/transforms_test.dart
+++ b/packages/postgrest/test/transforms_test.dart
@@ -258,7 +258,7 @@ void main() {
         await postgrest.from('users').select().maybeSingle();
         fail('maybeSingle with multiple rows did not throw.');
       } on PostgrestException catch (error) {
-        expect(error.code, 'PGRST116');
+        expect(error.code, '406');
       } catch (error) {
         fail(
             'maybeSingle with multiple rows threw ${error.runtimeType} instead of PostgrestException.');
@@ -276,7 +276,7 @@ void main() {
             .maybeSingle();
         fail('maybeSingle with multiple inserts did not throw.');
       } on PostgrestException catch (error) {
-        expect(error.code, 'PGRST116');
+        expect(error.code, '406');
       } catch (error) {
         fail(
             'maybeSingle with multiple inserts threw ${error.runtimeType} instead of PostgrestException.');

--- a/packages/postgrest/test/transforms_test.dart
+++ b/packages/postgrest/test/transforms_test.dart
@@ -282,5 +282,21 @@ void main() {
             'maybeSingle with multiple inserts threw ${error.runtimeType} instead of PostgrestException.');
       }
     });
+
+    test(
+        'maybeSingle followed by another transformer preserves the maybeSingle status',
+        () async {
+      try {
+        // maybeSingle followed by another transformer preserves the maybeSingle status
+        // and should throw when the returned data is more than 2 rows.
+        await postgrest.from('channels').select().maybeSingle().limit(2);
+        fail('maybeSingle with multiple inserts did not throw.');
+      } on PostgrestException catch (error) {
+        expect(error.code, '406');
+      } catch (error) {
+        fail(
+            'maybeSingle with multiple inserts threw ${error.runtimeType} instead of PostgrestException.');
+      }
+    });
   });
 }

--- a/packages/postgrest/test/transforms_test.dart
+++ b/packages/postgrest/test/transforms_test.dart
@@ -252,5 +252,17 @@ void main() {
           .maybeSingle();
       expect(user, isNull);
     });
+
+    test('maybeSingle with multiple rows throws', () async {
+      try {
+        await postgrest.from('users').select().maybeSingle();
+        fail('maybeSingle with multiple rows did not throw.');
+      } on PostgrestException catch (error) {
+        expect(error.code, 'PGRST116');
+      } catch (error) {
+        fail(
+            'maybeSingle with multiple rows threw ${error.runtimeType} instead of PostgrestException.');
+      }
+    });
   });
 }

--- a/packages/postgrest/test/transforms_test.dart
+++ b/packages/postgrest/test/transforms_test.dart
@@ -274,12 +274,11 @@ void main() {
             ])
             .select()
             .maybeSingle();
-        fail('maybeSingle with multiple inserts did not throw.');
+        fail('Query did not throw.');
       } on PostgrestException catch (error) {
         expect(error.code, '406');
       } catch (error) {
-        fail(
-            'maybeSingle with multiple inserts threw ${error.runtimeType} instead of PostgrestException.');
+        fail('Query threw ${error.runtimeType} instead of PostgrestException.');
       }
     });
 
@@ -290,12 +289,27 @@ void main() {
         // maybeSingle followed by another transformer preserves the maybeSingle status
         // and should throw when the returned data is more than 2 rows.
         await postgrest.from('channels').select().maybeSingle().limit(2);
-        fail('maybeSingle with multiple inserts did not throw.');
+        fail('Query did not throw.');
       } on PostgrestException catch (error) {
         expect(error.code, '406');
       } catch (error) {
-        fail(
-            'maybeSingle with multiple inserts threw ${error.runtimeType} instead of PostgrestException.');
+        fail('Query threw ${error.runtimeType} instead of PostgrestException.');
+      }
+    });
+
+    test('maybeSingle with converter throws if more than 1 rows were returned',
+        () async {
+      try {
+        await postgrest
+            .from('channels')
+            .select<PostgrestList>()
+            .maybeSingle()
+            .withConverter((data) => data.map((e) => e.toString()).toList());
+        fail('Query did not throw');
+      } on PostgrestException catch (error) {
+        expect(error.code, '406');
+      } catch (error) {
+        fail('Query threw ${error.runtimeType} instead of PostgrestException.');
       }
     });
   });

--- a/packages/postgrest/test/transforms_test.dart
+++ b/packages/postgrest/test/transforms_test.dart
@@ -264,5 +264,23 @@ void main() {
             'maybeSingle with multiple rows threw ${error.runtimeType} instead of PostgrestException.');
       }
     });
+    test('maybeSingle with multiple inserts throws', () async {
+      try {
+        await postgrest
+            .from('channels')
+            .insert([
+              {'data': {}, 'slug': 'channel1'},
+              {'data': {}, 'slug': 'channel2'},
+            ])
+            .select()
+            .maybeSingle();
+        fail('maybeSingle with multiple inserts did not throw.');
+      } on PostgrestException catch (error) {
+        expect(error.code, 'PGRST116');
+      } catch (error) {
+        fail(
+            'maybeSingle with multiple inserts threw ${error.runtimeType} instead of PostgrestException.');
+      }
+    });
   });
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Before this update, using `maybeSingle` and getting 0 results threw errors on the server. This PR fixes it by not requesting for a single object, but requesting arrays, and on the client side see if the returned array contains 0 or 1 objects. 

Fixes https://github.com/supabase/supabase-flutter/issues/560