### PR TITLE
fix(gotrue): signing in with pkce flow fires two `signedIn` auth event

### DIFF
--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -641,11 +641,6 @@ class GoTrueClient {
             'No session found for the auth code.');
       }
 
-      if (storeSession == true) {
-        _saveSession(session);
-        notifyAllSubscribers(AuthChangeEvent.signedIn);
-      }
-
       return AuthSessionUrlResponse(session: session, redirectType: null);
     }
     var url = originUrl;


### PR DESCRIPTION
## What kind of change does this PR introduce?

Currently when a user signs in with the pkce flow, two `signedIn` events are fired. This PR makes it one. 