### PR TITLE
feat(gotrue, supabase_flutter): Add identity linking and unlinking methods.

### DIFF
--- a/infra/gotrue/db/00-schema.sql
+++ b/infra/gotrue/db/00-schema.sql
@@ -95,7 +95,7 @@ INSERT INTO auth.identities (
     )
 VALUES (
         '18bc7a4e-c095-4573-93dc-e0be29bada97',
-        '18bc7a4e-c095-4573-93dc-e0be29bada97',
+        'google',
         '18bc7a4e-c095-4573-93dc-e0be29bada97',
         '{"sub": "18bc7a4e-c095-4573-93dc-e0be29bada97", "email": "fake1@email.com"}',
         'email',
@@ -105,7 +105,7 @@ VALUES (
     ),
     (
         '28bc7a4e-c095-4573-93dc-e0be29bada97',
-        '28bc7a4e-c095-4573-93dc-e0be29bada97',
+        'apple',
         '28bc7a4e-c095-4573-93dc-e0be29bada97',
         '{"sub": "28bc7a4e-c095-4573-93dc-e0be29bada97", "email": "fake2@email.com"}',
         'email',

--- a/infra/gotrue/db/00-schema.sql
+++ b/infra/gotrue/db/00-schema.sql
@@ -85,7 +85,7 @@ VALUES -- For unverified factors
 
 INSERT INTO auth.identities (
         id,
-        privider_id,
+        provider_id,
         user_id,
         identity_data,
         provider,

--- a/infra/gotrue/db/00-schema.sql
+++ b/infra/gotrue/db/00-schema.sql
@@ -85,7 +85,7 @@ VALUES -- For unverified factors
 
 INSERT INTO auth.identities (
         id,
-        provider_id,
+        prvider_id,
         user_id,
         identity_data,
         provider,
@@ -95,7 +95,7 @@ INSERT INTO auth.identities (
     )
 VALUES (
         '18bc7a4e-c095-4573-93dc-e0be29bada97',
-        'google',
+        '18bc7a4e-c095-4573-93dc-e0be29bada97',
         '18bc7a4e-c095-4573-93dc-e0be29bada97',
         '{"sub": "18bc7a4e-c095-4573-93dc-e0be29bada97", "email": "fake1@email.com"}',
         'email',
@@ -105,7 +105,7 @@ VALUES (
     ),
     (
         '28bc7a4e-c095-4573-93dc-e0be29bada97',
-        'google',
+        '28bc7a4e-c095-4573-93dc-e0be29bada97',
         '28bc7a4e-c095-4573-93dc-e0be29bada97',
         '{"sub": "28bc7a4e-c095-4573-93dc-e0be29bada97", "email": "fake2@email.com"}',
         'email',

--- a/infra/gotrue/db/00-schema.sql
+++ b/infra/gotrue/db/00-schema.sql
@@ -85,7 +85,7 @@ VALUES -- For unverified factors
 
 INSERT INTO auth.identities (
         id,
-        prvider_id,
+        provider_id,
         user_id,
         identity_data,
         provider,

--- a/infra/gotrue/db/00-schema.sql
+++ b/infra/gotrue/db/00-schema.sql
@@ -105,7 +105,7 @@ VALUES (
     ),
     (
         '28bc7a4e-c095-4573-93dc-e0be29bada97',
-        'apple',
+        'google',
         '28bc7a4e-c095-4573-93dc-e0be29bada97',
         '{"sub": "28bc7a4e-c095-4573-93dc-e0be29bada97", "email": "fake2@email.com"}',
         'email',

--- a/infra/gotrue/db/00-schema.sql
+++ b/infra/gotrue/db/00-schema.sql
@@ -85,6 +85,7 @@ VALUES -- For unverified factors
 
 INSERT INTO auth.identities (
         id,
+        privider_id,
         user_id,
         identity_data,
         provider,
@@ -95,6 +96,7 @@ INSERT INTO auth.identities (
 VALUES (
         '18bc7a4e-c095-4573-93dc-e0be29bada97',
         '18bc7a4e-c095-4573-93dc-e0be29bada97',
+        '18bc7a4e-c095-4573-93dc-e0be29bada97',
         '{"sub": "18bc7a4e-c095-4573-93dc-e0be29bada97", "email": "fake1@email.com"}',
         'email',
         now(),
@@ -102,6 +104,7 @@ VALUES (
         now()
     ),
     (
+        '28bc7a4e-c095-4573-93dc-e0be29bada97',
         '28bc7a4e-c095-4573-93dc-e0be29bada97',
         '28bc7a4e-c095-4573-93dc-e0be29bada97',
         '{"sub": "28bc7a4e-c095-4573-93dc-e0be29bada97", "email": "fake2@email.com"}',

--- a/infra/gotrue/docker-compose.yml
+++ b/infra/gotrue/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       GOTRUE_EXTERNAL_GOOGLE_CLIENT_ID: 53566906701-bmhc1ndue7hild39575gkpimhs06b7ds.apps.googleusercontent.com
       GOTRUE_EXTERNAL_GOOGLE_SECRET: Sm3s8RE85rDcS36iMy8YjrpC
       GOTRUE_EXTERNAL_GOOGLE_REDIRECT_URI: http://localhost:9998/callback
-      GOTRUE_MANUAL_LINKING_ENABLED: 'true'
+      GOTRUE_SECURITY_MANUAL_LINKING_ENABLED: 'true'
 
     depends_on:
       - db

--- a/infra/gotrue/docker-compose.yml
+++ b/infra/gotrue/docker-compose.yml
@@ -25,6 +25,7 @@ services:
       GOTRUE_EXTERNAL_GOOGLE_CLIENT_ID: 53566906701-bmhc1ndue7hild39575gkpimhs06b7ds.apps.googleusercontent.com
       GOTRUE_EXTERNAL_GOOGLE_SECRET: Sm3s8RE85rDcS36iMy8YjrpC
       GOTRUE_EXTERNAL_GOOGLE_REDIRECT_URI: http://localhost:9998/callback
+      GOTRUE_MANUAL_LINKING_ENABLED: 'true'
 
     depends_on:
       - db

--- a/infra/gotrue/docker-compose.yml
+++ b/infra/gotrue/docker-compose.yml
@@ -1,27 +1,27 @@
 # docker-compose.yml
-version: "3"
+version: '3'
 services:
   gotrue: # Signup enabled, autoconfirm on
-    image: supabase/gotrue:v2.40.1
+    image: supabase/gotrue:v2.129.0
     ports:
-      - "9998:9998"
+      - '9998:9998'
     environment:
-      GOTRUE_JWT_SECRET: "37c304f8-51aa-419a-a1af-06154e63707a"
+      GOTRUE_JWT_SECRET: '37c304f8-51aa-419a-a1af-06154e63707a'
       GOTRUE_JWT_EXP: 3600
       GOTRUE_DB_DRIVER: postgres
       DB_NAMESPACE: auth
       GOTRUE_API_HOST: 0.0.0.0
       PORT: 9998
-      GOTRUE_DISABLE_SIGNUP: "false"
+      GOTRUE_DISABLE_SIGNUP: 'false'
       API_EXTERNAL_URL: http://localhost:9998
       GOTRUE_SITE_URL: http://localhost:9998
-      GOTRUE_MAILER_AUTOCONFIRM: "true"
-      GOTRUE_SMS_AUTOCONFIRM: "true"
+      GOTRUE_MAILER_AUTOCONFIRM: 'true'
+      GOTRUE_SMS_AUTOCONFIRM: 'true'
       GOTRUE_LOG_LEVEL: DEBUG
       GOTRUE_OPERATOR_TOKEN: super-secret-operator-token
-      DATABASE_URL: "postgres://postgres:postgres@db:5432/postgres?sslmode=disable"
-      GOTRUE_EXTERNAL_PHONE_ENABLED: "true"
-      GOTRUE_EXTERNAL_GOOGLE_ENABLED: "true"
+      DATABASE_URL: 'postgres://postgres:postgres@db:5432/postgres?sslmode=disable'
+      GOTRUE_EXTERNAL_PHONE_ENABLED: 'true'
+      GOTRUE_EXTERNAL_GOOGLE_ENABLED: 'true'
       GOTRUE_EXTERNAL_GOOGLE_CLIENT_ID: 53566906701-bmhc1ndue7hild39575gkpimhs06b7ds.apps.googleusercontent.com
       GOTRUE_EXTERNAL_GOOGLE_SECRET: Sm3s8RE85rDcS36iMy8YjrpC
       GOTRUE_EXTERNAL_GOOGLE_REDIRECT_URI: http://localhost:9998/callback
@@ -45,7 +45,7 @@ services:
   db:
     image: supabase/postgres
     ports:
-      - "5432:5432"
+      - '5432:5432'
     volumes:
       - ./db:/docker-entrypoint-initdb.d/
     environment:

--- a/infra/gotrue/docker-compose.yml
+++ b/infra/gotrue/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       - db
     restart: on-failure
   rest:
-    image: postgrest/postgrest:v10.1.1.20221215
+    image: postgrest/postgrest:v11.2.2
     ports:
       - '3000:3000'
     environment:
@@ -44,7 +44,7 @@ services:
     depends_on:
       - db
   db:
-    image: supabase/postgres
+    image: supabase/postgres:15.1.0.37
     ports:
       - '5432:5432'
     volumes:

--- a/packages/gotrue/lib/src/fetch.dart
+++ b/packages/gotrue/lib/src/fetch.dart
@@ -50,7 +50,7 @@ class GotrueFetch {
       qs['redirect_to'] = options!.redirectTo!;
     }
     Uri uri = Uri.parse(url);
-    uri = uri.replace(queryParameters: qs);
+    uri = uri.replace(queryParameters: {...uri.queryParameters, ...qs});
     late final http.Response response;
 
     final bodyStr = json.encode(options?.body ?? {});

--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -800,6 +800,7 @@ class GoTrueClient {
       redirectTo: redirectTo,
       scopes: scopes,
       queryParams: queryParams,
+      skipBrowserRedirect: true,
     );
     final res = await _fetch.request(urlResponse.url!, RequestMethodType.get,
         options: GotrueRequestOptions(
@@ -872,6 +873,7 @@ class GoTrueClient {
     required String? scopes,
     required String? redirectTo,
     required Map<String, String>? queryParams,
+    bool skipBrowserRedirect = false,
   }) async {
     final urlParams = {'provider': provider.name};
     if (scopes != null) {
@@ -899,6 +901,9 @@ class GoTrueClient {
         'code_challenge_method': 's256',
       };
       urlParams.addAll(flowParams);
+    }
+    if (skipBrowserRedirect) {
+      urlParams['skip_http_redirect'] = 'true';
     }
     final oauthUrl = '$url?${Uri(queryParameters: urlParams).query}';
     return OAuthResponse(provider: provider, url: oauthUrl);

--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -801,12 +801,12 @@ class GoTrueClient {
       scopes: scopes,
       queryParams: queryParams,
     );
-    final url = await _fetch.request(urlResponse.url!, RequestMethodType.get,
+    final res = await _fetch.request(urlResponse.url!, RequestMethodType.get,
         options: GotrueRequestOptions(
           headers: _headers,
           jwt: _currentSession?.accessToken,
         ));
-    return OAuthResponse(provider: provider, url: url);
+    return OAuthResponse(provider: provider, url: res['url']);
   }
 
   /// Unlinks an identity from a user by deleting it.

--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -814,7 +814,7 @@ class GoTrueClient {
       queryParams: queryParams,
       skipBrowserRedirect: true,
     );
-    final res = await _fetch.request(urlResponse.url!, RequestMethodType.get,
+    final res = await _fetch.request(urlResponse.url, RequestMethodType.get,
         options: GotrueRequestOptions(
           headers: _headers,
           jwt: _currentSession?.accessToken,

--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -795,7 +795,7 @@ class GoTrueClient {
 
   /// Gets all the identities linked to a user.
   Future<List<UserIdentity>> getUserIdentities() async {
-    final res = await refreshSession();
+    final res = await getUser();
     return res.user?.identities ?? [];
   }
 

--- a/packages/gotrue/lib/src/types/auth_response.dart
+++ b/packages/gotrue/lib/src/types/auth_response.dart
@@ -20,12 +20,12 @@ class AuthResponse {
 /// Response of OAuth signin
 class OAuthResponse {
   final OAuthProvider provider;
-  final String? url;
+  final String url;
 
   /// Instanciates an `OAuthResponse` object from json response.
   const OAuthResponse({
     required this.provider,
-    this.url,
+    required this.url,
   });
 }
 

--- a/packages/gotrue/lib/src/types/user.dart
+++ b/packages/gotrue/lib/src/types/user.dart
@@ -178,6 +178,7 @@ class UserIdentity {
   final String id;
   final String userId;
   final Map<String, dynamic>? identityData;
+  final String identityId;
   final String provider;
   final String? createdAt;
   final String? lastSignInAt;
@@ -187,6 +188,7 @@ class UserIdentity {
     required this.id,
     required this.userId,
     required this.identityData,
+    required this.identityId,
     required this.provider,
     required this.createdAt,
     required this.lastSignInAt,
@@ -197,6 +199,7 @@ class UserIdentity {
     String? id,
     String? userId,
     Map<String, dynamic>? identityData,
+    String? identityId,
     String? provider,
     String? createdAt,
     String? lastSignInAt,
@@ -206,6 +209,7 @@ class UserIdentity {
       id: id ?? this.id,
       userId: userId ?? this.userId,
       identityData: identityData ?? this.identityData,
+      identityId: identityId ?? this.identityId,
       provider: provider ?? this.provider,
       createdAt: createdAt ?? this.createdAt,
       lastSignInAt: lastSignInAt ?? this.lastSignInAt,
@@ -218,6 +222,7 @@ class UserIdentity {
       id: map['id'] as String,
       userId: map['user_id'] as String,
       identityData: (map['identity_data'] as Map?)?.cast<String, dynamic>(),
+      identityId: (map['identity_id'] ?? '') as String,
       provider: map['provider'] as String,
       createdAt: map['created_at'] as String?,
       lastSignInAt: map['last_sign_in_at'] as String?,
@@ -230,6 +235,7 @@ class UserIdentity {
       'id': id,
       'user_id': userId,
       'identity_data': identityData,
+      'identity_id': identityId,
       'provider': provider,
       'created_at': createdAt,
       'last_sign_in_at': lastSignInAt,
@@ -239,7 +245,7 @@ class UserIdentity {
 
   @override
   String toString() {
-    return 'UserIdentity(id: $id, userId: $userId, identityData: $identityData, provider: $provider, createdAt: $createdAt, lastSignInAt: $lastSignInAt, updatedAt: $updatedAt)';
+    return 'UserIdentity(id: $id, userId: $userId, identityData: $identityData, identityId: $identityId, provider: $provider, createdAt: $createdAt, lastSignInAt: $lastSignInAt, updatedAt: $updatedAt)';
   }
 
   @override
@@ -251,6 +257,7 @@ class UserIdentity {
         other.id == id &&
         other.userId == userId &&
         mapEquals(other.identityData, identityData) &&
+        other.identityId == identityId &&
         other.provider == provider &&
         other.createdAt == createdAt &&
         other.lastSignInAt == lastSignInAt &&
@@ -262,6 +269,7 @@ class UserIdentity {
     return id.hashCode ^
         userId.hashCode ^
         identityData.hashCode ^
+        identityId.hashCode ^
         provider.hashCode ^
         createdAt.hashCode ^
         lastSignInAt.hashCode ^

--- a/packages/gotrue/test/client_test.dart
+++ b/packages/gotrue/test/client_test.dart
@@ -407,13 +407,15 @@ void main() {
       expect(client.currentSession, isNull);
     });
 
-    test('linkIdentity', () async {
+    test('Call getLinkIdentityUrl', () async {
       await client.signInWithPassword(
         email: email1,
         password: password,
       );
       final res = await client.getLinkIdentityUrl(OAuthProvider.google);
-      expect(res.url, '');
+      expect(res.url, isA<String>());
+      final uri = Uri.parse(res.url!);
+      expect(uri.host, 'accounts.google.com');
     });
   });
 

--- a/packages/gotrue/test/client_test.dart
+++ b/packages/gotrue/test/client_test.dart
@@ -479,4 +479,25 @@ void main() {
       expect(queryParameters['code_challenge'], isA<String>());
     });
   });
+
+  group('identity linking', () {
+    late GoTrueClient client;
+
+    setUpAll(() {
+      client = GoTrueClient(
+        url: gotrueUrl,
+        flowType: AuthFlowType.pkce,
+        asyncStorage: TestAsyncStorage(),
+      );
+    });
+
+    test('linkIdentity', () async {
+      await client.signInWithPassword(
+        email: email1,
+        password: password,
+      );
+      final res = await client.getLinkIdentityUrl(OAuthProvider.google);
+      expect(res.url, '');
+    });
+  });
 }

--- a/packages/gotrue/test/client_test.dart
+++ b/packages/gotrue/test/client_test.dart
@@ -304,7 +304,7 @@ void main() {
             provider: OAuthProvider.google, redirectTo: 'https://supabase.com');
         final expectedOutput =
             '$gotrueUrl/authorize?provider=google&redirect_to=https%3A%2F%2Fsupabase.com';
-        final queryParameters = Uri.parse(res.url!).queryParameters;
+        final queryParameters = Uri.parse(res.url).queryParameters;
 
         expect(res.url, startsWith(expectedOutput));
         expect(queryParameters, containsPair('flow_type', 'pkce'));
@@ -414,7 +414,7 @@ void main() {
       );
       final res = await client.getLinkIdentityUrl(OAuthProvider.google);
       expect(res.url, isA<String>());
-      final uri = Uri.parse(res.url!);
+      final uri = Uri.parse(res.url);
       expect(uri.host, 'accounts.google.com');
     });
   });
@@ -482,7 +482,7 @@ void main() {
       final response = await client.getOAuthSignInUrl(
         provider: OAuthProvider.google,
       );
-      final url = Uri.parse(response.url!);
+      final url = Uri.parse(response.url);
       final queryParameters = url.queryParameters;
       expect(queryParameters['provider'], 'google');
       expect(queryParameters['flow_type'], 'pkce');

--- a/packages/gotrue/test/client_test.dart
+++ b/packages/gotrue/test/client_test.dart
@@ -406,6 +406,15 @@ void main() {
 
       expect(client.currentSession, isNull);
     });
+
+    test('linkIdentity', () async {
+      await client.signInWithPassword(
+        email: email1,
+        password: password,
+      );
+      final res = await client.getLinkIdentityUrl(OAuthProvider.google);
+      expect(res.url, '');
+    });
   });
 
   group('Client with custom http client', () {
@@ -477,27 +486,6 @@ void main() {
       expect(queryParameters['flow_type'], 'pkce');
       expect(queryParameters['code_challenge_method'], 's256');
       expect(queryParameters['code_challenge'], isA<String>());
-    });
-  });
-
-  group('identity linking', () {
-    late GoTrueClient client;
-
-    setUpAll(() {
-      client = GoTrueClient(
-        url: gotrueUrl,
-        flowType: AuthFlowType.pkce,
-        asyncStorage: TestAsyncStorage(),
-      );
-    });
-
-    test('linkIdentity', () async {
-      await client.signInWithPassword(
-        email: email1,
-        password: password,
-      );
-      final res = await client.getLinkIdentityUrl(OAuthProvider.google);
-      expect(res.url, '');
     });
   });
 }

--- a/packages/supabase_flutter/lib/src/supabase_auth.dart
+++ b/packages/supabase_flutter/lib/src/supabase_auth.dart
@@ -274,7 +274,7 @@ extension GoTrueClientSignInProvider on GoTrueClient {
       scopes: scopes,
       queryParams: queryParams,
     );
-    final uri = Uri.parse(res.url!);
+    final uri = Uri.parse(res.url);
 
     LaunchMode launchMode = authScreenLaunchMode;
 
@@ -314,7 +314,7 @@ extension GoTrueClientSignInProvider on GoTrueClient {
       scopes: scopes,
       queryParams: queryParams,
     );
-    final uri = Uri.parse(res.url!);
+    final uri = Uri.parse(res.url);
 
     LaunchMode launchMode = authScreenLaunchMode;
 

--- a/packages/supabase_flutter/lib/src/supabase_auth.dart
+++ b/packages/supabase_flutter/lib/src/supabase_auth.dart
@@ -298,4 +298,39 @@ extension GoTrueClientSignInProvider on GoTrueClient {
     final random = Random.secure();
     return base64Url.encode(List<int>.generate(16, (_) => random.nextInt(256)));
   }
+
+  /// Links an oauth identity to an existing user.
+  /// This method supports the PKCE flow.
+  Future<bool> linkIdentity(
+    OAuthProvider provider, {
+    String? redirectTo,
+    String? scopes,
+    LaunchMode authScreenLaunchMode = LaunchMode.platformDefault,
+    Map<String, String>? queryParams,
+  }) async {
+    final res = await getLinkIdentityUrl(
+      provider,
+      redirectTo: redirectTo,
+      scopes: scopes,
+      queryParams: queryParams,
+    );
+    final uri = Uri.parse(res.url!);
+
+    LaunchMode launchMode = authScreenLaunchMode;
+
+    // `Platform.isAndroid` throws on web, so adding a guard for web here.
+    final isAndroid = !kIsWeb && Platform.isAndroid;
+
+    // Google login has to be performed on external browser window on Android
+    if (provider == OAuthProvider.google && isAndroid) {
+      launchMode = LaunchMode.externalApplication;
+    }
+
+    final result = await launchUrl(
+      uri,
+      mode: launchMode,
+      webOnlyWindowName: '_self',
+    );
+    return result;
+  }
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR brings one of the core auth launch announced at LWX.

Add a method to retrieve URL for manual linking OAuth providers, and adds a method to launch the URL obtained from Gotrue to supabase_flutter.

## What is the current behavior?

Manual identity linking is not possible using supabase_flutter.

## What is the new behavior?

Manual identity linking is now poissible.