### PR TITLE
feat!: use Object? instead of dynamic

### DIFF
--- a/packages/functions_client/lib/src/types.dart
+++ b/packages/functions_client/lib/src/types.dart
@@ -15,7 +15,7 @@ enum HttpMethod {
 
 class FunctionInvokeOptions {
   final Map<String, String>? headers;
-  final dynamic body;
+  final Object? body;
   final ResponseType? responseType;
 
   FunctionInvokeOptions({

--- a/packages/postgrest/lib/src/postgrest_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_builder.dart
@@ -27,7 +27,7 @@ typedef _Nullable<T> = T?;
 /// The base builder class.
 @immutable
 class PostgrestBuilder<T, S> implements Future<T> {
-  final dynamic _body;
+  final Object? _body;
   final Headers _headers;
   final bool _maybeSingle;
   final String? _method;
@@ -43,7 +43,7 @@ class PostgrestBuilder<T, S> implements Future<T> {
     required Headers headers,
     String? schema,
     String? method,
-    dynamic body,
+    Object? body,
     Client? httpClient,
     YAJsonIsolate? isolate,
     FetchOptions? options,
@@ -65,7 +65,7 @@ class PostgrestBuilder<T, S> implements Future<T> {
     Headers? headers,
     String? schema,
     String? method,
-    dynamic body,
+    Object? body,
     Client? httpClient,
     YAJsonIsolate? isolate,
     FetchOptions? options,
@@ -92,7 +92,7 @@ class PostgrestBuilder<T, S> implements Future<T> {
     Headers? headers,
     String? schema,
     String? method,
-    dynamic body,
+    Object? body,
     Client? httpClient,
     YAJsonIsolate? isolate,
     FetchOptions? options,
@@ -234,7 +234,7 @@ class PostgrestBuilder<T, S> implements Future<T> {
   Future<PostgrestResponse> _parseResponse(
       http.Response response, String method) async {
     if (response.statusCode >= 200 && response.statusCode <= 299) {
-      dynamic body;
+      Object? body;
       int? count;
 
       if (response.request!.method != METHOD_HEAD) {
@@ -277,6 +277,8 @@ class PostgrestBuilder<T, S> implements Future<T> {
             ? null
             : int.parse(contentRange.split('/').last);
       }
+
+      body as dynamic;
 
       // When using converter [S] is the type of the converter functions's argument. Otherwise [T] should be equal to [S]
       if (S == PostgrestList) {
@@ -466,7 +468,7 @@ class PostgrestBuilder<T, S> implements Future<T> {
         }
       }
     } catch (error, stack) {
-      final dynamic result;
+      final FutureOr<R> result;
       if (onError != null) {
         if (onError is Function(Object, StackTrace)) {
           result = onError(error, stack);

--- a/packages/postgrest/lib/src/postgrest_filter_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_filter_builder.dart
@@ -24,7 +24,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   ///     .select()
   ///     .not('status', 'eq', 'OFFLINE');
   /// ```
-  PostgrestFilterBuilder<T> not(String column, String operator, dynamic value) {
+  PostgrestFilterBuilder<T> not(String column, String operator, Object value) {
     final Uri url;
     if (value is List) {
       if (operator == "in") {
@@ -66,7 +66,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   ///     .select()
   ///     .eq('username', 'supabot');
   /// ```
-  PostgrestFilterBuilder<T> eq(String column, dynamic value) {
+  PostgrestFilterBuilder<T> eq(String column, Object value) {
     final Uri url;
     if (value is List) {
       url = appendSearchParams(column, 'eq.{${_cleanFilterArray(value)}}');
@@ -84,7 +84,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   ///     .select()
   ///     .neq('username', 'supabot');
   /// ```
-  PostgrestFilterBuilder<T> neq(String column, dynamic value) {
+  PostgrestFilterBuilder<T> neq(String column, Object value) {
     final Uri url;
     if (value is List) {
       url = appendSearchParams(column, 'neq.{${_cleanFilterArray(value)}}');
@@ -102,7 +102,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   ///     .select()
   ///     .gt('id', 1);
   /// ```
-  PostgrestFilterBuilder<T> gt(String column, dynamic value) {
+  PostgrestFilterBuilder<T> gt(String column, Object value) {
     return copyWithUrl(appendSearchParams(column, 'gt.$value'));
   }
 
@@ -114,7 +114,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   ///     .select()
   ///     .gte('id', 1);
   /// ```
-  PostgrestFilterBuilder<T> gte(String column, dynamic value) {
+  PostgrestFilterBuilder<T> gte(String column, Object value) {
     return copyWithUrl(appendSearchParams(column, 'gte.$value'));
   }
 
@@ -126,7 +126,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   ///     .select()
   ///     .lt('id', 2);
   /// ```
-  PostgrestFilterBuilder<T> lt(String column, dynamic value) {
+  PostgrestFilterBuilder<T> lt(String column, Object value) {
     return copyWithUrl(appendSearchParams(column, 'lt.$value'));
   }
 
@@ -138,7 +138,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   ///     .select()
   ///     .lte('id', 2);
   /// ```
-  PostgrestFilterBuilder<T> lte(String column, dynamic value) {
+  PostgrestFilterBuilder<T> lte(String column, Object value) {
     return copyWithUrl(appendSearchParams(column, 'lte.$value'));
   }
 
@@ -228,7 +228,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   ///     .is_('data', null);
   /// ```
   // ignore: non_constant_identifier_names
-  PostgrestFilterBuilder<T> is_(String column, dynamic value) {
+  PostgrestFilterBuilder<T> is_(String column, Object? value) {
     return copyWithUrl(appendSearchParams(column, 'is.$value'));
   }
 
@@ -254,7 +254,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   ///     .select()
   ///     .contains('age_range', '[1,2)');
   /// ```
-  PostgrestFilterBuilder<T> contains(String column, dynamic value) {
+  PostgrestFilterBuilder<T> contains(String column, Object value) {
     final Uri url;
     if (value is String) {
       // range types can be inclusive '[', ']' or exclusive '(', ')' so just
@@ -278,7 +278,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   ///     .select()
   ///     .containedBy('age_range', '[1,2)');
   /// ```
-  PostgrestFilterBuilder<T> containedBy(String column, dynamic value) {
+  PostgrestFilterBuilder<T> containedBy(String column, Object value) {
     final Uri url;
     if (value is String) {
       // range types can be inclusive '[', ']' or exclusive '(', ')' so just
@@ -362,7 +362,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   ///     .select()
   ///     .overlaps('age_range', '[2,25)');
   /// ```
-  PostgrestFilterBuilder<T> overlaps(String column, dynamic value) {
+  PostgrestFilterBuilder<T> overlaps(String column, Object value) {
     final Uri url;
     if (value is List) {
       // array
@@ -414,7 +414,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   ///     .filter('username', 'eq', 'supabot');
   /// ```
   PostgrestFilterBuilder<T> filter(
-      String column, String operator, dynamic value) {
+      String column, String operator, Object value) {
     final Uri url;
     if (value is List) {
       if (operator == "in") {

--- a/packages/postgrest/lib/src/postgrest_filter_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_filter_builder.dart
@@ -414,7 +414,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   ///     .filter('username', 'eq', 'supabot');
   /// ```
   PostgrestFilterBuilder<T> filter(
-      String column, String operator, Object value) {
+      String column, String operator, Object? value) {
     final Uri url;
     if (value is List) {
       if (operator == "in") {

--- a/packages/postgrest/lib/src/postgrest_query_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_query_builder.dart
@@ -110,7 +110,7 @@ class PostgrestQueryBuilder<T> extends PostgrestBuilder<T, T> {
   /// }).select();
   /// ```
   PostgrestFilterBuilder<T> insert(
-    dynamic values, {
+    Object values, {
     bool defaultToNull = true,
   }) {
     final newHeaders = {..._headers};
@@ -165,7 +165,7 @@ class PostgrestQueryBuilder<T> extends PostgrestBuilder<T, T> {
   /// }).select();
   /// ```
   PostgrestFilterBuilder<T> upsert(
-    dynamic values, {
+    Object values, {
     String? onConflict,
     bool ignoreDuplicates = false,
     bool defaultToNull = true,

--- a/packages/postgrest/lib/src/postgrest_rpc_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_rpc_builder.dart
@@ -19,7 +19,7 @@ class PostgrestRpcBuilder extends PostgrestBuilder {
 
   /// Performs stored procedures on the database.
   PostgrestFilterBuilder rpc([
-    dynamic params,
+    Object? params,
     FetchOptions options = const FetchOptions(),
   ]) {
     return PostgrestFilterBuilder(_copyWith(

--- a/packages/postgrest/lib/src/types.dart
+++ b/packages/postgrest/lib/src/types.dart
@@ -9,7 +9,7 @@ typedef PostgrestMapResponse = PostgrestResponse<PostgrestMap>;
 class PostgrestException implements Exception {
   final String message;
   final String? code;
-  final dynamic details;
+  final Object? details;
   final String? hint;
 
   const PostgrestException({
@@ -28,7 +28,7 @@ class PostgrestException implements Exception {
     return PostgrestException(
       message: (json['message'] ?? message) as String,
       code: (json['code'] ?? '$code') as String?,
-      details: (json['details'] ?? details) as dynamic,
+      details: (json['details'] ?? details),
       hint: json['hint'] as String?,
     );
   }

--- a/packages/supabase/lib/src/supabase_stream_builder.dart
+++ b/packages/supabase/lib/src/supabase_stream_builder.dart
@@ -85,7 +85,7 @@ class SupabaseStreamBuilder extends Stream<SupabaseStreamEvent> {
   /// ```dart
   /// supabase.from('users').stream(primaryKey: ['id']).eq('name', 'Supabase');
   /// ```
-  SupabaseStreamBuilder eq(String column, dynamic value) {
+  SupabaseStreamBuilder eq(String column, Object value) {
     assert(
       _streamFilter == null,
       'Only one filter can be applied to `.stream()`',
@@ -105,7 +105,7 @@ class SupabaseStreamBuilder extends Stream<SupabaseStreamEvent> {
   /// ```dart
   /// supabase.from('users').stream(primaryKey: ['id']).neq('name', 'Supabase');
   /// ```
-  SupabaseStreamBuilder neq(String column, dynamic value) {
+  SupabaseStreamBuilder neq(String column, Object value) {
     assert(
       _streamFilter == null,
       'Only one filter can be applied to `.stream()`',
@@ -125,7 +125,7 @@ class SupabaseStreamBuilder extends Stream<SupabaseStreamEvent> {
   /// ```dart
   /// supabase.from('users').stream(primaryKey: ['id']).lt('likes', 100);
   /// ```
-  SupabaseStreamBuilder lt(String column, dynamic value) {
+  SupabaseStreamBuilder lt(String column, Object value) {
     assert(
       _streamFilter == null,
       'Only one filter can be applied to `.stream()`',
@@ -145,7 +145,7 @@ class SupabaseStreamBuilder extends Stream<SupabaseStreamEvent> {
   /// ```dart
   /// supabase.from('users').stream(primaryKey: ['id']).lte('likes', 100);
   /// ```
-  SupabaseStreamBuilder lte(String column, dynamic value) {
+  SupabaseStreamBuilder lte(String column, Object value) {
     assert(
       _streamFilter == null,
       'Only one filter can be applied to `.stream()`',
@@ -165,7 +165,7 @@ class SupabaseStreamBuilder extends Stream<SupabaseStreamEvent> {
   /// ```dart
   /// supabase.from('users').stream(primaryKey: ['id']).gt('likes', '100');
   /// ```
-  SupabaseStreamBuilder gt(String column, dynamic value) {
+  SupabaseStreamBuilder gt(String column, Object value) {
     assert(
       _streamFilter == null,
       'Only one filter can be applied to `.stream()`',
@@ -185,7 +185,7 @@ class SupabaseStreamBuilder extends Stream<SupabaseStreamEvent> {
   /// ```dart
   /// supabase.from('users').stream(primaryKey: ['id']).gte('likes', 100);
   /// ```
-  SupabaseStreamBuilder gte(String column, dynamic value) {
+  SupabaseStreamBuilder gte(String column, Object value) {
     assert(
       _streamFilter == null,
       'Only one filter can be applied to `.stream()`',
@@ -205,7 +205,7 @@ class SupabaseStreamBuilder extends Stream<SupabaseStreamEvent> {
   /// ```dart
   /// supabase.from('users').stream(primaryKey: ['id']).inFilter('name', ['Andy', 'Amy', 'Terry']);
   /// ```
-  SupabaseStreamBuilder inFilter(String column, List<dynamic> values) {
+  SupabaseStreamBuilder inFilter(String column, List<Object> values) {
     assert(
       _streamFilter == null,
       'Only one filter can be applied to `.stream()`',


### PR DESCRIPTION
There are many arguments of type dynamic that should be of type `Object?` or even `Object` instead. It doesn't allow any property access without previously checking   that the object is of the correct type.

The best of this pr is that you can no longer pass null to e.g. `.eq` filter. Which was a runtime issue here https://github.com/supabase/supabase-flutter/pull/580

If used correctly, this pr shouldn't include any breaking change.