### PR TITLE
fix(realtime_client, supabase): pass apikey as the initial access token for realtime client

### DIFF
--- a/packages/realtime_client/lib/src/realtime_client.dart
+++ b/packages/realtime_client/lib/src/realtime_client.dart
@@ -104,7 +104,8 @@ class RealtimeClient {
       eventsPerSecondLimitMs = (1000 / int.parse(eventsPerSecond)).floor();
     }
 
-    accessToken = this.headers['Authorization']?.split(' ').last;
+    final customJWT = this.headers['Authorization']?.split(' ').last;
+    accessToken = customJWT ?? params['apikey'];
 
     this.reconnectAfterMs =
         reconnectAfterMs ?? RetryTimer.createRetryFunction();

--- a/packages/realtime_client/test/socket_test.dart
+++ b/packages/realtime_client/test/socket_test.dart
@@ -39,7 +39,8 @@ void main() {
 
   group('constructor', () {
     test('sets defaults', () async {
-      final socket = RealtimeClient('wss://example.com/socket');
+      final socket =
+          RealtimeClient('wss://example.com/socket', params: {'apikey': '123'});
       expect(socket.channels.length, 0);
       expect(socket.sendBuffer.length, 0);
       expect(socket.ref, 0);
@@ -65,6 +66,7 @@ void main() {
         socket.headers['X-Client-Info']!.split('/').first,
         'realtime-dart',
       );
+      expect(socket.accessToken, '123');
     });
 
     test('overrides some defaults with options', () async {

--- a/packages/supabase/test/client_test.dart
+++ b/packages/supabase/test/client_test.dart
@@ -55,6 +55,10 @@ void main() {
         containsPair('log_level', 'info'),
       );
     });
+
+    test('realtime access token is set properly', () {
+      expect(client.realtime.accessToken, supabaseKey);
+    });
   });
 
   group('auth', () {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Realtime server expects the anon key to be sent with the heart beat for unauthenticated users, but currently `null` is being sent. This PR sets the anon key as the initial value of `accessToken` for `RealtimeClient` so that unauthenticated client will send the anon key to realtime server .

Related https://github.com/supabase/realtime-js/pull/245