### PR TITLE
fix(supabase_flutter): session migration from hive to sharedPreferences now works properly

### DIFF
--- a/packages/supabase_flutter/lib/src/local_storage.dart
+++ b/packages/supabase_flutter/lib/src/local_storage.dart
@@ -196,7 +196,9 @@ class MigrationLocalStorage extends LocalStorage {
       final hasHive = await hiveLocalStorage.hasAccessToken();
       if (hasHive) {
         final accessToken = await hiveLocalStorage.accessToken();
-        await sharedPreferencesLocalStorage.persistSession(accessToken!);
+        final session =
+            Session.fromJson(jsonDecode(accessToken!)['currentSession']);
+        await sharedPreferencesLocalStorage.persistSession(jsonEncode(session));
         await hiveLocalStorage.removePersistedSession();
       }
       if (Hive.box(_hiveBoxName).isEmpty) {

--- a/packages/supabase_flutter/lib/src/local_storage.dart
+++ b/packages/supabase_flutter/lib/src/local_storage.dart
@@ -198,7 +198,11 @@ class MigrationLocalStorage extends LocalStorage {
         final accessToken = await hiveLocalStorage.accessToken();
         final session =
             Session.fromJson(jsonDecode(accessToken!)['currentSession']);
-        await sharedPreferencesLocalStorage.persistSession(jsonEncode(session));
+        if (session == null) {
+          return;
+        }
+        await sharedPreferencesLocalStorage
+            .persistSession(jsonEncode(session.toJson()));
         await hiveLocalStorage.removePersistedSession();
       }
       if (Hive.box(_hiveBoxName).isEmpty) {


### PR DESCRIPTION
## What kind of change does this PR introduce?

We have a `MigrationLocalStorage` class for anyone migrating from supabase_flutter v1 to v2 so that the auth session would keep working while we have switched from using hive to using sharedPreferences for storing session data. 

There  is currently a bug where the migration fails. This PR fixes the failing migration.