### PR TITLE
Add a Callback So We Can listen To Incoming Websocket Payloads From Supabase

### DIFF
--- a/packages/realtime_client/lib/src/realtime_client.dart
+++ b/packages/realtime_client/lib/src/realtime_client.dart
@@ -275,12 +275,18 @@ class RealtimeClient {
   RealtimeChannel channel(
     String topic, [
     RealtimeChannelConfig params = const RealtimeChannelConfig(),
+    TriggerCallback? onTrigger,
   ]) {
     if (!isConnected) {
       connect();
     }
 
-    final chan = RealtimeChannel('realtime:$topic', this, params: params);
+    final chan = RealtimeChannel(
+      'realtime:$topic',
+      this,
+      params: params,
+      onTrigger: onTrigger,
+    );
     channels.add(chan);
     return chan;
   }

--- a/packages/supabase/lib/src/supabase_query_builder.dart
+++ b/packages/supabase/lib/src/supabase_query_builder.dart
@@ -45,7 +45,10 @@ class SupabaseQueryBuilder extends PostgrestQueryBuilder {
   /// ```dart
   /// supabase.from('chats').stream(primaryKey: ['id']).eq('room_id','123').order('created_at').limit(20).listen(_onChatsReceived);
   /// ```
-  SupabaseStreamBuilder stream({required List<String> primaryKey}) {
+  SupabaseStreamBuilder stream({
+    required List<String> primaryKey,
+    TriggerCallback? onTrigger,
+  }) {
     assert(primaryKey.isNotEmpty, 'Please specify primary key column(s).');
     return SupabaseStreamBuilder(
       queryBuilder: this,
@@ -54,6 +57,7 @@ class SupabaseQueryBuilder extends PostgrestQueryBuilder {
       schema: _schema,
       table: _table,
       primaryKey: primaryKey,
+      onTrigger: onTrigger,
     );
   }
 }

--- a/packages/supabase/lib/src/supabase_stream_builder.dart
+++ b/packages/supabase/lib/src/supabase_stream_builder.dart
@@ -49,6 +49,8 @@ class SupabaseStreamBuilder extends Stream<SupabaseStreamEvent> {
   /// Used to identify which row has changed
   final List<String> _uniqueColumns;
 
+  late final TriggerCallback? _onTrigger;
+
   /// StreamController for `stream()` method.
   BehaviorSubject<SupabaseStreamEvent>? _streamController;
 
@@ -71,12 +73,14 @@ class SupabaseStreamBuilder extends Stream<SupabaseStreamEvent> {
     required String schema,
     required String table,
     required List<String> primaryKey,
+    TriggerCallback? onTrigger
   })  : _queryBuilder = queryBuilder,
         _realtimeTopic = realtimeTopic,
         _realtimeClient = realtimeClient,
         _schema = schema,
         _table = table,
-        _uniqueColumns = primaryKey;
+        _uniqueColumns = primaryKey,
+        _onTrigger = onTrigger;
 
   /// Filters the results where [column] equals [value].
   ///
@@ -296,7 +300,7 @@ class SupabaseStreamBuilder extends Stream<SupabaseStreamEvent> {
       }
     }
 
-    _channel = _realtimeClient.channel(_realtimeTopic);
+    _channel = _realtimeClient.channel(_realtimeTopic, const RealtimeChannelConfig(), _onTrigger);
     _channel!.on(
         RealtimeListenTypes.postgresChanges,
         ChannelFilter(


### PR DESCRIPTION
## What kind of change does this PR introduce?

This gives consumers the capacity to listen to all incoming web socket payloads

## What is the current behavior?

Consumers only see certain kinds of incoming payloads based on the PostgREST client

## What is the new behavior?

It is now possible to include a callback to log incoming payloads

```dart
supabase.client.from(table).stream(
  primaryKey: ['id'],
  onTrigger: (
    type, [
    payload,
    ref,
  ]) {
    //This converts the incoming payload back to JSON
    //and logs it in the console
    final json = jsonEncode(payload);
    print(json);
  },
).eq(column, value);
```

This is the output

<img width="739" alt="image" src="https://github.com/supabase/supabase-flutter/assets/16697547/d16af9c0-e517-41e2-83c2-79a1de666a77">

## Additional context

This is only a rough draft, and I only added this to explain an issue. The naming is probably poor. It is called `onTrigger` because the Realtime client has a method called `trigger` where payloads arrive. The name can be changed to anything, and I can add API docs.