### PR TITLE
fix: token refresh doesn't block on ClientException

### DIFF
--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -906,9 +906,12 @@ class GoTrueClient {
 
   /// Generates a new JWT.
   ///
-  /// To prevent multiple simultaneous requests it catches an already ongoing requests by using the global [_refreshTokenCompleter]. If that's not null and not completed it returns the future that the ongoing request.
+  /// To prevent multiple simultaneous requests it catches an already ongoing request by using the global [_refreshTokenCompleter].
+  /// If that's not null and not completed it returns the future of the ongoing request.
   ///
-  /// To be able to call [_callRefreshToken] again after a [ClientException] and not get trapped by the ongoing request, [ignorePendingRequest] is used to bypass that check.
+  /// To call [_callRefreshToken] during a running request [ignorePendingRequest] is used to bypass that check.
+  ///
+  /// When a [ClientException] occurs [_setTokenRefreshTimer] is used to schedule a retry in the background, which emits the result via [onAuthStateChange].
   Future<AuthResponse> _callRefreshToken({
     String? refreshToken,
     String? accessToken,

--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -29,7 +29,7 @@ part 'gotrue_mfa_api.dart';
 /// [asyncStorage] local storage to store pkce code verifiers. Required when using the pkce flow.
 ///
 /// Set [flowType] to [AuthFlowType.implicit] to perform old implicit auth flow.
-/// /// {@endtemplate}
+/// {@endtemplate}
 class GoTrueClient {
   /// Namespace for the GoTrue API methods.
   /// These can be used for example to get a user from a JWT in a server environment or reset a user's password.

--- a/packages/gotrue/test/client_test.dart
+++ b/packages/gotrue/test/client_test.dart
@@ -449,6 +449,7 @@ void main() {
       }
       await for (final AuthState event in client.onAuthStateChange) {
         expect(httpClient.retryCount, 4);
+        expect(event.event, AuthChangeEvent.tokenRefreshed);
         break;
       }
     });


### PR DESCRIPTION
Bug fix

## What is the current behavior?

When the device is offline the `refreshSession` takes **very** long until all retry attempts are done. This may be unexpected and blocks everything when awaited, as seen when using `Supabase.initialize()`. Additionally, postgrest requests now properly fail with a `ClientException` when being offline and not waiting endless when access token is expired.

## What is the new behavior?

`refreshSession` finishes after the first requests and throws when request fails. The refresh token timer is started in the background and emits a valid session to the `onAuthStateChange` stream when available.

## Additional context
This is hopefully the last pr to that refresh token offline issue...

close #630
