### PR TITLE
feat(postgrest)!: stronger type system for query building

### DIFF
--- a/infra/postgrest/db/00-schema.sql
+++ b/infra/postgrest/db/00-schema.sql
@@ -61,6 +61,13 @@ CREATE FUNCTION public.void_func()
 RETURNS void AS $$
 $$ LANGUAGE SQL;
 
+CREATE FUNCTION public.get_integer()
+    RETURNS integer AS $$
+    BEGIN
+        RETURN 42;
+    End;
+$$ LANGUAGE plpgsql;
+
 -- SECOND SCHEMA USERS
 CREATE TYPE personal.user_status AS ENUM ('ONLINE', 'OFFLINE');
 CREATE TABLE personal.users(

--- a/packages/postgrest/lib/src/postgrest.dart
+++ b/packages/postgrest/lib/src/postgrest.dart
@@ -77,7 +77,7 @@ class PostgrestClient {
   /// Perform a stored procedure call.
   ///
   /// ```dart
-  /// postgrest.rpc('get_status', params: {'name_param': 'supabot'})
+  /// supabase.rpc('get_status', params: {'name_param': 'supabot'})
   /// ```
   PostgrestFilterBuilder rpc(
     String fn, {

--- a/packages/postgrest/lib/src/postgrest.dart
+++ b/packages/postgrest/lib/src/postgrest.dart
@@ -82,7 +82,6 @@ class PostgrestClient {
   PostgrestFilterBuilder rpc(
     String fn, {
     Map? params,
-    FetchOptions options = const FetchOptions(),
   }) {
     final url = '${this.url}/rpc/$fn';
     return PostgrestRpcBuilder(
@@ -90,9 +89,8 @@ class PostgrestClient {
       headers: {...headers},
       schema: schema,
       httpClient: httpClient,
-      options: options,
       isolate: _isolate,
-    ).rpc(params, options);
+    ).rpc(params);
   }
 
   Future<void> dispose() async {

--- a/packages/postgrest/lib/src/postgrest.dart
+++ b/packages/postgrest/lib/src/postgrest.dart
@@ -79,7 +79,7 @@ class PostgrestClient {
   /// ```dart
   /// supabase.rpc('get_status', params: {'name_param': 'supabot'})
   /// ```
-  PostgrestFilterBuilder rpc(
+  PostgrestFilterBuilder<T> rpc<T>(
     String fn, {
     Map? params,
   }) {

--- a/packages/postgrest/lib/src/postgrest_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_builder.dart
@@ -352,8 +352,8 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
   }
 
   @override
-  Future<R> then<R>(
-    FutureOr<R> Function(T value) onValue, {
+  Future<U> then<U>(
+    FutureOr<U> Function(T value) onValue, {
     Function? onError,
   }) async {
     if (onError != null &&
@@ -371,7 +371,7 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
       final response = await _execute();
       return onValue(response);
     } catch (error, stack) {
-      final FutureOr<R> result;
+      final FutureOr<U> result;
       if (onError != null) {
         if (onError is Function(Object, StackTrace)) {
           result = onError(error, stack);

--- a/packages/postgrest/lib/src/postgrest_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_builder.dart
@@ -27,6 +27,7 @@ const METHOD_DELETE = 'DELETE';
 typedef _Nullable<T> = T?;
 
 /// The base builder class.
+///
 /// [T] for the overall return type, so `PostgrestResponse<S>` or [S]
 ///
 /// When using [_converter], [S] is the input and [R] is the output
@@ -225,7 +226,7 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
           body = PostgrestMap.from(body);
         }
       } else if (R == int) {
-        body = count;
+        if (count != null) body = count;
       }
       body as R;
 

--- a/packages/postgrest/lib/src/postgrest_filter_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_filter_builder.dart
@@ -1,7 +1,7 @@
 part of 'postgrest_builder.dart';
 
 class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
-  PostgrestFilterBuilder(PostgrestBuilder<T, T> builder) : super(builder);
+  PostgrestFilterBuilder(PostgrestBuilder<T, T, T> builder) : super(builder);
 
   @override
   PostgrestFilterBuilder<T> copyWithUrl(Uri url) =>

--- a/packages/postgrest/lib/src/postgrest_query_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_query_builder.dart
@@ -40,10 +40,6 @@ class PostgrestQueryBuilder<T> extends RawPostgrestBuilder<T, T, T> {
   /// supabase.from('users').select('id, messages').count(CountOption.exact);
   /// ```
   /// By appending [count] the return type is [PostgrestResponse]. Otherwise it's the data directly without the wrapper.
-  ///
-  /// The type specification for [R] is optional and enhances the type safety of the return value. But use with care as a wrong type specification will result in a runtime error
-  ///
-  /// There are optional typedefs for typical types: [PostgrestMap], [PostgrestList], [PostgrestMapResponse], [PostgrestListResponse]
   PostgrestFilterBuilder<PostgrestList> select([String columns = '*']) {
     // Remove whitespaces except when quoted
     var quoted = false;
@@ -254,7 +250,8 @@ class PostgrestQueryBuilder<T> extends RawPostgrestBuilder<T, T, T> {
   /// ```dart
   /// int count = await supabase.from('users').count();
   /// ```
-  RawPostgrestBuilder<int, int, int> count(CountOption option) {
+  RawPostgrestBuilder<int, int, int> count(
+      [CountOption option = CountOption.exact]) {
     return _copyWithType(
       method: METHOD_HEAD,
       count: option,

--- a/packages/postgrest/lib/src/postgrest_query_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_query_builder.dart
@@ -58,12 +58,9 @@ class PostgrestQueryBuilder<T> extends PostgrestBuilder<T, T> {
   /// - [PostgrestResponse]
   ///
   /// There are optional typedefs for [R]: [PostgrestMap], [PostgrestList], [PostgrestMapResponse], [PostgrestListResponse]
-  PostgrestFilterBuilder<R> select<R>([
+  PostgrestFilterBuilder<PostgrestList> select([
     String columns = '*',
-    FetchOptions options = const FetchOptions(),
   ]) {
-    _assertCorrectGeneric(R);
-
     // Remove whitespaces except when quoted
     var quoted = false;
     final re = RegExp(r'\s');
@@ -78,10 +75,9 @@ class PostgrestQueryBuilder<T> extends PostgrestBuilder<T, T> {
     }).join();
 
     final url = overrideSearchParams('select', cleanedColumns);
-    return PostgrestFilterBuilder<R>(_copyWithType(
+    return PostgrestFilterBuilder(_copyWithType(
       url: url,
       method: METHOD_GET,
-      options: options,
     ));
   }
 
@@ -125,7 +121,7 @@ class PostgrestQueryBuilder<T> extends PostgrestBuilder<T, T> {
       url = _setColumnsSearchParam(values);
     }
 
-    return PostgrestFilterBuilder<T>(_copyWith(
+    return PostgrestFilterBuilder(_copyWith(
       method: METHOD_POST,
       headers: newHeaders,
       body: values,
@@ -169,7 +165,6 @@ class PostgrestQueryBuilder<T> extends PostgrestBuilder<T, T> {
     String? onConflict,
     bool ignoreDuplicates = false,
     bool defaultToNull = true,
-    FetchOptions options = const FetchOptions(),
   }) {
     final newHeaders = {..._headers};
     newHeaders['Prefer'] =
@@ -195,7 +190,6 @@ class PostgrestQueryBuilder<T> extends PostgrestBuilder<T, T> {
     return PostgrestFilterBuilder<T>(_copyWith(
       method: METHOD_POST,
       headers: newHeaders,
-      options: options.ensureNotHead(),
       body: values,
       url: url,
     ));
@@ -221,10 +215,7 @@ class PostgrestQueryBuilder<T> extends PostgrestBuilder<T, T> {
   ///     .eq('message', 'foo')
   ///     .select();
   /// ```
-  PostgrestFilterBuilder<T> update(
-    Map values, {
-    FetchOptions options = const FetchOptions(),
-  }) {
+  PostgrestFilterBuilder<T> update(Map values) {
     final newHeaders = {..._headers};
     newHeaders['Prefer'] = '';
 
@@ -232,7 +223,6 @@ class PostgrestQueryBuilder<T> extends PostgrestBuilder<T, T> {
       method: METHOD_PATCH,
       headers: newHeaders,
       body: values,
-      options: options.ensureNotHead(),
     ));
   }
 
@@ -256,17 +246,12 @@ class PostgrestQueryBuilder<T> extends PostgrestBuilder<T, T> {
   ///     .eq('message', 'foo')
   ///     .select();
   /// ```
-  PostgrestFilterBuilder<T> delete({
-    @Deprecated('Append `.select()` on the query instead')
-    ReturningOption returning = ReturningOption.representation,
-    FetchOptions options = const FetchOptions(),
-  }) {
+  PostgrestFilterBuilder<T> delete() {
     final newHeaders = {..._headers};
     newHeaders['Prefer'] = '';
     return PostgrestFilterBuilder<T>(_copyWith(
       method: METHOD_DELETE,
       headers: newHeaders,
-      options: options.ensureNotHead(),
     ));
   }
 
@@ -279,5 +264,12 @@ class PostgrestQueryBuilder<T> extends PostgrestBuilder<T, T> {
       return appendSearchParams("columns", uniqueColumns);
     }
     return _url;
+  }
+
+  PostgrestBuilder<int, int> count(CountOption option) {
+    return _copyWithType(
+      method: METHOD_GET,
+      options: FetchOptions(count: option, head: true),
+    );
   }
 }

--- a/packages/postgrest/lib/src/postgrest_query_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_query_builder.dart
@@ -18,7 +18,6 @@ class PostgrestQueryBuilder<T> extends RawPostgrestBuilder<T, T, T> {
     Map<String, String>? headers,
     String? schema,
     Client? httpClient,
-    FetchOptions? options,
     YAJsonIsolate? isolate,
   }) : super(
           PostgrestBuilder(
@@ -27,7 +26,6 @@ class PostgrestQueryBuilder<T> extends RawPostgrestBuilder<T, T, T> {
             headers: headers ?? {},
             schema: schema,
             httpClient: httpClient,
-            options: options,
             isolate: isolate,
           ),
         );
@@ -258,8 +256,8 @@ class PostgrestQueryBuilder<T> extends RawPostgrestBuilder<T, T, T> {
   /// ```
   RawPostgrestBuilder<int, int, int> count(CountOption option) {
     return _copyWithType(
-      method: METHOD_GET,
-      options: FetchOptions(count: option, head: true),
+      method: METHOD_HEAD,
+      count: option,
     );
   }
 }

--- a/packages/postgrest/lib/src/postgrest_query_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_query_builder.dart
@@ -10,7 +10,7 @@ part of 'postgrest_builder.dart';
 /// * delete() - "delete"
 /// Once any of these are called the filters are passed down to the Request.
 /// /// {@endtemplate}
-class PostgrestQueryBuilder<T> extends PostgrestBuilder<T, T> {
+class PostgrestQueryBuilder<T> extends RawPostgrestBuilder<T, T, T> {
   /// {@macro postgrest_query_builder}
   PostgrestQueryBuilder({
     required Uri url,
@@ -21,13 +21,15 @@ class PostgrestQueryBuilder<T> extends PostgrestBuilder<T, T> {
     FetchOptions? options,
     YAJsonIsolate? isolate,
   }) : super(
-          url: url,
-          method: method,
-          headers: headers ?? {},
-          schema: schema,
-          httpClient: httpClient,
-          options: options,
-          isolate: isolate,
+          PostgrestBuilder(
+            url: url,
+            method: method,
+            headers: headers ?? {},
+            schema: schema,
+            httpClient: httpClient,
+            options: options,
+            isolate: isolate,
+          ),
         );
 
   /// Perform a SELECT query on the table or view.
@@ -266,7 +268,7 @@ class PostgrestQueryBuilder<T> extends PostgrestBuilder<T, T> {
     return _url;
   }
 
-  PostgrestBuilder<int, int> count(CountOption option) {
+  RawPostgrestBuilder<int, int, int> count(CountOption option) {
     return _copyWithType(
       method: METHOD_GET,
       options: FetchOptions(count: option, head: true),

--- a/packages/postgrest/lib/src/postgrest_query_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_query_builder.dart
@@ -35,34 +35,18 @@ class PostgrestQueryBuilder<T> extends RawPostgrestBuilder<T, T, T> {
   /// Perform a SELECT query on the table or view.
   ///
   /// ```dart
-  /// postgrest.from('users').select<PostgrestList>('id, messages');
+  /// supabase.from('users').select('id, messages');
   /// ```
   ///
   /// ```dart
-  /// postgrest.from('users').select<PostgrestListResponse>('id, messages', FetchOptions(count: CountOption.exact));
+  /// supabase.from('users').select('id, messages').count(CountOption.exact);
   /// ```
-  /// By setting [FetchOptions.count] to non null or [FetchOptions.forceResponse] to `true`, the return type is [PostgrestResponse<T>]. Otherwise it's `T` directly.
+  /// By appending [count] the return type is [PostgrestResponse]. Otherwise it's the data directly without the wrapper.
   ///
-  /// The type specification for [R] is optional and enhances the type safety of the return value. But use with care as a wrong type specification will result in a runtime error.
+  /// The type specification for [R] is optional and enhances the type safety of the return value. But use with care as a wrong type specification will result in a runtime error
   ///
-  /// `T` is
-  /// - [List<Map<String, dynamic>>] for queries without `.single()` or `maybeSingle()`
-  /// - [Map<String, dynamic>] for queries with `.single()`
-  /// - [Map<String, dynamic>?] for queries with `.maybeSingle()`
-  ///
-  /// Allowed types for [R] are:
-  /// - [List<Map<String, dynamic>>]
-  /// - [Map<String, dynamic>]
-  /// - [Map<String, dynamic>?]
-  /// - [PostgrestResponse<List<Map<String, dynamic>>>]
-  /// - [PostgrestResponse<Map<String, dynamic>>]
-  /// - [PostgrestResponse<Map<String, dynamic>?>]
-  /// - [PostgrestResponse]
-  ///
-  /// There are optional typedefs for [R]: [PostgrestMap], [PostgrestList], [PostgrestMapResponse], [PostgrestListResponse]
-  PostgrestFilterBuilder<PostgrestList> select([
-    String columns = '*',
-  ]) {
+  /// There are optional typedefs for typical types: [PostgrestMap], [PostgrestList], [PostgrestMapResponse], [PostgrestListResponse]
+  PostgrestFilterBuilder<PostgrestList> select([String columns = '*']) {
     // Remove whitespaces except when quoted
     var quoted = false;
     final re = RegExp(r'\s');
@@ -85,7 +69,7 @@ class PostgrestQueryBuilder<T> extends RawPostgrestBuilder<T, T, T> {
 
   /// Perform an INSERT into the table or view.
   ///
-  /// By default no data is returned. Use a trailing `select` to return data.
+  /// By default no data is returned. Use a trailing [select] to return data.
   ///
   /// When inserting multiple rows in bulk, [defaultToNull] is used to set the values of fields missing in a proper subset of rows
   /// to be either `NULL` or the default value of these columns.
@@ -199,7 +183,7 @@ class PostgrestQueryBuilder<T> extends RawPostgrestBuilder<T, T, T> {
 
   /// Perform an UPDATE on the table or view.
   ///
-  /// By default no data is returned. Use a trailing `select` to return data.
+  /// By default no data is returned. Use a trailing [select] to return data.
   ///
   /// Default (not returning data):
   /// ```dart
@@ -230,7 +214,7 @@ class PostgrestQueryBuilder<T> extends RawPostgrestBuilder<T, T, T> {
 
   /// Perform a DELETE on the table or view.
   ///
-  /// By default no data is returned. Use a trailing `select` to return data.
+  /// By default no data is returned. Use a trailing [select] to return data.
   ///
   /// Default (not returning data):
   /// ```dart
@@ -268,6 +252,10 @@ class PostgrestQueryBuilder<T> extends RawPostgrestBuilder<T, T, T> {
     return _url;
   }
 
+  /// Only performs a count query on the table or view.
+  /// ```dart
+  /// int count = await supabase.from('users').count();
+  /// ```
   RawPostgrestBuilder<int, int, int> count(CountOption option) {
     return _copyWithType(
       method: METHOD_GET,

--- a/packages/postgrest/lib/src/postgrest_rpc_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_rpc_builder.dart
@@ -20,12 +20,10 @@ class PostgrestRpcBuilder extends PostgrestBuilder {
   /// Performs stored procedures on the database.
   PostgrestFilterBuilder rpc([
     Object? params,
-    FetchOptions options = const FetchOptions(),
   ]) {
     return PostgrestFilterBuilder(_copyWith(
       method: METHOD_POST,
       body: params,
-      options: options.ensureNotHead(),
     ));
   }
 }

--- a/packages/postgrest/lib/src/postgrest_rpc_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_rpc_builder.dart
@@ -1,6 +1,6 @@
 part of 'postgrest_builder.dart';
 
-class PostgrestRpcBuilder extends PostgrestBuilder {
+class PostgrestRpcBuilder extends RawPostgrestBuilder {
   PostgrestRpcBuilder(
     String url, {
     Map<String, String>? headers,
@@ -8,18 +8,20 @@ class PostgrestRpcBuilder extends PostgrestBuilder {
     Client? httpClient,
     required YAJsonIsolate isolate,
   }) : super(
-          url: Uri.parse(url),
-          headers: headers ?? {},
-          schema: schema,
-          httpClient: httpClient,
-          isolate: isolate,
+          PostgrestBuilder(
+            url: Uri.parse(url),
+            headers: headers ?? {},
+            schema: schema,
+            httpClient: httpClient,
+            isolate: isolate,
+          ),
         );
 
   /// Performs stored procedures on the database.
-  PostgrestFilterBuilder rpc([
+  PostgrestFilterBuilder<T> rpc<T>([
     Object? params,
   ]) {
-    return PostgrestFilterBuilder(_copyWith(
+    return PostgrestFilterBuilder(_copyWithType(
       method: METHOD_POST,
       body: params,
     ));

--- a/packages/postgrest/lib/src/postgrest_rpc_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_rpc_builder.dart
@@ -6,14 +6,12 @@ class PostgrestRpcBuilder extends PostgrestBuilder {
     Map<String, String>? headers,
     String? schema,
     Client? httpClient,
-    FetchOptions? options,
     required YAJsonIsolate isolate,
   }) : super(
           url: Uri.parse(url),
           headers: headers ?? {},
           schema: schema,
           httpClient: httpClient,
-          options: options,
           isolate: isolate,
         );
 

--- a/packages/postgrest/lib/src/postgrest_transform_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_transform_builder.dart
@@ -16,8 +16,6 @@ class PostgrestTransformBuilder<T> extends RawPostgrestBuilder<T, T, T> {
   /// ```
   ///
   /// By appending [count] the return type is [PostgrestResponse]. Otherwise it's the data directly without the wrapper.
-  ///
-  /// There are optional typedefs for typical types: [PostgrestMap], [PostgrestList], [PostgrestMapResponse], [PostgrestListResponse]
   PostgrestTransformBuilder<PostgrestList> select([String columns = '*']) {
     // Remove whitespaces except when quoted
     var quoted = false;
@@ -203,7 +201,7 @@ class PostgrestTransformBuilder<T> extends RawPostgrestBuilder<T, T, T> {
   /// int count = res.count;
   /// ```
   ResponsePostgrestBuilder<PostgrestResponse<T>, T, T> count(
-      CountOption count) {
+      [CountOption count = CountOption.exact]) {
     return ResponsePostgrestBuilder(
       _copyWithType(count: count),
     );

--- a/packages/postgrest/lib/src/postgrest_transform_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_transform_builder.dart
@@ -1,19 +1,7 @@
 part of 'postgrest_builder.dart';
 
-class PostgrestTransformBuilder<T> extends PostgrestBuilder<T, T> {
-  PostgrestTransformBuilder(PostgrestBuilder<T, T> builder)
-      : super(
-          url: builder._url,
-          method: builder._method,
-          headers: builder._headers,
-          schema: builder._schema,
-          body: builder._body,
-          httpClient: builder._httpClient,
-          options: builder._options,
-          isolate: builder._isolate,
-          maybeSingle: builder._maybeSingle,
-          converter: builder._converter,
-        );
+class PostgrestTransformBuilder<T> extends RawPostgrestBuilder<T, T, T> {
+  PostgrestTransformBuilder(super.builder);
 
   PostgrestTransformBuilder<T> copyWithUrl(Uri url) =>
       PostgrestTransformBuilder(_copyWith(url: url));
@@ -165,7 +153,7 @@ class PostgrestTransformBuilder<T> extends PostgrestBuilder<T, T> {
   /// Data type is `Map<String, dynamic>`.
   ///
   /// By specifying this type via `.select<Map<String,dynamic>>()` you get more type safety.
-  PostgrestBuilder<PostgrestMap, PostgrestMap> single() {
+  RawPostgrestBuilder<PostgrestMap, PostgrestMap, PostgrestMap> single() {
     final newHeaders = {..._headers};
     newHeaders['Accept'] = 'application/vnd.pgrst.object+json';
 
@@ -184,7 +172,8 @@ class PostgrestTransformBuilder<T> extends PostgrestBuilder<T, T> {
   /// Data type is `Map<String, dynamic>?`.
   ///
   /// By specifying this type via `.select<Map<String,dynamic>?>()` you get more type safety.
-  PostgrestBuilder<PostgrestMap?, PostgrestMap?> maybeSingle() {
+  RawPostgrestBuilder<PostgrestMap?, PostgrestMap?, PostgrestMap?>
+      maybeSingle() {
     // Temporary fix for https://github.com/supabase/supabase-flutter/issues/560
     // Issue persists e.g. for `.insert([...]).select().maybeSingle()`
     final newHeaders = {..._headers};
@@ -207,7 +196,7 @@ class PostgrestTransformBuilder<T> extends PostgrestBuilder<T, T> {
   /// ```dart
   /// postgrest.from('users').select().csv()
   /// ```
-  PostgrestBuilder<String, String> csv() {
+  RawPostgrestBuilder<String, String, String> csv() {
     final newHeaders = {..._headers};
     newHeaders['Accept'] = 'text/csv';
 
@@ -216,11 +205,13 @@ class PostgrestTransformBuilder<T> extends PostgrestBuilder<T, T> {
     );
   }
 
-  PostgrestBuilder<PostgrestResponse<T>, T> count(CountOption option) {
-    return _copyWithType(options: FetchOptions(count: option));
+  ResponsePostgrestBuilder<PostgrestResponse<T>, T, T> count(
+      CountOption option) {
+    return ResponsePostgrestBuilder(
+        _copyWithType(options: FetchOptions(count: option)));
   }
 
-  PostgrestBuilder<void, void> head() {
+  PostgrestBuilder<void, void, void> head() {
     return _copyWithType(options: FetchOptions(head: true));
   }
 }

--- a/packages/postgrest/lib/src/postgrest_transform_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_transform_builder.dart
@@ -133,12 +133,14 @@ class PostgrestTransformBuilder<T> extends RawPostgrestBuilder<T, T, T> {
   ///     .limit(1)
   ///     .single();
   /// ```
-  RawPostgrestBuilder<PostgrestMap, PostgrestMap, PostgrestMap> single() {
+  PostgrestTransformBuilder<PostgrestMap> single() {
     final newHeaders = {..._headers};
     newHeaders['Accept'] = 'application/vnd.pgrst.object+json';
 
-    return _copyWithType(
-      headers: newHeaders,
+    return PostgrestTransformBuilder(
+      _copyWithType(
+        headers: newHeaders,
+      ),
     );
   }
 
@@ -147,8 +149,7 @@ class PostgrestTransformBuilder<T> extends RawPostgrestBuilder<T, T, T> {
   /// Result must be at most one row or nullable
   /// (e.g. using `eq` on a UNIQUE column or `limit(1)`),
   /// otherwise this will result in an error.
-  RawPostgrestBuilder<PostgrestMap?, PostgrestMap?, PostgrestMap?>
-      maybeSingle() {
+  PostgrestTransformBuilder<PostgrestMap?> maybeSingle() {
     // Temporary fix for https://github.com/supabase/supabase-flutter/issues/560
     // Issue persists e.g. for `.insert([...]).select().maybeSingle()`
     final newHeaders = {..._headers};
@@ -159,9 +160,11 @@ class PostgrestTransformBuilder<T> extends RawPostgrestBuilder<T, T, T> {
       newHeaders['Accept'] = 'application/vnd.pgrst.object+json';
     }
 
-    return _copyWithType(
-      maybeSingle: true,
-      headers: newHeaders,
+    return PostgrestTransformBuilder(
+      _copyWithType(
+        maybeSingle: true,
+        headers: newHeaders,
+      ),
     );
   }
 
@@ -172,12 +175,14 @@ class PostgrestTransformBuilder<T> extends RawPostgrestBuilder<T, T, T> {
   /// ```dart
   /// supabase.from('users').select().csv()
   /// ```
-  RawPostgrestBuilder<String, String, String> csv() {
+  PostgrestTransformBuilder<String> csv() {
     final newHeaders = {..._headers};
     newHeaders['Accept'] = 'text/csv';
 
-    return _copyWithType(
-      headers: newHeaders,
+    return PostgrestTransformBuilder(
+      _copyWithType(
+        headers: newHeaders,
+      ),
     );
   }
 

--- a/packages/postgrest/lib/src/postgrest_transform_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_transform_builder.dart
@@ -207,6 +207,16 @@ class PostgrestTransformBuilder<T> extends RawPostgrestBuilder<T, T, T> {
     );
   }
 
+  /// Performs a head request.
+  ///
+  /// This will not return any data, but can only be used for either
+  /// ```dart
+  /// supabase.from("table").select().head();
+  /// ```
+  /// or
+  /// ```dart
+  /// supabase.rpc("function").head();
+  ///```
   PostgrestBuilder<void, void, void> head() {
     return _copyWithType(method: METHOD_HEAD);
   }

--- a/packages/postgrest/lib/src/postgrest_transform_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_transform_builder.dart
@@ -198,13 +198,13 @@ class PostgrestTransformBuilder<T> extends RawPostgrestBuilder<T, T, T> {
   /// int count = res.count;
   /// ```
   ResponsePostgrestBuilder<PostgrestResponse<T>, T, T> count(
-      CountOption option) {
+      CountOption count) {
     return ResponsePostgrestBuilder(
-      _copyWithType(options: FetchOptions(count: option)),
+      _copyWithType(count: count),
     );
   }
 
   PostgrestBuilder<void, void, void> head() {
-    return _copyWithType(options: FetchOptions(head: true));
+    return _copyWithType(method: METHOD_HEAD);
   }
 }

--- a/packages/postgrest/lib/src/postgrest_transform_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_transform_builder.dart
@@ -183,6 +183,10 @@ class PostgrestTransformBuilder<T> extends RawPostgrestBuilder<T, T, T> {
 
   /// Performs additionally to the [select] a count query.
   ///
+  /// It's used to retrieve the total number of rows that satisfy the
+  /// query. The value for count respects any filters (e.g. eq, gt), but ignores
+  /// modifiers (e.g. limit, range).
+  ///
   /// This changes the return type from the data only to a [PostgrestResponse] with the data and the count.
   ///
   /// ```dart

--- a/packages/postgrest/lib/src/raw_postgrest_builder.dart
+++ b/packages/postgrest/lib/src/raw_postgrest_builder.dart
@@ -10,7 +10,7 @@ class RawPostgrestBuilder<T, S, R> extends PostgrestBuilder<T, S, R> {
           schema: builder._schema,
           body: builder._body,
           httpClient: builder._httpClient,
-          options: builder._options,
+          count: builder._count,
           isolate: builder._isolate,
           maybeSingle: builder._maybeSingle,
           converter: builder._converter,
@@ -25,7 +25,7 @@ class RawPostgrestBuilder<T, S, R> extends PostgrestBuilder<T, S, R> {
     Object? body,
     Client? httpClient,
     YAJsonIsolate? isolate,
-    FetchOptions? options,
+    CountOption? count,
     bool? maybeSingle,
   }) {
     return RawPostgrestBuilder<O, P, Q>(PostgrestBuilder(
@@ -36,7 +36,7 @@ class RawPostgrestBuilder<T, S, R> extends PostgrestBuilder<T, S, R> {
       body: body ?? _body,
       httpClient: httpClient ?? _httpClient,
       isolate: isolate ?? _isolate,
-      options: options ?? _options,
+      count: count ?? _count,
       maybeSingle: maybeSingle ?? _maybeSingle,
     ));
   }
@@ -61,7 +61,7 @@ class RawPostgrestBuilder<T, S, R> extends PostgrestBuilder<T, S, R> {
       body: _body,
       isolate: _isolate,
       httpClient: _httpClient,
-      options: _options,
+      count: _count,
       maybeSingle: _maybeSingle,
       converter: converter,
     );

--- a/packages/postgrest/lib/src/raw_postgrest_builder.dart
+++ b/packages/postgrest/lib/src/raw_postgrest_builder.dart
@@ -1,0 +1,58 @@
+part of 'postgrest_builder.dart';
+
+class RawPostgrestBuilder<T, S, R> extends PostgrestBuilder<T, S, R> {
+  RawPostgrestBuilder(PostgrestBuilder<T, S, R> builder)
+      : super(
+          url: builder._url,
+          method: builder._method,
+          headers: builder._headers,
+          schema: builder._schema,
+          body: builder._body,
+          httpClient: builder._httpClient,
+          options: builder._options,
+          isolate: builder._isolate,
+          maybeSingle: builder._maybeSingle,
+          converter: builder._converter,
+        );
+
+  /// Very similar to [_copyWith], but allows changing the generics, therefore [_converter] is omitted
+  RawPostgrestBuilder<O, P, Q> _copyWithType<O, P, Q>({
+    Uri? url,
+    Headers? headers,
+    String? schema,
+    String? method,
+    Object? body,
+    Client? httpClient,
+    YAJsonIsolate? isolate,
+    FetchOptions? options,
+    bool? maybeSingle,
+  }) {
+    return RawPostgrestBuilder<O, P, Q>(PostgrestBuilder(
+      url: url ?? _url,
+      headers: headers ?? _headers,
+      schema: schema ?? _schema,
+      method: method ?? _method,
+      body: body ?? _body,
+      httpClient: httpClient ?? _httpClient,
+      isolate: isolate ?? _isolate,
+      options: options ?? _options,
+      maybeSingle: maybeSingle ?? _maybeSingle,
+    ));
+  }
+
+  PostgrestBuilder<U, U, R> withConverter<U>(
+      PostgrestConverter<U, R> converter) {
+    return PostgrestBuilder(
+      url: _url,
+      headers: _headers,
+      schema: _schema,
+      method: _method,
+      body: _body,
+      isolate: _isolate,
+      httpClient: _httpClient,
+      options: _options,
+      maybeSingle: _maybeSingle,
+      converter: converter,
+    );
+  }
+}

--- a/packages/postgrest/lib/src/raw_postgrest_builder.dart
+++ b/packages/postgrest/lib/src/raw_postgrest_builder.dart
@@ -1,5 +1,6 @@
 part of 'postgrest_builder.dart';
 
+/// Needed as a wrapper around [PostgrestBuilder] to allow for the different return type of [withConverter] than in [ResponsePostgrestBuilder.withConverter].
 class RawPostgrestBuilder<T, S, R> extends PostgrestBuilder<T, S, R> {
   RawPostgrestBuilder(PostgrestBuilder<T, S, R> builder)
       : super(
@@ -40,6 +41,16 @@ class RawPostgrestBuilder<T, S, R> extends PostgrestBuilder<T, S, R> {
     ));
   }
 
+  /// Converts any response that comes from the server into a type-safe response.
+  ///
+  /// ```dart
+  /// List<User> users = await postgrest
+  ///     .from('users')
+  ///     .select()
+  ///     .withConverter(
+  ///       (users) => users.map(User.fromJson).toList(),
+  ///     );
+  /// ```
   PostgrestBuilder<U, U, R> withConverter<U>(
       PostgrestConverter<U, R> converter) {
     return PostgrestBuilder(

--- a/packages/postgrest/lib/src/response_postgrest_builder.dart
+++ b/packages/postgrest/lib/src/response_postgrest_builder.dart
@@ -10,7 +10,7 @@ class ResponsePostgrestBuilder<T, S, R> extends PostgrestBuilder<T, S, R> {
           schema: builder._schema,
           body: builder._body,
           httpClient: builder._httpClient,
-          options: builder._options,
+          count: builder._count,
           isolate: builder._isolate,
           maybeSingle: builder._maybeSingle,
           converter: builder._converter,
@@ -39,7 +39,7 @@ class ResponsePostgrestBuilder<T, S, R> extends PostgrestBuilder<T, S, R> {
       body: _body,
       isolate: _isolate,
       httpClient: _httpClient,
-      options: _options,
+      count: _count,
       maybeSingle: _maybeSingle,
       converter: converter,
     );

--- a/packages/postgrest/lib/src/response_postgrest_builder.dart
+++ b/packages/postgrest/lib/src/response_postgrest_builder.dart
@@ -1,0 +1,33 @@
+part of 'postgrest_builder.dart';
+
+class ResponsePostgrestBuilder<T, S, R> extends PostgrestBuilder<T, S, R> {
+  ResponsePostgrestBuilder(PostgrestBuilder<T, S, R> builder)
+      : super(
+          url: builder._url,
+          method: builder._method,
+          headers: builder._headers,
+          schema: builder._schema,
+          body: builder._body,
+          httpClient: builder._httpClient,
+          options: builder._options,
+          isolate: builder._isolate,
+          maybeSingle: builder._maybeSingle,
+          converter: builder._converter,
+        );
+
+  PostgrestBuilder<PostgrestResponse<U>, U, R> withConverter<U>(
+      PostgrestConverter<U, R> converter) {
+    return PostgrestBuilder(
+      url: _url,
+      headers: _headers,
+      schema: _schema,
+      method: _method,
+      body: _body,
+      isolate: _isolate,
+      httpClient: _httpClient,
+      options: _options,
+      maybeSingle: _maybeSingle,
+      converter: converter,
+    );
+  }
+}

--- a/packages/postgrest/lib/src/response_postgrest_builder.dart
+++ b/packages/postgrest/lib/src/response_postgrest_builder.dart
@@ -1,5 +1,6 @@
 part of 'postgrest_builder.dart';
 
+/// Needed as a wrapper around [PostgrestBuilder] to allow for the different return type of [withConverter] than in [RawPostgrestBuilder.withConverter].
 class ResponsePostgrestBuilder<T, S, R> extends PostgrestBuilder<T, S, R> {
   ResponsePostgrestBuilder(PostgrestBuilder<T, S, R> builder)
       : super(
@@ -15,6 +16,19 @@ class ResponsePostgrestBuilder<T, S, R> extends PostgrestBuilder<T, S, R> {
           converter: builder._converter,
         );
 
+  /// Converts any response that comes from the server into a type-safe response.
+  ///
+  /// ```dart
+  /// final res = await postgrest
+  ///     .from('users')
+  ///     .select()
+  ///     .count(CountOption.exact)
+  ///     .withConverter(
+  ///       (users) => users.map(User.fromJson).toList(),
+  ///     );
+  /// List<User> users = res.data;
+  /// int count = res.count;
+  /// ```
   PostgrestBuilder<PostgrestResponse<U>, U, R> withConverter<U>(
       PostgrestConverter<U, R> converter) {
     return PostgrestBuilder(

--- a/packages/postgrest/lib/src/types.dart
+++ b/packages/postgrest/lib/src/types.dart
@@ -110,7 +110,6 @@ extension TextSearchTypeName on TextSearchType {
 ///
 /// Set [head] to `true` if you only want the [count] value and not the underlying data.
 ///
-/// Set [forceResponse] to `true` if you want to force the return type to be [PostgrestResponse<T>].
 /// {endtemplate}
 class FetchOptions {
   /// Set [head] to true if you only want the [count] value and not the underlying data.
@@ -126,11 +125,4 @@ class FetchOptions {
     this.head = false,
     this.count,
   });
-
-  FetchOptions ensureNotHead() {
-    return FetchOptions(
-      head: false,
-      count: count,
-    );
-  }
 }

--- a/packages/postgrest/lib/src/types.dart
+++ b/packages/postgrest/lib/src/types.dart
@@ -69,8 +69,13 @@ class PostgrestResponse<T> {
 
 /// Returns count as part of the response when specified.
 enum CountOption {
+  /// Exact but slow count algorithm. Performs a `COUNT(*)` under the hood.
   exact,
+
+  /// Approximated but fast count algorithm. Uses the Postgres statistics under the hood.
   planned,
+
+  /// Uses exact count for low numbers and planned count for high numbers.
   estimated,
 }
 

--- a/packages/postgrest/lib/src/types.dart
+++ b/packages/postgrest/lib/src/types.dart
@@ -43,21 +43,17 @@ class PostgrestException implements Exception {
 class PostgrestResponse<T> {
   const PostgrestResponse({
     required this.data,
-    required this.status,
-    this.count,
+    required this.count,
   });
 
-  final T? data;
+  final T data;
 
-  final int status;
-
-  final int? count;
+  final int count;
 
   factory PostgrestResponse.fromJson(Map<String, dynamic> json) =>
       PostgrestResponse<T>(
         data: json['data'] as T,
-        status: json['status'] as int,
-        count: json['count'] as int?,
+        count: json['count'] as int,
       );
 }
 
@@ -125,21 +121,16 @@ class FetchOptions {
   /// modifiers (e.g. limit, range).
   final CountOption? count;
 
-  /// Set [forceResponse] to `true` if you want to force the return type to be [PostgrestResponse<T>].
-  final bool forceResponse;
-
   /// {@macro fetch_options}
   const FetchOptions({
     this.head = false,
     this.count,
-    this.forceResponse = false,
   });
 
   FetchOptions ensureNotHead() {
     return FetchOptions(
       head: false,
       count: count,
-      forceResponse: forceResponse,
     );
   }
 }

--- a/packages/postgrest/lib/src/types.dart
+++ b/packages/postgrest/lib/src/types.dart
@@ -55,6 +55,16 @@ class PostgrestResponse<T> {
         data: json['data'] as T,
         count: json['count'] as int,
       );
+
+  Map<String, dynamic> toJson() => {
+        'data': data,
+        'count': count,
+      };
+
+  @override
+  String toString() {
+    return 'PostgrestResponse(data: $data, count: $count)';
+  }
 }
 
 /// Returns count as part of the response when specified.

--- a/packages/postgrest/lib/src/types.dart
+++ b/packages/postgrest/lib/src/types.dart
@@ -100,29 +100,3 @@ extension TextSearchTypeName on TextSearchType {
     return toString().split('.').last;
   }
 }
-
-/// {@template fetch_options}
-/// Options for querying Supabase.
-///
-/// [count] options can be used to retrieve the total number of rows that satisfies the
-/// query. The value for count respects any filters (e.g. `eq`, `gt`), but ignores
-/// modifiers (e.g. `limit`, `range`).
-///
-/// Set [head] to `true` if you only want the [count] value and not the underlying data.
-///
-/// {endtemplate}
-class FetchOptions {
-  /// Set [head] to true if you only want the [count] value and not the underlying data.
-  final bool head;
-
-  /// [count] options can be used to retrieve the total number of rows that satisfies the
-  /// query. The value for count respects any filters (e.g. eq, gt), but ignores
-  /// modifiers (e.g. limit, range).
-  final CountOption? count;
-
-  /// {@macro fetch_options}
-  const FetchOptions({
-    this.head = false,
-    this.count,
-  });
-}

--- a/packages/postgrest/test/basic_test.dart
+++ b/packages/postgrest/test/basic_test.dart
@@ -36,19 +36,19 @@ void main() {
     });
 
     test('stored procedure', () async {
-      final res = await postgrest.rpc('get_status', params: {
+      final res = await postgrest.rpc<String>('get_status', params: {
         'name_param': 'supabot',
       });
       expect(res, 'ONLINE');
     });
 
     test('select on stored procedure', () async {
-      final List res = await postgrest.rpc(
+      final res = await postgrest.rpc(
         'get_username_and_status',
         params: {'name_param': 'supabot'},
       ).select('status');
       expect(
-        (res.first as Map<String, dynamic>)['status'],
+        res.first['status'],
         'ONLINE',
       );
     });
@@ -275,12 +275,7 @@ void main() {
     });
 
     test('select with head:true', () async {
-      await postgrest
-          .from('users')
-          .select(
-            '*',
-          )
-          .head();
+      await postgrest.from('users').select('*').head();
     });
 
     test('select with head:true, count: exact', () async {
@@ -305,7 +300,7 @@ void main() {
     });
 
     test('stored procedure with count: exact', () async {
-      final res = await postgrest.rpc(
+      final res = await postgrest.rpc<String>(
         'get_status',
         params: {'name_param': 'supabot'},
       ).count(CountOption.exact);
@@ -437,7 +432,7 @@ void main() {
     test('basic stored procedure call', () async {
       try {
         await postgrestCustomHttpClient
-            .rpc('get_status', params: {'name_param': 'supabot'});
+            .rpc<String>('get_status', params: {'name_param': 'supabot'});
         fail(
             'Stored procedure was able to be called, even tho it does not exist');
       } on PostgrestException catch (error) {

--- a/packages/postgrest/test/basic_test.dart
+++ b/packages/postgrest/test/basic_test.dart
@@ -30,13 +30,6 @@ void main() {
       await resetHelper.reset();
     });
 
-    test('temp', () async {
-      final res = await postgrest
-          .from("users")
-          .select()
-          .count(CountOption.exact)
-          .withConverter((data) => 5);
-    });
     test('basic select table', () async {
       final res = await postgrest.from('users').select();
       expect(res.length, 4);
@@ -288,14 +281,6 @@ void main() {
             '*',
           )
           .head();
-    });
-
-    test('select with head:true with converter', () async {
-      await postgrest
-          .from('users')
-          .select('*')
-          .head()
-          .withConverter((data) => data);
     });
 
     test('select with head:true, count: exact', () async {

--- a/packages/postgrest/test/basic_test.dart
+++ b/packages/postgrest/test/basic_test.dart
@@ -391,6 +391,17 @@ void main() {
       expect(res.first, isNotEmpty);
       expect(res.first, isA<List>());
     });
+
+    test('withConverter and count', () async {
+      final res = await postgrest
+          .from('users')
+          .select()
+          .count(CountOption.exact)
+          .withConverter((data) => [data]);
+      expect(res.data.first, isNotEmpty);
+      expect(res.data.first, isA<List>());
+      expect(res.count, greaterThan(3));
+    });
   });
   group("Custom http client", () {
     setUp(() {

--- a/packages/postgrest/test/basic_test.dart
+++ b/packages/postgrest/test/basic_test.dart
@@ -58,6 +58,11 @@ void main() {
       expect(res, isNull);
     });
 
+    test('stored procedure returns int', () async {
+      final res = await postgrest.rpc<int>('get_integer');
+      expect(res, isA<int>());
+    });
+
     test('custom headers', () async {
       final postgrest = PostgrestClient(rootUrl, headers: {'apikey': 'foo'});
       expect(postgrest.headers['apikey'], 'foo');

--- a/packages/postgrest/test/filter_test.dart
+++ b/packages/postgrest/test/filter_test.dart
@@ -24,7 +24,7 @@ void main() {
   test('not', () async {
     final res = await postgrest
         .from('users')
-        .select<PostgrestList>('status')
+        .select('status')
         .not('status', 'eq', 'OFFLINE');
     expect(res, isNotEmpty);
     for (final item in res) {
@@ -35,7 +35,7 @@ void main() {
   test('not with in filter', () async {
     final res = await postgrest
         .from('users')
-        .select<PostgrestList>('username')
+        .select('username')
         .not('username', 'in', ['supabot', 'kiwicopple']);
     expect(res, isNotEmpty);
 
@@ -48,7 +48,7 @@ void main() {
   test('not with List of values', () async {
     final res = await postgrest
         .from('users')
-        .select<PostgrestList>('status')
+        .select('status')
         .not('interests', 'cs', ['baseball', 'basketball']);
     expect(res, isNotEmpty);
     for (final item in res) {
@@ -63,7 +63,7 @@ void main() {
   test('or', () async {
     final res = await postgrest
         .from('users')
-        .select<PostgrestList>('status, username')
+        .select('status, username')
         .or('status.eq.OFFLINE,username.eq.supabot');
     expect(res, isNotEmpty);
 
@@ -79,7 +79,7 @@ void main() {
     test('eq string', () async {
       final res = await postgrest
           .from('users')
-          .select<PostgrestList>('username')
+          .select('username')
           .eq('username', 'supabot');
       expect(res, isNotEmpty);
 
@@ -91,7 +91,7 @@ void main() {
     test('eq list', () async {
       final res = await postgrest
           .from('users')
-          .select<PostgrestList>('username')
+          .select('username')
           .eq('interests', ["basketball", "baseball"]);
       expect(res, isNotEmpty);
 
@@ -105,7 +105,7 @@ void main() {
     test('neq string', () async {
       final res = await postgrest
           .from('users')
-          .select<PostgrestList>('username')
+          .select('username')
           .neq('username', 'supabot');
       expect(res, isNotEmpty);
 
@@ -117,7 +117,7 @@ void main() {
     test('neq list', () async {
       final res = await postgrest
           .from('users')
-          .select<PostgrestList>('username')
+          .select('username')
           .neq('interests', ["football"]);
       expect(res, isNotEmpty);
 
@@ -127,10 +127,7 @@ void main() {
   });
 
   test('gt', () async {
-    final res = await postgrest
-        .from('messages')
-        .select<PostgrestList>('id')
-        .gt('id', 1);
+    final res = await postgrest.from('messages').select('id').gt('id', 1);
     expect(res, isNotEmpty);
 
     for (final item in res) {
@@ -139,10 +136,7 @@ void main() {
   });
 
   test('gte', () async {
-    final res = await postgrest
-        .from('messages')
-        .select<PostgrestList>('id')
-        .gte('id', 1);
+    final res = await postgrest.from('messages').select('id').gte('id', 1);
     expect(res, isNotEmpty);
 
     for (final item in res) {
@@ -151,10 +145,7 @@ void main() {
   });
 
   test('lt', () async {
-    final res = await postgrest
-        .from('messages')
-        .select<PostgrestList>('id')
-        .lt('id', 2);
+    final res = await postgrest.from('messages').select('id').lt('id', 2);
     expect(res, isNotEmpty);
     for (final item in res) {
       expect((item['id'] as int) < 2, true);
@@ -162,10 +153,7 @@ void main() {
   });
 
   test('lte', () async {
-    final res = await postgrest
-        .from('messages')
-        .select<PostgrestList>('id')
-        .lte('id', 2);
+    final res = await postgrest.from('messages').select('id').lte('id', 2);
     expect(res, isNotEmpty);
     for (final item in res) {
       expect((item['id'] as int) > 2, false);
@@ -175,7 +163,7 @@ void main() {
   test('like', () async {
     final res = await postgrest
         .from('users')
-        .select<PostgrestList>('username')
+        .select('username')
         .like('username', '%supa%');
     expect(res, isNotEmpty);
     for (final item in res) {
@@ -186,7 +174,7 @@ void main() {
   test('likeAllOf', () async {
     PostgrestList res = await postgrest
         .from('users')
-        .select<PostgrestList>('username')
+        .select('username')
         .likeAllOf('username', ['%supa%', '%bot%']);
     expect(res, isNotEmpty);
     for (final item in res) {
@@ -198,7 +186,7 @@ void main() {
   test('likeAnyOf', () async {
     PostgrestList res = await postgrest
         .from('users')
-        .select<PostgrestList>('username')
+        .select('username')
         .likeAnyOf('username', ['%supa%', '%wai%']);
     expect(res, isNotEmpty);
     for (final item in res) {
@@ -211,7 +199,7 @@ void main() {
   test('ilike', () async {
     final res = await postgrest
         .from('users')
-        .select<PostgrestList>('username')
+        .select('username')
         .ilike('username', '%SUPA%');
     expect(res, isNotEmpty);
     for (final item in res) {
@@ -223,7 +211,7 @@ void main() {
   test('ilikeAllOf', () async {
     PostgrestList res = await postgrest
         .from('users')
-        .select<PostgrestList>('username')
+        .select('username')
         .ilikeAllOf('username', ['%SUPA%', '%bot%']);
     expect(res, isNotEmpty);
     for (final item in res) {
@@ -235,7 +223,7 @@ void main() {
   test('ilikeAnyOf', () async {
     PostgrestList res = await postgrest
         .from('users')
-        .select<PostgrestList>('username')
+        .select('username')
         .ilikeAnyOf('username', ['%SUPA%', '%wai%']);
     expect(res, isNotEmpty);
     for (final item in res) {
@@ -247,10 +235,7 @@ void main() {
   });
 
   test('is', () async {
-    final res = await postgrest
-        .from('users')
-        .select<PostgrestList>('data')
-        .is_('data', null);
+    final res = await postgrest.from('users').select('data').is_('data', null);
     expect(res, isNotEmpty);
     for (final item in res) {
       expect(item['data'], null);
@@ -260,7 +245,7 @@ void main() {
   test('in', () async {
     final res = await postgrest
         .from('users')
-        .select<PostgrestList>('status')
+        .select('status')
         .in_('status', ['ONLINE', 'OFFLINE']);
     expect(res, isNotEmpty);
     for (final item in res) {
@@ -272,7 +257,7 @@ void main() {
   });
 
   test('immutable filter', () async {
-    final query = postgrest.from("users").select<PostgrestList>();
+    final query = postgrest.from("users").select();
     final res1 = await query.eq("status", "OFFLINE");
     final res2 = await query.eq("username", "supabot");
 
@@ -286,7 +271,7 @@ void main() {
     test('contains range', () async {
       final res = await postgrest
           .from('users')
-          .select<PostgrestList>('username')
+          .select('username')
           .contains('age_range', '[1,2)');
       expect(res, isNotEmpty);
       expect(
@@ -298,7 +283,7 @@ void main() {
     test('contains list', () async {
       final res = await postgrest
           .from('users')
-          .select<PostgrestList>('username')
+          .select('username')
           .contains('interests', ["basketball", "baseball"]);
       expect(res, isNotEmpty);
       expect(
@@ -311,7 +296,7 @@ void main() {
     test('containedBy range', () async {
       final res = await postgrest
           .from('users')
-          .select<PostgrestList>('username')
+          .select('username')
           .containedBy('age_range', '[0,3)');
       expect(res, isNotEmpty);
       expect((res[0])['username'], 'supabot');
@@ -320,7 +305,7 @@ void main() {
     test('containedBy list', () async {
       final res = await postgrest
           .from('users')
-          .select<PostgrestList>('username')
+          .select('username')
           .containedBy('interests', ["basketball", "baseball", "xxxx"]);
       expect(res, isNotEmpty);
       expect(res[0]['username'], 'supabot');
@@ -330,7 +315,7 @@ void main() {
   test('rangeLt', () async {
     final res = await postgrest
         .from('users')
-        .select<PostgrestList>('username')
+        .select('username')
         .rangeLt('age_range', '[2,25)');
     expect(res, isNotEmpty);
     expect(res[0]['username'], 'supabot');
@@ -339,7 +324,7 @@ void main() {
   test('rangeGt', () async {
     final res = await postgrest
         .from('users')
-        .select<PostgrestList>('age_range')
+        .select('age_range')
         .rangeGt('age_range', '[2,25)');
     expect(res, isNotEmpty);
     for (final item in res) {
@@ -350,7 +335,7 @@ void main() {
   test('rangeGte', () async {
     final res = await postgrest
         .from('users')
-        .select<PostgrestList>('age_range')
+        .select('age_range')
         .rangeGte('age_range', '[2,25)');
     expect(res, isNotEmpty);
     for (final item in res) {
@@ -361,7 +346,7 @@ void main() {
   test('rangeLte', () async {
     final res = await postgrest
         .from('users')
-        .select<PostgrestList>('username')
+        .select('username')
         .rangeLte('age_range', '[2,25)');
     expect(res, isNotEmpty);
     for (final item in res) {
@@ -372,7 +357,7 @@ void main() {
   test('rangeAdjacent', () async {
     final res = await postgrest
         .from('users')
-        .select<PostgrestList>('age_range')
+        .select('age_range')
         .rangeAdjacent('age_range', '[2,25)');
     expect(res.length, 3);
   });
@@ -381,7 +366,7 @@ void main() {
     test('overlaps range', () async {
       final res = await postgrest
           .from('users')
-          .select<PostgrestList>('username')
+          .select('username')
           .overlaps('age_range', '[2,25)');
       expect(
         (res[0])['username'],
@@ -392,7 +377,7 @@ void main() {
     test('overlaps list', () async {
       final res = await postgrest
           .from('users')
-          .select<PostgrestList>('username')
+          .select('username')
           .overlaps('interests', ["basketball", "baseball"]);
       expect(
         (res[0])['username'],
@@ -404,16 +389,13 @@ void main() {
   test('textSearch', () async {
     final res = await postgrest
         .from('users')
-        .select<PostgrestList>('username')
+        .select('username')
         .textSearch('catchphrase', "'fat' & 'cat'", config: 'english');
     expect(res[0]['username'], 'supabot');
   });
 
   test('textSearch with plainto_tsquery', () async {
-    final res = await postgrest
-        .from('users')
-        .select<PostgrestList>('username')
-        .textSearch(
+    final res = await postgrest.from('users').select('username').textSearch(
           'catchphrase',
           "'fat' & 'cat'",
           config: 'english',
@@ -423,10 +405,7 @@ void main() {
   });
 
   test('textSearch with phraseto_tsquery', () async {
-    final res = await postgrest
-        .from('users')
-        .select<PostgrestList>('username')
-        .textSearch(
+    final res = await postgrest.from('users').select('username').textSearch(
           'catchphrase',
           'cat',
           config: 'english',
@@ -436,10 +415,7 @@ void main() {
   });
 
   test('textSearch with websearch_to_tsquery', () async {
-    final res = await postgrest
-        .from('users')
-        .select<PostgrestList>('username')
-        .textSearch(
+    final res = await postgrest.from('users').select('username').textSearch(
           'catchphrase',
           "'fat' & 'cat'",
           config: 'english',
@@ -451,7 +427,7 @@ void main() {
   test('multiple filters', () async {
     final res = await postgrest
         .from('users')
-        .select<PostgrestList>()
+        .select()
         .eq('username', 'supabot')
         .is_('data', null)
         .overlaps('age_range', '[1,2)')
@@ -464,7 +440,7 @@ void main() {
     test('filter', () async {
       final res = await postgrest
           .from('users')
-          .select<PostgrestList>()
+          .select()
           .filter('username', 'eq', 'supabot');
       expect(res[0]['username'], 'supabot');
     });
@@ -472,7 +448,7 @@ void main() {
     test('filter in with List of values', () async {
       final res = await postgrest
           .from('users')
-          .select<PostgrestList>()
+          .select()
           .filter('username', 'in', ['supabot', 'kiwicopple']);
       expect(res.length, 2);
       for (final item in res) {
@@ -487,7 +463,7 @@ void main() {
   test('match', () async {
     final res = await postgrest
         .from('users')
-        .select<PostgrestList>()
+        .select()
         .match({'username': 'supabot', 'status': 'ONLINE'});
     expect(res[0]['username'], 'supabot');
   });
@@ -501,7 +477,7 @@ void main() {
   test('date range filter 1', () async {
     final res = await postgrest
         .from('messages')
-        .select<PostgrestList>()
+        .select()
         .gte('inserted_at', DateTime.parse('2021-06-24').toIso8601String())
         .lte('inserted_at', DateTime.parse('2021-06-26').toIso8601String());
     expect(res.length, 1);
@@ -510,7 +486,7 @@ void main() {
   test('date range filter 2', () async {
     final res = await postgrest
         .from('messages')
-        .select<PostgrestList>()
+        .select()
         .gte('inserted_at', DateTime.parse('2021-06-24').toIso8601String())
         .lte('inserted_at', DateTime.parse('2021-06-30').toIso8601String());
     expect(res.length, 2);

--- a/packages/postgrest/test/reset_helper.dart
+++ b/packages/postgrest/test/reset_helper.dart
@@ -11,10 +11,10 @@ class ResetHelper {
 
   Future<void> initialize(PostgrestClient postgrest) async {
     _postgrest = postgrest;
-    _users = (await _postgrest.from('users').select<PostgrestList>());
-    _channels = await _postgrest.from('channels').select<PostgrestList>();
-    _messages = await _postgrest.from('messages').select<PostgrestList>();
-    _reactions = await _postgrest.from('reactions').select<PostgrestList>();
+    _users = (await _postgrest.from('users').select());
+    _channels = await _postgrest.from('channels').select();
+    _messages = await _postgrest.from('messages').select();
+    _reactions = await _postgrest.from('reactions').select();
   }
 
   Future<void> reset([int delay = 0]) async {
@@ -27,8 +27,7 @@ class ResetHelper {
 
       await _postgrest.from('users').insert(_users);
 
-      final insertedUsers =
-          await _postgrest.from('users').select<PostgrestList>();
+      final insertedUsers = await _postgrest.from('users').select();
 
       // Somehow the order of the users is sometimes not correct. Adding the delay should solve this.
       if (!DeepCollectionEquality().equals(insertedUsers, _users)) {

--- a/packages/postgrest/test/resource_embedding_test.dart
+++ b/packages/postgrest/test/resource_embedding_test.dart
@@ -22,8 +22,7 @@ void main() {
   });
 
   test('embedded select', () async {
-    final res =
-        await postgrest.from('users').select<PostgrestList>('messages(*)');
+    final res = await postgrest.from('users').select('messages(*)');
     expect(
       res[0]['messages']!.length,
       3,
@@ -37,7 +36,7 @@ void main() {
   test('embedded eq', () async {
     final res = await postgrest
         .from('users')
-        .select<PostgrestList>('messages(*)')
+        .select('messages(*)')
         .eq('messages.channel_id', 1);
     expect(
       res[0]['messages']!.length,
@@ -60,7 +59,7 @@ void main() {
   test('embedded order', () async {
     final res = await postgrest
         .from('users')
-        .select<PostgrestList>('messages(*)')
+        .select('messages(*)')
         .order('channel_id', foreignTable: 'messages');
     expect(
       res[0]['messages']!.length,
@@ -79,7 +78,7 @@ void main() {
   test('embedded order on multiple columns', () async {
     final res = await postgrest
         .from('users')
-        .select<PostgrestList>('username, messages(*)')
+        .select('username, messages(*)')
         .order('username', ascending: true)
         .order('channel_id', foreignTable: 'messages');
     expect(
@@ -107,7 +106,7 @@ void main() {
   test('embedded limit', () async {
     final res = await postgrest
         .from('users')
-        .select<PostgrestList>('messages(*)')
+        .select('messages(*)')
         .limit(1, foreignTable: 'messages');
     expect(
       res[0]['messages']!.length,
@@ -130,7 +129,7 @@ void main() {
   test('embedded range', () async {
     final res = await postgrest
         .from('users')
-        .select<PostgrestList>('messages(*)')
+        .select('messages(*)')
         .range(1, 1, foreignTable: 'messages');
     expect(
       res[0]['messages']!.length,

--- a/packages/postgrest/test/transforms_test.dart
+++ b/packages/postgrest/test/transforms_test.dart
@@ -23,8 +23,7 @@ void main() {
   });
 
   test('order', () async {
-    final res =
-        await postgrest.from('users').select<PostgrestList>().order('username');
+    final res = await postgrest.from('users').select().order('username');
     expect(
       res[1]['username'],
       'kiwicopple',
@@ -35,7 +34,7 @@ void main() {
   test('order on multiple columns', () async {
     final res = await postgrest
         .from('users')
-        .select<PostgrestList>()
+        .select()
         .order('status', ascending: true)
         .order('username');
     expect(
@@ -61,7 +60,7 @@ void main() {
   test('order with filters on the same column', () async {
     final res = await postgrest
         .from('users')
-        .select<PostgrestList>()
+        .select()
         .gt('username', 'b')
         .lt('username', 'r')
         .order('username');
@@ -77,7 +76,7 @@ void main() {
   test("order on foreign table", () async {
     final data = await postgrest
         .from("users")
-        .select<PostgrestMap>(
+        .select(
           '''
           username,
           messages(
@@ -108,14 +107,14 @@ void main() {
   });
 
   test('limit', () async {
-    final res = await postgrest.from('users').select<PostgrestList>().limit(1);
+    final res = await postgrest.from('users').select().limit(1);
     expect(res.length, 1);
   });
 
   test("limit on foreign table", () async {
     final data = await postgrest
         .from("users")
-        .select<PostgrestMap>(
+        .select(
           '''
             username,
             messages(
@@ -145,8 +144,7 @@ void main() {
   test('range', () async {
     const from = 1;
     const to = 3;
-    final res =
-        await postgrest.from('users').select<PostgrestList>().range(from, to);
+    final res = await postgrest.from('users').select().range(from, to);
     //from -1 so that the index is included
     expect(res.length, to - (from - 1));
   });
@@ -154,8 +152,7 @@ void main() {
   test('range 1-1', () async {
     const from = 1;
     const to = 1;
-    final res =
-        await postgrest.from('users').select<PostgrestList>().range(from, to);
+    final res = await postgrest.from('users').select().range(from, to);
     //from -1 so that the index is included
     expect(res.length, to - (from - 1));
   });
@@ -165,7 +162,7 @@ void main() {
     const to = 2;
     final data = await postgrest
         .from("users")
-        .select<PostgrestMap>(
+        .select(
           '''
             username,
             messages(
@@ -191,7 +188,7 @@ void main() {
     const to = 1;
     final data = await postgrest
         .from("users")
-        .select<PostgrestMap>(
+        .select(
           '''
             username,
             messages(
@@ -216,7 +213,7 @@ void main() {
   test('single', () async {
     final res = await postgrest
         .from('users')
-        .select<PostgrestMap>()
+        .select()
         .eq('username', 'supabot')
         .single();
     expect(res['username'], 'supabot');
@@ -227,27 +224,26 @@ void main() {
     test('maybeSingle with 1 row', () async {
       final user = await postgrest
           .from('users')
-          .select<PostgrestMap?>()
+          .select()
           .eq('username', 'dragarcia')
           .maybeSingle();
       expect(user, isNotNull);
       expect(user?['username'], 'dragarcia');
     });
 
-    test('maybeSingle with 0 row and force response', () async {
+    test('maybeSingle with 0 row', () async {
       final user = await postgrest
           .from('users')
-          .select<PostgrestResponse>("*", FetchOptions(forceResponse: true))
+          .select("*")
           .eq('username', 'xxxxx')
           .maybeSingle();
-      expect(user, isA<PostgrestResponse>());
-      expect(user.data, isNull);
+      expect(user, isNull);
     });
 
     test('maybeSingle with 0 rows', () async {
       final user = await postgrest
           .from('users')
-          .select<PostgrestMap?>()
+          .select()
           .eq('username', 'xxxxx')
           .maybeSingle();
       expect(user, isNull);
@@ -282,13 +278,9 @@ void main() {
       }
     });
 
-    test(
-        'maybeSingle followed by another transformer preserves the maybeSingle status',
-        () async {
+    test('two transformer in a row', () async {
       try {
-        // maybeSingle followed by another transformer preserves the maybeSingle status
-        // and should throw when the returned data is more than 2 rows.
-        await postgrest.from('channels').select().maybeSingle().limit(2);
+        await postgrest.from('channels').select().limit(2).maybeSingle();
         fail('Query did not throw.');
       } on PostgrestException catch (error) {
         expect(error.code, '406');
@@ -302,9 +294,9 @@ void main() {
       try {
         await postgrest
             .from('channels')
-            .select<PostgrestList>()
+            .select()
             .maybeSingle()
-            .withConverter((data) => data.map((e) => e.toString()).toList());
+            .withConverter((data) => data?.entries.length);
         fail('Query did not throw');
       } on PostgrestException catch (error) {
         expect(error.code, '406');

--- a/packages/postgrest/test/transforms_test.dart
+++ b/packages/postgrest/test/transforms_test.dart
@@ -220,6 +220,17 @@ void main() {
     expect(res['status'], 'ONLINE');
   });
 
+  test('single with count', () async {
+    final res = await postgrest
+        .from('users')
+        .select()
+        .limit(1)
+        .single()
+        .count(CountOption.exact);
+    expect(res.data, isA<Map>());
+    expect(res.count, greaterThan(3));
+  });
+
   group("maybe single", () {
     test('maybeSingle with 1 row', () async {
       final user = await postgrest
@@ -278,9 +289,13 @@ void main() {
       }
     });
 
-    test('two transformer in a row', () async {
+    test(
+        'maybeSingle followed by another transformer preserves the maybeSingle status',
+        () async {
       try {
-        await postgrest.from('channels').select().limit(2).maybeSingle();
+        // maybeSingle followed by another transformer preserves the maybeSingle status
+        // and should throw when the returned data is more than 2 rows.
+        await postgrest.from('channels').select().maybeSingle().limit(2);
         fail('Query did not throw.');
       } on PostgrestException catch (error) {
         expect(error.code, '406');

--- a/packages/supabase/lib/src/supabase_client.dart
+++ b/packages/supabase/lib/src/supabase_client.dart
@@ -183,7 +183,7 @@ class SupabaseClient {
   }
 
   /// Perform a stored procedure call.
-  PostgrestFilterBuilder rpc(
+  PostgrestFilterBuilder<T> rpc<T>(
     String fn, {
     Map<String, dynamic>? params,
   }) {

--- a/packages/supabase/lib/src/supabase_client.dart
+++ b/packages/supabase/lib/src/supabase_client.dart
@@ -186,10 +186,9 @@ class SupabaseClient {
   PostgrestFilterBuilder rpc(
     String fn, {
     Map<String, dynamic>? params,
-    FetchOptions options = const FetchOptions(),
   }) {
     rest.headers.addAll({...rest.headers, ...headers});
-    return rest.rpc(fn, params: params, options: options);
+    return rest.rpc(fn, params: params);
   }
 
   /// Creates a Realtime channel with Broadcast, Presence, and Postgres Changes.

--- a/packages/supabase/test/mock_test.dart
+++ b/packages/supabase/test/mock_test.dart
@@ -379,7 +379,7 @@ void main() {
 
     test('test mock server', () async {
       final data = await client.from('todos').select('task, status');
-      expect((data as List).length, 2);
+      expect(data.length, 2);
     });
 
     group('Basic client test', () {


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the current behavior?

The type system makes everything dynamic, which is not very efficient. Additionally, the way a method argument changes the overall return type is not very darty.

## What is the new behavior?

By changing the api and class structure, everything is perfectly typed.

Before
```dart
supabase.from('users').insert().select<PostgrestListResponse>('id, messages', FetchOptions(count: CountOption.exact));

supabase.from('users').select('id, messages', FetchOptions(count: CountOption.exact));

supabase.from('users').select('*', FetchOptions(count: CountOption.exact, head: true));

```
After
```dart
supabase.from('users').insert().select('id, messages').count(CountOption.exact);

supabase.from('users').select('id, messages').count(CountOption.exact);

supabase.from('users').count(CountOption.exact);
```

## Breaking points
- `FetchOptions` is removed from `select` etc. and made to stand alone methods


## Additional context

The pr turned bigger than expected, but I think it's real magic how the return type perfectly changes by adding `single` and `withConverter` etc. So I think it's worth it.