### PR TITLE
fix(storage_client): prevent the SDK from throwing when null path was returned from calling `createSignedUrls()`

### DIFF
--- a/packages/storage_client/lib/src/storage_file_api.dart
+++ b/packages/storage_client/lib/src/storage_file_api.dart
@@ -364,7 +364,7 @@ class StorageFileApi {
     final List<SignedUrl> urls = (response as List).map((e) {
       print(e);
       return SignedUrl(
-        path: e['path'],
+        path: e['path'] ?? '',
         signedUrl: '$url${e['signedURL']}',
       );
     }).toList();

--- a/packages/storage_client/lib/src/storage_file_api.dart
+++ b/packages/storage_client/lib/src/storage_file_api.dart
@@ -362,6 +362,7 @@ class StorageFileApi {
       options: options,
     );
     final List<SignedUrl> urls = (response as List).map((e) {
+      print(e);
       return SignedUrl(
         path: e['path'],
         signedUrl: '$url${e['signedURL']}',

--- a/packages/storage_client/lib/src/storage_file_api.dart
+++ b/packages/storage_client/lib/src/storage_file_api.dart
@@ -362,8 +362,9 @@ class StorageFileApi {
       options: options,
     );
     final List<SignedUrl> urls = (response as List).map((e) {
-      print(e);
       return SignedUrl(
+        // Prevents exceptions being thrown when null value is returned
+        // https://github.com/supabase/storage-api/issues/353
         path: e['path'] ?? '',
         signedUrl: '$url${e['signedURL']}',
       );

--- a/packages/storage_client/lib/src/storage_file_api.dart
+++ b/packages/storage_client/lib/src/storage_file_api.dart
@@ -362,7 +362,6 @@ class StorageFileApi {
       options: options,
     );
     final List<SignedUrl> urls = (response as List).map((e) {
-      print(e);
       return SignedUrl(
         path: e['path'],
         signedUrl: '$url${e['signedURL']}',

--- a/packages/storage_client/test/client_test.dart
+++ b/packages/storage_client/test/client_test.dart
@@ -71,6 +71,9 @@ void main() {
     final response = await storage.createBucket(newBucketName);
     expect(response, newBucketName);
   });
+  test('createSignedUrls does not throw', () async {
+        await storage.from(newBucketName).createSignedUrls([uploadPath], 2000);
+  });
 
   test('Create new public bucket', () async {
     const newPublicBucketName = 'my-new-public-bucket';

--- a/packages/storage_client/test/client_test.dart
+++ b/packages/storage_client/test/client_test.dart
@@ -72,7 +72,7 @@ void main() {
     expect(response, newBucketName);
   });
   test('createSignedUrls does not throw', () async {
-        await storage.from(newBucketName).createSignedUrls([uploadPath], 2000);
+    await storage.from(newBucketName).createSignedUrls([uploadPath], 2000);
   });
 
   test('Create new public bucket', () async {

--- a/packages/storage_client/test/client_test.dart
+++ b/packages/storage_client/test/client_test.dart
@@ -72,6 +72,7 @@ void main() {
     expect(response, newBucketName);
   });
   test('createSignedUrls does not throw', () async {
+    await storage.from(newBucketName).upload(uploadPath, file);
     await storage.from(newBucketName).createSignedUrls([uploadPath], 2000);
   });
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

On certain versions of Storage-api, the `path` value that was supposed to be returned when calling `createSignedUrls()` was missing. This PR adds a safety guard for when the SDK is used against such versions. 

Related https://github.com/supabase/storage-api/issues/353