### PR TITLE
Optionally ignore deep links

### DIFF
--- a/packages/supabase_flutter/lib/src/supabase.dart
+++ b/packages/supabase_flutter/lib/src/supabase.dart
@@ -79,6 +79,7 @@ class Supabase {
     AuthFlowType authFlowType = AuthFlowType.implicit,
     GotrueAsyncStorage? pkceAsyncStorage,
     bool? debug,
+    bool ignoreDeepLinks = false,
   }) async {
     assert(
       !_instance._initialized,
@@ -103,6 +104,7 @@ class Supabase {
       localStorage: localStorage ?? const HiveLocalStorage(),
       authCallbackUrlHostname: authCallbackUrlHostname,
       authFlowType: authFlowType,
+      ignoreDeepLinks: ignoreDeepLinks,
     );
 
     return _instance;

--- a/packages/supabase_flutter/lib/src/supabase_auth.dart
+++ b/packages/supabase_flutter/lib/src/supabase_auth.dart
@@ -56,6 +56,8 @@ class SupabaseAuth with WidgetsBindingObserver {
 
   final _appLinks = AppLinks();
 
+  bool _ignoreDeepLinks = false;
+
   /// A [SupabaseAuth] instance.
   ///
   /// If not initialized, an [AssertionError] is thrown
@@ -75,6 +77,7 @@ class SupabaseAuth with WidgetsBindingObserver {
     LocalStorage localStorage = const HiveLocalStorage(),
     String? authCallbackUrlHostname,
     required AuthFlowType authFlowType,
+    bool ignoreDeepLinks = false,
   }) async {
     try {
       _instance._initialized = true;
@@ -82,6 +85,7 @@ class SupabaseAuth with WidgetsBindingObserver {
       _instance._authCallbackUrlHostname = authCallbackUrlHostname;
       _instance._initialSessionCompleter = Completer();
       _instance._authFlowType = authFlowType;
+      _instance._ignoreDeepLinks = ignoreDeepLinks;
 
       _instance.initialSession.catchError((e, d) {
         return null;
@@ -281,7 +285,7 @@ class SupabaseAuth with WidgetsBindingObserver {
 
   /// Callback when deeplink receiving succeeds
   Future<void> _handleDeeplink(Uri uri) async {
-    if (!_instance._isAuthCallbackDeeplink(uri)) return;
+    if (_ignoreDeepLinks || !_instance._isAuthCallbackDeeplink(uri)) return;
 
     Supabase.instance.log('***** SupabaseAuthState handleDeeplink $uri');
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR adds the ability to prevent supabase_flutter from handing deep links (which affords the opportunity for a user to fully handle deep linking on their own). This is done by adding a parameter `ignoreDeepLinks` to  the`Supabase.initialize` method.

This PR is another attempt to address #541.

## What is the current behavior?

Currently, supabase_flutter handles deep linking and there is no way for a user of supabase_flutter to opt out. A good summary of the issue can be found here: #541.

A different PR (#605) was made to tackle that issue, but it doesn't seem like it will be accepted. #605 was attempting to expose any deep links that supabase_flutter didn't handle to the user. However, the following was said in response to #605:

> Instead of fixing this in supabase-flutter, I would instead fix that in app_links so that they create only one stream and broadcast that.

This PR in contrast, is simply allowing for an escape hatch to stop supabase_flutter from handing any deep links, so a user can fully handle them on their own.

## What is the new behavior?

When `ignoreDeepLinks` is `true`, then supabase_flutter doesn't handle deep links at all.