### PR TITLE
feat(postgrest): immutability

### DIFF
--- a/packages/postgrest/lib/src/postgrest.dart
+++ b/packages/postgrest/lib/src/postgrest.dart
@@ -53,7 +53,7 @@ class PostgrestClient {
   PostgrestQueryBuilder<void> from(String table) {
     final url = '${this.url}/$table';
     return PostgrestQueryBuilder<void>(
-      url,
+      url: Uri.parse(url),
       headers: {...headers},
       schema: schema,
       httpClient: httpClient,

--- a/packages/postgrest/lib/src/postgrest_filter_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_filter_builder.dart
@@ -3,6 +3,10 @@ part of 'postgrest_builder.dart';
 class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   PostgrestFilterBuilder(PostgrestBuilder<T, T> builder) : super(builder);
 
+  @override
+  PostgrestFilterBuilder<T> copyWithUrl(Uri uri) =>
+      PostgrestFilterBuilder(copyWith(url: uri));
+
   /// Convert list filter to query params string
   String _cleanFilterArray(List filter) {
     if (filter.every((element) => element is num)) {
@@ -21,22 +25,23 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   ///     .not('status', 'eq', 'OFFLINE');
   /// ```
   PostgrestFilterBuilder<T> not(String column, String operator, dynamic value) {
+    final Uri url;
     if (value is List) {
       if (operator == "in") {
-        appendSearchParams(
+        url = appendSearchParams(
           column,
           'not.$operator.(${_cleanFilterArray(value)})',
         );
       } else {
-        appendSearchParams(
+        url = appendSearchParams(
           column,
           'not.$operator.{${_cleanFilterArray(value)}}',
         );
       }
     } else {
-      appendSearchParams(column, 'not.$operator.$value');
+      url = appendSearchParams(column, 'not.$operator.$value');
     }
-    return this;
+    return copyWithUrl(url);
   }
 
   /// Finds all rows satisfying at least one of the filters.
@@ -49,8 +54,8 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   /// ```
   PostgrestFilterBuilder<T> or(String filters, {String? foreignTable}) {
     final key = foreignTable != null ? '$foreignTable.or' : 'or';
-    appendSearchParams(key, '($filters)');
-    return this;
+    final url = appendSearchParams(key, '($filters)');
+    return copyWithUrl(url);
   }
 
   /// Finds all rows whose value on the stated [column] exactly matches the specified [value].
@@ -62,12 +67,13 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   ///     .eq('username', 'supabot');
   /// ```
   PostgrestFilterBuilder<T> eq(String column, dynamic value) {
+    final Uri url;
     if (value is List) {
-      appendSearchParams(column, 'eq.{${_cleanFilterArray(value)}}');
+      url = appendSearchParams(column, 'eq.{${_cleanFilterArray(value)}}');
     } else {
-      appendSearchParams(column, 'eq.$value');
+      url = appendSearchParams(column, 'eq.$value');
     }
-    return this;
+    return copyWithUrl(url);
   }
 
   /// Finds all rows whose value on the stated [column] doesn't match the specified [value].
@@ -79,12 +85,13 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   ///     .neq('username', 'supabot');
   /// ```
   PostgrestFilterBuilder<T> neq(String column, dynamic value) {
+    final Uri url;
     if (value is List) {
-      appendSearchParams(column, 'neq.{${_cleanFilterArray(value)}}');
+      url = appendSearchParams(column, 'neq.{${_cleanFilterArray(value)}}');
     } else {
-      appendSearchParams(column, 'neq.$value');
+      url = appendSearchParams(column, 'neq.$value');
     }
-    return this;
+    return copyWithUrl(url);
   }
 
   /// Finds all rows whose value on the stated [column] is greater than the specified [value].
@@ -96,8 +103,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   ///     .gt('id', 1);
   /// ```
   PostgrestFilterBuilder<T> gt(String column, dynamic value) {
-    appendSearchParams(column, 'gt.$value');
-    return this;
+    return copyWithUrl(appendSearchParams(column, 'gt.$value'));
   }
 
   /// Finds all rows whose value on the stated [column] is greater than or equal to the specified [value].
@@ -109,8 +115,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   ///     .gte('id', 1);
   /// ```
   PostgrestFilterBuilder<T> gte(String column, dynamic value) {
-    appendSearchParams(column, 'gte.$value');
-    return this;
+    return copyWithUrl(appendSearchParams(column, 'gte.$value'));
   }
 
   /// Finds all rows whose value on the stated [column] is less than the specified [value].
@@ -122,8 +127,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   ///     .lt('id', 2);
   /// ```
   PostgrestFilterBuilder<T> lt(String column, dynamic value) {
-    appendSearchParams(column, 'lt.$value');
-    return this;
+    return copyWithUrl(appendSearchParams(column, 'lt.$value'));
   }
 
   /// Finds all rows whose value on the stated [column] is less than or equal to the specified [value].
@@ -135,8 +139,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   ///     .lte('id', 2);
   /// ```
   PostgrestFilterBuilder<T> lte(String column, dynamic value) {
-    appendSearchParams(column, 'lte.$value');
-    return this;
+    return copyWithUrl(appendSearchParams(column, 'lte.$value'));
   }
 
   /// Finds all rows whose value in the stated [column] matches the supplied [pattern] (case sensitive).
@@ -148,8 +151,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   ///     .like('username', '%supa%');
   /// ```
   PostgrestFilterBuilder<T> like(String column, String pattern) {
-    appendSearchParams(column, 'like.$pattern');
-    return this;
+    return copyWithUrl(appendSearchParams(column, 'like.$pattern'));
   }
 
   /// Match only rows where [column] matches all of [patterns] case-sensitively.
@@ -161,8 +163,8 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   ///     .likeAllOf('username', ['%supa%', '%bot%']);
   /// ```
   PostgrestFilterBuilder likeAllOf(String column, List<String> patterns) {
-    appendSearchParams(column, 'like(all).{${patterns.join(',')}}');
-    return this;
+    return copyWithUrl(
+        appendSearchParams(column, 'like(all).{${patterns.join(',')}}'));
   }
 
   /// Match only rows where [column] matches any of [patterns] case-sensitively.
@@ -174,8 +176,8 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   ///     .likeAnyOf('username', ['%supa%', '%bot%']);
   /// ```
   PostgrestFilterBuilder likeAnyOf(String column, List<String> patterns) {
-    appendSearchParams(column, 'like(any).{${patterns.join(',')}}');
-    return this;
+    return copyWithUrl(
+        appendSearchParams(column, 'like(any).{${patterns.join(',')}}'));
   }
 
   /// Finds all rows whose value in the stated [column] matches the supplied [pattern] (case insensitive).
@@ -187,8 +189,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   ///     .ilike('username', '%SUPA%');
   /// ```
   PostgrestFilterBuilder<T> ilike(String column, String pattern) {
-    appendSearchParams(column, 'ilike.$pattern');
-    return this;
+    return copyWithUrl(appendSearchParams(column, 'ilike.$pattern'));
   }
 
   /// Match only rows where [column] matches all of [patterns] case-insensitively.
@@ -200,8 +201,8 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   ///     .ilikeAllOf('username', ['%supa%', '%bot%']);
   /// ```
   PostgrestFilterBuilder ilikeAllOf(String column, List<String> patterns) {
-    appendSearchParams(column, 'ilike(all).{${patterns.join(',')}}');
-    return this;
+    return copyWithUrl(
+        appendSearchParams(column, 'ilike(all).{${patterns.join(',')}}'));
   }
 
   /// Match only rows where [column] matches any of [patterns] case-insensitively.
@@ -213,8 +214,8 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   ///     .ilikeAnyOf('username', ['%supa%', '%bot%']);
   /// ```
   PostgrestFilterBuilder ilikeAnyOf(String column, List<String> patterns) {
-    appendSearchParams(column, 'ilike(any).{${patterns.join(',')}}');
-    return this;
+    return copyWithUrl(
+        appendSearchParams(column, 'ilike(any).{${patterns.join(',')}}'));
   }
 
   /// A check for exact equality (null, true, false)
@@ -228,8 +229,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   /// ```
   // ignore: non_constant_identifier_names
   PostgrestFilterBuilder<T> is_(String column, dynamic value) {
-    appendSearchParams(column, 'is.$value');
-    return this;
+    return copyWithUrl(appendSearchParams(column, 'is.$value'));
   }
 
   /// Finds all rows whose value on the stated [column] is found on the specified [values].
@@ -242,8 +242,8 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   /// ```
   // ignore: non_constant_identifier_names
   PostgrestFilterBuilder<T> in_(String column, List values) {
-    appendSearchParams(column, 'in.(${_cleanFilterArray(values)})');
-    return this;
+    return copyWithUrl(
+        appendSearchParams(column, 'in.(${_cleanFilterArray(values)})'));
   }
 
   /// Finds all rows whose json, array, or range value on the stated [column] contains the values specified in [value].
@@ -255,18 +255,19 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   ///     .contains('age_range', '[1,2)');
   /// ```
   PostgrestFilterBuilder<T> contains(String column, dynamic value) {
+    final Uri url;
     if (value is String) {
       // range types can be inclusive '[', ']' or exclusive '(', ')' so just
       // keep it simple and accept a string
-      appendSearchParams(column, 'cs.$value');
+      url = appendSearchParams(column, 'cs.$value');
     } else if (value is List) {
       // array
-      appendSearchParams(column, 'cs.{${_cleanFilterArray(value)}}');
+      url = appendSearchParams(column, 'cs.{${_cleanFilterArray(value)}}');
     } else {
       // json
-      appendSearchParams(column, 'cs.${json.encode(value)}');
+      url = appendSearchParams(column, 'cs.${json.encode(value)}');
     }
-    return this;
+    return copyWithUrl(url);
   }
 
   /// Finds all rows whose json, array, or range value on the stated [column] is contained by the specified [value].
@@ -278,18 +279,19 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   ///     .containedBy('age_range', '[1,2)');
   /// ```
   PostgrestFilterBuilder<T> containedBy(String column, dynamic value) {
+    final Uri url;
     if (value is String) {
       // range types can be inclusive '[', ']' or exclusive '(', ')' so just
       // keep it simple and accept a string
-      appendSearchParams(column, 'cd.$value');
+      url = appendSearchParams(column, 'cd.$value');
     } else if (value is List) {
       // array
-      appendSearchParams(column, 'cd.{${_cleanFilterArray(value)}}');
+      url = appendSearchParams(column, 'cd.{${_cleanFilterArray(value)}}');
     } else {
       // json
-      appendSearchParams(column, 'cd.${json.encode(value)}');
+      url = appendSearchParams(column, 'cd.${json.encode(value)}');
     }
-    return this;
+    return copyWithUrl(url);
   }
 
   /// Finds all rows whose range value on the stated [column] is strictly to the left of the specified [range].
@@ -301,8 +303,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   ///     .sl('age_range', '[2,25)');
   /// ```
   PostgrestFilterBuilder<T> rangeLt(String column, String range) {
-    appendSearchParams(column, 'sl.$range');
-    return this;
+    return copyWithUrl(appendSearchParams(column, 'sl.$range'));
   }
 
   /// Finds all rows whose range value on the stated [column] is strictly to the right of the specified [range].
@@ -314,8 +315,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   ///     .rangeGt('age_range', '[2,25)');
   /// ```
   PostgrestFilterBuilder<T> rangeGt(String column, String range) {
-    appendSearchParams(column, 'sr.$range');
-    return this;
+    return copyWithUrl(appendSearchParams(column, 'sr.$range'));
   }
 
   /// Finds all rows whose range value on the stated [column] does not extend to the left of the specified [range].
@@ -327,8 +327,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   ///     .rangeGte('age_range', '[2,25)');
   /// ```
   PostgrestFilterBuilder<T> rangeGte(String column, String range) {
-    appendSearchParams(column, 'nxl.$range');
-    return this;
+    return copyWithUrl(appendSearchParams(column, 'nxl.$range'));
   }
 
   /// Finds all rows whose range value on the stated [column] does not extend to the right of the specified [range].
@@ -340,8 +339,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   ///     .rangeLte('age_range', '[2,25)');
   /// ```
   PostgrestFilterBuilder<T> rangeLte(String column, String range) {
-    appendSearchParams(column, 'nxr.$range');
-    return this;
+    return copyWithUrl(appendSearchParams(column, 'nxr.$range'));
   }
 
   /// Finds all rows whose range value on the stated [column] is adjacent to the specified [range].
@@ -353,8 +351,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   ///     .rangeAdjacent('age_range', '[2,25)');
   /// ```
   PostgrestFilterBuilder<T> rangeAdjacent(String column, String range) {
-    appendSearchParams(column, 'adj.$range');
-    return this;
+    return copyWithUrl(appendSearchParams(column, 'adj.$range'));
   }
 
   /// Finds all rows whose array or range value on the stated [column] overlaps (has a value in common) with the specified [value].
@@ -366,15 +363,16 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   ///     .overlaps('age_range', '[2,25)');
   /// ```
   PostgrestFilterBuilder<T> overlaps(String column, dynamic value) {
-    if (value is String) {
+    final Uri url;
+    if (value is List) {
+      // array
+      url = appendSearchParams(column, 'ov.{${_cleanFilterArray(value)}}');
+    } else {
       // range types can be inclusive '[', ']' or exclusive '(', ')' so just
       // keep it simple and accept a string
-      appendSearchParams(column, 'ov.$value');
-    } else if (value is List) {
-      // array
-      appendSearchParams(column, 'ov.{${_cleanFilterArray(value)}}');
+      url = appendSearchParams(column, 'ov.$value');
     }
-    return this;
+    return copyWithUrl(url);
   }
 
   /// Finds all rows whose text or tsvector value on the stated [column] matches the tsquery in [query].
@@ -403,8 +401,8 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
       typePart = 'w';
     }
     final configPart = config == null ? '' : '($config)';
-    appendSearchParams(column, '${typePart}fts$configPart.$query');
-    return this;
+    return copyWithUrl(
+        appendSearchParams(column, '${typePart}fts$configPart.$query'));
   }
 
   /// Finds all rows whose [column] satisfies the filter.
@@ -417,22 +415,23 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   /// ```
   PostgrestFilterBuilder<T> filter(
       String column, String operator, dynamic value) {
+    final Uri url;
     if (value is List) {
       if (operator == "in") {
-        appendSearchParams(
+        url = appendSearchParams(
           column,
           '$operator.(${_cleanFilterArray(value)})',
         );
       } else {
-        appendSearchParams(
+        url = appendSearchParams(
           column,
           '$operator.{${_cleanFilterArray(value)}}',
         );
       }
     } else {
-      appendSearchParams(column, '$operator.$value');
+      url = appendSearchParams(column, '$operator.$value');
     }
-    return this;
+    return copyWithUrl(url);
   }
 
   /// Finds all rows whose columns match the specified [query] object.
@@ -445,7 +444,8 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   /// });
   /// ```
   PostgrestFilterBuilder<T> match(Map query) {
-    query.forEach((k, v) => appendSearchParams('$k', 'eq.$v'));
-    return this;
+    var url = _url;
+    query.forEach((k, v) => url = appendSearchParams('$k', 'eq.$v', url));
+    return copyWithUrl(url);
   }
 }

--- a/packages/postgrest/lib/src/postgrest_rpc_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_rpc_builder.dart
@@ -22,9 +22,10 @@ class PostgrestRpcBuilder extends PostgrestBuilder {
     dynamic params,
     FetchOptions options = const FetchOptions(),
   ]) {
-    _method = METHOD_POST;
-    _body = params;
-    _options = options.ensureNotHead();
-    return PostgrestFilterBuilder(this);
+    return PostgrestFilterBuilder(copyWith(
+      method: METHOD_POST,
+      body: params,
+      options: options.ensureNotHead(),
+    ));
   }
 }

--- a/packages/postgrest/lib/src/postgrest_transform_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_transform_builder.dart
@@ -11,7 +11,12 @@ class PostgrestTransformBuilder<T> extends PostgrestBuilder<T, T> {
           httpClient: builder._httpClient,
           options: builder._options,
           isolate: builder._isolate,
+          maybeSingle: builder._maybeSingle,
+          converter: builder._converter,
         );
+
+  PostgrestTransformBuilder<T> copyWithUrl(Uri uri) =>
+      PostgrestTransformBuilder(copyWith(url: uri));
 
   /// Performs horizontal filtering with SELECT.
   ///
@@ -55,22 +60,17 @@ class PostgrestTransformBuilder<T> extends PostgrestBuilder<T, T> {
       }
       return c;
     }).join();
+    final newHeaders = {..._headers};
 
-    overrideSearchParams('select', cleanedColumns);
-    if (_headers['Prefer'] != null) {
-      _headers['Prefer'] = '${_headers['Prefer']},';
+    final uri = overrideSearchParams('select', cleanedColumns);
+    if (newHeaders['Prefer'] != null) {
+      newHeaders['Prefer'] = '${newHeaders['Prefer']},';
     }
-    _headers['Prefer'] = '${_headers['Prefer']}return=representation';
+    newHeaders['Prefer'] = '${newHeaders['Prefer']}return=representation';
     return PostgrestTransformBuilder<R>(
-      PostgrestBuilder(
-        headers: _headers,
-        url: _url,
-        httpClient: _httpClient,
-        isolate: _isolate,
-        options: _options,
-        body: _body,
-        method: _method,
-        schema: _schema,
+      copyWithType(
+        url: uri,
+        headers: newHeaders,
       ),
     );
   }
@@ -103,9 +103,8 @@ class PostgrestTransformBuilder<T> extends PostgrestBuilder<T, T> {
     final existingOrder = _url.queryParameters[key];
     final value = '${existingOrder == null ? '' : '$existingOrder,'}'
         '$column.${ascending ? 'asc' : 'desc'}.${nullsFirst ? 'nullsfirst' : 'nullslast'}';
-
-    overrideSearchParams(key, value);
-    return this;
+    final url = overrideSearchParams(key, value);
+    return PostgrestTransformBuilder(copyWithUrl(url));
   }
 
   /// Limits the result with the specified `count`.
@@ -124,8 +123,8 @@ class PostgrestTransformBuilder<T> extends PostgrestBuilder<T, T> {
   PostgrestTransformBuilder<T> limit(int count, {String? foreignTable}) {
     final key = foreignTable == null ? 'limit' : '$foreignTable.limit';
 
-    appendSearchParams(key, '$count');
-    return this;
+    final url = appendSearchParams(key, '$count');
+    return PostgrestTransformBuilder(copyWithUrl(url));
   }
 
   /// Limits the result to rows within the specified range, inclusive.
@@ -148,9 +147,9 @@ class PostgrestTransformBuilder<T> extends PostgrestBuilder<T, T> {
     final keyOffset = foreignTable == null ? 'offset' : '$foreignTable.offset';
     final keyLimit = foreignTable == null ? 'limit' : '$foreignTable.limit';
 
-    appendSearchParams(keyOffset, '$from');
-    appendSearchParams(keyLimit, '${to - from + 1}');
-    return this;
+    var url = appendSearchParams(keyOffset, '$from');
+    url = appendSearchParams(keyLimit, '${to - from + 1}', url);
+    return PostgrestTransformBuilder(copyWithUrl(url));
   }
 
   /// Retrieves only one row from the result.
@@ -168,8 +167,11 @@ class PostgrestTransformBuilder<T> extends PostgrestBuilder<T, T> {
   ///
   /// By specifying this type via `.select<Map<String,dynamic>>()` you get more type safety.
   PostgrestTransformBuilder<T> single() {
-    _headers['Accept'] = 'application/vnd.pgrst.object+json';
-    return this;
+    final newHeaders = {..._headers};
+    newHeaders['Accept'] = 'application/vnd.pgrst.object+json';
+    return PostgrestTransformBuilder(copyWith(
+      headers: newHeaders,
+    ));
   }
 
   /// Retrieves at most one row from the result.
@@ -185,13 +187,18 @@ class PostgrestTransformBuilder<T> extends PostgrestBuilder<T, T> {
   PostgrestTransformBuilder<T> maybeSingle() {
     // Temporary fix for https://github.com/supabase/supabase-flutter/issues/560
     // Issue persists e.g. for `.insert([...]).select().maybeSingle()`
+    final newHeaders = {..._headers};
+
     if (_method?.toUpperCase() == 'GET') {
-      _headers['Accept'] = 'application/json';
+      newHeaders['Accept'] = 'application/json';
     } else {
-      _headers['Accept'] = 'application/vnd.pgrst.object+json';
+      newHeaders['Accept'] = 'application/vnd.pgrst.object+json';
     }
-    _maybeSingle = true;
-    return this;
+
+    return PostgrestTransformBuilder<T>(copyWith(
+      maybeSingle: true,
+      headers: newHeaders,
+    ));
   }
 
   /// Retrieves the response as CSV.
@@ -201,7 +208,11 @@ class PostgrestTransformBuilder<T> extends PostgrestBuilder<T, T> {
   /// postgrest.from('users').select().csv()
   /// ```
   PostgrestTransformBuilder<T> csv() {
-    _headers['Accept'] = 'text/csv';
-    return this;
+    final newHeaders = {..._headers};
+    newHeaders['Accept'] = 'text/csv';
+
+    return PostgrestTransformBuilder<T>(copyWith(
+      headers: newHeaders,
+    ));
   }
 }

--- a/packages/supabase/lib/src/supabase_query_builder.dart
+++ b/packages/supabase/lib/src/supabase_query_builder.dart
@@ -23,7 +23,7 @@ class SupabaseQueryBuilder extends PostgrestQueryBuilder {
         _table = table,
         _incrementId = incrementId,
         super(
-          url,
+          url: Uri.parse(url),
           headers: headers,
           schema: schema,
           httpClient: httpClient,


### PR DESCRIPTION
# Changes
- Makes the postgrest query building immutable
Makes the following possible
```dart
final query = postgrest.from("table").select();
final res1 = await query.eq("id", 1);
final res2 = await query.gt("id", 2);
```
- BREAKING: make `PostgrestQueryBuilder.url` a required named parameter