### PR TITLE
fix(gotrue): remove OtpType deprecation and add assertion to check type for resend method

### DIFF
--- a/packages/gotrue/lib/src/constants.dart
+++ b/packages/gotrue/lib/src/constants.dart
@@ -50,10 +50,8 @@ extension GenerateLinkTypeExtended on GenerateLinkType {
 enum OtpType {
   sms,
   phoneChange,
-  @Deprecated('Use OtpType.email instead')
   signup,
   invite,
-  @Deprecated('Use OtpType.email instead')
   magiclink,
   recovery,
   emailChange,

--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -528,7 +528,6 @@ class GoTrueClient {
 
   /// Resends an existing signup confirmation email, email change email, SMS OTP or phone change OTP.
   ///
-  ///
   /// For [type] of [OtpType.signup] or [OtpType.emailChange] [email] must be
   /// provided, and for [type] or [OtpType.sms] or [OtpType.phoneChange],
   /// [phone] must be provided

--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -526,9 +526,13 @@ class GoTrueClient {
     );
   }
 
-  ///Resends an existing signup confirmation email, email change email, SMS OTP or phone change OTP.
+  /// Resends an existing signup confirmation email, email change email, SMS OTP or phone change OTP.
   ///
-  ///Use [EmailResendParams] or [PhoneResendParams] to specify the type of resend.
+  /// Use [EmailResendParams] or [PhoneResendParams] to specify the type of resend.
+  ///
+  /// For [type] of [OtpType.signup] or [OtpType.emailChange] [email] must be
+  /// provided, and for [type] or [OtpType.sms] or [OtpType.phoneChange],
+  /// [phone] must be provided
   Future<ResendResponse> resend({
     String? email,
     String? phone,
@@ -538,6 +542,14 @@ class GoTrueClient {
   }) async {
     assert((email != null && phone == null) || (email == null && phone != null),
         '`email` or `phone` needs to be specified.');
+    if (email != null) {
+      assert([OtpType.signup, OtpType.emailChange].contains(type),
+          'email must be provided for type ${type.name}');
+    }
+    if (phone != null) {
+      assert([OtpType.sms, OtpType.phoneChange].contains(type),
+          'phone must be provided for type ${type.name}');
+    }
 
     if (type != OtpType.emailChange && type != OtpType.phoneChange) {
       _removeSession();

--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -528,7 +528,6 @@ class GoTrueClient {
 
   /// Resends an existing signup confirmation email, email change email, SMS OTP or phone change OTP.
   ///
-  /// Use [EmailResendParams] or [PhoneResendParams] to specify the type of resend.
   ///
   /// For [type] of [OtpType.signup] or [OtpType.emailChange] [email] must be
   /// provided, and for [type] or [OtpType.sms] or [OtpType.phoneChange],


### PR DESCRIPTION
## What kind of change does this PR introduce?

Some `OtpType` enum values were deprecated in this PR, but it seems like Gotrue server requires the deprecated values in some APIs. 

This PR removes the deprecated flag so that the users can use the resend method without deprecation warnings. 

We can add back the deprecation warnings when the backend properly starts accepting the new `email` type. 

Related https://github.com/supabase/gotrue-js/pull/642

Issue report from user https://github.com/supabase/supabase-flutter/pull/517#issuecomment-1646917472