### PR TITLE
fix: sign out on already used refresh token

### DIFF
--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -981,7 +981,7 @@ class GoTrueClient {
       rethrow;
     } catch (error, stack) {
       if (error is AuthException) {
-        if (error.message == 'Invalid Refresh Token: Refresh Token Not Found') {
+        if (error.message.startsWith('Invalid Refresh Token:')) {
           await signOut();
         }
       }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When a token refresh fails with the error that it's already used, just an error is thrown.

## What is the new behavior?

Every Token refresh failure issues a sign out.

## Additional context

close #710
