### PR TITLE
feat: send messages via broadcast endpoint

### DIFF
--- a/packages/realtime_client/lib/src/realtime_channel.dart
+++ b/packages/realtime_client/lib/src/realtime_channel.dart
@@ -115,15 +115,22 @@ class RealtimeChannel {
   late RetryTimer _rejoinTimer;
   List<Push> _pushBuffer = [];
   late RealtimePresence presence;
-
+  late final String broadcastEndpointURL;
+  final String subTopic;
   final String topic;
   Map<String, dynamic> params;
   final RealtimeClient socket;
 
-  RealtimeChannel(this.topic, this.socket,
-      {RealtimeChannelConfig params = const RealtimeChannelConfig()})
-      : _timeout = socket.timeout,
-        params = params.toMap() {
+  RealtimeChannel(
+    this.topic,
+    this.socket, {
+    RealtimeChannelConfig params = const RealtimeChannelConfig(),
+  })  : _timeout = socket.timeout,
+        params = params.toMap(),
+        subTopic = topic.replaceFirst(
+            RegExp(r"^realtime:", caseSensitive: false), "") {
+    broadcastEndpointURL = _broadcastEndpointURL;
+
     joinPush = Push(
       this,
       ChannelEvents.join,
@@ -192,6 +199,9 @@ class RealtimeChannel {
     void Function(String status, [Object? error])? callback,
     Duration? timeout,
   ]) {
+    if (!socket.isConnected) {
+      socket.connect();
+    }
     if (joinedOnce == true) {
       throw "tried to subscribe multiple times. 'subscribe' can only be called a single time per channel instance";
     } else {
@@ -393,7 +403,7 @@ class RealtimeChannel {
     String? event,
     required Map<String, dynamic> payload,
     Map<String, dynamic> opts = const {},
-  }) {
+  }) async {
     final completer = Completer<ChannelResponse>();
 
     payload['type'] = type.toType();
@@ -401,35 +411,60 @@ class RealtimeChannel {
       payload['event'] = event;
     }
 
-    final push = this.push(
-      ChannelEventsExtended.fromType(payload['type']),
-      payload,
-      opts['timeout'] ?? _timeout,
-    );
+    if (!canPush && type == RealtimeListenTypes.broadcast) {
+      final headers = {
+        'Content-Type': 'application/json',
+        'apikey': socket.accessToken ?? '',
+        ...socket.headers
+      };
+      final body = {
+        'messages': [
+          {
+            'topic': subTopic,
+            'payload': payload['endpoint_payload'],
+            'event': payload['event'],
+          }
+        ]
+      };
+      try {
+        await socket.httpClient.post(
+          Uri.parse(broadcastEndpointURL),
+          headers: headers,
+          body: json.encode(body),
+        );
+      } catch (e) {
+        completer.completeError(e);
+      }
+    } else {
+      final push = this.push(
+        ChannelEventsExtended.fromType(payload['type']),
+        payload,
+        opts['timeout'] ?? _timeout,
+      );
 
-    if (push.rateLimited) {
-      completer.complete(ChannelResponse.rateLimited);
+      if (push.rateLimited) {
+        completer.complete(ChannelResponse.rateLimited);
+      }
+
+      if (payload['type'] == 'broadcast' &&
+          (params['config']?['broadcast']?['ack'] == null ||
+              params['config']?['broadcast']?['ack'] == false)) {
+        if (!completer.isCompleted) {
+          completer.complete(ChannelResponse.ok);
+        }
+      }
+
+      push.receive('ok', (_) {
+        if (!completer.isCompleted) {
+          completer.complete(ChannelResponse.ok);
+        }
+      });
+      push.receive('timeout', (_) {
+        if (!completer.isCompleted) {
+          completer.complete(ChannelResponse.timedOut);
+        }
+      });
     }
-
-    if (payload['type'] == 'broadcast' &&
-        (params['config']?['broadcast']?['ack'] == null ||
-            params['config']?['broadcast']?['ack'] == false)) {
-      if (!completer.isCompleted) {
-        completer.complete(ChannelResponse.ok);
-      }
-    }
-
-    push.receive('ok', (_) {
-      if (!completer.isCompleted) {
-        completer.complete(ChannelResponse.ok);
-      }
-    });
-    push.receive('timeout', (_) {
-      if (!completer.isCompleted) {
-        completer.complete(ChannelResponse.timedOut);
-      }
-    });
-
     return completer.future;
   }
 
@@ -484,6 +519,18 @@ class RealtimeChannel {
     }
 
     return completer.future;
+  }
+
+  String get _broadcastEndpointURL {
+    var url = socket.endPoint;
+    url = url.replaceFirst(RegExp(r'^ws', caseSensitive: false), 'http');
+    url = url.replaceAll(
+      RegExp(r'(/socket/websocket|/socket|/websocket)/?$',
+          caseSensitive: false),
+      '',
+    );
+    url = '${url.replaceAll(RegExp(r'/+$'), '')}/api/broadcast';
+    return url;
   }
 
   /// Overridable message hook

--- a/packages/realtime_client/lib/src/realtime_client.dart
+++ b/packages/realtime_client/lib/src/realtime_client.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'dart:core';
 
 import 'package:collection/collection.dart';
+import 'package:http/http.dart';
 import 'package:meta/meta.dart';
 import 'package:realtime_client/src/constants.dart';
 import 'package:realtime_client/src/message.dart';
@@ -54,6 +55,7 @@ class RealtimeClient {
   final Map<String, dynamic> params;
   final Duration timeout;
   final WebSocketTransport transport;
+  final Client httpClient;
   int heartbeatIntervalMs = 30000;
   Timer? heartbeatTimer;
 
@@ -108,6 +110,7 @@ class RealtimeClient {
     this.params = const {},
     this.longpollerTimeout = 20000,
     RealtimeLogLevel? logLevel,
+    Client? httpClient,
   })  : endPoint = Uri.parse('$endPoint/${Transports.websocket}')
             .replace(
               queryParameters:
@@ -118,7 +121,8 @@ class RealtimeClient {
           ...Constants.defaultHeaders,
           if (headers != null) ...headers,
         },
-        transport = transport ?? createWebSocketClient {
+        transport = transport ?? createWebSocketClient,
+        httpClient = httpClient ?? Client() {
     final eventsPerSecond = params['eventsPerSecond'];
     if (eventsPerSecond != null) {
       eventsPerSecondLimitMs = (1000 / int.parse(eventsPerSecond)).floor();
@@ -276,10 +280,6 @@ class RealtimeClient {
     String topic, [
     RealtimeChannelConfig params = const RealtimeChannelConfig(),
   ]) {
-    if (!isConnected) {
-      connect();
-    }
-
     final chan = RealtimeChannel('realtime:$topic', this, params: params);
     channels.add(chan);
     return chan;

--- a/packages/realtime_client/pubspec.yaml
+++ b/packages/realtime_client/pubspec.yaml
@@ -10,6 +10,7 @@ environment:
 
 dependencies:
   collection: ^1.15.0
+  http: ^1.1.0
   meta: ^1.7.0
   web_socket_channel: ^2.3.0
 

--- a/packages/realtime_client/pubspec.yaml
+++ b/packages/realtime_client/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 
 dependencies:
   collection: ^1.15.0
-  http: ^1.1.0
+  http: '>=0.13.0 <2.0.0'
   meta: ^1.7.0
   web_socket_channel: ^2.3.0
 

--- a/packages/realtime_client/test/channel_test.dart
+++ b/packages/realtime_client/test/channel_test.dart
@@ -241,7 +241,7 @@ void main() {
   });
 
   group('send', () {
-    late final HttpServer mockServer;
+    late HttpServer mockServer;
 
     setUp(() async {
       mockServer = await HttpServer.bind('localhost', 0);
@@ -253,9 +253,9 @@ void main() {
       channel = socket.channel('myTopic');
     });
 
-    tearDown(() {
+    tearDown(() async {
       socket.disconnect();
-      channel.unsubscribe();
+      await channel.unsubscribe();
     });
 
     test('sets endpoint', () {

--- a/packages/realtime_client/test/channel_test.dart
+++ b/packages/realtime_client/test/channel_test.dart
@@ -1,3 +1,7 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
 import 'package:realtime_client/realtime_client.dart';
 import 'package:realtime_client/src/constants.dart';
 import 'package:test/test.dart';
@@ -233,6 +237,86 @@ void main() {
       channel.joinPush.trigger('ok', {});
 
       expect(socket.channels.length, 0);
+    });
+  });
+
+  group('send', () {
+    late final HttpServer mockServer;
+
+    setUp(() async {
+      mockServer = await HttpServer.bind('localhost', 0);
+      socket = RealtimeClient(
+        'ws://${mockServer.address.host}:${mockServer.port}/realtime/v1',
+        params: {'apikey': 'supabaseKey'},
+      );
+
+      channel = socket.channel('myTopic');
+    });
+
+    tearDown(() {
+      socket.disconnect();
+      channel.unsubscribe();
+    });
+
+    test('sets endpoint', () {
+      expect(channel.broadcastEndpointURL,
+          'http://${mockServer.address.host}:${mockServer.port}/realtime/v1/api/broadcast');
+      expect(channel.subTopic, 'myTopic');
+    });
+
+    test('send message via ws conn when subscribed to channel', () async {
+      channel.subscribe((status, [error]) async {
+        if (status == "SUBSCRIBED") {
+          final completer = Completer<ChannelResponse>();
+          channel.send(
+            type: RealtimeListenTypes.broadcast,
+            payload: {
+              'myKey': 'myValue',
+            },
+          ).then(
+            (value) => completer.complete(value),
+            onError: (e) => completer.completeError(e),
+          );
+
+          await for (final HttpRequest req in mockServer) {
+            expect(req.uri.toString(), startsWith('/realtime/v1/websocket'));
+            await req.response.close();
+            break;
+          }
+          expect(await completer.future, ChannelResponse.ok);
+        }
+      });
+    });
+
+    test(
+        'send message via http request to Broadcast endpoint when not subscribed to channel',
+        () async {
+      final completer = Completer<ChannelResponse>();
+      channel.send(
+        type: RealtimeListenTypes.broadcast,
+        payload: {
+          'myKey': 'myValue',
+        },
+      ).then(
+        (value) => completer.complete(value),
+        onError: (e) => completer.completeError(e),
+      );
+
+      await for (final HttpRequest req in mockServer) {
+        expect(req.uri.toString(), '/realtime/v1/api/broadcast');
+        expect(req.headers.value('apikey'), 'supabaseKey');
+
+        final body = json.decode(await utf8.decodeStream(req));
+        final message = body['messages'][0];
+        final payload = message['payload'];
+
+        expect(payload, containsPair('myKey', 'myValue'));
+        expect(message, containsPair('topic', 'myTopic'));
+
+        await req.response.close();
+        break;
+      }
+      expect(await completer.future, ChannelResponse.ok);
     });
   });
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the new behavior?

Enables sending messages to server via a broadcast HTTP endpoint request instead of waiting for a WebSocket connection, subscribing to a channel, and then sending messages.

## Additional context

js pr: https://github.com/supabase/realtime-js/pull/251

close #652