### PR TITLE
feat!(realtime_client): Provide better typing for realtime presence.

### DIFF
--- a/packages/realtime_client/lib/src/realtime_channel.dart
+++ b/packages/realtime_client/lib/src/realtime_channel.dart
@@ -360,7 +360,7 @@ class RealtimeChannel {
         switch (event) {
           case PresenceEvent.sync:
             callback(
-                PresencePayload.fromJson(Map<String, dynamic>.from(payload))
+                PresenceSyncPayload.fromJson(Map<String, dynamic>.from(payload))
                     as T);
             break;
           case PresenceEvent.join:

--- a/packages/realtime_client/lib/src/realtime_channel.dart
+++ b/packages/realtime_client/lib/src/realtime_channel.dart
@@ -330,19 +330,19 @@ class RealtimeChannel {
   /// ```dart
   /// final channel = supabase.channel('my_channel');
   /// channel
-  ///     .onPresence(
+  ///     .onPresence<PresenceSyncPayload>(
   ///         event: PresenceEvent.sync,
-  ///         callback: (payload) {
+  ///         callback: (PresenceSyncPayload payload) {
   ///           print('Synced presence state: ${channel.presenceState()}');
   ///         })
-  ///     .onPresence(
+  ///     .onPresence<PresenceJoinPayload>(
   ///         event: PresenceEvent.join,
-  ///         callback: (payload) {
+  ///         callback: (PresenceJoinPayload payload) {
   ///           print('Newly joined presences $payload');
   ///         })
-  ///     .onPresence(
+  ///     .onPresence<PresenceLeavePayload>(
   ///         event: PresenceEvent.leave,
-  ///         callback: (payload) {
+  ///         callback: (PresenceLeavePayload payload) {
   ///           print('Newly left presences: $payload');
   ///         })
   ///     .subscribe();

--- a/packages/realtime_client/lib/src/realtime_channel.dart
+++ b/packages/realtime_client/lib/src/realtime_channel.dart
@@ -326,54 +326,80 @@ class RealtimeChannel {
     );
   }
 
-  /// Sets up a listen for realtime presence.
-  ///
-  /// [event] sets which presence event to listen to.
+  /// Sets up a listener for realtime presence sync event.
   ///
   /// ```dart
   /// final channel = supabase.channel('my_channel');
   /// channel
-  ///     .onPresence<RealtimePresenceSyncPayload>(
-  ///         event: PresenceEvent.sync,
-  ///         callback: (RealtimePresenceSyncPayload payload) {
+  ///     .onPresenceSync(
+  ///         (RealtimePresenceSyncPayload payload) {
   ///           print('Synced presence state: ${channel.presenceState()}');
-  ///         })
-  ///     .onPresence<RealtimePresenceJoinPayload>(
-  ///         event: PresenceEvent.join,
-  ///         callback: (RealtimePresenceJoinPayload payload) {
-  ///           print('Newly joined presences $payload');
-  ///         })
-  ///     .onPresence<RealtimePresenceLeavePayload>(
-  ///         event: PresenceEvent.leave,
-  ///         callback: (RealtimePresenceLeavePayload payload) {
-  ///           print('Newly left presences: $payload');
   ///         })
   ///     .subscribe();
   /// ```
-  RealtimeChannel onPresence<T extends RealtimePresencePayload>({
-    required PresenceEvent event,
-    required void Function(T payload) callback,
-  }) {
+  RealtimeChannel onPresenceSync(
+    void Function(RealtimePresenceSyncPayload payload) callback,
+  ) {
     return onEvents(
       'presence',
       ChannelFilter(
-        event: event.name,
+        event: PresenceEvent.sync.name,
       ),
       (payload, [ref]) {
-        switch (event) {
-          case PresenceEvent.sync:
-            callback(RealtimePresenceSyncPayload.fromJson(
-                Map<String, dynamic>.from(payload)) as T);
-            break;
-          case PresenceEvent.join:
-            callback(RealtimePresenceJoinPayload.fromJson(
-                Map<String, dynamic>.from(payload)) as T);
-            break;
-          case PresenceEvent.leave:
-            callback(RealtimePresenceLeavePayload.fromJson(
-                Map<String, dynamic>.from(payload)) as T);
-            break;
-        }
+        callback(RealtimePresenceSyncPayload.fromJson(
+            Map<String, dynamic>.from(payload)));
+      },
+    );
+  }
+
+  /// Sets up a listener for realtime presence join event.
+  ///
+  /// ```dart
+  /// final channel = supabase.channel('my_channel');
+  /// channel
+  ///     .onPresenceJoin(
+  ///         (RealtimePresenceJoinPayload payload) {
+  ///           print('Newly joined Presence: ${channel.presenceState()}');
+  ///         })
+  ///     .subscribe();
+  /// ```
+  RealtimeChannel onPresenceJoin(
+    void Function(RealtimePresenceJoinPayload payload) callback,
+  ) {
+    return onEvents(
+      'presence',
+      ChannelFilter(
+        event: PresenceEvent.join.name,
+      ),
+      (payload, [ref]) {
+        callback(RealtimePresenceJoinPayload.fromJson(
+            Map<String, dynamic>.from(payload)));
+      },
+    );
+  }
+
+  /// Sets up a listener for realtime presence leave event.
+  ///
+  /// ```dart
+  /// final channel = supabase.channel('my_channel');
+  /// channel
+  ///     .onPresenceLeave(
+  ///         (RealtimePresenceLeavePayload payload) {
+  ///           print('Newly left Presence: ${channel.presenceState()}');
+  ///         })
+  ///     .subscribe();
+  /// ```
+  RealtimeChannel onPresenceLeave(
+    void Function(RealtimePresenceLeavePayload payload) callback,
+  ) {
+    return onEvents(
+      'presence',
+      ChannelFilter(
+        event: PresenceEvent.leave.name,
+      ),
+      (payload, [ref]) {
+        callback(RealtimePresenceLeavePayload.fromJson(
+            Map<String, dynamic>.from(payload)));
       },
     );
   }

--- a/packages/realtime_client/lib/src/realtime_channel.dart
+++ b/packages/realtime_client/lib/src/realtime_channel.dart
@@ -347,16 +347,33 @@ class RealtimeChannel {
   ///         })
   ///     .subscribe();
   /// ```
-  RealtimeChannel onPresence({
+  RealtimeChannel onPresence<T extends PresencePayload>({
     required PresenceEvent event,
-    required void Function(Map<String, dynamic> payload) callback,
+    required void Function(T payload) callback,
   }) {
     return onEvents(
       'presence',
       ChannelFilter(
         event: event.name,
       ),
-      (payload, [ref]) => callback(Map<String, dynamic>.from(payload)),
+      (payload, [ref]) {
+        switch (event) {
+          case PresenceEvent.sync:
+            callback(
+                PresencePayload.fromJson(Map<String, dynamic>.from(payload))
+                    as T);
+            break;
+          case PresenceEvent.join:
+            callback(
+                PresenceJoinPayload.fromJson(Map<String, dynamic>.from(payload))
+                    as T);
+            break;
+          case PresenceEvent.leave:
+            callback(PresenceLeavePayload.fromJson(
+                Map<String, dynamic>.from(payload)) as T);
+            break;
+        }
+      },
     );
   }
 

--- a/packages/realtime_client/lib/src/realtime_channel.dart
+++ b/packages/realtime_client/lib/src/realtime_channel.dart
@@ -216,8 +216,11 @@ class RealtimeChannel {
     return this;
   }
 
-  Map<String, dynamic> presenceState() {
-    return presence.state;
+  List<SinglePresenceState> presenceState() {
+    return presence.state.entries
+        .map((entry) =>
+            SinglePresenceState(key: entry.key, presences: entry.value))
+        .toList();
   }
 
   Future<ChannelResponse> track(Map<String, dynamic> payload,
@@ -330,24 +333,24 @@ class RealtimeChannel {
   /// ```dart
   /// final channel = supabase.channel('my_channel');
   /// channel
-  ///     .onPresence<PresenceSyncPayload>(
+  ///     .onPresence<RealtimePresenceSyncPayload>(
   ///         event: PresenceEvent.sync,
-  ///         callback: (PresenceSyncPayload payload) {
+  ///         callback: (RealtimePresenceSyncPayload payload) {
   ///           print('Synced presence state: ${channel.presenceState()}');
   ///         })
-  ///     .onPresence<PresenceJoinPayload>(
+  ///     .onPresence<RealtimePresenceJoinPayload>(
   ///         event: PresenceEvent.join,
-  ///         callback: (PresenceJoinPayload payload) {
+  ///         callback: (RealtimePresenceJoinPayload payload) {
   ///           print('Newly joined presences $payload');
   ///         })
-  ///     .onPresence<PresenceLeavePayload>(
+  ///     .onPresence<RealtimePresenceLeavePayload>(
   ///         event: PresenceEvent.leave,
-  ///         callback: (PresenceLeavePayload payload) {
+  ///         callback: (RealtimePresenceLeavePayload payload) {
   ///           print('Newly left presences: $payload');
   ///         })
   ///     .subscribe();
   /// ```
-  RealtimeChannel onPresence<T extends PresencePayload>({
+  RealtimeChannel onPresence<T extends RealtimePresencePayload>({
     required PresenceEvent event,
     required void Function(T payload) callback,
   }) {
@@ -359,17 +362,15 @@ class RealtimeChannel {
       (payload, [ref]) {
         switch (event) {
           case PresenceEvent.sync:
-            callback(
-                PresenceSyncPayload.fromJson(Map<String, dynamic>.from(payload))
-                    as T);
+            callback(RealtimePresenceSyncPayload.fromJson(
+                Map<String, dynamic>.from(payload)) as T);
             break;
           case PresenceEvent.join:
-            callback(
-                PresenceJoinPayload.fromJson(Map<String, dynamic>.from(payload))
-                    as T);
+            callback(RealtimePresenceJoinPayload.fromJson(
+                Map<String, dynamic>.from(payload)) as T);
             break;
           case PresenceEvent.leave:
-            callback(PresenceLeavePayload.fromJson(
+            callback(RealtimePresenceLeavePayload.fromJson(
                 Map<String, dynamic>.from(payload)) as T);
             break;
         }

--- a/packages/realtime_client/lib/src/realtime_presence.dart
+++ b/packages/realtime_client/lib/src/realtime_presence.dart
@@ -1,3 +1,4 @@
+// ignore_for_file: public_member_api_docs, sort_constructors_first
 import 'package:realtime_client/realtime_client.dart';
 import 'package:realtime_client/src/types.dart';
 
@@ -5,16 +6,19 @@ class Presence {
   final String presenceRef;
   final Map<String, dynamic> payload;
 
-  Presence(Map<String, dynamic> map)
+  Presence.fromJson(Map<String, dynamic> map)
       : presenceRef = map['presence_ref'],
         payload = map..remove('presence_ref');
 
   Presence deepClone() {
-    return Presence({
+    return Presence.fromJson({
       'presence_ref': presenceRef,
       ...payload,
     });
   }
+
+  @override
+  String toString() => 'Presence(presenceRef: $presenceRef, payload: $payload)';
 }
 
 typedef PresenceChooser<T> = T Function(String key, dynamic presence);
@@ -298,7 +302,7 @@ class RealtimePresence {
           presence.remove('phx_ref');
           presence.remove('phx_ref_prev');
 
-          return Presence(presence);
+          return Presence.fromJson(presence);
         }).toList();
       } else {
         // presences is List<Presence>

--- a/packages/realtime_client/lib/src/realtime_presence.dart
+++ b/packages/realtime_client/lib/src/realtime_presence.dart
@@ -2,8 +2,12 @@
 import 'package:realtime_client/realtime_client.dart';
 import 'package:realtime_client/src/types.dart';
 
+/// A single shared state between users with Realtime Presence.
 class Presence {
+  /// Reference to the presence object.
   final String presenceRef;
+
+  /// The payload shared by users.
   final Map<String, dynamic> payload;
 
   Presence.fromJson(Map<String, dynamic> map)

--- a/packages/realtime_client/lib/src/types.dart
+++ b/packages/realtime_client/lib/src/types.dart
@@ -315,6 +315,7 @@ class RealtimePresenceSyncPayload extends RealtimePresencePayload {
 /// Payload for [PresenceEvent.join] callback.
 class RealtimePresenceJoinPayload extends RealtimePresencePayload {
   /// Unique identifier for the clients.
+  ///
   /// By default the realtime server generates a UUIDv1 key for each client.
   final String key;
 

--- a/packages/realtime_client/lib/src/types.dart
+++ b/packages/realtime_client/lib/src/types.dart
@@ -349,6 +349,7 @@ class RealtimePresenceJoinPayload extends RealtimePresencePayload {
 /// Payload for [PresenceEvent.leave] callback.
 class RealtimePresenceLeavePayload extends RealtimePresencePayload {
   /// Unique identifier for the clients.
+  /// 
   /// By default the realtime server generates a UUIDv1 key for each client.
   final String key;
 

--- a/packages/realtime_client/lib/src/types.dart
+++ b/packages/realtime_client/lib/src/types.dart
@@ -280,11 +280,9 @@ class PostgresChangeFilter {
   }
 }
 
-/// Object for the presence callback payload for when the event is [PresenceEvent.sync].
-///
-/// For [PresenceEvent.join] event, [PresenceJoinPayload] will be returned, and
-/// for [PresenceEvent.leave] event, [PresenceLeavePayload] will be returned.
-class PresencePayload {
+/// Base class for the payload in `.onPresence()` callback functions.
+abstract class PresencePayload {
+  /// Name of the presence event.
   final PresenceEvent event;
 
   PresencePayload({
@@ -295,10 +293,29 @@ class PresencePayload {
       : event = PresenceEventExtended.fromString(json['event']);
 }
 
-/// Object for the presence callback payload for when the event is `join`.
+/// Payload for [PresenceEvent.sync] callback.
+class PresenceSyncPayload extends PresencePayload {
+  PresenceSyncPayload({
+    required super.event,
+  });
+
+  factory PresenceSyncPayload.fromJson(Map<String, dynamic> json) {
+    return PresenceSyncPayload(
+      event: PresenceEventExtended.fromString(json['event']),
+    );
+  }
+}
+
+/// Payload for [PresenceEvent.join] callback.
 class PresenceJoinPayload extends PresencePayload {
+  /// Unique identifier for the clients.
+  /// By default the realtime server generates a UUIDv1 key for each client.
   final String key;
+
+  /// List of newly joined presences in the callback.
   final List<Presence> newPresences;
+
+  /// List of currently present presences.
   final List<Presence> currentPresences;
 
   PresenceJoinPayload({
@@ -318,10 +335,16 @@ class PresenceJoinPayload extends PresencePayload {
   }
 }
 
-/// Object for the presence callback payload for when the event is `leave`.
+/// Payload for [PresenceEvent.leave] callback.
 class PresenceLeavePayload extends PresencePayload {
+  /// Unique identifier for the clients.
+  /// By default the realtime server generates a UUIDv1 key for each client.
   final String key;
+
+  /// List of presences that left in the callback.
   final List<Presence> leftPresences;
+
+  /// List of currently present presences.
   final List<Presence> currentPresences;
 
   PresenceLeavePayload({

--- a/packages/realtime_client/lib/src/types.dart
+++ b/packages/realtime_client/lib/src/types.dart
@@ -281,15 +281,15 @@ class PostgresChangeFilter {
 }
 
 /// Base class for the payload in `.onPresence()` callback functions.
-abstract class PresencePayload {
+abstract class RealtimePresencePayload {
   /// Name of the presence event.
   final PresenceEvent event;
 
-  PresencePayload({
+  RealtimePresencePayload({
     required this.event,
   });
 
-  PresencePayload.fromJson(Map<String, dynamic> json)
+  RealtimePresencePayload.fromJson(Map<String, dynamic> json)
       : event = PresenceEventExtended.fromString(json['event']);
 
   @override
@@ -297,13 +297,13 @@ abstract class PresencePayload {
 }
 
 /// Payload for [PresenceEvent.sync] callback.
-class PresenceSyncPayload extends PresencePayload {
-  PresenceSyncPayload({
+class RealtimePresenceSyncPayload extends RealtimePresencePayload {
+  RealtimePresenceSyncPayload({
     required super.event,
   });
 
-  factory PresenceSyncPayload.fromJson(Map<String, dynamic> json) {
-    return PresenceSyncPayload(
+  factory RealtimePresenceSyncPayload.fromJson(Map<String, dynamic> json) {
+    return RealtimePresenceSyncPayload(
       event: PresenceEventExtended.fromString(json['event']),
     );
   }
@@ -313,7 +313,7 @@ class PresenceSyncPayload extends PresencePayload {
 }
 
 /// Payload for [PresenceEvent.join] callback.
-class PresenceJoinPayload extends PresencePayload {
+class RealtimePresenceJoinPayload extends RealtimePresencePayload {
   /// Unique identifier for the clients.
   /// By default the realtime server generates a UUIDv1 key for each client.
   final String key;
@@ -324,15 +324,15 @@ class PresenceJoinPayload extends PresencePayload {
   /// List of currently present presences.
   final List<Presence> currentPresences;
 
-  PresenceJoinPayload({
+  RealtimePresenceJoinPayload({
     required super.event,
     required this.key,
     required this.currentPresences,
     required this.newPresences,
   });
 
-  factory PresenceJoinPayload.fromJson(Map<String, dynamic> json) {
-    return PresenceJoinPayload(
+  factory RealtimePresenceJoinPayload.fromJson(Map<String, dynamic> json) {
+    return RealtimePresenceJoinPayload(
       event: PresenceEventExtended.fromString(json['event']),
       key: json['key'] as String,
       newPresences: json['newPresences'] as List<Presence>,
@@ -346,7 +346,7 @@ class PresenceJoinPayload extends PresencePayload {
 }
 
 /// Payload for [PresenceEvent.leave] callback.
-class PresenceLeavePayload extends PresencePayload {
+class RealtimePresenceLeavePayload extends RealtimePresencePayload {
   /// Unique identifier for the clients.
   /// By default the realtime server generates a UUIDv1 key for each client.
   final String key;
@@ -357,15 +357,15 @@ class PresenceLeavePayload extends PresencePayload {
   /// List of currently present presences.
   final List<Presence> currentPresences;
 
-  PresenceLeavePayload({
+  RealtimePresenceLeavePayload({
     required super.event,
     required this.key,
     required this.currentPresences,
     required this.leftPresences,
   });
 
-  factory PresenceLeavePayload.fromJson(Map<String, dynamic> json) {
-    return PresenceLeavePayload(
+  factory RealtimePresenceLeavePayload.fromJson(Map<String, dynamic> json) {
+    return RealtimePresenceLeavePayload(
       event: PresenceEventExtended.fromString(json['event']),
       key: json['key'] as String,
       leftPresences: json['leftPresences'] as List<Presence>,
@@ -376,4 +376,21 @@ class PresenceLeavePayload extends PresencePayload {
   @override
   String toString() =>
       'PresenceLeavePayload(key: $key, leftPresences: $leftPresences, currentPresences: $currentPresences)';
+}
+
+/// A single client connected through presence.
+class SinglePresenceState {
+  /// Presence key of the client.
+  final String key;
+
+  /// List of shared payloads of the client.
+  final List<Presence> presences;
+
+  SinglePresenceState({
+    required this.key,
+    required this.presences,
+  });
+
+  @override
+  String toString() => 'PresenceState(key: $key, presences: $presences)';
 }

--- a/packages/realtime_client/lib/src/types.dart
+++ b/packages/realtime_client/lib/src/types.dart
@@ -291,6 +291,9 @@ abstract class PresencePayload {
 
   PresencePayload.fromJson(Map<String, dynamic> json)
       : event = PresenceEventExtended.fromString(json['event']);
+
+  @override
+  String toString() => 'PresencePayload(event: $event)';
 }
 
 /// Payload for [PresenceEvent.sync] callback.
@@ -304,6 +307,9 @@ class PresenceSyncPayload extends PresencePayload {
       event: PresenceEventExtended.fromString(json['event']),
     );
   }
+
+  @override
+  String toString() => 'PresenceSyncPayload(event: $event)';
 }
 
 /// Payload for [PresenceEvent.join] callback.
@@ -333,6 +339,10 @@ class PresenceJoinPayload extends PresencePayload {
       currentPresences: json['currentPresences'] as List<Presence>,
     );
   }
+
+  @override
+  String toString() =>
+      'PresenceJoinPayload(key: $key, newPresences: $newPresences, currentPresences: $currentPresences)';
 }
 
 /// Payload for [PresenceEvent.leave] callback.
@@ -362,4 +372,8 @@ class PresenceLeavePayload extends PresencePayload {
       currentPresences: json['currentPresences'] as List<Presence>,
     );
   }
+
+  @override
+  String toString() =>
+      'PresenceLeavePayload(key: $key, leftPresences: $leftPresences, currentPresences: $currentPresences)';
 }

--- a/packages/realtime_client/lib/src/types.dart
+++ b/packages/realtime_client/lib/src/types.dart
@@ -349,7 +349,7 @@ class RealtimePresenceJoinPayload extends RealtimePresencePayload {
 /// Payload for [PresenceEvent.leave] callback.
 class RealtimePresenceLeavePayload extends RealtimePresencePayload {
   /// Unique identifier for the clients.
-  /// 
+  ///
   /// By default the realtime server generates a UUIDv1 key for each client.
   final String key;
 

--- a/packages/realtime_client/test/channel_test.dart
+++ b/packages/realtime_client/test/channel_test.dart
@@ -320,4 +320,46 @@ void main() {
       expect(await completer.future, ChannelResponse.ok);
     });
   });
+
+  group('presence', () {
+    setUp(() {
+      socket = RealtimeClient('', timeout: const Duration(milliseconds: 1234));
+      channel =
+          RealtimeChannel('topic', socket, params: RealtimeChannelConfig());
+    });
+
+    test('description', () async {
+      bool syncCalled = false, joinCalled = false, leaveCalled = false;
+      channel.onPresenceSync((payload) {
+        syncCalled = true;
+      }).onPresenceJoin((payload) {
+        joinCalled = true;
+      }).onPresenceLeave((payload) {
+        leaveCalled = true;
+      }).subscribe();
+
+      channel.trigger('presence', {'event': 'sync'}, '1');
+      expect(syncCalled, isTrue);
+      channel.trigger(
+          'presence',
+          {
+            'event': 'join',
+            'key': 'joinKey',
+            'newPresences': <Presence>[],
+            'currentPresences': <Presence>[],
+          },
+          '2');
+      expect(joinCalled, isTrue);
+      channel.trigger(
+          'presence',
+          {
+            'event': 'leave',
+            'key': 'leaveKey',
+            'leftPresences': <Presence>[],
+            'currentPresences': <Presence>[],
+          },
+          '3');
+      expect(leaveCalled, isTrue);
+    });
+  });
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Currently, a lot of data passed around the realtime presence feature relies on `Map`. Some of them have very weird typing using Map such as the return type of `channel.presenceState()` being `Map<String, List<Presence>>`. This PR aims to add better typing for better developer experiences. 

## What is the current behavior?
`payload` in callback is `Map<String, dynamic>` when the SDK knows a bit more about what data could come in.

Also `channel.presenceState()` has `Map<String, List<Presence>>` as its return type;

```dart
    channel = supabase
        .channel('name')
        .onPresence(
          event: PresenceEvent.sync,
          callback: (payload) {
            print(payload); // `payload` is type `Map<String, dynamic>`
            print(channel.presenceState()); // prints `{'UUID': [Presence(key: 'presenceKey', payload: {'my': 'payload'})]}
          },
        ).subscribe();
````

## What is the new behavior?

Now `onPresence` takes a generic that extends a newly created `RealtimePresencePayload` object. 

There are three types for the payload `PresenceSyncPayload`, `PresenceJoinPayload`, and `PresenceLeavePayload`, and the users are required to add the generics to use presence. 

```dart
channel = supabase
    .channel('name')
    .onPresenceSync(
      (PresenceSyncPayload payload) {
        print(payload);
        print(channel.presenceState()); // returns type `List<SinglePresenceState>`
      },
    )
    .onPresenceJoin(
      (PresenceJoinPayload payload) {
        payload.event;
        payload.key;
        payload.currentPresences;
        payload.newPresences;
      },
    )
    .onPresence(
      (PresenceLeavePayload payload) {
        payload.event;
        payload.key;
        payload.currentPresences;
        payload.leftPresences;
      },
    )
    .subscribe();
```

Also `channel.presenceState()` now returns type `List<SinglePresenceState>`, which should be more intuitive to the users. 

Before, the returned type for `channel.resenceState()` was a Map with the key being a server generate UUID `key`, and the value was the list of `Presence`. 

Now, instead of using Map, we just return a `List` of `SinglePresenceState` instances, which contains the `key` and the `presences` object. 
