### PR TITLE
fix!: throw exception on non 2xx status

### DIFF
--- a/packages/functions_client/lib/src/functions_client.dart
+++ b/packages/functions_client/lib/src/functions_client.dart
@@ -100,8 +100,11 @@ class FunctionsClient {
         break;
     }
 
-    final responseType =
-        (response.headers['Content-Type'] ?? 'text/plain').split(';')[0].trim();
+    final responseType = (response.headers['Content-Type'] ??
+            response.headers['content-type'] ??
+            'text/plain')
+        .split(';')[0]
+        .trim();
 
     final data = switch (responseType) {
       'application/json' => response.bodyBytes.isEmpty

--- a/packages/functions_client/lib/src/functions_client.dart
+++ b/packages/functions_client/lib/src/functions_client.dart
@@ -110,7 +110,12 @@ class FunctionsClient {
       'application/octet-stream' => response.bodyBytes,
       _ => utf8.decode(response.bodyBytes),
     };
-    return FunctionResponse(data: data, status: response.statusCode);
+
+    if (200 <= response.statusCode && response.statusCode < 300) {
+      return FunctionResponse(data: data, status: response.statusCode);
+    } else {
+      throw FunctionException(response.statusCode, data);
+    }
   }
 
   /// Disposes the self created isolate for json encoding/decoding

--- a/packages/functions_client/lib/src/functions_client.dart
+++ b/packages/functions_client/lib/src/functions_client.dart
@@ -110,11 +110,14 @@ class FunctionsClient {
       'application/octet-stream' => response.bodyBytes,
       _ => utf8.decode(response.bodyBytes),
     };
-
     if (200 <= response.statusCode && response.statusCode < 300) {
       return FunctionResponse(data: data, status: response.statusCode);
     } else {
-      throw FunctionException(response.statusCode, data);
+      throw FunctionException(
+        status: response.statusCode,
+        details: data,
+        reasonPhrase: response.reasonPhrase,
+      );
     }
   }
 

--- a/packages/functions_client/lib/src/types.dart
+++ b/packages/functions_client/lib/src/types.dart
@@ -25,7 +25,8 @@ class FunctionResponse {
 
 class FunctionException {
   final int status;
-  final Object reason;
+  final dynamic details;
+  final String? reasonPhrase;
 
-  FunctionException(this.status, this.reason);
+  FunctionException({required this.status, this.details, this.reasonPhrase});
 }

--- a/packages/functions_client/lib/src/types.dart
+++ b/packages/functions_client/lib/src/types.dart
@@ -15,10 +15,17 @@ class FunctionResponse {
   /// - 'octet/stream': [Uint8List]
   /// - 'application/json': dynamic ([jsonDecode] is used)
   final dynamic data;
-  final int? status;
+  final int status;
 
   FunctionResponse({
     this.data,
-    this.status,
+    required this.status,
   });
+}
+
+class FunctionException {
+  final int status;
+  final Object reason;
+
+  FunctionException(this.status, this.reason);
 }

--- a/packages/functions_client/test/custom_http_client.dart
+++ b/packages/functions_client/test/custom_http_client.dart
@@ -5,14 +5,25 @@ import 'package:http/http.dart';
 class CustomHttpClient extends BaseClient {
   @override
   Future<StreamedResponse> send(BaseRequest request) async {
-    //Return custom status code to check for usage of this client.
-    return StreamedResponse(
-      Stream.value(utf8.encode(jsonEncode({"key": "Hello World"}))),
-      420,
-      request: request,
-      headers: {
-        "Content-Type": "application/json",
-      },
-    );
+    if (request.url.path.endsWith("function")) {
+      //Return custom status code to check for usage of this client.
+      return StreamedResponse(
+        Stream.value(utf8.encode(jsonEncode({"key": "Hello World"}))),
+        420,
+        request: request,
+        headers: {
+          "Content-Type": "application/json",
+        },
+      );
+    } else {
+      return StreamedResponse(
+        Stream.value(utf8.encode(jsonEncode({"key": "Hello World"}))),
+        200,
+        request: request,
+        headers: {
+          "Content-Type": "application/json",
+        },
+      );
+    }
   }
 }

--- a/packages/functions_client/test/functions_dart_test.dart
+++ b/packages/functions_client/test/functions_dart_test.dart
@@ -1,4 +1,5 @@
 import 'package:functions_client/src/functions_client.dart';
+import 'package:functions_client/src/types.dart';
 import 'package:test/test.dart';
 import 'package:yet_another_json_isolate/yet_another_json_isolate.dart';
 
@@ -12,9 +13,19 @@ void main() {
       functionsCustomHttpClient =
           FunctionsClient("", {}, httpClient: CustomHttpClient());
     });
-    test('simple function call', () async {
-      final res = await functionsCustomHttpClient.invoke('function');
-      expect(res.status, 420);
+    test('function throws', () async {
+      try {
+        await functionsCustomHttpClient.invoke('function');
+        fail('should throw');
+      } on FunctionException catch (e) {
+        expect(e.status, 420);
+      }
+    });
+
+    test('function call', () async {
+      final res = await functionsCustomHttpClient.invoke('function1');
+      expect(res.data, {'key': 'Hello World'});
+      expect(res.status, 200);
     });
 
     test('dispose isolate', () async {
@@ -31,7 +42,7 @@ void main() {
       );
 
       await client.dispose();
-      final res = await client.invoke('function');
+      final res = await client.invoke('function1');
       expect(res.data, {'key': 'Hello World'});
     });
   });


### PR DESCRIPTION
## What is the current behavior?

On non 2xx status code a normal response is returned,

## What is the new behavior?

An exception is thrown on non 2xx status code. This aligns the behavior to the [js client](https://github.com/supabase/functions-js/blob/main/src/FunctionsClient.ts)

