### PR TITLE
refactor!(realtime_client): make channel methods private and add `@internal` label

### DIFF
--- a/packages/realtime_client/lib/src/realtime_channel.dart
+++ b/packages/realtime_client/lib/src/realtime_channel.dart
@@ -52,14 +52,14 @@ class RealtimeChannel {
       _pushBuffer = [];
     });
 
-    onClose(() {
+    _onClose(() {
       _rejoinTimer.reset();
       socket.log('channel', 'close $topic $joinRef');
       _state = ChannelStates.closed;
       socket.remove(this);
     });
 
-    onError((String? reason) {
+    _onError((String? reason) {
       if (isLeaving || isClosed) {
         return;
       }
@@ -111,10 +111,10 @@ class RealtimeChannel {
       final broadcast = params['config']['broadcast'];
       final presence = params['config']['presence'];
 
-      onError((e) {
+      _onError((e) {
         if (callback != null) callback(RealtimeSubscribeStatus.channelError, e);
       });
-      onClose(() {
+      _onClose(() {
         if (callback != null) callback(RealtimeSubscribeStatus.closed, null);
       });
 
@@ -237,13 +237,13 @@ class RealtimeChannel {
   }
 
   /// Registers a callback that will be executed when the channel closes.
-  void onClose(Function callback) {
+  void _onClose(Function callback) {
     onEvents(ChannelEvents.close.eventName(), ChannelFilter(),
         (reason, [ref]) => callback());
   }
 
   /// Registers a callback that will be executed when the channel encounteres an error.
-  void onError(void Function(String?) callback) {
+  void _onError(void Function(String?) callback) {
     onEvents(ChannelEvents.error.eventName(), ChannelFilter(),
         (reason, [ref]) => callback(reason?.toString()));
   }
@@ -256,6 +256,7 @@ class RealtimeChannel {
     return onEvents(type.toType(), filter, callback);
   }
 
+  @internal
   RealtimeChannel onEvents(
       String type, ChannelFilter filter, BindingCallback callback) {
     final typeLower = type.toLowerCase();
@@ -271,6 +272,7 @@ class RealtimeChannel {
     return this;
   }
 
+  @internal
   RealtimeChannel off(String type, Map<String, String> filter) {
     final typeLower = type.toLowerCase();
 
@@ -286,6 +288,7 @@ class RealtimeChannel {
     return socket.isConnected && isJoined;
   }
 
+  @internal
   Push push(
     ChannelEvents event,
     Map<String, dynamic> payload, [
@@ -380,6 +383,7 @@ class RealtimeChannel {
     return completer.future;
   }
 
+  @internal
   void updateJoinPayload(Map<String, dynamic> payload) {
     joinPush.updatePayload(payload);
   }
@@ -449,14 +453,17 @@ class RealtimeChannel {
   ///
   /// Receives all events for specialized message handling before dispatching to the channel callbacks.
   /// Must return the payload, modified or unmodified.
+  @internal
   dynamic onMessage(String event, dynamic payload, [String? ref]) {
     return payload;
   }
 
+  @internal
   bool isMember(String? topic) {
     return this.topic == topic;
   }
 
+  @internal
   String get joinRef => joinPush.ref;
 
   @internal
@@ -530,6 +537,7 @@ class RealtimeChannel {
     }
   }
 
+  @internal
   String replyEventName(String? ref) {
     return 'chan_reply_$ref';
   }


### PR DESCRIPTION
## What kind of change does this PR introduce?

No functional changes and just hiding what should be hidden. 

Technically it might be a breaking change because it includes making public members private, but users shouldn't really be using them, so the affect should be minimal. 