### PR TITLE
fix(gotrue): export everything in constants.dart and hide what we want to hide instead of using show

### DIFF
--- a/packages/gotrue/lib/gotrue.dart
+++ b/packages/gotrue/lib/gotrue.dart
@@ -1,7 +1,6 @@
 library gotrue;
 
-export 'src/constants.dart'
-    show AuthChangeEvent, GenerateLinkType, OtpType, SignOutScope;
+export 'src/constants.dart' hide Constants, GenerateLinkTypeExtended;
 export 'src/gotrue_admin_api.dart';
 export 'src/gotrue_client.dart';
 export 'src/types/auth_exception.dart';


### PR DESCRIPTION
## What kind of change does this PR introduce?

Currently we use the `show` keyword in exporting symbols from constants.dart file in gotrue. This requires us to add the new symbol to the export every time we create a new one. This PR changes to using `hide` to hide what we don't want to export so that new symbols are exported by default instead.