### PR TITLE
chore(release): publish packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,49 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 2023-12-05
+
+### Changes
+
+---
+
+Packages with breaking changes:
+
+ - [`realtime_client` - `v2.0.0-dev.3`](#realtime_client---v200-dev3)
+ - [`postgrest` - `v2.0.0-dev.2`](#postgrest---v200-dev2)
+ - [`supabase` - `v2.0.0-dev.4`](#supabase---v200-dev4)
+
+Packages with other changes:
+
+ - [`gotrue` - `v2.0.0-dev.2`](#gotrue---v200-dev2)
+ - [`supabase_flutter` - `v2.0.0-dev.4`](#supabase_flutter---v200-dev4)
+
+---
+
+#### `gotrue` - `v2.0.0-dev.2`
+
+ - **FIX**: PKCE flow not emitting password recovery event ([#744](https://github.com/supabase/supabase-flutter/issues/744)). ([65859bd2](https://github.com/supabase/supabase-flutter/commit/65859bd2676873c685397b4b37d2685bed18b5a1))
+ - **FIX**: sign out on already used refresh token ([#740](https://github.com/supabase/supabase-flutter/issues/740)). ([72ffb9ee](https://github.com/supabase/supabase-flutter/commit/72ffb9ee1a1386fb7ab8085b68cd9bc6f6d72c78))
+ - **FIX**(gotrue): signing in with pkce flow fires two `signedIn` auth event ([#734](https://github.com/supabase/supabase-flutter/issues/734)). ([6dee1660](https://github.com/supabase/supabase-flutter/commit/6dee1660024afcb926853ec77cd7da685dfa479b))
+ - **FEAT**(gotrue): add Figma to  OAuth provider. ([#743](https://github.com/supabase/supabase-flutter/issues/743)). ([f5b72d47](https://github.com/supabase/supabase-flutter/commit/f5b72d47e7af4b62aa99f3e380557ef039b1e2d9))
+
+#### `realtime_client` - `v2.0.0-dev.3`
+
+- **BREAKING** **FEAT**(realtime_client): Introduce type safe realtime methods ([#725](https://github.com/supabase/supabase-flutter/pull/725)).
+- **BREAKING** **FEAT**(realtime_client): Provide better typing for realtime presence. ([#747](https://github.com/supabase/supabase-flutter/pull/747)).
+
+#### `supabase` - `v2.0.0-dev.4`
+
+ - **FIX**: realtime ordering on double ([#741](https://github.com/supabase/supabase-flutter/issues/741)). ([f20faef7](https://github.com/supabase/supabase-flutter/commit/f20faef710e4e730590543ccd0a7bafd072be2ff))
+
+#### `supabase_flutter` - `v2.0.0-dev.4`
+
+ - **FIX**: PKCE flow not emitting password recovery event ([#744](https://github.com/supabase/supabase-flutter/issues/744)). ([65859bd2](https://github.com/supabase/supabase-flutter/commit/65859bd2676873c685397b4b37d2685bed18b5a1))
+ - **FIX**: update sign in with Apple instruction on readme ([#746](https://github.com/supabase/supabase-flutter/issues/746)). ([a4897d06](https://github.com/supabase/supabase-flutter/commit/a4897d06684d38bb159721f8f308fcbde836095e))
+ - **FIX**: use SharedPreferences on web ([#738](https://github.com/supabase/supabase-flutter/issues/738)). ([d0cc2015](https://github.com/supabase/supabase-flutter/commit/d0cc20153f23004f1ef2f821b0e9c6d9189f6b03))
+ - **FIX**(supabase_flutter): session migration from hive to sharedPreferences now works properly ([#731](https://github.com/supabase/supabase-flutter/issues/731)). ([c81cf07f](https://github.com/supabase/supabase-flutter/commit/c81cf07f75be13916b8b90ccc1ded20f1ad4aec9))
+
+
 ## 2023-11-23
 
 ### Changes

--- a/packages/gotrue/CHANGELOG.md
+++ b/packages/gotrue/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.0.0-dev.2
+
+ - **FIX**: PKCE flow not emitting password recovery event ([#744](https://github.com/supabase/supabase-flutter/issues/744)). ([65859bd2](https://github.com/supabase/supabase-flutter/commit/65859bd2676873c685397b4b37d2685bed18b5a1))
+ - **FIX**: sign out on already used refresh token ([#740](https://github.com/supabase/supabase-flutter/issues/740)). ([72ffb9ee](https://github.com/supabase/supabase-flutter/commit/72ffb9ee1a1386fb7ab8085b68cd9bc6f6d72c78))
+ - **FIX**(gotrue): signing in with pkce flow fires two `signedIn` auth event ([#734](https://github.com/supabase/supabase-flutter/issues/734)). ([6dee1660](https://github.com/supabase/supabase-flutter/commit/6dee1660024afcb926853ec77cd7da685dfa479b))
+ - **FEAT**(gotrue): add Figma to  OAuth provider. ([#743](https://github.com/supabase/supabase-flutter/issues/743)). ([f5b72d47](https://github.com/supabase/supabase-flutter/commit/f5b72d47e7af4b62aa99f3e380557ef039b1e2d9))
+
 ## 2.0.0-dev.1
 
  - **FIX**(gotrue): allow empty session response for verifyOtp method ([#680](https://github.com/supabase/supabase-flutter/issues/680)). ([dc6146dc](https://github.com/supabase/supabase-flutter/commit/dc6146dc81e7daa80daacc7e4c4562b033a1b5e8))

--- a/packages/gotrue/lib/src/version.dart
+++ b/packages/gotrue/lib/src/version.dart
@@ -1,1 +1,1 @@
-const version = '2.0.0-dev.1';
+const version = '2.0.0-dev.2';

--- a/packages/gotrue/pubspec.yaml
+++ b/packages/gotrue/pubspec.yaml
@@ -1,6 +1,6 @@
 name: gotrue
 description: A dart client library for the GoTrue API.
-version: 2.0.0-dev.1
+version: 2.0.0-dev.2
 homepage: 'https://supabase.com'
 repository: 'https://github.com/supabase/supabase-flutter/tree/main/packages/gotrue'
 documentation: 'https://supabase.com/docs/reference/dart/auth-signup'

--- a/packages/postgrest/CHANGELOG.md
+++ b/packages/postgrest/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.0-dev.2
+
+ - **REFACTOR**: make `schema` variable private and rename `useSchema()` to `schema()` ([#737](https://github.com/supabase/supabase-flutter/issues/737)).
+
 ## 2.0.0-dev.1
 
 > Note: This release has breaking changes.

--- a/packages/postgrest/lib/src/version.dart
+++ b/packages/postgrest/lib/src/version.dart
@@ -1,1 +1,1 @@
-const version = '2.0.0-dev.1';
+const version = '2.0.0-dev.2';

--- a/packages/postgrest/pubspec.yaml
+++ b/packages/postgrest/pubspec.yaml
@@ -1,6 +1,6 @@
 name: postgrest
 description: PostgREST client for Dart. This library provides an ORM interface to PostgREST.
-version: 2.0.0-dev.1
+version: 2.0.0-dev.2
 homepage: 'https://supabase.com'
 repository: 'https://github.com/supabase/supabase-flutter/tree/main/packages/postgrest'
 documentation: 'https://supabase.com/docs/reference/dart/select'

--- a/packages/realtime_client/CHANGELOG.md
+++ b/packages/realtime_client/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.0.0-dev.3
+
+- **BREAKING** **FEAT**(realtime_client): Introduce type safe realtime methods ([#725](https://github.com/supabase/supabase-flutter/pull/725)).
+- **BREAKING** **FEAT**(realtime_client): Provide better typing for realtime presence. ([#747](https://github.com/supabase/supabase-flutter/pull/747)).
+
 ## 2.0.0-dev.2
 
 - **BREAKING** **REFACTOR**(realtime_client): make channel methods private and add @internal label ([#724](https://github.com/supabase/supabase-flutter/pull/724)).

--- a/packages/realtime_client/lib/src/version.dart
+++ b/packages/realtime_client/lib/src/version.dart
@@ -1,1 +1,1 @@
-const version = '2.0.0-dev.2';
+const version = '2.0.0-dev.3';

--- a/packages/realtime_client/pubspec.yaml
+++ b/packages/realtime_client/pubspec.yaml
@@ -1,6 +1,6 @@
 name: realtime_client
 description: Listens to changes in a PostgreSQL Database and via websockets. This is for usage with Supabase Realtime server.
-version: 2.0.0-dev.2
+version: 2.0.0-dev.3
 homepage: 'https://supabase.com'
 repository: 'https://github.com/supabase/supabase-flutter/tree/main/packages/realtime_client'
 documentation: 'https://supabase.com/docs/reference/dart/subscribe'

--- a/packages/supabase/CHANGELOG.md
+++ b/packages/supabase/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.0.0-dev.4
+
+ - **FIX**: realtime ordering on double ([#741](https://github.com/supabase/supabase-flutter/issues/741)). ([f20faef7](https://github.com/supabase/supabase-flutter/commit/f20faef710e4e730590543ccd0a7bafd072be2ff))
+ - **REFACTOR**: make `schema` variable private and rename `useSchema()` to `schema()` ([#737](https://github.com/supabase/supabase-flutter/issues/737)). 
+
 ## 2.0.0-dev.3
 
  - Update a dependency to the latest release.

--- a/packages/supabase/lib/src/version.dart
+++ b/packages/supabase/lib/src/version.dart
@@ -1,1 +1,1 @@
-const version = '2.0.0-dev.3';
+const version = '2.0.0-dev.4';

--- a/packages/supabase/pubspec.yaml
+++ b/packages/supabase/pubspec.yaml
@@ -1,6 +1,6 @@
 name: supabase
 description: A dart client for Supabase. This client makes it simple for developers to build secure and scalable products.
-version: 2.0.0-dev.3
+version: 2.0.0-dev.4
 homepage: 'https://supabase.com'
 repository: 'https://github.com/supabase/supabase-flutter/tree/main/packages/supabase'
 documentation: 'https://supabase.com/docs/reference/dart/introduction'
@@ -10,10 +10,10 @@ environment:
 
 dependencies:
   functions_client: ^2.0.0-dev.0
-  gotrue: ^2.0.0-dev.1
+  gotrue: ^2.0.0-dev.2
   http: '>=0.13.5 <2.0.0'
-  postgrest: ^2.0.0-dev.1
-  realtime_client: ^2.0.0-dev.2
+  postgrest: ^2.0.0-dev.2
+  realtime_client: ^2.0.0-dev.3
   storage_client: ^2.0.0-dev.0
   rxdart: ^0.27.5
   yet_another_json_isolate: ^2.0.0-dev.0

--- a/packages/supabase_flutter/CHANGELOG.md
+++ b/packages/supabase_flutter/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.0.0-dev.4
+
+ - **FIX**: PKCE flow not emitting password recovery event ([#744](https://github.com/supabase/supabase-flutter/issues/744)). ([65859bd2](https://github.com/supabase/supabase-flutter/commit/65859bd2676873c685397b4b37d2685bed18b5a1))
+ - **FIX**: update sign in with Apple instruction on readme ([#746](https://github.com/supabase/supabase-flutter/issues/746)). ([a4897d06](https://github.com/supabase/supabase-flutter/commit/a4897d06684d38bb159721f8f308fcbde836095e))
+ - **FIX**: use SharedPreferences on web ([#738](https://github.com/supabase/supabase-flutter/issues/738)). ([d0cc2015](https://github.com/supabase/supabase-flutter/commit/d0cc20153f23004f1ef2f821b0e9c6d9189f6b03))
+ - **FIX**(supabase_flutter): session migration from hive to sharedPreferences now works properly ([#731](https://github.com/supabase/supabase-flutter/issues/731)). ([c81cf07f](https://github.com/supabase/supabase-flutter/commit/c81cf07f75be13916b8b90ccc1ded20f1ad4aec9))
+
 ## 2.0.0-dev.3
 
  - Update a dependency to the latest release.

--- a/packages/supabase_flutter/lib/src/version.dart
+++ b/packages/supabase_flutter/lib/src/version.dart
@@ -1,1 +1,1 @@
-const version = '2.0.0-dev.3';
+const version = '2.0.0-dev.4';

--- a/packages/supabase_flutter/pubspec.yaml
+++ b/packages/supabase_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: supabase_flutter
 description: Flutter integration for Supabase. This package makes it simple for developers to build secure and scalable products.
-version: 2.0.0-dev.3
+version: 2.0.0-dev.4
 homepage: 'https://supabase.com'
 repository: 'https://github.com/supabase/supabase-flutter/tree/main/packages/supabase_flutter'
 documentation: 'https://supabase.com/docs/reference/dart/introduction'
@@ -19,7 +19,7 @@ dependencies:
   hive_flutter: ^1.1.0
   http: '>=0.13.4 <2.0.0'
   meta: ^1.7.0
-  supabase: ^2.0.0-dev.3
+  supabase: ^2.0.0-dev.4
   url_launcher: ^6.1.2
   path_provider: ^2.0.0
   shared_preferences: ^2.0.0


### PR DESCRIPTION
- `realtime_client` - `v2.0.0-dev.3`
- `postgrest` - `v2.0.0-dev.2`
- `supabase` - `v2.0.0-dev.4`
- `gotrue` - `v2.0.0-dev.2`
- `supabase_flutter` - `v2.0.0-dev.4`

Let's make this the last developer preview version of v2 unless we find something critical, and release a stable v2 next week. 