### PR TITLE
fix: make Supabase client work in Dart Edge again

### DIFF
--- a/packages/realtime_client/lib/src/realtime_channel.dart
+++ b/packages/realtime_client/lib/src/realtime_channel.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:http/http.dart';
 import 'package:meta/meta.dart';
 import 'package:realtime_client/realtime_client.dart';
 import 'package:realtime_client/src/constants.dart';
@@ -427,7 +428,7 @@ class RealtimeChannel {
         ]
       };
       try {
-        final res = await socket.httpClient.post(
+        final res = await (socket.httpClient?.post ?? post)(
           Uri.parse(broadcastEndpointURL),
           headers: headers,
           body: json.encode(body),

--- a/packages/realtime_client/lib/src/realtime_client.dart
+++ b/packages/realtime_client/lib/src/realtime_client.dart
@@ -55,7 +55,7 @@ class RealtimeClient {
   final Map<String, dynamic> params;
   final Duration timeout;
   final WebSocketTransport transport;
-  final Client httpClient;
+  final Client? httpClient;
   int heartbeatIntervalMs = 30000;
   Timer? heartbeatTimer;
 
@@ -122,7 +122,7 @@ class RealtimeClient {
           if (headers != null) ...headers,
         },
         transport = transport ?? createWebSocketClient,
-        httpClient = httpClient ?? Client() {
+        httpClient = httpClient {
     final eventsPerSecond = params['eventsPerSecond'];
     if (eventsPerSecond != null) {
       eventsPerSecondLimitMs = (1000 / int.parse(eventsPerSecond)).floor();


### PR DESCRIPTION
## What kind of change does this PR introduce?

Beats me why this fixes it, but with this update SupabaseClient can be initialized within Dart Edge environment again.

fixes https://github.com/supabase/supabase-flutter/issues/666