### PR TITLE
refactor!(realtime_client): some realtime refactor

### DIFF
--- a/packages/realtime_client/lib/realtime_client.dart
+++ b/packages/realtime_client/lib/realtime_client.dart
@@ -1,5 +1,6 @@
-export 'src/realtime_channel.dart' hide ToType;
+export 'src/constants.dart' show RealtimeLogLevel;
+export 'src/realtime_channel.dart';
 export 'src/realtime_client.dart';
 export 'src/realtime_presence.dart';
 export 'src/transformers.dart' hide getEnrichedPayload, getPayloadRecords;
-export 'src/constants.dart' show RealtimeLogLevel;
+export 'src/types.dart' hide ToType;

--- a/packages/realtime_client/lib/src/push.dart
+++ b/packages/realtime_client/lib/src/push.dart
@@ -1,8 +1,8 @@
 import 'dart:async';
 
+import 'package:realtime_client/realtime_client.dart';
 import 'package:realtime_client/src/constants.dart';
 import 'package:realtime_client/src/message.dart';
-import 'package:realtime_client/src/realtime_channel.dart';
 
 typedef Callback = void Function(dynamic response);
 

--- a/packages/realtime_client/lib/src/realtime_client.dart
+++ b/packages/realtime_client/lib/src/realtime_client.dart
@@ -4,9 +4,9 @@ import 'dart:core';
 
 import 'package:collection/collection.dart';
 import 'package:meta/meta.dart';
+import 'package:realtime_client/realtime_client.dart';
 import 'package:realtime_client/src/constants.dart';
 import 'package:realtime_client/src/message.dart';
-import 'package:realtime_client/src/realtime_channel.dart';
 import 'package:realtime_client/src/retry_timer.dart';
 import 'package:realtime_client/src/websocket/websocket.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';

--- a/packages/realtime_client/lib/src/realtime_presence.dart
+++ b/packages/realtime_client/lib/src/realtime_presence.dart
@@ -1,4 +1,4 @@
-import 'package:realtime_client/src/realtime_channel.dart';
+import 'package:realtime_client/realtime_client.dart';
 
 class Presence {
   final String presenceRef;

--- a/packages/realtime_client/lib/src/types.dart
+++ b/packages/realtime_client/lib/src/types.dart
@@ -1,0 +1,106 @@
+typedef BindingCallback = void Function(dynamic payload, [dynamic ref]);
+
+class Binding {
+  String type;
+  Map<String, String> filter;
+  BindingCallback callback;
+  String? id;
+
+  Binding(
+    this.type,
+    this.filter,
+    this.callback, [
+    this.id,
+  ]);
+
+  Binding copyWith({
+    String? type,
+    Map<String, String>? filter,
+    BindingCallback? callback,
+    String? id,
+  }) {
+    return Binding(
+      type ?? this.type,
+      filter ?? this.filter,
+      callback ?? this.callback,
+      id ?? this.id,
+    );
+  }
+}
+
+class ChannelFilter {
+  /// For [RealtimeListenTypes.postgresChanges] it's one of: `INSERT`, `UPDATE`, `DELETE`
+  ///
+  /// For [RealtimeListenTypes.presence] it's one of: `sync`, `join`, `leave`
+  ///
+  /// For [RealtimeListenTypes.broadcast] it can be any string
+  final String? event;
+  final String? schema;
+  final String? table;
+
+  /// For [RealtimeListenTypes.postgresChanges] it's of the format `column=filter.value` with `filter` being one of `eq, neq, lt, lte, gt, gte, in`
+  ///
+  /// Only one filter can be applied
+  final String? filter;
+
+  ChannelFilter({
+    this.event,
+    this.schema,
+    this.table,
+    this.filter,
+  });
+
+  Map<String, String> toMap() {
+    return {
+      if (event != null) 'event': event!,
+      if (schema != null) 'schema': schema!,
+      if (table != null) 'table': table!,
+      if (filter != null) 'filter': filter!,
+    };
+  }
+}
+
+enum ChannelResponse { ok, timedOut, rateLimited }
+
+enum RealtimeListenTypes { postgresChanges, broadcast, presence }
+
+extension ToType on RealtimeListenTypes {
+  String toType() {
+    if (this == RealtimeListenTypes.postgresChanges) {
+      return 'postgres_changes';
+    } else {
+      return name;
+    }
+  }
+}
+
+class RealtimeChannelConfig {
+  /// [ack] option instructs server to acknowlege that broadcast message was received
+  final bool ack;
+
+  /// [self] option enables client to receive message it broadcasted
+  final bool self;
+
+  /// [key] option is used to track presence payload across clients
+  final String key;
+
+  const RealtimeChannelConfig({
+    this.ack = false,
+    this.self = false,
+    this.key = '',
+  });
+
+  Map<String, dynamic> toMap() {
+    return {
+      'config': {
+        'broadcast': {
+          'ack': ack,
+          'self': self,
+        },
+        'presence': {
+          'key': key,
+        },
+      }
+    };
+  }
+}

--- a/packages/realtime_client/lib/src/types.dart
+++ b/packages/realtime_client/lib/src/types.dart
@@ -64,6 +64,8 @@ enum ChannelResponse { ok, timedOut, rateLimited }
 
 enum RealtimeListenTypes { postgresChanges, broadcast, presence }
 
+enum RealtimeSubscribeStatus { subscribed, channelError, closed, timedOut }
+
 extension ToType on RealtimeListenTypes {
   String toType() {
     if (this == RealtimeListenTypes.postgresChanges) {

--- a/packages/realtime_client/test/mock_test.dart
+++ b/packages/realtime_client/test/mock_test.dart
@@ -289,11 +289,12 @@ void main() {
     });
 
     test("correct CHANNEL_ERROR data on heartbeat timeout", () async {
-      final subscribeCallback = expectAsync2((event, [data]) {
-        if (event == "CHANNEL_ERROR") {
+      final subscribeCallback =
+          expectAsync2((RealtimeSubscribeStatus event, data) {
+        if (event == RealtimeSubscribeStatus.channelError) {
           expect(data, "heartbeat timeout");
         } else {
-          expect(event, "CLOSED");
+          expect(event, RealtimeSubscribeStatus.closed);
         }
       }, count: 2);
 


### PR DESCRIPTION
# Breaking changes
- move types from realtime_channel.dart to types.dart
- make the error parameter for `.subscribe()` non optional
- make the status parameter for `subscribe()` an enum instead of a String
- add some documentation to `ChannelFilter`, because I found no way to use an enum for `ChannelFilter.event`, because for broadcast it can be any string

I think that's it for now that can be type wise improved.