### PR TITLE
fix: stream with a different schema

### DIFF
--- a/packages/supabase/lib/src/counter.dart
+++ b/packages/supabase/lib/src/counter.dart
@@ -1,0 +1,9 @@
+class Counter {
+  int _value = 0;
+
+  int get value => _value;
+
+  int increment() {
+    return _value++;
+  }
+}

--- a/packages/supabase/lib/src/supabase_client.dart
+++ b/packages/supabase/lib/src/supabase_client.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 
 import 'package:http/http.dart';
 import 'package:supabase/src/constants.dart';
-import 'package:supabase/src/supabase_wrapper.dart';
+import 'package:supabase/src/supabase_query_schema.dart';
 import 'package:supabase/supabase.dart';
 import 'package:yet_another_json_isolate/yet_another_json_isolate.dart';
 
@@ -156,9 +156,9 @@ class SupabaseClient {
   /// Select a schema to query or perform an function (rpc) call.
   ///
   /// The schema needs to be on the list of exposed schemas inside Supabase.
-  SupabaseSchemaQuery useSchema(String schema) {
+  SupabaseQuerySchema useSchema(String schema) {
     final newRest = rest.useSchema(schema);
-    return SupabaseSchemaQuery(
+    return SupabaseQuerySchema(
       counter: _incrementId,
       restUrl: _restUrl,
       headers: headers,

--- a/packages/supabase/lib/src/supabase_client.dart
+++ b/packages/supabase/lib/src/supabase_client.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 
 import 'package:http/http.dart';
 import 'package:supabase/src/constants.dart';
-import 'package:supabase/src/supabase_query_schema.dart';
 import 'package:supabase/supabase.dart';
 import 'package:yet_another_json_isolate/yet_another_json_isolate.dart';
 

--- a/packages/supabase/lib/src/supabase_client.dart
+++ b/packages/supabase/lib/src/supabase_client.dart
@@ -162,7 +162,7 @@ class SupabaseClient {
       counter: _incrementId,
       restUrl: _restUrl,
       headers: headers,
-      postgrestOptions: _postgrestOptions,
+      schema: schema,
       isolate: _isolate,
       authHttpClient: _authHttpClient,
       realtime: realtime,

--- a/packages/supabase/lib/src/supabase_query_schema.dart
+++ b/packages/supabase/lib/src/supabase_query_schema.dart
@@ -9,7 +9,7 @@ class SupabaseQuerySchema {
   final Counter _counter;
   final String _restUrl;
   final Map<String, String> _headers;
-  final PostgrestClientOptions _postgrestOptions;
+  final String _schema;
   final YAJsonIsolate _isolate;
   final Client? _authHttpClient;
   final RealtimeClient _realtime;
@@ -19,7 +19,7 @@ class SupabaseQuerySchema {
     required Counter counter,
     required String restUrl,
     required Map<String, String> headers,
-    required PostgrestClientOptions postgrestOptions,
+    required String schema,
     required YAJsonIsolate isolate,
     required Client? authHttpClient,
     required RealtimeClient realtime,
@@ -27,7 +27,7 @@ class SupabaseQuerySchema {
   })  : _counter = counter,
         _restUrl = restUrl,
         _headers = headers,
-        _postgrestOptions = postgrestOptions,
+        _schema = schema,
         _isolate = isolate,
         _authHttpClient = authHttpClient,
         _realtime = realtime,
@@ -40,7 +40,7 @@ class SupabaseQuerySchema {
       url,
       _realtime,
       headers: {..._rest.headers, ..._headers},
-      schema: _postgrestOptions.schema,
+      schema: _schema,
       table: table,
       httpClient: _authHttpClient,
       incrementId: _counter.increment(),
@@ -55,5 +55,19 @@ class SupabaseQuerySchema {
   }) {
     _rest.headers.addAll({..._rest.headers, ..._headers});
     return _rest.rpc(fn, params: params);
+  }
+
+  SupabaseQuerySchema useSchema(String schema) {
+    final newRest = _rest.useSchema(schema);
+    return SupabaseQuerySchema(
+      counter: _counter,
+      restUrl: _restUrl,
+      headers: _headers,
+      schema: schema,
+      isolate: _isolate,
+      authHttpClient: _authHttpClient,
+      realtime: _realtime,
+      rest: newRest,
+    );
   }
 }

--- a/packages/supabase/lib/src/supabase_query_schema.dart
+++ b/packages/supabase/lib/src/supabase_query_schema.dart
@@ -5,7 +5,7 @@ import 'package:yet_another_json_isolate/yet_another_json_isolate.dart';
 import 'counter.dart';
 
 /// Used to perform [rpc] and [from] operations with a different schema than in [SupabaseClient].
-class SupabaseSchemaQuery {
+class SupabaseQuerySchema {
   final Counter _counter;
   final String _restUrl;
   final Map<String, String> _headers;
@@ -15,7 +15,7 @@ class SupabaseSchemaQuery {
   final RealtimeClient _realtime;
   final PostgrestClient _rest;
 
-  SupabaseSchemaQuery({
+  SupabaseQuerySchema({
     required Counter counter,
     required String restUrl,
     required Map<String, String> headers,

--- a/packages/supabase/lib/src/supabase_wrapper.dart
+++ b/packages/supabase/lib/src/supabase_wrapper.dart
@@ -1,0 +1,59 @@
+import 'package:http/http.dart';
+import 'package:supabase/supabase.dart';
+import 'package:yet_another_json_isolate/yet_another_json_isolate.dart';
+
+import 'counter.dart';
+
+/// Used to perform [rpc] and [from] operations with a different schema than in [SupabaseClient].
+class SupabaseSchemaQuery {
+  final Counter _counter;
+  final String _restUrl;
+  final Map<String, String> _headers;
+  final PostgrestClientOptions _postgrestOptions;
+  final YAJsonIsolate _isolate;
+  final Client? _authHttpClient;
+  final RealtimeClient _realtime;
+  final PostgrestClient _rest;
+
+  SupabaseSchemaQuery({
+    required Counter counter,
+    required String restUrl,
+    required Map<String, String> headers,
+    required PostgrestClientOptions postgrestOptions,
+    required YAJsonIsolate isolate,
+    required Client? authHttpClient,
+    required RealtimeClient realtime,
+    required PostgrestClient rest,
+  })  : _counter = counter,
+        _restUrl = restUrl,
+        _headers = headers,
+        _postgrestOptions = postgrestOptions,
+        _isolate = isolate,
+        _authHttpClient = authHttpClient,
+        _realtime = realtime,
+        _rest = rest;
+
+  /// Perform a table operation.
+  SupabaseQueryBuilder from(String table) {
+    final url = '$_restUrl/$table';
+    return SupabaseQueryBuilder(
+      url,
+      _realtime,
+      headers: {..._rest.headers, ..._headers},
+      schema: _postgrestOptions.schema,
+      table: table,
+      httpClient: _authHttpClient,
+      incrementId: _counter.increment(),
+      isolate: _isolate,
+    );
+  }
+
+  /// Perform a stored procedure call.
+  PostgrestFilterBuilder<T> rpc<T>(
+    String fn, {
+    Map<String, dynamic>? params,
+  }) {
+    _rest.headers.addAll({..._rest.headers, ..._headers});
+    return _rest.rpc(fn, params: params);
+  }
+}

--- a/packages/supabase/lib/supabase.dart
+++ b/packages/supabase/lib/supabase.dart
@@ -17,5 +17,6 @@ export 'src/supabase_client.dart';
 export 'src/supabase_client_options.dart';
 export 'src/supabase_event_types.dart';
 export 'src/supabase_query_builder.dart';
+export 'src/supabase_query_schema.dart';
 export 'src/supabase_realtime_error.dart';
 export 'src/supabase_stream_builder.dart';


### PR DESCRIPTION


Bug fix

## What is the current behavior?

When using `client.useSchema("mySchema").from("myTabel")` you can't append `.stream()`

## What is the new behavior?

You can now stream from a different schema.

## Additional context

close #610 