### PR TITLE
feat: add `logLevel` parameter to `RealtimeClientOptions`

### DIFF
--- a/packages/realtime_client/lib/realtime_client.dart
+++ b/packages/realtime_client/lib/realtime_client.dart
@@ -2,3 +2,4 @@ export 'src/realtime_channel.dart' hide ToType;
 export 'src/realtime_client.dart';
 export 'src/realtime_presence.dart';
 export 'src/transformers.dart' hide getEnrichedPayload, getPayloadRecords;
+export 'src/constants.dart' show RealtimeLogLevel;

--- a/packages/realtime_client/lib/src/constants.dart
+++ b/packages/realtime_client/lib/src/constants.dart
@@ -53,3 +53,5 @@ extension ChannelEventsExtended on ChannelEvents {
 class Transports {
   static const String websocket = 'websocket';
 }
+
+enum RealtimeLogLevel { info, debug, warn, error }

--- a/packages/realtime_client/lib/src/realtime_client.dart
+++ b/packages/realtime_client/lib/src/realtime_client.dart
@@ -87,6 +87,7 @@ class RealtimeClient {
     Map<String, String>? headers,
     this.params = const {},
     this.longpollerTimeout = 20000,
+    RealtimeLogLevel? logLevel,
   })  : endPoint = '$endPoint/${Transports.websocket}',
         headers = {
           ...Constants.defaultHeaders,

--- a/packages/realtime_client/lib/src/realtime_client.dart
+++ b/packages/realtime_client/lib/src/realtime_client.dart
@@ -88,7 +88,12 @@ class RealtimeClient {
     this.params = const {},
     this.longpollerTimeout = 20000,
     RealtimeLogLevel? logLevel,
-  })  : endPoint = '$endPoint/${Transports.websocket}',
+  })  : endPoint = Uri.parse('$endPoint/${Transports.websocket}')
+            .replace(
+              queryParameters:
+                  logLevel == null ? null : {'log_level': logLevel.name},
+            )
+            .toString(),
         headers = {
           ...Constants.defaultHeaders,
           if (headers != null) ...headers,
@@ -416,9 +421,10 @@ class RealtimeClient {
     }
 
     var endpoint = Uri.parse(url);
-    final searchParams = Map<String, dynamic>.from(endpoint.queryParameters);
-    params.forEach((k, v) => searchParams[k] = v);
-    endpoint = endpoint.replace(queryParameters: searchParams);
+    endpoint = endpoint.replace(queryParameters: {
+      ...endpoint.queryParameters,
+      ...params,
+    });
 
     return endpoint.toString();
   }

--- a/packages/supabase/lib/src/realtime_client_options.dart
+++ b/packages/supabase/lib/src/realtime_client_options.dart
@@ -9,7 +9,7 @@ class RealtimeClientOptions {
   /// Defaults to 10 events per second
   final int? eventsPerSecond;
 
-  /// Level of realtime server logs to log
+  /// Level of realtime server logs to to be logged
   final RealtimeLogLevel? logLevel;
 
   /// {@macro realtime_client_options}

--- a/packages/supabase/lib/src/realtime_client_options.dart
+++ b/packages/supabase/lib/src/realtime_client_options.dart
@@ -1,3 +1,5 @@
+import 'package:realtime_client/realtime_client.dart';
+
 /// {@template realtime_client_options}
 /// Options to pass to the RealtimeClient.
 /// {@endtemplate}
@@ -7,6 +9,12 @@ class RealtimeClientOptions {
   /// Defaults to 10 events per second
   final int? eventsPerSecond;
 
+  /// Level of realtime server logs to log
+  final RealtimeLogLevel? logLevel;
+
   /// {@macro realtime_client_options}
-  const RealtimeClientOptions({this.eventsPerSecond});
+  const RealtimeClientOptions({
+    this.eventsPerSecond,
+    this.logLevel,
+  });
 }

--- a/packages/supabase/lib/src/supabase_client.dart
+++ b/packages/supabase/lib/src/supabase_client.dart
@@ -135,7 +135,14 @@ class SupabaseClient {
     GotrueAsyncStorage? gotrueAsyncStorage,
     AuthFlowType authFlowType = AuthFlowType.implicit,
   })  : restUrl = '$supabaseUrl/rest/v1',
-        realtimeUrl = '$supabaseUrl/realtime/v1'.replaceAll('http', 'ws'),
+        realtimeUrl = Uri.parse('$supabaseUrl/realtime/v1')
+            .replace(
+              scheme: 'ws',
+              queryParameters: realtimeClientOptions.logLevel == null
+                  ? null
+                  : {'log_level': realtimeClientOptions.logLevel?.name},
+            )
+            .toString(),
         authUrl = '$supabaseUrl/auth/v1',
         storageUrl = '$supabaseUrl/storage/v1',
         functionsUrl = '$supabaseUrl/functions/v1',

--- a/packages/supabase/lib/src/supabase_client.dart
+++ b/packages/supabase/lib/src/supabase_client.dart
@@ -135,14 +135,7 @@ class SupabaseClient {
     GotrueAsyncStorage? gotrueAsyncStorage,
     AuthFlowType authFlowType = AuthFlowType.implicit,
   })  : restUrl = '$supabaseUrl/rest/v1',
-        realtimeUrl = Uri.parse('$supabaseUrl/realtime/v1')
-            .replace(
-              scheme: 'ws',
-              queryParameters: realtimeClientOptions.logLevel == null
-                  ? null
-                  : {'log_level': realtimeClientOptions.logLevel?.name},
-            )
-            .toString(),
+        realtimeUrl = '$supabaseUrl/realtime/v1'.replaceAll('http', 'ws'),
         authUrl = '$supabaseUrl/auth/v1',
         storageUrl = '$supabaseUrl/storage/v1',
         functionsUrl = '$supabaseUrl/functions/v1',

--- a/packages/supabase/test/client_test.dart
+++ b/packages/supabase/test/client_test.dart
@@ -8,7 +8,7 @@ import 'utils.dart';
 
 void main() {
   group('Standard Header', () {
-    const supabaseUrl = '';
+    const supabaseUrl = 'https://nlbsnpoablmsiwndbmer.supabase.co';
     const supabaseKey = '';
     late SupabaseClient client;
 
@@ -30,6 +30,20 @@ void main() {
       final xClientHeaderBeforeSlash =
           client.storage.headers['X-Client-Info']!.split('/').first;
       expect(xClientHeaderBeforeSlash, 'supabase-dart');
+    });
+
+    test('realtime URL is properly being set', () {
+      var realtimeUrl = client.realtimeUrl;
+      expect(realtimeUrl, 'ws://nlbsnpoablmsiwndbmer.supabase.co/realtime/v1');
+
+      client = SupabaseClient(supabaseUrl, supabaseKey,
+          realtimeClientOptions:
+              RealtimeClientOptions(logLevel: RealtimeLogLevel.info));
+      realtimeUrl = client.realtimeUrl;
+      expect(
+        realtimeUrl,
+        'ws://nlbsnpoablmsiwndbmer.supabase.co/realtime/v1?log_level=info',
+      );
     });
   });
 

--- a/packages/supabase/test/client_test.dart
+++ b/packages/supabase/test/client_test.dart
@@ -34,15 +34,25 @@ void main() {
 
     test('realtime URL is properly being set', () {
       var realtimeUrl = client.realtimeUrl;
-      expect(realtimeUrl, 'ws://nlbsnpoablmsiwndbmer.supabase.co/realtime/v1');
+      var realtimeWebsocketURL = client.realtime.endPointURL;
+      expect(realtimeUrl, 'wss://nlbsnpoablmsiwndbmer.supabase.co/realtime/v1');
+      expect(
+        realtimeWebsocketURL,
+        'wss://nlbsnpoablmsiwndbmer.supabase.co/realtime/v1/websocket?vsn=1.0.0',
+      );
 
       client = SupabaseClient(supabaseUrl, supabaseKey,
           realtimeClientOptions:
               RealtimeClientOptions(logLevel: RealtimeLogLevel.info));
       realtimeUrl = client.realtimeUrl;
+      realtimeWebsocketURL = client.realtime.endPointURL;
       expect(
         realtimeUrl,
-        'ws://nlbsnpoablmsiwndbmer.supabase.co/realtime/v1?log_level=info',
+        'wss://nlbsnpoablmsiwndbmer.supabase.co/realtime/v1?log_level=info',
+      );
+      expect(
+        realtimeWebsocketURL,
+        'wss://nlbsnpoablmsiwndbmer.supabase.co/realtime/v1/websocket?log_level=info&vsn=1.0.0',
       );
     });
   });


### PR DESCRIPTION
## What kind of change does this PR introduce?

Adds a `logLevel` parameter, which changes the level of logs to be shown on the Supabase dashboard for realtime events. Setting `logLevel` add a query parameter to the websocket query parameter with key `log_level`. 

Currently the JS SDK doesn't have a complete implementation, but [here](https://github.com/supabase/realtime-js/blob/master/src/RealtimeClient.ts#L27) is where `log_level` parameter on js is defined. 