### PR TITLE
chore: Add notes about using flavors to support multiple SHA-1 fingerprint certificates

### DIFF
--- a/packages/supabase_flutter/README.md
+++ b/packages/supabase_flutter/README.md
@@ -182,6 +182,27 @@ Future<AuthResponse> signInWithGoogle() {
 }
 ```
 
+When going to production on Android, you may have multiple SHA-1 fingerprint certificates, debug and the production certificate provided from Play Store. You will need to create one Google OAuth 2.0 Client ID for each certificates. You can then utilize [flavors](https://docs.flutter.dev/deployment/flavors#using-flavors-in-android) to dynamically update the `appAuthRedirectScheme` like this:
+
+```groovy
+flavorDimensions "default"
+productFlavors {
+    dev {
+        dimension "default"
+        versionNameSuffix ".dev"
+        manifestPlaceholders += [
+            'appAuthRedirectScheme': 'com.googleusercontent.apps.*DEBUG_CLIENT_ID*'
+        ]
+    }
+    prod {
+        dimension "default"
+        manifestPlaceholders += [
+            'appAuthRedirectScheme': 'com.googleusercontent.apps.*PROD_CLIENT_ID*'
+        ]
+    }
+}
+```
+
 ### OAuth login
 
 For providers other than Apple or Google, you need to use the `signInWithOAuth()` method to perform OAuth login. This will open the web browser to perform the OAuth login.

--- a/packages/supabase_flutter/README.md
+++ b/packages/supabase_flutter/README.md
@@ -133,7 +133,7 @@ Future<AuthResponse> signInWithGoogle() {
 
   final appAuth = FlutterAppAuth();
 
-  // authorize the user by opening the concent page
+  // authorize the user by opening the consent page
   final result = await appAuth.authorize(
     AuthorizationRequest(
       clientId,
@@ -176,6 +176,7 @@ Future<AuthResponse> signInWithGoogle() {
   return supabase.auth.signInWithIdToken(
     provider: Provider.google,
     idToken: idToken,
+    accessToken: tokenResponse?.accessToken,
     nonce: rawNonce,
   );
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Current example oof the Google login setup assumes there is only one SHA1 fingerprint certificate, but in production there will be multiple of them, from debug certificate to the one provided by Play Store. This PR adds an instruction on how to handle such situation.