### PR TITLE
feat: adds `.explain()` for debugging performance issues on Supabase client generated queries. 

### DIFF
--- a/infra/postgrest/docker-compose.yml
+++ b/infra/postgrest/docker-compose.yml
@@ -3,7 +3,7 @@
 version: '3'
 services:
   rest:
-    image: postgrest/postgrest:v11.0.0
+    image: postgrest/postgrest:v11.2.2
     ports:
       - '3000:3000'
     environment:

--- a/infra/postgrest/docker-compose.yml
+++ b/infra/postgrest/docker-compose.yml
@@ -3,7 +3,7 @@
 version: '3'
 services:
   rest:
-    image: postgrest/postgrest:v11.2.2
+    image: postgrest/postgrest:v11.0.0
     ports:
       - '3000:3000'
     environment:

--- a/packages/postgrest/lib/src/postgrest_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_builder.dart
@@ -178,6 +178,9 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
           body = null;
         } else if (response.request!.headers['Accept'] == 'text/csv') {
           body = response.body;
+        } else if (_headers['Accept'] != null &&
+            _headers['Accept']!.contains('application/vnd.pgrst.plan+text')) {
+          body = response.body;
         } else {
           try {
             if ((response.contentLength ?? 0) > 10000 && _isolate != null) {

--- a/packages/postgrest/lib/src/postgrest_transform_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_transform_builder.dart
@@ -228,6 +228,12 @@ class PostgrestTransformBuilder<T> extends RawPostgrestBuilder<T, T, T> {
 
   /// Obtains the EXPLAIN plan for this request.
   ///
+  /// Before using this method, you need to enable `explain()` on your
+  /// Supabase instance by following the guide below. Note that `explain()`
+  /// should only be enabled on an development environment.
+  ///
+  /// https://supabase.com/docs/guides/api/rest/debugging-performance#enabling-explain
+  ///
   /// [analyze] If `true`, the query will be executed and the actual run time will be displayed.
   ///
   /// [verbose] If `true`, the query identifier will be displayed and the result will include the output columns of the query.
@@ -243,7 +249,6 @@ class PostgrestTransformBuilder<T> extends RawPostgrestBuilder<T, T, T> {
     settings = false,
     buffers = false,
     wal = false,
-    format = 'text',
   }) {
     final options = [
       if (analyze) 'analyze',
@@ -257,7 +262,7 @@ class PostgrestTransformBuilder<T> extends RawPostgrestBuilder<T, T, T> {
     final forMediatype = _headers['Accept'] ?? 'application/json';
     final newHeaders = {..._headers};
     newHeaders['Accept'] =
-        'application/vnd.pgrst.plan+$format; for="$forMediatype"; options=$options;';
+        'application/vnd.pgrst.plan+text; for="$forMediatype"; options=$options;';
     return _copyWithType(headers: newHeaders);
   }
 }

--- a/packages/postgrest/lib/src/postgrest_transform_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_transform_builder.dart
@@ -243,7 +243,7 @@ class PostgrestTransformBuilder<T> extends RawPostgrestBuilder<T, T, T> {
   /// [buffers] If `true`, include information on buffer usage.
   ///
   /// [wal] If `true`, include information on WAL record generation
-  PostgrestBuilder<String, T, T> explain({
+  PostgrestBuilder<String, void, void> explain({
     bool analyze = false,
     bool verbose = false,
     bool settings = false,

--- a/packages/postgrest/lib/src/postgrest_transform_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_transform_builder.dart
@@ -244,11 +244,11 @@ class PostgrestTransformBuilder<T> extends RawPostgrestBuilder<T, T, T> {
   ///
   /// [wal] If `true`, include information on WAL record generation
   PostgrestBuilder<String, T, T> explain({
-    analyze = false,
-    verbose = false,
-    settings = false,
-    buffers = false,
-    wal = false,
+    bool analyze = false,
+    bool verbose = false,
+    bool settings = false,
+    bool buffers = false,
+    bool wal = false,
   }) {
     final options = [
       if (analyze) 'analyze',

--- a/packages/postgrest/lib/src/postgrest_transform_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_transform_builder.dart
@@ -225,4 +225,39 @@ class PostgrestTransformBuilder<T> extends RawPostgrestBuilder<T, T, T> {
   PostgrestBuilder<void, void, void> head() {
     return _copyWithType(method: METHOD_HEAD);
   }
+
+  /// Obtains the EXPLAIN plan for this request.
+  ///
+  /// [analyze] If `true`, the query will be executed and the actual run time will be displayed.
+  ///
+  /// [verbose] If `true`, the query identifier will be displayed and the result will include the output columns of the query.
+  ///
+  /// [settings] If `true`, include information on configuration parameters that affect query planning.
+  ///
+  /// [buffers] If `true`, include information on buffer usage.
+  ///
+  /// [wal] If `true`, include information on WAL record generation
+  PostgrestBuilder<String, T, T> explain({
+    analyze = false,
+    verbose = false,
+    settings = false,
+    buffers = false,
+    wal = false,
+    format = 'text',
+  }) {
+    final options = [
+      if (analyze) 'analyze',
+      if (verbose) 'verbose',
+      if (settings) 'settings',
+      if (buffers) 'buffers',
+      if (wal) 'wal',
+    ].join('|');
+
+    // An Accept header can carry multiple media types but postgrest-js always sends one
+    final forMediatype = _headers['Accept'] ?? 'application/json';
+    final newHeaders = {..._headers};
+    newHeaders['Accept'] =
+        'application/vnd.pgrst.plan+$format; for="$forMediatype"; options=$options;';
+    return _copyWithType(headers: newHeaders);
+  }
 }

--- a/packages/postgrest/lib/src/postgrest_transform_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_transform_builder.dart
@@ -243,7 +243,7 @@ class PostgrestTransformBuilder<T> extends RawPostgrestBuilder<T, T, T> {
   /// [buffers] If `true`, include information on buffer usage.
   ///
   /// [wal] If `true`, include information on WAL record generation
-  PostgrestBuilder<String, void, void> explain({
+  PostgrestBuilder<String, String, String> explain({
     bool analyze = false,
     bool verbose = false,
     bool settings = false,

--- a/packages/postgrest/test/transforms_test.dart
+++ b/packages/postgrest/test/transforms_test.dart
@@ -326,4 +326,13 @@ void main() {
     final regex = RegExp(r'/Aggregate  \(cost=.*/');
     expect(regex.hasMatch(res), isTrue);
   });
+
+  test('explain with options', () async {
+    final res = await postgrest.from('users').select().explain(
+          analyze: true,
+          verbose: true,
+        );
+    final regex = RegExp(r'/Aggregate  \(cost=.*/');
+    expect(regex.hasMatch(res), isTrue);
+  });
 }

--- a/packages/postgrest/test/transforms_test.dart
+++ b/packages/postgrest/test/transforms_test.dart
@@ -320,4 +320,10 @@ void main() {
       }
     });
   });
+
+  test('explain', () async {
+    final res = await postgrest.from('users').select().explain();
+    final regex = RegExp(r'/Aggregate  \(cost=.*/');
+    expect(regex.hasMatch(res), isTrue);
+  });
 }

--- a/packages/postgrest/test/transforms_test.dart
+++ b/packages/postgrest/test/transforms_test.dart
@@ -323,7 +323,7 @@ void main() {
 
   test('explain', () async {
     final res = await postgrest.from('users').select().explain();
-    final regex = RegExp(r'/Aggregate  \(cost=.*/');
+    final regex = RegExp(r'Aggregate  \(cost=.*');
     expect(regex.hasMatch(res), isTrue);
   });
 
@@ -332,7 +332,7 @@ void main() {
           analyze: true,
           verbose: true,
         );
-    final regex = RegExp(r'/Aggregate  \(cost=.*/');
+    final regex = RegExp(r'Aggregate  \(cost=.*');
     expect(regex.hasMatch(res), isTrue);
   });
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Adds a new `.explain()` transformer that will return 

```dart
final String plan = await supabase.from('table').select().explain(); 

// `plan` will be something like this as plain String:
// Aggregate  (cost=8.18..8.20 rows=1 width=112)
//  ->  Index Scan using projects_pkey on projects  (cost=0.15..8.17 rows=1 width=40)
//        Index Cond: (id = 1)
```

The JS SDK has a `json` and `text` response types, but [`text` is preferred](https://github.com/supabase/postgrest-js/pull/302), so I think it's okay to only have `text` for Dart SDK. 

JS implementation here https://github.com/supabase/postgrest-js/blob/master/src/PostgrestTransformBuilder.ts#L245

Closes https://github.com/supabase/supabase-flutter/issues/717