### PR TITLE
feat(gotrue): add Figma to  OAuth provider.

### DIFF
--- a/packages/gotrue/lib/src/types/o_auth_provider.dart
+++ b/packages/gotrue/lib/src/types/o_auth_provider.dart
@@ -4,6 +4,7 @@ enum OAuthProvider {
   bitbucket,
   discord,
   facebook,
+  figma,
   github,
   gitlab,
   google,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Figma is not listed as a provider even though supabase supports it

## What is the new behavior?

Figma is now listed as a provider

## Additional context

I tested getOAuthSignInUrl with Provider.figma and it worked as expected. (admittably it was on v1)
