### PR TITLE
fix: compile with webdev

### DIFF
--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -29,7 +29,7 @@ part 'gotrue_mfa_api.dart';
 /// [asyncStorage] local storage to store pkce code verifiers. Required when using the pkce flow.
 ///
 /// Set [flowType] to `AuthFlowType.pkce` to perform pkce auth flow.
-/// /// {@endtemplate}
+/// {@endtemplate}
 class GoTrueClient {
   /// Namespace for the GoTrue API methods.
   /// These can be used for example to get a user from a JWT in a server environment or reset a user's password.

--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:io';
 import 'dart:math';
 
 import 'package:collection/collection.dart';
@@ -13,7 +14,6 @@ import 'package:http/http.dart';
 import 'package:jwt_decode/jwt_decode.dart';
 import 'package:meta/meta.dart';
 import 'package:rxdart/subjects.dart';
-import 'package:universal_io/io.dart';
 
 part 'gotrue_mfa_api.dart';
 
@@ -966,7 +966,7 @@ class GoTrueClient {
       _notifyAllSubscribers(AuthChangeEvent.tokenRefreshed);
       _refreshTokenCompleter!.complete(authResponse);
       return authResponse;
-    } on SocketException {
+    } on ClientException {
       _setTokenRefreshTimer(
         Constants.retryInterval * pow(2, _refreshTokenRetryCount),
         refreshToken: token,

--- a/packages/gotrue/pubspec.yaml
+++ b/packages/gotrue/pubspec.yaml
@@ -13,7 +13,6 @@ dependencies:
   crypto: ^3.0.2
   http: '>=0.13.0 <2.0.0'
   jwt_decode: ^0.3.1
-  universal_io: ^2.0.4
   rxdart: ^0.27.7
   meta: ^1.7.0
 

--- a/packages/gotrue/test/custom_http_client.dart
+++ b/packages/gotrue/test/custom_http_client.dart
@@ -2,7 +2,6 @@ import 'dart:convert';
 
 import 'package:dart_jsonwebtoken/dart_jsonwebtoken.dart';
 import 'package:http/http.dart';
-import 'package:universal_io/io.dart';
 
 import 'utils.dart';
 
@@ -74,7 +73,7 @@ class RetryTestHttpClient extends BaseClient {
   Future<StreamedResponse> send(BaseRequest request) async {
     retryCount++;
     if (retryCount < 4) {
-      throw SocketException('Retry #$retryCount');
+      throw ClientException('Retry #$retryCount');
     }
     final jwt = JWT(
       {'exp': (DateTime.now().millisecondsSinceEpoch / 1000).round() + 60},

--- a/packages/storage_client/lib/src/fetch.dart
+++ b/packages/storage_client/lib/src/fetch.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:io' show File;
 import 'dart:typed_data';
 
 import 'package:http/http.dart' as http;
@@ -8,7 +9,6 @@ import 'package:http_parser/http_parser.dart' show MediaType;
 import 'package:mime/mime.dart';
 import 'package:retry/retry.dart';
 import 'package:storage_client/src/types.dart';
-import 'package:universal_io/io.dart';
 
 Fetch storageFetch = Fetch();
 
@@ -108,7 +108,7 @@ class Fetch {
       },
       retryIf: (error) =>
           retryController?.cancelled != true &&
-          (error is SocketException || error is TimeoutException),
+          (error is ClientException || error is TimeoutException),
     );
 
     return _handleResponse(streamedResponse, options);
@@ -152,7 +152,7 @@ class Fetch {
       },
       retryIf: (error) =>
           retryController?.cancelled != true &&
-          (error is SocketException || error is TimeoutException),
+          (error is ClientException || error is TimeoutException),
     );
 
     return _handleResponse(streamedResponse, options);

--- a/packages/storage_client/lib/src/fetch.dart
+++ b/packages/storage_client/lib/src/fetch.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io' show File;
 import 'dart:typed_data';
 
 import 'package:http/http.dart' as http;
@@ -9,6 +8,8 @@ import 'package:http_parser/http_parser.dart' show MediaType;
 import 'package:mime/mime.dart';
 import 'package:retry/retry.dart';
 import 'package:storage_client/src/types.dart';
+
+import 'file_io.dart' if (dart.library.js) './file_stub.dart';
 
 Fetch storageFetch = Fetch();
 

--- a/packages/storage_client/lib/src/file_io.dart
+++ b/packages/storage_client/lib/src/file_io.dart
@@ -1,0 +1,1 @@
+export 'dart:io' show File;

--- a/packages/storage_client/lib/src/file_stub.dart
+++ b/packages/storage_client/lib/src/file_stub.dart
@@ -1,0 +1,8 @@
+import 'dart:typed_data';
+
+/// A stub for the `dart:io` [File] class. Only the methods used by the storage client are stubbed.
+class File {
+  String get path => throw UnimplementedError();
+
+  Uint8List readAsBytesSync() => throw UnimplementedError();
+}

--- a/packages/storage_client/lib/src/storage_file_api.dart
+++ b/packages/storage_client/lib/src/storage_file_api.dart
@@ -1,8 +1,9 @@
-import 'dart:io' show File;
 import 'dart:typed_data';
 
 import 'package:storage_client/src/fetch.dart';
 import 'package:storage_client/src/types.dart';
+
+import 'file_io.dart' if (dart.library.js) './file_stub.dart';
 
 class StorageFileApi {
   final String url;

--- a/packages/storage_client/lib/src/storage_file_api.dart
+++ b/packages/storage_client/lib/src/storage_file_api.dart
@@ -1,8 +1,8 @@
+import 'dart:io' show File;
 import 'dart:typed_data';
 
 import 'package:storage_client/src/fetch.dart';
 import 'package:storage_client/src/types.dart';
-import 'package:universal_io/io.dart';
 
 class StorageFileApi {
   final String url;

--- a/packages/storage_client/pubspec.yaml
+++ b/packages/storage_client/pubspec.yaml
@@ -12,7 +12,6 @@ dependencies:
   http: '>=0.13.4 <2.0.0'
   http_parser: ^4.0.1
   mime: ^1.0.2
-  universal_io: ^2.0.4
   retry: ^3.1.0
 
 dev_dependencies:

--- a/packages/storage_client/test/custom_http_client.dart
+++ b/packages/storage_client/test/custom_http_client.dart
@@ -1,7 +1,6 @@
 import 'dart:convert';
 
 import 'package:http/http.dart';
-import 'package:universal_io/io.dart';
 
 class CustomHttpClient extends BaseClient {
   @override
@@ -22,7 +21,7 @@ class RetryHttpClient extends BaseClient {
   Future<StreamedResponse> send(BaseRequest request) async {
     if (failureCount < 3) {
       failureCount++;
-      throw SocketException('Offline');
+      throw ClientException('Offline');
     }
     //Return custom status code to check for usage of this client.
     return StreamedResponse(


### PR DESCRIPTION
Bug fix

## What is the current behavior?

- We only catch `SocketException`, which in only thrown in native Dart, but not for example in dart2js
- We use `File` from `dart:io`

## What is the new behavior?

- We instead use `ClientException`, which is also thrown in js runtime as documented [here](https://pub.dev/documentation/http/latest/http/Client-class.html)
- Created a stub for `File` to be able to compile the package with `webdev`

## Additional context
~~This was meant to fix #641, but this would require the removal of `File`, which im very unsure about. I think it makes things MUCH easier to be able to work with `File` on native platform, but somehow not being able to compile this to dart web is a bummer. I'm wondering why this package compiles for Flutter web though.~~
close #641