### PR TITLE
feat(postgrest): adding null support for eq and neq filters

### DIFF
--- a/packages/postgrest/lib/src/postgrest_filter_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_filter_builder.dart
@@ -64,6 +64,8 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   PostgrestFilterBuilder<T> eq(String column, dynamic value) {
     if (value is List) {
       appendSearchParams(column, 'eq.{${_cleanFilterArray(value)}}');
+    } else if (value == null) {
+      appendSearchParams(column, 'is.null');
     } else {
       appendSearchParams(column, 'eq.$value');
     }
@@ -81,6 +83,8 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   PostgrestFilterBuilder<T> neq(String column, dynamic value) {
     if (value is List) {
       appendSearchParams(column, 'neq.{${_cleanFilterArray(value)}}');
+    } else if (value == null) {
+      appendSearchParams(column, 'not.is.null');
     } else {
       appendSearchParams(column, 'neq.$value');
     }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Postgrest feature

## What is the current behavior?

When using the `eq` and `neq` filters with nullable values, exception is thrown if the value is null, because these filter by default do not work with null values.

## What is the new behavior?

If null value is used in the `eq` and `neq` filters, the `is` and `not.is` filter is used automatically, making it more convenient to filter based on nullable values without conditional filtering. 

## Additional context

-
