### PR TITLE
feat(gotrue): add Figma as the OAuth provider

### DIFF
--- a/packages/gotrue/lib/src/types/provider.dart
+++ b/packages/gotrue/lib/src/types/provider.dart
@@ -4,6 +4,7 @@ enum Provider {
   bitbucket,
   discord,
   facebook,
+  figma,
   github,
   gitlab,
   google,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Figma is not listed as a provider even though supabase supports it

## What is the new behavior?

Figma is now listed as a provider

## Additional context

I tested getOAuthSignInUrl with Provider.figma and it worked as expected.
