### PR TITLE
fix(gotrue, supabase): allow refreshSession after exception

### DIFF
--- a/packages/gotrue/test/client_test.dart
+++ b/packages/gotrue/test/client_test.dart
@@ -340,6 +340,39 @@ void main() {
       }
     });
 
+    test('token refresh calls are bundled', () async {
+      final httpClient = RetryTestHttpClient();
+      final client = GoTrueClient(
+        url: gotrueUrl,
+        headers: {
+          'Authorization': 'Bearer $anonToken',
+          'apikey': anonToken,
+        },
+        asyncStorage: TestAsyncStorage(),
+        httpClient: httpClient,
+      );
+      final session =
+          '{"currentSession":{"access_token":"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2ODAzNDE3MDUsInN1YiI6IjRkMjU4M2RhLThkZTQtNDlkMy05Y2QxLTM3YTlhNzRmNTViZCIsImVtYWlsIjoiZmFrZTE2ODAzMzgxMDVAZW1haWwuY29tIiwicGhvbmUiOiIiLCJhcHBfbWV0YWRhdGEiOnsicHJvdmlkZXIiOiJlbWFpbCIsInByb3ZpZGVycyI6WyJlbWFpbCJdfSwidXNlcl9tZXRhZGF0YSI6eyJIZWxsbyI6IldvcmxkIn0sInJvbGUiOiIiLCJhYWwiOiJhYWwxIiwiYW1yIjpbeyJtZXRob2QiOiJwYXNzd29yZCIsInRpbWVzdGFtcCI6MTY4MDMzODEwNX1dLCJzZXNzaW9uX2lkIjoiYzhiOTg2Y2UtZWJkZC00ZGUxLWI4MjAtZjIyOWYyNjg1OGIwIn0.0x1rFlPKbIU1rZPY1SH_FNSZaXerfkFA1Y-EOlhuzUs","expires_in":3600,"refresh_token":"-yeS4omysFs9tpUYBws9Rg","token_type":"bearer","provider_token":null,"provider_refresh_token":null,"user":{"id":"4d2583da-8de4-49d3-9cd1-37a9a74f55bd","app_metadata":{"provider":"email","providers":["email"]},"user_metadata":{"Hello":"World"},"aud":"","email":"fake1680338105@email.com","phone":"","created_at":"2023-04-01T08:35:05.208586Z","confirmed_at":null,"email_confirmed_at":"2023-04-01T08:35:05.220096086Z","phone_confirmed_at":null,"last_sign_in_at":"2023-04-01T08:35:05.222755878Z","role":"","updated_at":"2023-04-01T08:35:05.226938Z"}},"expiresAt":1680341705}';
+
+      ///These 3 are bundled and in sum 4 refresh token requests are made, because the first 3 fail in [RetryTestHttpClient]
+      await Future.wait([
+        client.recoverSession(session),
+        client.recoverSession(session),
+        client.recoverSession(session),
+      ]);
+
+      expect(httpClient.retryCount, 4);
+
+      /// Again these 3 are bundled and only one refresh token request is made
+      await Future.wait([
+        client.recoverSession(session),
+        client.recoverSession(session),
+        client.recoverSession(session),
+      ]);
+
+      expect(httpClient.retryCount, 5);
+    });
+
     test('Sign out on wrong refresh token', () async {
       await client.signInWithPassword(password: password, email: email1);
 
@@ -403,7 +436,7 @@ void main() {
     test('Session recovery succeeds after retries', () async {
       await client.recoverSession(
           '{"currentSession":{"access_token":"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2ODAzNDE3MDUsInN1YiI6IjRkMjU4M2RhLThkZTQtNDlkMy05Y2QxLTM3YTlhNzRmNTViZCIsImVtYWlsIjoiZmFrZTE2ODAzMzgxMDVAZW1haWwuY29tIiwicGhvbmUiOiIiLCJhcHBfbWV0YWRhdGEiOnsicHJvdmlkZXIiOiJlbWFpbCIsInByb3ZpZGVycyI6WyJlbWFpbCJdfSwidXNlcl9tZXRhZGF0YSI6eyJIZWxsbyI6IldvcmxkIn0sInJvbGUiOiIiLCJhYWwiOiJhYWwxIiwiYW1yIjpbeyJtZXRob2QiOiJwYXNzd29yZCIsInRpbWVzdGFtcCI6MTY4MDMzODEwNX1dLCJzZXNzaW9uX2lkIjoiYzhiOTg2Y2UtZWJkZC00ZGUxLWI4MjAtZjIyOWYyNjg1OGIwIn0.0x1rFlPKbIU1rZPY1SH_FNSZaXerfkFA1Y-EOlhuzUs","expires_in":3600,"refresh_token":"-yeS4omysFs9tpUYBws9Rg","token_type":"bearer","provider_token":null,"provider_refresh_token":null,"user":{"id":"4d2583da-8de4-49d3-9cd1-37a9a74f55bd","app_metadata":{"provider":"email","providers":["email"]},"user_metadata":{"Hello":"World"},"aud":"","email":"fake1680338105@email.com","phone":"","created_at":"2023-04-01T08:35:05.208586Z","confirmed_at":null,"email_confirmed_at":"2023-04-01T08:35:05.220096086Z","phone_confirmed_at":null,"last_sign_in_at":"2023-04-01T08:35:05.222755878Z","role":"","updated_at":"2023-04-01T08:35:05.226938Z"}},"expiresAt":1680341705}');
-      expect(httpClient.retryCount, 3);
+      expect(httpClient.retryCount, 4);
     });
   });
 

--- a/packages/gotrue/test/custom_http_client.dart
+++ b/packages/gotrue/test/custom_http_client.dart
@@ -72,9 +72,9 @@ class RetryTestHttpClient extends BaseClient {
 
   @override
   Future<StreamedResponse> send(BaseRequest request) async {
-    if (retryCount < 3) {
-      retryCount++;
-      throw SocketException('Retry #${retryCount + 1}');
+    retryCount++;
+    if (retryCount < 4) {
+      throw SocketException('Retry #$retryCount');
     }
     final jwt = JWT(
       {'exp': (DateTime.now().millisecondsSinceEpoch / 1000).round() + 60},

--- a/packages/supabase/lib/src/auth_http_client.dart
+++ b/packages/supabase/lib/src/auth_http_client.dart
@@ -11,7 +11,9 @@ class AuthHttpClient extends BaseClient {
   @override
   Future<StreamedResponse> send(BaseRequest request) async {
     if (_auth.currentSession?.isExpired ?? false) {
-      await _auth.refreshSession();
+      try {
+        await _auth.refreshSession();
+      } catch (_) {}
     }
     final authBearer = _auth.currentSession?.accessToken ?? _supabaseKey;
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix for #630 

## What is the current behavior?

When a token refresh failed with a socket exception future token refreshes only happen after the specific timer

## What is the new behavior?

It's again possible to refresh the token before the timer executes.

## Additional context

The idea with the refresh token completer was to prevent multiple simultaneous requests. That's still achieved, but once a request is done a new request is possible.
