### PR TITLE
refactor!(supabase_flutter): Remove webview from dependencies

### DIFF
--- a/packages/supabase_flutter/pubspec.yaml
+++ b/packages/supabase_flutter/pubspec.yaml
@@ -21,7 +21,6 @@ dependencies:
   sign_in_with_apple: '>=4.3.0 <6.0.0'
   supabase: ^1.11.6
   url_launcher: ^6.1.2
-  webview_flutter: ^4.0.0
   path_provider: ^2.0.0
   shared_preferences: ^2.0.0
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

This could be another controversial PR. This PR basically removes the webview dependency added in this PR https://github.com/supabase/supabase-flutter/pull/355.

The original reason for adding the webview was to fix issues of browser window not automatically going back tot he app when performing `signInWithOAuth()`, but with Supabase having native OAuth support for Apple and Google login, I think the use cases of using the webview are limited, and I think we are rather safe just dropping it from the dependencies. 