### PR TITLE
fix(realtime_client): correct channel error data

### DIFF
--- a/packages/realtime_client/lib/src/realtime_channel.dart
+++ b/packages/realtime_client/lib/src/realtime_channel.dart
@@ -283,7 +283,7 @@ class RealtimeChannel {
         }
         return;
       }).receive('timeout', (_) {
-        if (callback != null) callback('TIMED OUT');
+        if (callback != null) callback('TIMED_OUT');
         return;
       });
     }

--- a/packages/realtime_client/lib/src/realtime_client.dart
+++ b/packages/realtime_client/lib/src/realtime_client.dart
@@ -136,7 +136,7 @@ class RealtimeClient {
           if (connState != SocketStates.disconnected) {
             connState = SocketStates.closed;
           }
-          _onConnClose('');
+          _onConnClose();
         },
       );
     } catch (e) {
@@ -369,13 +369,14 @@ class RealtimeClient {
   }
 
   /// communication has been closed
-  void _onConnClose(String event) {
+  void _onConnClose() {
+    final event = conn?.closeReason ?? '';
     log('transport', 'close', event);
 
     /// SocketStates.disconnected: by user with socket.disconnect()
     /// SocketStates.closed: NOT by user, should try to reconnect
     if (connState == SocketStates.closed) {
-      _triggerChanError();
+      _triggerChanError(event);
       reconnectTimer.scheduleTimeout();
     }
     if (heartbeatTimer != null) heartbeatTimer!.cancel();


### PR DESCRIPTION
# Changes
- fixes a small, but significant, typo in the timeout event name
- uses the connection close reason as data/payload for the channel error event

close #527