### PR TITLE
fix!(gotrue): change the default signOut scope to local from global

### DIFF
--- a/.github/workflows/gotrue_ci.yml
+++ b/.github/workflows/gotrue_ci.yml
@@ -62,4 +62,4 @@ jobs:
           time: '5s'
 
       - name: Run tests
-        run: dart test
+        run: dart test --concurrency=1

--- a/packages/gotrue/lib/src/constants.dart
+++ b/packages/gotrue/lib/src/constants.dart
@@ -65,11 +65,14 @@ enum OtpChannel {
   whatsapp,
 }
 
-///Determines which sessions should be logged out.
-///
-///[global] means all sessions by this account will be signed out.
-///
-///[local] means only this session will be signed out.
-///
-///[others] means all other sessions except the current one will be signed out. When using others, there is no [AuthChangeEvent.signedOut] event fired on the current session!
-enum SignOutScope { global, local, others }
+/// Determines which sessions should be logged out.
+enum SignOutScope {
+  /// All sessions by this account will be signed out.
+  global,
+
+  /// Only this session will be signed out.
+  local,
+
+  /// All other sessions except the current one will be signed out. When using others, there is no [AuthChangeEvent.signedOut] event fired on the current session!
+  others,
+}

--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -720,7 +720,7 @@ class GoTrueClient {
   ///
   /// If using [SignOutScope.others] scope, no [AuthChangeEvent.signedOut] event is fired!
   Future<void> signOut({
-    SignOutScope scope = SignOutScope.global,
+    SignOutScope scope = SignOutScope.local,
   }) async {
     final accessToken = currentSession?.accessToken;
 

--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -718,6 +718,8 @@ class GoTrueClient {
 
   /// Signs out the current user, if there is a logged in user.
   ///
+  /// [scope] dtermines which sessions should be logged out.
+  ///
   /// If using [SignOutScope.others] scope, no [AuthChangeEvent.signedOut] event is fired!
   Future<void> signOut({
     SignOutScope scope = SignOutScope.local,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Currently when the developer calls `auth.signOut()`, it signs out the user from every device. This PR changes the default value to `local`, which is probably more aligned with what a developer would expect to happen when calling `auth.signOut()`. 