### PR TITLE
refactor!: rename is_ and in_ to isFilter and inFilter

### DIFF
--- a/packages/postgrest/lib/src/postgrest_filter_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_filter_builder.dart
@@ -228,7 +228,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   ///     .is_('data', null);
   /// ```
   // ignore: non_constant_identifier_names
-  PostgrestFilterBuilder<T> is_(String column, Object? value) {
+  PostgrestFilterBuilder<T> isFilter(String column, Object? value) {
     return copyWithUrl(appendSearchParams(column, 'is.$value'));
   }
 
@@ -241,7 +241,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   ///     .in_('status', ['ONLINE', 'OFFLINE']);
   /// ```
   // ignore: non_constant_identifier_names
-  PostgrestFilterBuilder<T> in_(String column, List values) {
+  PostgrestFilterBuilder<T> inFilter(String column, List values) {
     return copyWithUrl(
         appendSearchParams(column, 'in.(${_cleanFilterArray(values)})'));
   }

--- a/packages/postgrest/lib/src/postgrest_query_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_query_builder.dart
@@ -9,7 +9,7 @@ part of 'postgrest_builder.dart';
 /// * update() - "patch"
 /// * delete() - "delete"
 /// Once any of these are called the filters are passed down to the Request.
-/// /// {@endtemplate}
+/// {@endtemplate}
 class PostgrestQueryBuilder<T> extends RawPostgrestBuilder<T, T, T> {
   /// {@macro postgrest_query_builder}
   PostgrestQueryBuilder({

--- a/packages/postgrest/test/basic_test.dart
+++ b/packages/postgrest/test/basic_test.dart
@@ -221,7 +221,7 @@ void main() {
           .update(
             {'channel_id': 2},
           )
-          .is_("data", null)
+          .isFilter("data", null)
           .select();
       expect(res, isNotEmpty);
       expect(res, everyElement(containsPair("channel_id", 2)));

--- a/packages/postgrest/test/filter_test.dart
+++ b/packages/postgrest/test/filter_test.dart
@@ -235,7 +235,7 @@ void main() {
   });
 
   test('is', () async {
-    final res = await postgrest.from('users').select('data').is_('data', null);
+    final res = await postgrest.from('users').select('data').isFilter('data', null);
     expect(res, isNotEmpty);
     for (final item in res) {
       expect(item['data'], null);
@@ -246,7 +246,7 @@ void main() {
     final res = await postgrest
         .from('users')
         .select('status')
-        .in_('status', ['ONLINE', 'OFFLINE']);
+        .inFilter('status', ['ONLINE', 'OFFLINE']);
     expect(res, isNotEmpty);
     for (final item in res) {
       expect(
@@ -429,7 +429,7 @@ void main() {
         .from('users')
         .select()
         .eq('username', 'supabot')
-        .is_('data', null)
+        .isFilter('data', null)
         .overlaps('age_range', '[1,2)')
         .eq('status', 'ONLINE')
         .textSearch('catchphrase', 'cat');

--- a/packages/postgrest/test/filter_test.dart
+++ b/packages/postgrest/test/filter_test.dart
@@ -235,7 +235,8 @@ void main() {
   });
 
   test('is', () async {
-    final res = await postgrest.from('users').select('data').isFilter('data', null);
+    final res =
+        await postgrest.from('users').select('data').isFilter('data', null);
     expect(res, isNotEmpty);
     for (final item in res) {
       expect(item['data'], null);

--- a/packages/supabase/lib/src/supabase_stream_builder.dart
+++ b/packages/supabase/lib/src/supabase_stream_builder.dart
@@ -233,7 +233,7 @@ class SupabaseStreamBuilder extends Stream<SupabaseStreamEvent> {
           query = query.gte(_streamFilter!.column, _streamFilter!.value);
           break;
         case _FilterType.inFilter:
-          query = query.in_(_streamFilter!.column, _streamFilter!.value);
+          query = query.inFilter(_streamFilter!.column, _streamFilter!.value);
           break;
       }
     }


### PR DESCRIPTION
# Breaking Changes
- rename `is_` and `in_` to `isFilter` and `inFilter`


This should be the last pr from our v2 changes list. Will merge main into next and udpate the READMEs next