### PR TITLE
fix(gotrue): allow empty session response for verifyOtp method

### DIFF
--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -495,14 +495,10 @@ class GoTrueClient {
 
     final authResponse = AuthResponse.fromJson(response);
 
-    if (authResponse.session == null) {
-      throw AuthException(
-        'An error occurred on token verification.',
-      );
+    if (authResponse.session != null) {
+      _saveSession(authResponse.session!);
+      _notifyAllSubscribers(AuthChangeEvent.signedIn);
     }
-
-    _saveSession(authResponse.session!);
-    _notifyAllSubscribers(AuthChangeEvent.signedIn);
 
     return authResponse;
   }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Calling `auth.verifyOtp()` method with the 6-digit OTP returns an `AuthResponse` with `null` session. The supabase_flutter SDK currently however does not allow `null` session returned from the `verifyOtp()` method, but this PR enables empty session to be returned. 