### PR TITLE
Update AuthChangeEvent constant in README.md

### DIFF
--- a/packages/supabase_flutter/README.md
+++ b/packages/supabase_flutter/README.md
@@ -197,7 +197,7 @@ await supabase.auth.signInWithOAuth(
 // Listen to auth state changes in order to detect when ther OAuth login is complete.
 supabase.auth.onAuthStateChange.listen((data) {
   final AuthChangeEvent event = data.event;
-  if(event == AuthChangeEvent.signIn) {
+  if(event == AuthChangeEvent.signedIn) {
     // Do something when user sign in
   }
 });


### PR DESCRIPTION
Should be `AuthChangeEvent.signedIn` instead of `AuthChangeEvent.signIn`

## What kind of change does this PR introduce?

Doc update

## What is the current behavior?

`AuthChangeEvent.signIn` stated in the README file

## What is the new behavior?

Changed to `AuthChangeEvent.signedIn`

## Additional context

-
