### PR TITLE
refactor!(postgrest): rename `foreignTable` parameter to `referencedTable`

### DIFF
--- a/packages/postgrest/lib/src/postgrest_filter_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_filter_builder.dart
@@ -52,8 +52,8 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   ///     .select()
   ///     .or('status.eq.OFFLINE,username.eq.supabot');
   /// ```
-  PostgrestFilterBuilder<T> or(String filters, {String? foreignTable}) {
-    final key = foreignTable != null ? '$foreignTable.or' : 'or';
+  PostgrestFilterBuilder<T> or(String filters, {String? referencedTable}) {
+    final key = referencedTable != null ? '$referencedTable.or' : 'or';
     final url = appendSearchParams(key, '($filters)');
     return copyWithUrl(url);
   }

--- a/packages/postgrest/lib/src/postgrest_transform_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_transform_builder.dart
@@ -54,21 +54,21 @@ class PostgrestTransformBuilder<T> extends RawPostgrestBuilder<T, T, T> {
   ///     .select()
   ///     .order('username', ascending: false);
   /// ````
-  /// If [column] is a foreign column, [foreignTable] has to be set
+  /// If [column] is a referenced table column, [referencedTable] has to be set
   /// ```dart
   /// final data = await supabase
   ///     .from('users')
   ///     .select('messages(*)')
   ///     .order('channel_id',
-  ///         foreignTable: 'messages', ascending: false);
+  ///         referencedTable: 'messages', ascending: false);
   /// ```
   PostgrestTransformBuilder<T> order(
     String column, {
     bool ascending = false,
     bool nullsFirst = false,
-    String? foreignTable,
+    String? referencedTable,
   }) {
-    final key = foreignTable == null ? 'order' : '$foreignTable.order';
+    final key = referencedTable == null ? 'order' : '$referencedTable.order';
     final existingOrder = _url.queryParameters[key];
     final value = '${existingOrder == null ? '' : '$existingOrder,'}'
         '$column.${ascending ? 'asc' : 'desc'}.${nullsFirst ? 'nullsfirst' : 'nullslast'}';
@@ -82,15 +82,16 @@ class PostgrestTransformBuilder<T> extends RawPostgrestBuilder<T, T, T> {
   /// final data = await supabase.from('users').select().limit(1);
   /// ```
   ///
-  /// If we want to limit a foreign column, [foreignTable] has to be set
+  /// If we want to limit a referenced table column, [referencedTable]
+  /// has to beset
   /// ```dart
   /// final data = await supabase
   ///   .from('users')
   ///   .select('messages(*)')
-  ///   .limit(1, foreignTable: 'messages');
+  ///   .limit(1, referencedTable: 'messages');
   /// ```
-  PostgrestTransformBuilder<T> limit(int count, {String? foreignTable}) {
-    final key = foreignTable == null ? 'limit' : '$foreignTable.limit';
+  PostgrestTransformBuilder<T> limit(int count, {String? referencedTable}) {
+    final key = referencedTable == null ? 'limit' : '$referencedTable.limit';
 
     final url = appendSearchParams(key, '$count');
     return PostgrestTransformBuilder(copyWithUrl(url));
@@ -105,16 +106,20 @@ class PostgrestTransformBuilder<T> extends RawPostgrestBuilder<T, T, T> {
   ///     .range(1, 1);
   /// ```
   ///
-  /// If we want to limit a foreign column, [foreignTable] has to be set
+  /// If we want to limit a referenced table column, [referencedTable]
+  /// has to be set
   /// ```dart
   /// final data = await supabase
   ///     .from('users')
   ///     .select('messages(*)')
-  ///     .range(1, 1, foreignTable: 'messages');
+  ///     .range(1, 1, referencedTable: 'messages');
   /// ```
-  PostgrestTransformBuilder<T> range(int from, int to, {String? foreignTable}) {
-    final keyOffset = foreignTable == null ? 'offset' : '$foreignTable.offset';
-    final keyLimit = foreignTable == null ? 'limit' : '$foreignTable.limit';
+  PostgrestTransformBuilder<T> range(int from, int to,
+      {String? referencedTable}) {
+    final keyOffset =
+        referencedTable == null ? 'offset' : '$referencedTable.offset';
+    final keyLimit =
+        referencedTable == null ? 'limit' : '$referencedTable.limit';
 
     var url = appendSearchParams(keyOffset, '$from');
     url = appendSearchParams(keyLimit, '${to - from + 1}', url);

--- a/packages/postgrest/test/resource_embedding_test.dart
+++ b/packages/postgrest/test/resource_embedding_test.dart
@@ -60,7 +60,7 @@ void main() {
     final res = await postgrest
         .from('users')
         .select('messages(*)')
-        .order('channel_id', foreignTable: 'messages');
+        .order('channel_id', referencedTable: 'messages');
     expect(
       res[0]['messages']!.length,
       3,
@@ -80,7 +80,7 @@ void main() {
         .from('users')
         .select('username, messages(*)')
         .order('username', ascending: true)
-        .order('channel_id', foreignTable: 'messages');
+        .order('channel_id', referencedTable: 'messages');
     expect(
       res[0]['username'],
       'awailas',
@@ -107,7 +107,7 @@ void main() {
     final res = await postgrest
         .from('users')
         .select('messages(*)')
-        .limit(1, foreignTable: 'messages');
+        .limit(1, referencedTable: 'messages');
     expect(
       res[0]['messages']!.length,
       1,
@@ -130,7 +130,7 @@ void main() {
     final res = await postgrest
         .from('users')
         .select('messages(*)')
-        .range(1, 1, foreignTable: 'messages');
+        .range(1, 1, referencedTable: 'messages');
     expect(
       res[0]['messages']!.length,
       1,

--- a/packages/postgrest/test/transforms_test.dart
+++ b/packages/postgrest/test/transforms_test.dart
@@ -73,7 +73,7 @@ void main() {
     );
   });
 
-  test("order on foreign table", () async {
+  test("order on referenced table", () async {
     final data = await postgrest
         .from("users")
         .select(
@@ -89,7 +89,7 @@ void main() {
         ''',
         )
         .eq("username", "supabot")
-        .order("created_at", foreignTable: "messages.reactions")
+        .order("created_at", referencedTable: "messages.reactions")
         .single();
 
     final messages = data['messages'] as List;
@@ -111,7 +111,7 @@ void main() {
     expect(res.length, 1);
   });
 
-  test("limit on foreign table", () async {
+  test("limit on referenced table", () async {
     final data = await postgrest
         .from("users")
         .select(
@@ -127,7 +127,7 @@ void main() {
           ''',
         )
         .eq("username", "supabot")
-        .limit(1, foreignTable: "messages.reactions")
+        .limit(1, referencedTable: "messages.reactions")
         .single();
 
     final messages = data['messages'] as List;
@@ -157,7 +157,7 @@ void main() {
     expect(res.length, to - (from - 1));
   });
 
-  test("range on foreign table", () async {
+  test("range on referenced table", () async {
     const from = 0;
     const to = 2;
     final data = await postgrest
@@ -176,14 +176,14 @@ void main() {
         )
         .eq("username", "supabot")
         .eq("messages.id", 1)
-        .range(from, to, foreignTable: "messages.reactions")
+        .range(from, to, referencedTable: "messages.reactions")
         .single();
     final message = (data['messages'] as List)[0];
     final reactions = (message as Map)["reactions"] as List;
     expect(reactions.length, to - (from - 1));
   });
 
-  test("range 1-1 on foreign table", () async {
+  test("range 1-1 on referenced table", () async {
     const from = 1;
     const to = 1;
     final data = await postgrest
@@ -202,7 +202,7 @@ void main() {
         )
         .eq("username", "supabot")
         .eq("messages.id", 1)
-        .range(from, to, foreignTable: "messages.reactions")
+        .range(from, to, referencedTable: "messages.reactions")
         .single();
 
     final message = (data['messages'] as List)[0];


### PR DESCRIPTION
## What kind of change does this PR introduce?

There has been a bit of confusion around using the term `foreign table` in context of a table referenced with foreign key constraint after Supabase adding [Supabase wrappers](https://supabase.com/docs/guides/database/extensions/wrappers/overview). An experienced Postgres developer will more likely to think about table connected using foreign data wrappers as foreign tables, and not a table that is referenced by a foreign key constraint when they hear the term `foreign table`. 

JS PR here: https://github.com/supabase/postgrest-js/pull/493