### PR TITLE
fix: PKCE flow not emitting password recovery event

### DIFF
--- a/packages/gotrue/lib/gotrue.dart
+++ b/packages/gotrue/lib/gotrue.dart
@@ -1,6 +1,7 @@
 library gotrue;
 
-export 'src/constants.dart' hide Constants, GenerateLinkTypeExtended;
+export 'src/constants.dart'
+    hide Constants, GenerateLinkTypeExtended, AuthChangeEventExtended;
 export 'src/gotrue_admin_api.dart';
 export 'src/gotrue_client.dart';
 export 'src/types/auth_exception.dart';

--- a/packages/gotrue/lib/src/constants.dart
+++ b/packages/gotrue/lib/src/constants.dart
@@ -28,13 +28,13 @@ enum AuthChangeEvent {
 }
 
 extension AuthChangeEventExtended on AuthChangeEvent {
-  static GenerateLinkType fromString(String? val) {
-    for (final event in GenerateLinkType.values) {
+  static AuthChangeEvent fromString(String? val) {
+    for (final event in AuthChangeEvent.values) {
       if (event.name == val) {
         return event;
       }
     }
-    return GenerateLinkType.unknown;
+    return AuthChangeEvent.signedIn;
   }
 }
 

--- a/packages/gotrue/lib/src/constants.dart
+++ b/packages/gotrue/lib/src/constants.dart
@@ -27,6 +27,17 @@ enum AuthChangeEvent {
   mfaChallengeVerified,
 }
 
+extension AuthChangeEventExtended on AuthChangeEvent {
+  static GenerateLinkType fromString(String? val) {
+    for (final event in GenerateLinkType.values) {
+      if (event.name == val) {
+        return event;
+      }
+    }
+    return GenerateLinkType.unknown;
+  }
+}
+
 enum GenerateLinkType {
   signup,
   invite,

--- a/packages/gotrue/lib/src/constants.dart
+++ b/packages/gotrue/lib/src/constants.dart
@@ -28,13 +28,13 @@ enum AuthChangeEvent {
 }
 
 extension AuthChangeEventExtended on AuthChangeEvent {
-  static AuthChangeEvent fromString(String? val) {
+  static AuthChangeEvent? fromString(String? val) {
     for (final event in AuthChangeEvent.values) {
       if (event.name == val) {
         return event;
       }
     }
-    return AuthChangeEvent.signedIn;
+    return null;
   }
 }
 

--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -643,10 +643,7 @@ class GoTrueClient {
         throw AuthPKCEGrantCodeExchangeError(
             'No code detected in query parameters.');
       }
-      final data = await exchangeCodeForSession(authCode);
-      final session = data.session;
-
-      return AuthSessionUrlResponse(session: session, redirectType: null);
+      return await exchangeCodeForSession(authCode);
     }
     var url = originUrl;
     if (originUrl.hasQuery) {

--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -289,14 +289,14 @@ class GoTrueClient {
     assert(_asyncStorage != null,
         'You need to provide asyncStorage to perform pkce flow.');
 
-    final rawString = await _asyncStorage!
+    final codeVerifierRawString = await _asyncStorage!
         .getItem(key: '${Constants.defaultStorageKey}-code-verifier');
-    if (rawString == null) {
+    if (codeVerifierRawString == null) {
       throw AuthException('Code verifier could not be found in local storage.');
     }
-    final codeVerifier = rawString.split('/').first;
-    final typeString = rawString.split('/').last;
-    final type = AuthChangeEventExtended.fromString(typeString);
+    final codeVerifier = codeVerifierRawString.split('/').first;
+    final eventName = codeVerifierRawString.split('/').last;
+    final type = AuthChangeEventExtended.fromString(eventName);
 
     final Map<String, dynamic> response = await _fetch.request(
       '$_url/token',

--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -296,7 +296,7 @@ class GoTrueClient {
     }
     final codeVerifier = codeVerifierRawString.split('/').first;
     final eventName = codeVerifierRawString.split('/').last;
-    final type = AuthChangeEventExtended.fromString(eventName);
+    final redirectType = AuthChangeEventExtended.fromString(eventName);
 
     final Map<String, dynamic> response = await _fetch.request(
       '$_url/token',
@@ -321,7 +321,7 @@ class GoTrueClient {
     final session = authResponse.session;
     if (session != null) {
       _saveSession(session);
-      if (type == AuthChangeEvent.passwordRecovery) {
+      if (redirectType == AuthChangeEvent.passwordRecovery) {
         notifyAllSubscribers(AuthChangeEvent.passwordRecovery);
       } else {
         notifyAllSubscribers(AuthChangeEvent.signedIn);

--- a/packages/supabase_flutter/test/supabase_flutter_test.dart
+++ b/packages/supabase_flutter/test/supabase_flutter_test.dart
@@ -107,7 +107,10 @@ void main() {
         httpClient: pkceHttpClient,
         authOptions: FlutterAuthClientOptions(
           localStorage: MockEmptyLocalStorage(),
-          pkceAsyncStorage: MockAsyncStorage(),
+          pkceAsyncStorage: MockAsyncStorage()
+            ..setItem(
+                key: 'supabase.auth.token-code-verifier',
+                value: 'raw-code-verifier'),
         ),
       );
     });


### PR DESCRIPTION
## What kind of change does this PR introduce?

Currently with PKCE flow, `passwordRecovery` auth event is not emitted for email password reset flow. This PR fixes it.

## What is the current behavior?

`signIn` event is emitted after clicking on the link sent to the email.

## What is the new behavior?

`passwordRecovery` event is emitted after opening the link sent to the email.

## Additional context

Fixes https://github.com/supabase/supabase-flutter/issues/664
