### PR TITLE
refactor!(postgrest, supabase): make `schema` variable private and rename `useSchema()` to `schema()`

### DIFF
--- a/packages/postgrest/lib/src/postgrest.dart
+++ b/packages/postgrest/lib/src/postgrest.dart
@@ -7,14 +7,14 @@ import 'package:yet_another_json_isolate/yet_another_json_isolate.dart';
 class PostgrestClient {
   final String url;
   final Map<String, String> headers;
-  final String? schema;
+  final String? _schema;
   final Client? httpClient;
   final YAJsonIsolate _isolate;
   final bool _hasCustomIsolate;
 
   /// To create a [PostgrestClient], you need to provide an [url] endpoint.
   ///
-  /// You can also provide custom [headers] and [schema] if needed
+  /// You can also provide custom [headers] and [_schema] if needed
   /// ```dart
   /// PostgrestClient(REST_URL)
   /// PostgrestClient(REST_URL, headers: {'apikey': 'foo'})
@@ -26,10 +26,11 @@ class PostgrestClient {
   PostgrestClient(
     this.url, {
     Map<String, String>? headers,
-    this.schema,
+    String? schema,
     this.httpClient,
     YAJsonIsolate? isolate,
-  })  : headers = {...defaultHeaders, if (headers != null) ...headers},
+  })  : _schema = schema,
+        headers = {...defaultHeaders, if (headers != null) ...headers},
         _isolate = isolate ?? (YAJsonIsolate()..initialize()),
         _hasCustomIsolate = isolate != null;
 
@@ -55,7 +56,7 @@ class PostgrestClient {
     return PostgrestQueryBuilder<void>(
       url: Uri.parse(url),
       headers: {...headers},
-      schema: schema,
+      schema: _schema,
       httpClient: httpClient,
       isolate: _isolate,
     );
@@ -64,7 +65,7 @@ class PostgrestClient {
   /// Select a schema to query or perform an function (rpc) call.
   ///
   /// The schema needs to be on the list of exposed schemas inside Supabase.
-  PostgrestClient useSchema(String schema) {
+  PostgrestClient schema(String schema) {
     return PostgrestClient(
       url,
       headers: {...headers},
@@ -87,7 +88,7 @@ class PostgrestClient {
     return PostgrestRpcBuilder(
       url,
       headers: {...headers},
-      schema: schema,
+      schema: _schema,
       httpClient: httpClient,
       isolate: _isolate,
     ).rpc(params);

--- a/packages/postgrest/test/basic_test.dart
+++ b/packages/postgrest/test/basic_test.dart
@@ -96,7 +96,7 @@ void main() {
     test('query non-public schema dynamically', () async {
       final postgrest = PostgrestClient(rootUrl);
       final personalData =
-          await postgrest.useSchema('personal').from('users').select();
+          await postgrest.schema('personal').from('users').select();
       expect(personalData.length, 5);
 
       // confirm that the client defaults to its initialized schema by default.

--- a/packages/supabase/lib/src/supabase_client.dart
+++ b/packages/supabase/lib/src/supabase_client.dart
@@ -154,8 +154,8 @@ class SupabaseClient {
   /// Select a schema to query or perform an function (rpc) call.
   ///
   /// The schema needs to be on the list of exposed schemas inside Supabase.
-  SupabaseQuerySchema useSchema(String schema) {
-    final newRest = rest.useSchema(schema);
+  SupabaseQuerySchema schema(String schema) {
+    final newRest = rest.schema(schema);
     return SupabaseQuerySchema(
       counter: _incrementId,
       restUrl: _restUrl,

--- a/packages/supabase/lib/src/supabase_query_schema.dart
+++ b/packages/supabase/lib/src/supabase_query_schema.dart
@@ -57,8 +57,8 @@ class SupabaseQuerySchema {
     return _rest.rpc(fn, params: params);
   }
 
-  SupabaseQuerySchema useSchema(String schema) {
-    final newRest = _rest.useSchema(schema);
+  SupabaseQuerySchema schema(String schema) {
+    final newRest = _rest.schema(schema);
     return SupabaseQuerySchema(
       counter: _counter,
       restUrl: _restUrl,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Currently the JS library uses `.schema()` to change the schema for calling APIs to non-public schema. However, the Dart library uses `useSchema()`, because `schema` symbol was already taken by the [`schema`](https://github.com/supabase/supabase-flutter/blob/main/packages/postgrest/lib/src/postgrest.dart#L10) variable in postgrest.dart. 

This PR renames the `schema` variable to `_schema` and `.useSchema()` to `.schema()` to align the public API with the JS library.

## What is the current behavior?

```dart
await supabase.useSchema('custom_schema').from('table').select();
```

## What is the new behavior?

```dart
await supabase.schema('custom_schema').from('table').select();
```