### PR TITLE
chore(release): publish packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,59 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 2023-10-23
+
+### Changes
+
+---
+
+Packages with breaking changes:
+
+ - There are no breaking changes in this release.
+
+Packages with other changes:
+
+ - [`gotrue` - `v1.12.5`](#gotrue---v1125)
+ - [`postgrest` - `v1.5.2`](#postgrest---v152)
+ - [`realtime_client` - `v1.4.0`](#realtime_client---v140)
+ - [`storage_client` - `v1.5.4`](#storage_client---v154)
+ - [`supabase` - `v1.11.10`](#supabase---v11110)
+ - [`supabase_flutter` - `v1.10.23`](#supabase_flutter---v11023)
+
+Packages with dependency updates only:
+
+> Packages listed below depend on other packages in this workspace that have had changes. Their versions have been incremented to bump the minimum dependency versions of the packages they depend upon in this project.
+
+ - `supabase_flutter` - `v1.10.23`
+
+---
+
+#### `gotrue` - `v1.12.5`
+
+ - **FIX**(gotrue): remove import of dart:io from gotrue_client.dart ([#659](https://github.com/supabase/supabase-flutter/issues/659)). ([7280b490](https://github.com/supabase/supabase-flutter/commit/7280b490f10a8de5c69509c5242aff98e348c162))
+ - **FIX**: compile with webdev ([#653](https://github.com/supabase/supabase-flutter/issues/653)). ([23242287](https://github.com/supabase/supabase-flutter/commit/232422874df7f09fcf76ab5879822741a7272245))
+ - **FIX**(gotrue,supabase): allow refreshSession after exception ([#633](https://github.com/supabase/supabase-flutter/issues/633)). ([8853155f](https://github.com/supabase/supabase-flutter/commit/8853155fdaaec984818323b35718cb1c4c3ede4c))
+
+#### `postgrest` - `v1.5.2`
+
+ - **FIX**: don't try to decode an empty body ([#631](https://github.com/supabase/supabase-flutter/issues/631)). ([ec13c88f](https://github.com/supabase/supabase-flutter/commit/ec13c88f78f116d41c06a8f97e49a13d78b90172))
+
+#### `realtime_client` - `v1.4.0`
+
+ - **FIX**: make Supabase client work in Dart Edge again ([#675](https://github.com/supabase/supabase-flutter/issues/675)). ([53530f22](https://github.com/supabase/supabase-flutter/commit/53530f222b1430debf40d0beb95f75f279d1830f))
+ - **FIX**: Remove error parameter on `_triggerChanError` ([#637](https://github.com/supabase/supabase-flutter/issues/637)). ([c4291c97](https://github.com/supabase/supabase-flutter/commit/c4291c97c87342cbd84795297c046b7ababef5ac))
+ - **FEAT**: send messages via broadcast endpoint ([#654](https://github.com/supabase/supabase-flutter/issues/654)). ([2ff950d7](https://github.com/supabase/supabase-flutter/commit/2ff950d7b228fd377ba0da2c45f4803d90b3368d))
+
+#### `storage_client` - `v1.5.4`
+
+ - **FIX**: compile with webdev ([#653](https://github.com/supabase/supabase-flutter/issues/653)). ([23242287](https://github.com/supabase/supabase-flutter/commit/232422874df7f09fcf76ab5879822741a7272245))
+
+#### `supabase` - `v1.11.10`
+
+ - **FIX**: make Supabase client work in Dart Edge again ([#675](https://github.com/supabase/supabase-flutter/issues/675)). ([53530f22](https://github.com/supabase/supabase-flutter/commit/53530f222b1430debf40d0beb95f75f279d1830f))
+ - **FIX**(gotrue,supabase): allow refreshSession after exception ([#633](https://github.com/supabase/supabase-flutter/issues/633)). ([8853155f](https://github.com/supabase/supabase-flutter/commit/8853155fdaaec984818323b35718cb1c4c3ede4c))
+
+
 ## 2023-10-09
 
 ### Changes

--- a/packages/gotrue/CHANGELOG.md
+++ b/packages/gotrue/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.12.5
+
+ - **FIX**(gotrue): remove import of dart:io from gotrue_client.dart ([#659](https://github.com/supabase/supabase-flutter/issues/659)). ([7280b490](https://github.com/supabase/supabase-flutter/commit/7280b490f10a8de5c69509c5242aff98e348c162))
+ - **FIX**: compile with webdev ([#653](https://github.com/supabase/supabase-flutter/issues/653)). ([23242287](https://github.com/supabase/supabase-flutter/commit/232422874df7f09fcf76ab5879822741a7272245))
+ - **FIX**(gotrue,supabase): allow refreshSession after exception ([#633](https://github.com/supabase/supabase-flutter/issues/633)). ([8853155f](https://github.com/supabase/supabase-flutter/commit/8853155fdaaec984818323b35718cb1c4c3ede4c))
+
 ## 1.12.4
 
  - **FIX**(gotrue): remove import of dart:io from gotrue_client.dart ([#659](https://github.com/supabase/supabase-flutter/issues/659)). ([7280b490](https://github.com/supabase/supabase-flutter/commit/7280b490f10a8de5c69509c5242aff98e348c162))

--- a/packages/gotrue/lib/src/version.dart
+++ b/packages/gotrue/lib/src/version.dart
@@ -1,1 +1,1 @@
-const version = '1.12.4';
+const version = '1.12.5';

--- a/packages/gotrue/pubspec.yaml
+++ b/packages/gotrue/pubspec.yaml
@@ -1,6 +1,6 @@
 name: gotrue
 description: A dart client library for the GoTrue API.
-version: 1.12.4
+version: 1.12.5
 homepage: 'https://supabase.com'
 repository: 'https://github.com/supabase/supabase-flutter/tree/main/packages/gotrue'
 documentation: 'https://supabase.com/docs/reference/dart/auth-signup'

--- a/packages/postgrest/CHANGELOG.md
+++ b/packages/postgrest/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.5.2
+
+ - **FIX**: don't try to decode an empty body ([#631](https://github.com/supabase/supabase-flutter/issues/631)). ([ec13c88f](https://github.com/supabase/supabase-flutter/commit/ec13c88f78f116d41c06a8f97e49a13d78b90172))
+
 ## 1.5.1
 
  - **FIX**: don't try to decode an empty body ([#631](https://github.com/supabase/supabase-flutter/issues/631)). ([ec13c88f](https://github.com/supabase/supabase-flutter/commit/ec13c88f78f116d41c06a8f97e49a13d78b90172))

--- a/packages/postgrest/lib/src/version.dart
+++ b/packages/postgrest/lib/src/version.dart
@@ -1,1 +1,1 @@
-const version = '1.5.1';
+const version = '1.5.2';

--- a/packages/postgrest/pubspec.yaml
+++ b/packages/postgrest/pubspec.yaml
@@ -1,6 +1,6 @@
 name: postgrest
 description: PostgREST client for Dart. This library provides an ORM interface to PostgREST.
-version: 1.5.1
+version: 1.5.2
 homepage: 'https://supabase.com'
 repository: 'https://github.com/supabase/supabase-flutter/tree/main/packages/postgrest'
 documentation: 'https://supabase.com/docs/reference/dart/select'

--- a/packages/realtime_client/CHANGELOG.md
+++ b/packages/realtime_client/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.4.0
+
+ - **FIX**: make Supabase client work in Dart Edge again ([#675](https://github.com/supabase/supabase-flutter/issues/675)). ([53530f22](https://github.com/supabase/supabase-flutter/commit/53530f222b1430debf40d0beb95f75f279d1830f))
+ - **FIX**: Remove error parameter on `_triggerChanError` ([#637](https://github.com/supabase/supabase-flutter/issues/637)). ([c4291c97](https://github.com/supabase/supabase-flutter/commit/c4291c97c87342cbd84795297c046b7ababef5ac))
+ - **FEAT**: send messages via broadcast endpoint ([#654](https://github.com/supabase/supabase-flutter/issues/654)). ([2ff950d7](https://github.com/supabase/supabase-flutter/commit/2ff950d7b228fd377ba0da2c45f4803d90b3368d))
+
 ## 1.3.0
 
  - **FEAT**: send messages via broadcast endpoint ([#654](https://github.com/supabase/supabase-flutter/issues/654)). ([2ff950d7](https://github.com/supabase/supabase-flutter/commit/2ff950d7b228fd377ba0da2c45f4803d90b3368d))

--- a/packages/realtime_client/lib/src/version.dart
+++ b/packages/realtime_client/lib/src/version.dart
@@ -1,1 +1,1 @@
-const version = '1.3.0';
+const version = '1.4.0';

--- a/packages/realtime_client/pubspec.yaml
+++ b/packages/realtime_client/pubspec.yaml
@@ -1,6 +1,6 @@
 name: realtime_client
 description: Listens to changes in a PostgreSQL Database and via websockets. This is for usage with Supabase Realtime server.
-version: 1.3.0
+version: 1.4.0
 homepage: 'https://supabase.com'
 repository: 'https://github.com/supabase/supabase-flutter/tree/main/packages/realtime_client'
 documentation: 'https://supabase.com/docs/reference/dart/subscribe'

--- a/packages/storage_client/CHANGELOG.md
+++ b/packages/storage_client/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.5.4
+
+ - **FIX**: compile with webdev ([#653](https://github.com/supabase/supabase-flutter/issues/653)). ([23242287](https://github.com/supabase/supabase-flutter/commit/232422874df7f09fcf76ab5879822741a7272245))
+
 ## 1.5.3
 
  - **FIX**: compile with webdev ([#653](https://github.com/supabase/supabase-flutter/issues/653)). ([23242287](https://github.com/supabase/supabase-flutter/commit/232422874df7f09fcf76ab5879822741a7272245))

--- a/packages/storage_client/lib/src/version.dart
+++ b/packages/storage_client/lib/src/version.dart
@@ -1,1 +1,1 @@
-const version = '1.5.3';
+const version = '1.5.4';

--- a/packages/storage_client/pubspec.yaml
+++ b/packages/storage_client/pubspec.yaml
@@ -1,6 +1,6 @@
 name: storage_client
 description: Dart client library to interact with Supabase Storage. Supabase Storage provides an interface for managing Files stored in S3, using Postgres to manage permissions.
-version: 1.5.3
+version: 1.5.4
 homepage: 'https://supabase.com'
 repository: 'https://github.com/supabase/supabase-flutter/tree/main/packages/storage_client'
 documentation: 'https://supabase.com/docs/reference/dart/storage-createbucket'

--- a/packages/supabase/CHANGELOG.md
+++ b/packages/supabase/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.11.10
+
+ - **FIX**: make Supabase client work in Dart Edge again ([#675](https://github.com/supabase/supabase-flutter/issues/675)). ([53530f22](https://github.com/supabase/supabase-flutter/commit/53530f222b1430debf40d0beb95f75f279d1830f))
+ - **FIX**(gotrue,supabase): allow refreshSession after exception ([#633](https://github.com/supabase/supabase-flutter/issues/633)). ([8853155f](https://github.com/supabase/supabase-flutter/commit/8853155fdaaec984818323b35718cb1c4c3ede4c))
+
 ## 1.11.9
 
  - Update a dependency to the latest release.

--- a/packages/supabase/lib/src/version.dart
+++ b/packages/supabase/lib/src/version.dart
@@ -1,1 +1,1 @@
-const version = '1.11.9';
+const version = '1.11.10';

--- a/packages/supabase/pubspec.yaml
+++ b/packages/supabase/pubspec.yaml
@@ -1,6 +1,6 @@
 name: supabase
 description: A dart client for Supabase. This client makes it simple for developers to build secure and scalable products.
-version: 1.11.9
+version: 1.11.10
 homepage: 'https://supabase.com'
 repository: 'https://github.com/supabase/supabase-flutter/tree/main/packages/supabase'
 documentation: 'https://supabase.com/docs/reference/dart/introduction'
@@ -10,11 +10,11 @@ environment:
 
 dependencies:
   functions_client: ^1.3.2
-  gotrue: ^1.12.4
+  gotrue: ^1.12.5
   http: '>=0.13.5 <2.0.0'
-  postgrest: ^1.5.1
-  realtime_client: ^1.3.0
-  storage_client: ^1.5.3
+  postgrest: ^1.5.2
+  realtime_client: ^1.4.0
+  storage_client: ^1.5.4
   rxdart: ^0.27.5
   yet_another_json_isolate: ^1.1.1
 

--- a/packages/supabase_flutter/CHANGELOG.md
+++ b/packages/supabase_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.10.23
+
+ - Update a dependency to the latest release.
+
 ## 1.10.22
 
  - Update a dependency to the latest release.

--- a/packages/supabase_flutter/lib/src/version.dart
+++ b/packages/supabase_flutter/lib/src/version.dart
@@ -1,1 +1,1 @@
-const version = '1.10.22';
+const version = '1.10.23';

--- a/packages/supabase_flutter/pubspec.yaml
+++ b/packages/supabase_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: supabase_flutter
 description: Flutter integration for Supabase. This package makes it simple for developers to build secure and scalable products.
-version: 1.10.22
+version: 1.10.23
 homepage: 'https://supabase.com'
 repository: 'https://github.com/supabase/supabase-flutter/tree/main/packages/supabase_flutter'
 documentation: 'https://supabase.com/docs/reference/dart/introduction'
@@ -19,7 +19,7 @@ dependencies:
   http: '>=0.13.4 <2.0.0'
   meta: ^1.7.0
   sign_in_with_apple: '>=4.3.0 <6.0.0'
-  supabase: ^1.11.9
+  supabase: ^1.11.10
   url_launcher: ^6.1.2
   webview_flutter: ^4.0.0
   path_provider: ^2.0.0


### PR DESCRIPTION
 - gotrue@1.12.5
 - postgrest@1.5.2
 - realtime_client@1.4.0
 - storage_client@1.5.4
 - supabase@1.11.10
 - supabase_flutter@1.10.23
 
Bunch of duplicate messages showing up seemingly as a byproduct of this PR. https://github.com/supabase/supabase-flutter/pull/672 It's harmless, so we're just going to ignore them and publish this one. 