### PR TITLE
fix: Remove error parameter on `_triggerChanError`

### DIFF
--- a/packages/realtime_client/lib/src/constants.dart
+++ b/packages/realtime_client/lib/src/constants.dart
@@ -9,7 +9,17 @@ class Constants {
   };
 }
 
-enum SocketStates { connecting, open, closing, closed, disconnected }
+enum SocketStates {
+  connecting,
+  open,
+  closing,
+
+  /// Socket being close not by the user. Realtime should attempt to reconnect.
+  closed,
+
+  /// Socket being closed by the user
+  disconnected,
+}
 
 enum ChannelStates { closed, errored, joined, joining, leaving }
 

--- a/packages/realtime_client/lib/src/constants.dart
+++ b/packages/realtime_client/lib/src/constants.dart
@@ -10,8 +10,13 @@ class Constants {
 }
 
 enum SocketStates {
+  /// Client attempting to establish a connection
   connecting,
+
+  /// Connection is live and connected
   open,
+
+  /// Socket is closing.
   closing,
 
   /// Socket being close not by the user. Realtime should attempt to reconnect.

--- a/packages/realtime_client/lib/src/realtime_client.dart
+++ b/packages/realtime_client/lib/src/realtime_client.dart
@@ -428,15 +428,15 @@ class RealtimeClient {
 
   void _onConnError(dynamic error) {
     log('transport', error.toString());
-    _triggerChanError(error);
+    _triggerChanError();
     for (final callback in stateChangeCallbacks['error']!) {
       callback(error);
     }
   }
 
-  void _triggerChanError([dynamic error]) {
+  void _triggerChanError() {
     for (final channel in channels) {
-      channel.trigger(ChannelEvents.error.eventName(), error);
+      channel.trigger(ChannelEvents.error.eventName());
     }
   }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

When the device is offline, `SocketExceptions` and `WebSocketExceptions` gets thrown by the websocket connection stream [here](https://github.com/supabase/supabase-flutter/blob/main/packages/realtime_client/lib/src/realtime_client.dart#L168). This was causing rapid errors to be passed to the `.subscribe()` callback, and therefore causing rapid errors to be thrown when listening to data changes using `.stream()` method.

## What is the new behavior?

The errors from the web socket connection is not passed to `_triggerChanError`, which is aligned with the js SDK https://github.com/supabase/realtime-js/blob/master/src/RealtimeClient.ts#L402

## Additional context

This PR reverts some of the work done in https://github.com/supabase/realtime-dart/pull/62/files, but we can default to the same behavior as the js SDK for now and fix things if necessary in the future. 
