### PR TITLE
refactor!: create package specific configs

### DIFF
--- a/packages/supabase/lib/src/supabase_client.dart
+++ b/packages/supabase/lib/src/supabase_client.dart
@@ -121,7 +121,7 @@ class SupabaseClient {
     this.supabaseUrl,
     this.supabaseKey, {
     PostgrestClientOptions postgrestOptions = const PostgrestClientOptions(),
-    GoTrueClientOptions goTrueOptions = const GoTrueClientOptions(),
+    AuthClientOptions authOptions = const AuthClientOptions(),
     StorageClientOptions storageOptions = const StorageClientOptions(),
     RealtimeClientOptions realtimeClientOptions = const RealtimeClientOptions(),
     Map<String, String>? headers,
@@ -140,9 +140,9 @@ class SupabaseClient {
         _httpClient = httpClient,
         _isolate = isolate ?? (YAJsonIsolate()..initialize()) {
     auth = _initSupabaseAuthClient(
-      autoRefreshToken: goTrueOptions.autoRefreshToken,
-      gotrueAsyncStorage: goTrueOptions.pkceAsyncStorage,
-      authFlowType: goTrueOptions.authFlowType,
+      autoRefreshToken: authOptions.autoRefreshToken,
+      gotrueAsyncStorage: authOptions.pkceAsyncStorage,
+      authFlowType: authOptions.authFlowType,
     );
     _authHttpClient = AuthHttpClient(supabaseKey, httpClient ?? Client(), auth);
     rest = _initRestClient();

--- a/packages/supabase/lib/src/supabase_client_options.dart
+++ b/packages/supabase/lib/src/supabase_client_options.dart
@@ -6,12 +6,12 @@ class PostgrestClientOptions {
   const PostgrestClientOptions({this.schema = 'public'});
 }
 
-class GoTrueClientOptions {
+class AuthClientOptions {
   final bool autoRefreshToken;
   final GotrueAsyncStorage? pkceAsyncStorage;
   final AuthFlowType authFlowType;
 
-  const GoTrueClientOptions({
+  const AuthClientOptions({
     this.autoRefreshToken = true,
     this.pkceAsyncStorage,
     this.authFlowType = AuthFlowType.pkce,

--- a/packages/supabase/lib/src/supabase_client_options.dart
+++ b/packages/supabase/lib/src/supabase_client_options.dart
@@ -1,0 +1,25 @@
+import 'package:supabase/supabase.dart';
+
+class PostgrestClientOptions {
+  final String schema;
+
+  const PostgrestClientOptions({this.schema = 'public'});
+}
+
+class GoTrueClientOptions {
+  final bool autoRefreshToken;
+  final GotrueAsyncStorage? pkceAsyncStorage;
+  final AuthFlowType authFlowType;
+
+  const GoTrueClientOptions({
+    this.autoRefreshToken = true,
+    this.pkceAsyncStorage,
+    this.authFlowType = AuthFlowType.pkce,
+  });
+}
+
+class StorageClientOptions {
+  final int retryAttempts;
+
+  const StorageClientOptions({this.retryAttempts = 0});
+}

--- a/packages/supabase/lib/supabase.dart
+++ b/packages/supabase/lib/supabase.dart
@@ -14,6 +14,7 @@ export 'src/auth_user.dart';
 export 'src/realtime_client_options.dart';
 export 'src/remove_subscription_result.dart';
 export 'src/supabase_client.dart';
+export 'src/supabase_client_options.dart';
 export 'src/supabase_event_types.dart';
 export 'src/supabase_query_builder.dart';
 export 'src/supabase_realtime_error.dart';

--- a/packages/supabase/test/client_test.dart
+++ b/packages/supabase/test/client_test.dart
@@ -69,7 +69,7 @@ void main() {
       final client = SupabaseClient(
         'http://${mockServer.address.host}:${mockServer.port}',
         "supabaseKey",
-        goTrueOptions: GoTrueClientOptions(autoRefreshToken: false),
+        authOptions: AuthClientOptions(autoRefreshToken: false),
       );
       await client.auth.recoverSession(sessionString);
 
@@ -101,7 +101,7 @@ void main() {
       final client = SupabaseClient(
         'http://${mockServer.address.host}:${mockServer.port}',
         "supabaseKey",
-        goTrueOptions: GoTrueClientOptions(autoRefreshToken: false),
+        authOptions: AuthClientOptions(autoRefreshToken: false),
       );
       final sessionData = getSessionData(expiresAt);
       await client.auth.recoverSession(sessionData.sessionString);

--- a/packages/supabase/test/client_test.dart
+++ b/packages/supabase/test/client_test.dart
@@ -69,7 +69,7 @@ void main() {
       final client = SupabaseClient(
         'http://${mockServer.address.host}:${mockServer.port}',
         "supabaseKey",
-        autoRefreshToken: false,
+        goTrueOptions: GoTrueClientOptions(autoRefreshToken: false),
       );
       await client.auth.recoverSession(sessionString);
 
@@ -101,7 +101,7 @@ void main() {
       final client = SupabaseClient(
         'http://${mockServer.address.host}:${mockServer.port}',
         "supabaseKey",
-        autoRefreshToken: false,
+        goTrueOptions: GoTrueClientOptions(autoRefreshToken: false),
       );
       final sessionData = getSessionData(expiresAt);
       await client.auth.recoverSession(sessionData.sessionString);

--- a/packages/supabase_flutter/lib/src/flutter_go_true_client_options.dart
+++ b/packages/supabase_flutter/lib/src/flutter_go_true_client_options.dart
@@ -1,22 +1,22 @@
 import 'package:supabase_flutter/supabase_flutter.dart';
 
-class FlutterGoTrueClientOptions extends GoTrueClientOptions {
+class FlutterAuthClientOptions extends AuthClientOptions {
   final LocalStorage? localStorage;
 
-  const FlutterGoTrueClientOptions({
+  const FlutterAuthClientOptions({
     super.authFlowType,
     super.autoRefreshToken,
     super.pkceAsyncStorage,
     this.localStorage,
   });
 
-  FlutterGoTrueClientOptions copyWith({
+  FlutterAuthClientOptions copyWith({
     AuthFlowType? authFlowType,
     bool? autoRefreshToken,
     LocalStorage? localStorage,
     dynamic pkceAsyncStorage,
   }) {
-    return FlutterGoTrueClientOptions(
+    return FlutterAuthClientOptions(
       authFlowType: authFlowType ?? this.authFlowType,
       autoRefreshToken: autoRefreshToken ?? this.autoRefreshToken,
       localStorage: localStorage ?? this.localStorage,

--- a/packages/supabase_flutter/lib/src/flutter_go_true_client_options.dart
+++ b/packages/supabase_flutter/lib/src/flutter_go_true_client_options.dart
@@ -10,13 +10,17 @@ class FlutterGoTrueClientOptions extends GoTrueClientOptions {
     this.localStorage,
   });
 
-  FlutterGoTrueClientOptions maybeWith({
+  FlutterGoTrueClientOptions copyWith({
+    AuthFlowType? authFlowType,
+    bool? autoRefreshToken,
     LocalStorage? localStorage,
-    GotrueAsyncStorage? gotrueAsyncStorage,
+    dynamic pkceAsyncStorage,
   }) {
     return FlutterGoTrueClientOptions(
-      localStorage: this.localStorage ?? localStorage,
-      pkceAsyncStorage: pkceAsyncStorage ?? gotrueAsyncStorage,
+      authFlowType: authFlowType ?? this.authFlowType,
+      autoRefreshToken: autoRefreshToken ?? this.autoRefreshToken,
+      localStorage: localStorage ?? this.localStorage,
+      pkceAsyncStorage: pkceAsyncStorage ?? this.pkceAsyncStorage,
     );
   }
 }

--- a/packages/supabase_flutter/lib/src/flutter_go_true_client_options.dart
+++ b/packages/supabase_flutter/lib/src/flutter_go_true_client_options.dart
@@ -1,0 +1,22 @@
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+class FlutterGoTrueClientOptions extends GoTrueClientOptions {
+  final LocalStorage? localStorage;
+
+  const FlutterGoTrueClientOptions({
+    super.authFlowType,
+    super.autoRefreshToken,
+    super.pkceAsyncStorage,
+    this.localStorage,
+  });
+
+  FlutterGoTrueClientOptions maybeWith({
+    LocalStorage? localStorage,
+    GotrueAsyncStorage? gotrueAsyncStorage,
+  }) {
+    return FlutterGoTrueClientOptions(
+      localStorage: this.localStorage ?? localStorage,
+      pkceAsyncStorage: pkceAsyncStorage ?? gotrueAsyncStorage,
+    );
+  }
+}

--- a/packages/supabase_flutter/lib/src/supabase.dart
+++ b/packages/supabase_flutter/lib/src/supabase.dart
@@ -2,6 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:http/http.dart';
 import 'package:supabase/supabase.dart';
 import 'package:supabase_flutter/src/constants.dart';
+import 'package:supabase_flutter/src/flutter_go_true_client_options.dart';
 import 'package:supabase_flutter/src/local_storage.dart';
 import 'package:supabase_flutter/src/supabase_auth.dart';
 
@@ -65,14 +66,13 @@ class Supabase {
   static Future<Supabase> initialize({
     required String url,
     required String anonKey,
-    String? schema,
     Map<String, String>? headers,
-    LocalStorage? localStorage,
     Client? httpClient,
-    int storageRetryAttempts = 0,
     RealtimeClientOptions realtimeClientOptions = const RealtimeClientOptions(),
-    AuthFlowType authFlowType = AuthFlowType.pkce,
-    GotrueAsyncStorage? pkceAsyncStorage,
+    PostgrestClientOptions postgrestOptions = const PostgrestClientOptions(),
+    StorageClientOptions storageOptions = const StorageClientOptions(),
+    FlutterGoTrueClientOptions goTrueOptions =
+        const FlutterGoTrueClientOptions(),
     bool? debug,
   }) async {
     assert(
@@ -84,22 +84,23 @@ class Supabase {
       anonKey,
       httpClient: httpClient,
       customHeaders: headers,
-      schema: schema,
-      storageRetryAttempts: storageRetryAttempts,
       realtimeClientOptions: realtimeClientOptions,
-      gotrueAsyncStorage:
-          pkceAsyncStorage ?? SharedPreferencesGotrueAsyncStorage(),
-      authFlowType: authFlowType,
+      goTrueOptions: goTrueOptions.maybeWith(
+        gotrueAsyncStorage: SharedPreferencesGotrueAsyncStorage(),
+      ),
+      postgrestOptions: postgrestOptions,
+      storageOptions: storageOptions,
     );
     _instance._debugEnable = debug ?? kDebugMode;
     _instance.log('***** Supabase init completed $_instance');
 
     await SupabaseAuth.initialize(
-      localStorage: localStorage ??
-          MigrationLocalStorage(
-              persistSessionKey:
-                  "sb-${Uri.parse(url).host.split(".").first}-auth-token"),
-      authFlowType: authFlowType,
+      options: goTrueOptions.maybeWith(
+        localStorage: MigrationLocalStorage(
+          persistSessionKey:
+              "sb-${Uri.parse(url).host.split(".").first}-auth-token",
+        ),
+      ),
     );
 
     return _instance;
@@ -128,11 +129,10 @@ class Supabase {
     String supabaseAnonKey, {
     Client? httpClient,
     Map<String, String>? customHeaders,
-    String? schema,
-    required int storageRetryAttempts,
     required RealtimeClientOptions realtimeClientOptions,
-    required GotrueAsyncStorage gotrueAsyncStorage,
-    required AuthFlowType authFlowType,
+    required PostgrestClientOptions postgrestOptions,
+    required StorageClientOptions storageOptions,
+    required GoTrueClientOptions goTrueOptions,
   }) {
     final headers = {
       ...Constants.defaultHeaders,
@@ -143,11 +143,10 @@ class Supabase {
       supabaseAnonKey,
       httpClient: httpClient,
       headers: headers,
-      schema: schema,
-      storageRetryAttempts: storageRetryAttempts,
       realtimeClientOptions: realtimeClientOptions,
-      gotrueAsyncStorage: gotrueAsyncStorage,
-      authFlowType: authFlowType,
+      postgrestOptions: postgrestOptions,
+      storageOptions: storageOptions,
+      goTrueOptions: goTrueOptions,
     );
     _initialized = true;
   }

--- a/packages/supabase_flutter/lib/src/supabase.dart
+++ b/packages/supabase_flutter/lib/src/supabase.dart
@@ -79,29 +79,33 @@ class Supabase {
       !_instance._initialized,
       'This instance is already initialized',
     );
+    if (goTrueOptions.pkceAsyncStorage == null) {
+      goTrueOptions = goTrueOptions.copyWith(
+        pkceAsyncStorage: SharedPreferencesGotrueAsyncStorage(),
+      );
+    }
+    if (goTrueOptions.localStorage == null) {
+      goTrueOptions = goTrueOptions.copyWith(
+        localStorage: MigrationLocalStorage(
+          persistSessionKey:
+              "sb-${Uri.parse(url).host.split(".").first}-auth-token",
+        ),
+      );
+    }
     _instance._init(
       url,
       anonKey,
       httpClient: httpClient,
       customHeaders: headers,
       realtimeClientOptions: realtimeClientOptions,
-      goTrueOptions: goTrueOptions.maybeWith(
-        gotrueAsyncStorage: SharedPreferencesGotrueAsyncStorage(),
-      ),
+      goTrueOptions: goTrueOptions,
       postgrestOptions: postgrestOptions,
       storageOptions: storageOptions,
     );
     _instance._debugEnable = debug ?? kDebugMode;
     _instance.log('***** Supabase init completed $_instance');
 
-    await SupabaseAuth.initialize(
-      options: goTrueOptions.maybeWith(
-        localStorage: MigrationLocalStorage(
-          persistSessionKey:
-              "sb-${Uri.parse(url).host.split(".").first}-auth-token",
-        ),
-      ),
-    );
+    await SupabaseAuth.initialize(options: goTrueOptions);
 
     return _instance;
   }

--- a/packages/supabase_flutter/lib/src/supabase.dart
+++ b/packages/supabase_flutter/lib/src/supabase.dart
@@ -71,21 +71,21 @@ class Supabase {
     RealtimeClientOptions realtimeClientOptions = const RealtimeClientOptions(),
     PostgrestClientOptions postgrestOptions = const PostgrestClientOptions(),
     StorageClientOptions storageOptions = const StorageClientOptions(),
-    FlutterGoTrueClientOptions goTrueOptions =
-        const FlutterGoTrueClientOptions(),
+    FlutterAuthClientOptions authOptions =
+        const FlutterAuthClientOptions(),
     bool? debug,
   }) async {
     assert(
       !_instance._initialized,
       'This instance is already initialized',
     );
-    if (goTrueOptions.pkceAsyncStorage == null) {
-      goTrueOptions = goTrueOptions.copyWith(
+    if (authOptions.pkceAsyncStorage == null) {
+      authOptions = authOptions.copyWith(
         pkceAsyncStorage: SharedPreferencesGotrueAsyncStorage(),
       );
     }
-    if (goTrueOptions.localStorage == null) {
-      goTrueOptions = goTrueOptions.copyWith(
+    if (authOptions.localStorage == null) {
+      authOptions = authOptions.copyWith(
         localStorage: MigrationLocalStorage(
           persistSessionKey:
               "sb-${Uri.parse(url).host.split(".").first}-auth-token",
@@ -98,7 +98,7 @@ class Supabase {
       httpClient: httpClient,
       customHeaders: headers,
       realtimeClientOptions: realtimeClientOptions,
-      goTrueOptions: goTrueOptions,
+      authOptions: authOptions,
       postgrestOptions: postgrestOptions,
       storageOptions: storageOptions,
     );
@@ -106,7 +106,7 @@ class Supabase {
     _instance.log('***** Supabase init completed $_instance');
 
     _instance._supabaseAuth = SupabaseAuth();
-    await _instance._supabaseAuth.initialize(options: goTrueOptions);
+    await _instance._supabaseAuth.initialize(options: authOptions);
 
     return _instance;
   }
@@ -140,7 +140,7 @@ class Supabase {
     required RealtimeClientOptions realtimeClientOptions,
     required PostgrestClientOptions postgrestOptions,
     required StorageClientOptions storageOptions,
-    required GoTrueClientOptions goTrueOptions,
+    required AuthClientOptions authOptions,
   }) {
     final headers = {
       ...Constants.defaultHeaders,
@@ -154,7 +154,7 @@ class Supabase {
       realtimeClientOptions: realtimeClientOptions,
       postgrestOptions: postgrestOptions,
       storageOptions: storageOptions,
-      goTrueOptions: goTrueOptions,
+      authOptions: authOptions,
     );
     _initialized = true;
   }

--- a/packages/supabase_flutter/lib/src/supabase.dart
+++ b/packages/supabase_flutter/lib/src/supabase.dart
@@ -105,7 +105,8 @@ class Supabase {
     _instance._debugEnable = debug ?? kDebugMode;
     _instance.log('***** Supabase init completed $_instance');
 
-    await SupabaseAuth.initialize(options: goTrueOptions);
+    _instance._supabaseAuth = SupabaseAuth();
+    await _instance._supabaseAuth.initialize(options: goTrueOptions);
 
     return _instance;
   }
@@ -119,12 +120,15 @@ class Supabase {
   ///
   /// Throws an error if [Supabase.initialize] was not called.
   late SupabaseClient client;
+
+  late SupabaseAuth _supabaseAuth;
+
   bool _debugEnable = false;
 
   /// Dispose the instance to free up resources.
   void dispose() {
     client.dispose();
-    SupabaseAuth.instance.dispose();
+    _instance._supabaseAuth.dispose();
     _initialized = false;
   }
 

--- a/packages/supabase_flutter/lib/src/supabase_auth.dart
+++ b/packages/supabase_flutter/lib/src/supabase_auth.dart
@@ -17,29 +17,15 @@ import 'package:webview_flutter/webview_flutter.dart';
 
 /// SupabaseAuth
 class SupabaseAuth with WidgetsBindingObserver {
-  SupabaseAuth._();
-
   static WidgetsBinding? get _widgetsBindingInstance => WidgetsBinding.instance;
 
-  static final SupabaseAuth _instance = SupabaseAuth._();
-
-  bool _initialized = false;
   late LocalStorage _localStorage;
   late AuthFlowType _authFlowType;
-
-  /// The [LocalStorage] instance used to persist the user session.
-  LocalStorage get localStorage => _localStorage;
-
-  /// {@macro supabase.localstorage.hasAccessToken}
-  Future<bool> get hasAccessToken => _localStorage.hasAccessToken();
-
-  /// {@macro supabase.localstorage.accessToken}
-  Future<String?> get accessToken => _localStorage.accessToken();
 
   /// **ATTENTION**: `getInitialLink`/`getInitialUri` should be handled
   /// ONLY ONCE in your app's lifetime, since it is not meant to change
   /// throughout your app's life.
-  bool _initialDeeplinkIsHandled = false;
+  static bool _initialDeeplinkIsHandled = false;
 
   StreamSubscription<AuthState>? _authSubscription;
 
@@ -47,47 +33,27 @@ class SupabaseAuth with WidgetsBindingObserver {
 
   final _appLinks = AppLinks();
 
-  /// A [SupabaseAuth] instance.
-  ///
-  /// If not initialized, an [AssertionError] is thrown
-  static SupabaseAuth get instance {
-    assert(
-      _instance._initialized,
-      'You must initialize the supabase instance before calling Supabase.instance',
-    );
-
-    return _instance;
-  }
-
-  /// Initialize the [SupabaseAuth] instance.
-  ///
-  /// It's necessary to initialize before calling [SupabaseAuth.instance]
-  ///
-  /// Should not be initialized manually, but automatically by  [Supabase.initialize]
-  @internal
-  static Future<SupabaseAuth> initialize({
+  Future<void> initialize({
     required FlutterGoTrueClientOptions options,
   }) async {
-    _instance._initialized = true;
-    _instance._localStorage = options.localStorage!;
-    _instance._authFlowType = options.authFlowType;
+    _localStorage = options.localStorage!;
+    _authFlowType = options.authFlowType;
 
-    _instance._authSubscription =
-        Supabase.instance.client.auth.onAuthStateChange.listen(
+    _authSubscription = Supabase.instance.client.auth.onAuthStateChange.listen(
       (data) {
-        _instance._onAuthStateChange(data.event, data.session);
+        _onAuthStateChange(data.event, data.session);
       },
       onError: (error, stackTrace) {
         Supabase.instance.log(error.toString(), stackTrace);
       },
     );
 
-    await _instance._localStorage.initialize();
+    await _localStorage.initialize();
 
-    final hasPersistedSession = await _instance._localStorage.hasAccessToken();
+    final hasPersistedSession = await _localStorage.hasAccessToken();
     var shouldEmitInitialSession = true;
     if (hasPersistedSession) {
-      final persistedSession = await _instance._localStorage.accessToken();
+      final persistedSession = await _localStorage.accessToken();
       if (persistedSession != null) {
         try {
           // At this point either an [AuthChangeEvent.signedIn] event or an exception should next be emitted by `onAuthStateChange`
@@ -100,14 +66,14 @@ class SupabaseAuth with WidgetsBindingObserver {
         }
       }
     }
-    _widgetsBindingInstance?.addObserver(_instance);
+    _widgetsBindingInstance?.addObserver(this);
     if (kIsWeb ||
         Platform.isAndroid ||
         Platform.isIOS ||
         Platform.isMacOS ||
         Platform.isWindows ||
         Platform.environment.containsKey('FLUTTER_TEST')) {
-      await _instance._startDeeplinkObserver();
+      await _startDeeplinkObserver();
     }
 
     // Emit a null session if the user did not have persisted session
@@ -116,7 +82,6 @@ class SupabaseAuth with WidgetsBindingObserver {
           // ignore: invalid_use_of_internal_member
           .notifyAllSubscribers(AuthChangeEvent.initialSession);
     }
-    return _instance;
   }
 
   /// Dispose the instance to free up resources
@@ -141,14 +106,12 @@ class SupabaseAuth with WidgetsBindingObserver {
   /// Recover/refresh session if it's available
   /// e.g. called on a splash screen when the app starts.
   Future<bool> _recoverSupabaseSession() async {
-    final bool exist =
-        await SupabaseAuth.instance.localStorage.hasAccessToken();
+    final bool exist = await _localStorage.hasAccessToken();
     if (!exist) {
       return false;
     }
 
-    final String? jsonStr =
-        await SupabaseAuth.instance.localStorage.accessToken();
+    final String? jsonStr = await _localStorage.accessToken();
     if (jsonStr == null) {
       return false;
     }
@@ -157,7 +120,7 @@ class SupabaseAuth with WidgetsBindingObserver {
       await Supabase.instance.client.auth.recoverSession(jsonStr);
       return true;
     } catch (error) {
-      SupabaseAuth.instance.localStorage.removePersistedSession();
+      _localStorage.removePersistedSession();
       return false;
     }
   }
@@ -242,7 +205,7 @@ class SupabaseAuth with WidgetsBindingObserver {
 
   /// Callback when deeplink receiving succeeds
   Future<void> _handleDeeplink(Uri uri) async {
-    if (!_instance._isAuthCallbackDeeplink(uri)) return;
+    if (!_isAuthCallbackDeeplink(uri)) return;
 
     Supabase.instance.log('***** SupabaseAuthState handleDeeplink $uri');
 

--- a/packages/supabase_flutter/lib/src/supabase_auth.dart
+++ b/packages/supabase_flutter/lib/src/supabase_auth.dart
@@ -34,7 +34,7 @@ class SupabaseAuth with WidgetsBindingObserver {
   final _appLinks = AppLinks();
 
   Future<void> initialize({
-    required FlutterGoTrueClientOptions options,
+    required FlutterAuthClientOptions options,
   }) async {
     _localStorage = options.localStorage!;
     _authFlowType = options.authFlowType;

--- a/packages/supabase_flutter/lib/src/supabase_auth.dart
+++ b/packages/supabase_flutter/lib/src/supabase_auth.dart
@@ -62,13 +62,15 @@ class SupabaseAuth with WidgetsBindingObserver {
   /// Initialize the [SupabaseAuth] instance.
   ///
   /// It's necessary to initialize before calling [SupabaseAuth.instance]
+  ///
+  /// Should not be initialized manually, but automatically by  [Supabase.initialize]
+  @internal
   static Future<SupabaseAuth> initialize({
-    required LocalStorage localStorage,
-    required AuthFlowType authFlowType,
+    required FlutterGoTrueClientOptions options,
   }) async {
     _instance._initialized = true;
-    _instance._localStorage = localStorage;
-    _instance._authFlowType = authFlowType;
+    _instance._localStorage = options.localStorage!;
+    _instance._authFlowType = options.authFlowType;
 
     _instance._authSubscription =
         Supabase.instance.client.auth.onAuthStateChange.listen(

--- a/packages/supabase_flutter/lib/supabase_flutter.dart
+++ b/packages/supabase_flutter/lib/supabase_flutter.dart
@@ -9,4 +9,3 @@ export 'package:url_launcher/url_launcher.dart' show LaunchMode;
 export 'src/flutter_go_true_client_options.dart';
 export 'src/local_storage.dart';
 export 'src/supabase.dart';
-export 'src/supabase_auth.dart';

--- a/packages/supabase_flutter/lib/supabase_flutter.dart
+++ b/packages/supabase_flutter/lib/supabase_flutter.dart
@@ -4,7 +4,9 @@
 library supabase_flutter;
 
 export 'package:supabase/supabase.dart';
+export 'package:url_launcher/url_launcher.dart' show LaunchMode;
+
+export 'src/flutter_go_true_client_options.dart';
 export 'src/local_storage.dart';
 export 'src/supabase.dart';
 export 'src/supabase_auth.dart';
-export 'package:url_launcher/url_launcher.dart' show LaunchMode;

--- a/packages/supabase_flutter/test/supabase_flutter_test.dart
+++ b/packages/supabase_flutter/test/supabase_flutter_test.dart
@@ -14,7 +14,7 @@ void main() {
       await Supabase.initialize(
         url: supabaseUrl,
         anonKey: supabaseKey,
-        goTrueOptions: FlutterGoTrueClientOptions(
+        authOptions: FlutterAuthClientOptions(
           localStorage: MockLocalStorage(),
           pkceAsyncStorage: MockAsyncStorage(),
         ),
@@ -35,7 +35,7 @@ void main() {
       await Supabase.initialize(
         url: supabaseUrl,
         anonKey: supabaseKey,
-        goTrueOptions: FlutterGoTrueClientOptions(
+        authOptions: FlutterAuthClientOptions(
           localStorage: MockLocalStorage(),
           pkceAsyncStorage: MockAsyncStorage(),
         ),
@@ -52,7 +52,7 @@ void main() {
       await Supabase.initialize(
         url: supabaseUrl,
         anonKey: supabaseKey,
-        goTrueOptions: FlutterGoTrueClientOptions(
+        authOptions: FlutterAuthClientOptions(
           localStorage: MockExpiredStorage(),
           pkceAsyncStorage: MockAsyncStorage(),
         ),
@@ -73,7 +73,7 @@ void main() {
       await Supabase.initialize(
         url: supabaseUrl,
         anonKey: supabaseKey,
-        goTrueOptions: FlutterGoTrueClientOptions(
+        authOptions: FlutterAuthClientOptions(
           localStorage: MockEmptyLocalStorage(),
           pkceAsyncStorage: MockAsyncStorage(),
         ),
@@ -102,7 +102,7 @@ void main() {
         url: supabaseUrl,
         anonKey: supabaseKey,
         httpClient: pkceHttpClient,
-        goTrueOptions: FlutterGoTrueClientOptions(
+        authOptions: FlutterAuthClientOptions(
           localStorage: MockEmptyLocalStorage(),
           pkceAsyncStorage: MockAsyncStorage(),
         ),

--- a/packages/supabase_flutter/test/supabase_flutter_test.dart
+++ b/packages/supabase_flutter/test/supabase_flutter_test.dart
@@ -14,8 +14,10 @@ void main() {
       await Supabase.initialize(
         url: supabaseUrl,
         anonKey: supabaseKey,
-        localStorage: MockLocalStorage(),
-        pkceAsyncStorage: MockAsyncStorage(),
+        goTrueOptions: FlutterGoTrueClientOptions(
+          localStorage: MockLocalStorage(),
+          pkceAsyncStorage: MockAsyncStorage(),
+        ),
       );
     });
 
@@ -33,8 +35,10 @@ void main() {
       await Supabase.initialize(
         url: supabaseUrl,
         anonKey: supabaseKey,
-        localStorage: MockLocalStorage(),
-        pkceAsyncStorage: MockAsyncStorage(),
+        goTrueOptions: FlutterGoTrueClientOptions(
+          localStorage: MockLocalStorage(),
+          pkceAsyncStorage: MockAsyncStorage(),
+        ),
       );
 
       final newClient = Supabase.instance.client;
@@ -48,8 +52,10 @@ void main() {
       await Supabase.initialize(
         url: supabaseUrl,
         anonKey: supabaseKey,
-        localStorage: MockExpiredStorage(),
-        pkceAsyncStorage: MockAsyncStorage(),
+        goTrueOptions: FlutterGoTrueClientOptions(
+          localStorage: MockExpiredStorage(),
+          pkceAsyncStorage: MockAsyncStorage(),
+        ),
       );
     });
 
@@ -67,8 +73,10 @@ void main() {
       await Supabase.initialize(
         url: supabaseUrl,
         anonKey: supabaseKey,
-        localStorage: MockEmptyLocalStorage(),
-        pkceAsyncStorage: MockAsyncStorage(),
+        goTrueOptions: FlutterGoTrueClientOptions(
+          localStorage: MockEmptyLocalStorage(),
+          pkceAsyncStorage: MockAsyncStorage(),
+        ),
       );
     });
 
@@ -93,10 +101,11 @@ void main() {
       await Supabase.initialize(
         url: supabaseUrl,
         anonKey: supabaseKey,
-        authFlowType: AuthFlowType.pkce,
         httpClient: pkceHttpClient,
-        localStorage: MockEmptyLocalStorage(),
-        pkceAsyncStorage: MockAsyncStorage(),
+        goTrueOptions: FlutterGoTrueClientOptions(
+          localStorage: MockEmptyLocalStorage(),
+          pkceAsyncStorage: MockAsyncStorage(),
+        ),
       );
     });
 

--- a/packages/supabase_flutter/test/widget_test.dart
+++ b/packages/supabase_flutter/test/widget_test.dart
@@ -21,8 +21,10 @@ void main() {
     await Supabase.initialize(
       url: supabaseUrl,
       anonKey: supabaseKey,
-      localStorage: MockLocalStorage(),
-      pkceAsyncStorage: MockAsyncStorage(),
+      goTrueOptions: FlutterGoTrueClientOptions(
+        localStorage: MockLocalStorage(),
+        pkceAsyncStorage: MockAsyncStorage(),
+      ),
     );
     await tester.pumpWidget(const MaterialApp(home: MockWidget()));
     await tester.tap(find.text('Sign out'));

--- a/packages/supabase_flutter/test/widget_test.dart
+++ b/packages/supabase_flutter/test/widget_test.dart
@@ -21,7 +21,7 @@ void main() {
     await Supabase.initialize(
       url: supabaseUrl,
       anonKey: supabaseKey,
-      goTrueOptions: FlutterGoTrueClientOptions(
+      authOptions: FlutterAuthClientOptions(
         localStorage: MockLocalStorage(),
         pkceAsyncStorage: MockAsyncStorage(),
       ),


### PR DESCRIPTION
# Breaking Changes
- create package specific config classes in `supabase` and `supabase_flutter`
- make many fields private
- mark `SupabaseAuth.initialize` as internal as I see no reason to manually initialize. It depends on `Supabase.instance` so it can't be initialized alone either.

This aligns a bit with how supabase-js does this, but I've done the naming a bit different.

Actually, I noticed there is not really a reason for a global `SupabaseAuth.instance`, because it only provides access to the localstorage used. So I would be open to remove it and instead make it a simple object of the `Supabase` class in `supabase_flutter`.