### PR TITLE
feat: add getUser() method

### DIFF
--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -597,7 +597,7 @@ class GoTrueClient {
   }
 
   /// Gets the current user details from current session or custom [jwt]
-  Future<UserResponse> getUser(String? jwt) async {
+  Future<UserResponse> getUser([String? jwt]) async {
     if (jwt == null && currentSession?.accessToken == null) {
       throw AuthException('Cannot get user: no current session.');
     }


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the current behavior?

There's no `getUser` method to get a user object from a jwt.

## What is the new behavior?

Add `getUser`

## Additional context

close #752