### PR TITLE
refactor!:  remove `signInWithApple` method and make `generateRawNonce` public

### DIFF
--- a/packages/supabase_flutter/lib/src/supabase_auth.dart
+++ b/packages/supabase_flutter/lib/src/supabase_auth.dart
@@ -4,12 +4,9 @@ import 'dart:io' show Platform;
 import 'dart:math';
 
 import 'package:app_links/app_links.dart';
-import 'package:crypto/crypto.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:meta/meta.dart';
-import 'package:sign_in_with_apple/sign_in_with_apple.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:url_launcher/url_launcher_string.dart';
@@ -303,41 +300,7 @@ extension GoTrueClientSignInProvider on GoTrueClient {
     }
   }
 
-  /// Signs a user in using native Apple Login.
-  ///
-  /// This method only works on iOS and MacOS. If you want to sign in a user using Apple
-  /// on other platforms, please use the `signInWithOAuth` method.
-  ///
-  /// This method is experimental as the underlying `signInWithIdToken` method is experimental.
-  @experimental
-  Future<AuthResponse> signInWithApple() async {
-    assert(!kIsWeb && (Platform.isIOS || Platform.isMacOS),
-        'Please use signInWithOAuth for non-iOS platforms');
-    final rawNonce = _generateRandomString();
-    final hashedNonce = sha256.convert(utf8.encode(rawNonce)).toString();
-
-    final credential = await SignInWithApple.getAppleIDCredential(
-      scopes: [
-        AppleIDAuthorizationScopes.email,
-        AppleIDAuthorizationScopes.fullName,
-      ],
-      nonce: hashedNonce,
-    );
-
-    final idToken = credential.identityToken;
-    if (idToken == null) {
-      throw const AuthException(
-          'Could not find ID Token from generated credential.');
-    }
-
-    return signInWithIdToken(
-      provider: OAuthProvider.apple,
-      idToken: idToken,
-      nonce: rawNonce,
-    );
-  }
-
-  String _generateRandomString() {
+  String generateRawNonce() {
     final random = Random.secure();
     return base64Url.encode(List<int>.generate(16, (_) => random.nextInt(256)));
   }

--- a/packages/supabase_flutter/pubspec.yaml
+++ b/packages/supabase_flutter/pubspec.yaml
@@ -18,7 +18,6 @@ dependencies:
   hive_flutter: ^1.1.0
   http: '>=0.13.4 <2.0.0'
   meta: ^1.7.0
-  sign_in_with_apple: '>=4.3.0 <6.0.0'
   supabase: ^1.11.6
   url_launcher: ^6.1.2
   webview_flutter: ^4.0.0


### PR DESCRIPTION
## What kind of change does this PR introduce?

I know this PR could be controversial, but I want to hear what you all think. This PR includes the following
- Removes the `signInWithApple()` method
- Make `generateRawNonce method available for developers to easily generate a secure nonce. 

I think it's okay to remove sign_in_with_apple dependencies, as I see a lot of developers implementing Google login despite it being far more complicated than signing in with Apple. I think by looking at this, we learned that developers will be happy as long as there is a way to implement Apple sign in, so I personally think we should remove sign_in_with_apple dependencies, but am open to comments. 

Related: https://github.com/supabase/supabase-flutter/issues/399#issuecomment-1610598390