### PR TITLE
ci: make test work again

### DIFF
--- a/.github/workflows/functions_client_ci.yml
+++ b/.github/workflows/functions_client_ci.yml
@@ -23,7 +23,6 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        node: ['12']
         sdk: [2.17.0, stable, beta, dev]
 
     defaults:

--- a/.github/workflows/gotrue_ci.yml
+++ b/.github/workflows/gotrue_ci.yml
@@ -20,7 +20,6 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        node: ['12']
         sdk: [2.17.0, stable, beta, dev]
 
     defaults:

--- a/.github/workflows/postgrest_ci.yml
+++ b/.github/workflows/postgrest_ci.yml
@@ -22,7 +22,6 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        node: ['12']
         sdk: [2.17.0, stable, beta, dev]
 
     defaults:

--- a/.github/workflows/realtime_client_ci.yml
+++ b/.github/workflows/realtime_client_ci.yml
@@ -20,7 +20,6 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        node: ['12']
         sdk: [2.17.0, stable, beta, dev]
 
     defaults:

--- a/.github/workflows/storage_client_ci.yml
+++ b/.github/workflows/storage_client_ci.yml
@@ -19,7 +19,6 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        node: ['12']
         sdk: [2.17.0, stable, beta, dev]
 
     defaults:

--- a/.github/workflows/supabase_ci.yml
+++ b/.github/workflows/supabase_ci.yml
@@ -30,7 +30,6 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        node: ['12']
         sdk: [2.17.0, stable, beta, dev]
 
     defaults:

--- a/.github/workflows/yet_another_json_isolate_ci.yml
+++ b/.github/workflows/yet_another_json_isolate_ci.yml
@@ -20,7 +20,6 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        node: ['12']
         sdk: [2.17.0, stable, beta, dev]
 
     defaults:

--- a/melos.yaml
+++ b/melos.yaml
@@ -30,6 +30,12 @@ scripts:
 
   format:
     exec: dart format lib test -l 80 --set-exit-if-changed
+  
+  upgrade:
+    exec: dart pub upgrade
+  
+  outdated:
+    exec: dart pub outdated
 
   update-version:
     run: |

--- a/packages/supabase/test/mock_test.dart
+++ b/packages/supabase/test/mock_test.dart
@@ -353,8 +353,6 @@ void main() {
   });
 
   tearDown(() async {
-    listeners.clear();
-
     await client.dispose();
     await customHeadersClient.dispose();
 
@@ -364,6 +362,8 @@ void main() {
 
     // Wait for the realtime updates to come through
     await Future.delayed(Duration(milliseconds: 100));
+
+    listeners.clear();
 
     await webSocket?.close();
 
@@ -512,16 +512,12 @@ void main() {
         final stream = client
             .from('todos')
             .stream(primaryKey: ['id']).asyncMap((event) => event);
-        stream.listen(expectAsync1((event) {
-          print(event);
-        }, count: 5));
+        stream.listen(expectAsync1((event) {}, count: 5));
 
         await Future.delayed(Duration(seconds: 3));
 
         // All realtime events are done emitting, so should receive the currnet data
-        stream.listen(expectAsync1((event) {
-          print('called');
-        }, count: 1));
+        stream.listen(expectAsync1((event) {}, count: 1));
       });
 
       test('emits data with custom headers', () {


### PR DESCRIPTION
# Changes
- fix the supabase package tests
- add upgrade and outdated scripts to melos to be able to easily upgrade all packages
- remove unused and outdated node version from matrix