### PR TITLE
refactor!: disallow multiple stream filter

### DIFF
--- a/packages/supabase/lib/src/supabase_query_builder.dart
+++ b/packages/supabase/lib/src/supabase_query_builder.dart
@@ -1,5 +1,4 @@
 import 'package:http/http.dart';
-import 'package:supabase/src/supabase_stream_builder.dart';
 import 'package:supabase/supabase.dart';
 import 'package:yet_another_json_isolate/yet_another_json_isolate.dart';
 
@@ -45,9 +44,9 @@ class SupabaseQueryBuilder extends PostgrestQueryBuilder {
   /// ```dart
   /// supabase.from('chats').stream(primaryKey: ['id']).eq('room_id','123').order('created_at').limit(20).listen(_onChatsReceived);
   /// ```
-  SupabaseStreamBuilder stream({required List<String> primaryKey}) {
+  SupabaseStreamFilterBuilder stream({required List<String> primaryKey}) {
     assert(primaryKey.isNotEmpty, 'Please specify primary key column(s).');
-    return SupabaseStreamBuilder(
+    return SupabaseStreamFilterBuilder(
       queryBuilder: this,
       realtimeClient: _realtime,
       realtimeTopic: '$_schema:$_table:$_incrementId',

--- a/packages/supabase/lib/src/supabase_stream_builder.dart
+++ b/packages/supabase/lib/src/supabase_stream_builder.dart
@@ -3,6 +3,8 @@ import 'dart:async';
 import 'package:rxdart/rxdart.dart';
 import 'package:supabase/supabase.dart';
 
+part 'supabase_stream_filter_builder.dart';
+
 enum _FilterType { eq, neq, lt, lte, gt, gte, inFilter }
 
 class _StreamPostgrestFilter {
@@ -77,146 +79,6 @@ class SupabaseStreamBuilder extends Stream<SupabaseStreamEvent> {
         _schema = schema,
         _table = table,
         _uniqueColumns = primaryKey;
-
-  /// Filters the results where [column] equals [value].
-  ///
-  /// Only one filter can be applied to `.stream()`.
-  ///
-  /// ```dart
-  /// supabase.from('users').stream(primaryKey: ['id']).eq('name', 'Supabase');
-  /// ```
-  SupabaseStreamBuilder eq(String column, Object value) {
-    assert(
-      _streamFilter == null,
-      'Only one filter can be applied to `.stream()`',
-    );
-    _streamFilter = _StreamPostgrestFilter(
-      type: _FilterType.eq,
-      column: column,
-      value: value,
-    );
-    return this;
-  }
-
-  /// Filters the results where [column] does not equal [value].
-  ///
-  /// Only one filter can be applied to `.stream()`.
-  ///
-  /// ```dart
-  /// supabase.from('users').stream(primaryKey: ['id']).neq('name', 'Supabase');
-  /// ```
-  SupabaseStreamBuilder neq(String column, Object value) {
-    assert(
-      _streamFilter == null,
-      'Only one filter can be applied to `.stream()`',
-    );
-    _streamFilter = _StreamPostgrestFilter(
-      type: _FilterType.neq,
-      column: column,
-      value: value,
-    );
-    return this;
-  }
-
-  /// Filters the results where [column] is less than [value].
-  ///
-  /// Only one filter can be applied to `.stream()`.
-  ///
-  /// ```dart
-  /// supabase.from('users').stream(primaryKey: ['id']).lt('likes', 100);
-  /// ```
-  SupabaseStreamBuilder lt(String column, Object value) {
-    assert(
-      _streamFilter == null,
-      'Only one filter can be applied to `.stream()`',
-    );
-    _streamFilter = _StreamPostgrestFilter(
-      type: _FilterType.lt,
-      column: column,
-      value: value,
-    );
-    return this;
-  }
-
-  /// Filters the results where [column] is less than or equal to [value].
-  ///
-  /// Only one filter can be applied to `.stream()`.
-  ///
-  /// ```dart
-  /// supabase.from('users').stream(primaryKey: ['id']).lte('likes', 100);
-  /// ```
-  SupabaseStreamBuilder lte(String column, Object value) {
-    assert(
-      _streamFilter == null,
-      'Only one filter can be applied to `.stream()`',
-    );
-    _streamFilter = _StreamPostgrestFilter(
-      type: _FilterType.lte,
-      column: column,
-      value: value,
-    );
-    return this;
-  }
-
-  /// Filters the results where [column] is greater than [value].
-  ///
-  /// Only one filter can be applied to `.stream()`.
-  ///
-  /// ```dart
-  /// supabase.from('users').stream(primaryKey: ['id']).gt('likes', '100');
-  /// ```
-  SupabaseStreamBuilder gt(String column, Object value) {
-    assert(
-      _streamFilter == null,
-      'Only one filter can be applied to `.stream()`',
-    );
-    _streamFilter = _StreamPostgrestFilter(
-      type: _FilterType.gt,
-      column: column,
-      value: value,
-    );
-    return this;
-  }
-
-  /// Filters the results where [column] is greater than or equal to [value].
-  ///
-  /// Only one filter can be applied to `.stream()`.
-  ///
-  /// ```dart
-  /// supabase.from('users').stream(primaryKey: ['id']).gte('likes', 100);
-  /// ```
-  SupabaseStreamBuilder gte(String column, Object value) {
-    assert(
-      _streamFilter == null,
-      'Only one filter can be applied to `.stream()`',
-    );
-    _streamFilter = _StreamPostgrestFilter(
-      type: _FilterType.gte,
-      column: column,
-      value: value,
-    );
-    return this;
-  }
-
-  /// Filters the results where [column] is included in [value].
-  ///
-  /// Only one filter can be applied to `.stream()`.
-  ///
-  /// ```dart
-  /// supabase.from('users').stream(primaryKey: ['id']).inFilter('name', ['Andy', 'Amy', 'Terry']);
-  /// ```
-  SupabaseStreamBuilder inFilter(String column, List<Object> values) {
-    assert(
-      _streamFilter == null,
-      'Only one filter can be applied to `.stream()`',
-    );
-    _streamFilter = _StreamPostgrestFilter(
-      type: _FilterType.inFilter,
-      column: column,
-      value: values,
-    );
-    return this;
-  }
 
   /// Orders the result with the specified [column].
   ///

--- a/packages/supabase/lib/src/supabase_stream_filter_builder.dart
+++ b/packages/supabase/lib/src/supabase_stream_filter_builder.dart
@@ -1,0 +1,152 @@
+part of './supabase_stream_builder.dart';
+
+class SupabaseStreamFilterBuilder extends SupabaseStreamBuilder {
+  SupabaseStreamFilterBuilder({
+    required super.queryBuilder,
+    required super.realtimeTopic,
+    required super.realtimeClient,
+    required super.schema,
+    required super.table,
+    required super.primaryKey,
+  });
+
+  /// Filters the results where [column] equals [value].
+  ///
+  /// Only one filter can be applied to `.stream()`.
+  ///
+  /// ```dart
+  /// supabase.from('users').stream(primaryKey: ['id']).eq('name', 'Supabase');
+  /// ```
+  SupabaseStreamBuilder eq(String column, Object value) {
+    assert(
+      _streamFilter == null,
+      'Only one filter can be applied to `.stream()`',
+    );
+    _streamFilter = _StreamPostgrestFilter(
+      type: _FilterType.eq,
+      column: column,
+      value: value,
+    );
+    return this;
+  }
+
+  /// Filters the results where [column] does not equal [value].
+  ///
+  /// Only one filter can be applied to `.stream()`.
+  ///
+  /// ```dart
+  /// supabase.from('users').stream(primaryKey: ['id']).neq('name', 'Supabase');
+  /// ```
+  SupabaseStreamBuilder neq(String column, Object value) {
+    assert(
+      _streamFilter == null,
+      'Only one filter can be applied to `.stream()`',
+    );
+    _streamFilter = _StreamPostgrestFilter(
+      type: _FilterType.neq,
+      column: column,
+      value: value,
+    );
+    return this;
+  }
+
+  /// Filters the results where [column] is less than [value].
+  ///
+  /// Only one filter can be applied to `.stream()`.
+  ///
+  /// ```dart
+  /// supabase.from('users').stream(primaryKey: ['id']).lt('likes', 100);
+  /// ```
+  SupabaseStreamBuilder lt(String column, Object value) {
+    assert(
+      _streamFilter == null,
+      'Only one filter can be applied to `.stream()`',
+    );
+    _streamFilter = _StreamPostgrestFilter(
+      type: _FilterType.lt,
+      column: column,
+      value: value,
+    );
+    return this;
+  }
+
+  /// Filters the results where [column] is less than or equal to [value].
+  ///
+  /// Only one filter can be applied to `.stream()`.
+  ///
+  /// ```dart
+  /// supabase.from('users').stream(primaryKey: ['id']).lte('likes', 100);
+  /// ```
+  SupabaseStreamBuilder lte(String column, Object value) {
+    assert(
+      _streamFilter == null,
+      'Only one filter can be applied to `.stream()`',
+    );
+    _streamFilter = _StreamPostgrestFilter(
+      type: _FilterType.lte,
+      column: column,
+      value: value,
+    );
+    return this;
+  }
+
+  /// Filters the results where [column] is greater than [value].
+  ///
+  /// Only one filter can be applied to `.stream()`.
+  ///
+  /// ```dart
+  /// supabase.from('users').stream(primaryKey: ['id']).gt('likes', '100');
+  /// ```
+  SupabaseStreamBuilder gt(String column, Object value) {
+    assert(
+      _streamFilter == null,
+      'Only one filter can be applied to `.stream()`',
+    );
+    _streamFilter = _StreamPostgrestFilter(
+      type: _FilterType.gt,
+      column: column,
+      value: value,
+    );
+    return this;
+  }
+
+  /// Filters the results where [column] is greater than or equal to [value].
+  ///
+  /// Only one filter can be applied to `.stream()`.
+  ///
+  /// ```dart
+  /// supabase.from('users').stream(primaryKey: ['id']).gte('likes', 100);
+  /// ```
+  SupabaseStreamBuilder gte(String column, Object value) {
+    assert(
+      _streamFilter == null,
+      'Only one filter can be applied to `.stream()`',
+    );
+    _streamFilter = _StreamPostgrestFilter(
+      type: _FilterType.gte,
+      column: column,
+      value: value,
+    );
+    return this;
+  }
+
+  /// Filters the results where [column] is included in [value].
+  ///
+  /// Only one filter can be applied to `.stream()`.
+  ///
+  /// ```dart
+  /// supabase.from('users').stream(primaryKey: ['id']).inFilter('name', ['Andy', 'Amy', 'Terry']);
+  /// ```
+  SupabaseStreamBuilder inFilter(String column, List<Object> values) {
+    assert(
+      _streamFilter == null,
+      'Only one filter can be applied to `.stream()`',
+    );
+    _streamFilter = _StreamPostgrestFilter(
+      type: _FilterType.inFilter,
+      column: column,
+      value: values,
+    );
+    return this;
+  }
+}

--- a/packages/supabase/lib/supabase.dart
+++ b/packages/supabase/lib/supabase.dart
@@ -17,3 +17,4 @@ export 'src/supabase_client.dart';
 export 'src/supabase_event_types.dart';
 export 'src/supabase_query_builder.dart';
 export 'src/supabase_realtime_error.dart';
+export 'src/supabase_stream_builder.dart';


### PR DESCRIPTION
## What kind of change does this PR introduce?

Improves developer experience around filtering .stream()

## What is the current behavior?

Users could chain multiple filters on .stream() and it would not throw static error. Users could only find out that it's invalid after running the code.

```dart
supabase.from('table')
  .stream([])
  .eq('column', 'val')
  .neq('another_column', 'val')
  .lt('third_column', 'val')
  .listen((_) {});
  ```

## What is the new behavior?

The above example fails at the .new statically. Additionally, I exported the `SupabaseStreamBuilder` class

## Additional context

There was already a [pr](https://github.com/supabase/supabase-dart/pull/179), but I think the effort of creating classes for order and limit are worth it, because I see no sense in wanting to call the same method multiple times, so I don't disallow it.
