### PR TITLE
fix(supabase_flutter): session recovery while offline does not remove the existing session.

### DIFF
--- a/packages/supabase_flutter/lib/src/supabase_auth.dart
+++ b/packages/supabase_flutter/lib/src/supabase_auth.dart
@@ -100,23 +100,23 @@ class SupabaseAuth with WidgetsBindingObserver {
 
   /// Recover/refresh session if it's available
   /// e.g. called on a splash screen when the app starts.
-  Future<bool> _recoverSupabaseSession() async {
+  Future<void> _recoverSupabaseSession() async {
     final bool exist = await _localStorage.hasAccessToken();
     if (!exist) {
-      return false;
+      return;
     }
 
     final String? jsonStr = await _localStorage.accessToken();
     if (jsonStr == null) {
-      return false;
+      return;
     }
 
     try {
       await Supabase.instance.client.auth.recoverSession(jsonStr);
-      return true;
     } catch (error) {
-      _localStorage.removePersistedSession();
-      return false;
+      // When there is an exception thrown while recovering the session,
+      // the appropriate action (retry, revoking session) will be taken by
+      // the gotrue library, so need to do anything here.
     }
   }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Currently if the Flutter SDK calls `_recoverSupabaseSession()` and `auth.recoverSession()` throws, the stored session is deleted within supabase_flutter. This is unnecessary as gotrue will catch the errors and handle them [here](https://github.com/supabase/supabase-flutter/blob/next/packages/gotrue/lib/src/gotrue_client.dart#L960). 

This PR simply removes the supabase_flutter code that is deleting the session stored on local storage. 

fixes https://github.com/supabase/supabase-flutter/issues/716