### PR TITLE
fix: emit passwordRecovery event when using pkce

### DIFF
--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -312,12 +312,6 @@ class GoTrueClient {
 
     final authResponse = AuthResponse.fromJson(response);
 
-    final session = authResponse.session;
-    if (session != null) {
-      _saveSession(session);
-      notifyAllSubscribers(AuthChangeEvent.signedIn);
-    }
-
     return authResponse;
   }
 
@@ -630,6 +624,8 @@ class GoTrueClient {
   }) async {
     if (_flowType == AuthFlowType.pkce) {
       final authCode = originUrl.queryParameters['code'];
+      final redirectType = originUrl.queryParameters['type'];
+
       if (authCode == null) {
         throw AuthPKCEGrantCodeExchangeError(
             'No code detected in query parameters.');
@@ -639,6 +635,15 @@ class GoTrueClient {
       if (session == null) {
         throw AuthPKCEGrantCodeExchangeError(
             'No session found for the auth code.');
+      }
+
+      if (storeSession == true) {
+        _saveSession(session);
+        if (redirectType == 'recovery') {
+          notifyAllSubscribers(AuthChangeEvent.passwordRecovery);
+        } else {
+          notifyAllSubscribers(AuthChangeEvent.signedIn);
+        }
       }
 
       return AuthSessionUrlResponse(session: session, redirectType: null);


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When using pkce no password recovery event is send. Instead just a sign in event is send.

## What is the new behavior?

Send a password recovery event when needed

## Additional context

Note that I haven't had the time to actual test this. I don't even know if the url from the redirect contains the `type` query parameter, but I guess so.

Will try to add tests.

close #664
