### PR TITLE
fix(functions_client): use header for response parsing

### DIFF
--- a/packages/functions_client/lib/src/types.dart
+++ b/packages/functions_client/lib/src/types.dart
@@ -1,28 +1,9 @@
-enum ResponseType {
-  json,
-  text,
-  arraybuffer,
-  blob,
-}
-
 enum HttpMethod {
   get,
   post,
   put,
   delete,
   patch,
-}
-
-class FunctionInvokeOptions {
-  final Map<String, String>? headers;
-  final Object? body;
-  final ResponseType? responseType;
-
-  FunctionInvokeOptions({
-    this.headers,
-    this.body,
-    this.responseType,
-  });
 }
 
 class FunctionResponse {

--- a/packages/functions_client/lib/src/types.dart
+++ b/packages/functions_client/lib/src/types.dart
@@ -1,3 +1,6 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
 enum HttpMethod {
   get,
   post,
@@ -7,6 +10,10 @@ enum HttpMethod {
 }
 
 class FunctionResponse {
+  /// The data returned by the function. Type depends on the header `Content-Type`:
+  /// - 'text/plain': [String]
+  /// - 'octet/stream': [Uint8List]
+  /// - 'application/json': dynamic ([jsonDecode] is used)
   final dynamic data;
   final int? status;
 

--- a/packages/functions_client/test/custom_http_client.dart
+++ b/packages/functions_client/test/custom_http_client.dart
@@ -10,6 +10,9 @@ class CustomHttpClient extends BaseClient {
       Stream.value(utf8.encode(jsonEncode({"key": "Hello World"}))),
       420,
       request: request,
+      headers: {
+        "Content-Type": "application/json",
+      },
     );
   }
 }


### PR DESCRIPTION
# Changes
Switches to depend on the response headers on how to parse the response data

That's the way how it's done in `functions-js`  as well. I'm thinking about switching `FunctionResponse.data` to `Object`. That way the user has to verify the response is of their desired type, but I'm unsure this is appreciated.

Close #614