### PR TITLE
fix: web compilation

### DIFF
--- a/packages/storage_client/lib/src/file_stub.dart
+++ b/packages/storage_client/lib/src/file_stub.dart
@@ -1,8 +1,2 @@
-import 'dart:typed_data';
-
-/// A stub for the `dart:io` [File] class. Only the methods used by the storage client are stubbed.
-class File {
-  String get path => throw UnimplementedError();
-
-  Uint8List readAsBytesSync() => throw UnimplementedError();
-}
+/// A stub for the `dart:io` [File] class.
+typedef File = dynamic;


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

```dart
import 'package:supabase_flutter/supabase_flutter.dart';
import 'package:universal_io/io.dart';

final String path = '$userId/${i.toString()}';
final String res;
if (!kIsWeb) {
  final File file = File("myPath");
  res = await _supabase.storage
      .from('profile')
      .upload(path, file));
}
  ```
Even though the if body will never be called on web, the compiler still throws an error that two different `File` implementations are used, because we stub `File` on web in `storage_client`.
```
Error: The argument type 'File/*1*/' can't be assigned to the parameter type 'File/*2*/'.
 - 'File/*1*/' is from 'dart:io'.
 - 'File/*2*/' is from 'package:storage_client/src/file_stub.dart' ('../../../.pub-cache/hosted/pub.dev/storage_client-1.5.4/lib/src/file_stub.dart').
          .upload(path, file);
```
## What is the new behavior?

On web the type of `File` is now `dynamic`, so that the client can compile with any methods called on a dynamic object, while a `File` object from `dart:io` can technically be assigned to a `dynamic` type.

I've tested flutter web and webdev.

## Additional context

close #685
