### PR TITLE
fix(gotrue): remove import of dart:io from gotrue_client.dart

### DIFF
--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io';
 import 'dart:math';
 
 import 'package:collection/collection.dart';
@@ -925,7 +924,7 @@ class GoTrueClient {
   ///
   /// To prevent multiple simultaneous requests it catches an already ongoing requests by using the global [_refreshTokenCompleter]. If that's not null and not completed it returns the future that the ongoing request.
   ///
-  /// To be able to call [_callRefreshToken] again after a [SocketException] and not get trapped by the ongoing request, [ignorePendingRequest] is used to bypass that check.
+  /// To be able to call [_callRefreshToken] again after a [ClientException] and not get trapped by the ongoing request, [ignorePendingRequest] is used to bypass that check.
   Future<AuthResponse> _callRefreshToken({
     String? refreshToken,
     String? accessToken,


### PR DESCRIPTION
Fixes #658

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

- #658

## What is the new behavior?

- Removed the import dart:io from gotrue_client.dart to enable Dart web apps to be built successfully.

## Additional context

dart:io was only used to refer to `SocketException` in the document of the `_callRefreshToken()` method. `SocketException` was replaced with `ClientException` in 6b5966f3b9fafc796b0a0f7e4c716616826468dd.
