### PR TITLE
fix: don't try to decode an empty body

### DIFF
--- a/packages/postgrest/lib/src/postgrest_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_builder.dart
@@ -212,7 +212,9 @@ class PostgrestBuilder<T, S> implements Future<T> {
       int? count;
 
       if (response.request!.method != METHOD_HEAD) {
-        if (response.request!.headers['Accept'] == 'text/csv') {
+        if (response.bodyBytes.isEmpty) {
+          body = null;
+        } else if (response.request!.headers['Accept'] == 'text/csv') {
           body = response.body;
         } else {
           try {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

A `FormatException` is thrown on when trying to parse an empty body

## What is the new behavior?

The empty body is caught and no decoding is happening.

## Additional context

#627 
