### PR TITLE
fix: use SharedPreferences on web

### DIFF
--- a/packages/supabase_flutter/lib/src/local_storage.dart
+++ b/packages/supabase_flutter/lib/src/local_storage.dart
@@ -158,8 +158,9 @@ class SharedPreferencesLocalStorage extends LocalStorage {
   Future<void> removePersistedSession() async {
     if (_useWebLocalStorage) {
       web.removePersistedSession(persistSessionKey);
+    } else {
+      await _prefs.remove(persistSessionKey);
     }
-    await _prefs.remove(persistSessionKey);
   }
 
   @override


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Due to a missing else/return statement, SharedPreferences is used.

## What is the new behavior?

Skip the SharedPreferences access.

## Additional context

close #703
