### PR TITLE
fix(supabase_flutter): export `signInWithOAuth()` and `generateRawNonce()`

### DIFF
--- a/packages/supabase_flutter/example/lib/main.dart
+++ b/packages/supabase_flutter/example/lib/main.dart
@@ -178,7 +178,7 @@ class _ProfileFormState extends State<_ProfileForm> {
       final data = (await Supabase.instance.client
           .from('profiles')
           .select()
-          .match({'id': userId}).maybeSingle()) as Map?;
+          .match({'id': userId}).maybeSingle());
       if (data != null) {
         setState(() {
           _usernameController.text = data['username'];

--- a/packages/supabase_flutter/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/packages/supabase_flutter/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -8,13 +8,11 @@ import Foundation
 import app_links
 import path_provider_foundation
 import shared_preferences_foundation
-import sign_in_with_apple
 import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AppLinksMacosPlugin.register(with: registry.registrar(forPlugin: "AppLinksMacosPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
-  SignInWithApplePlugin.register(with: registry.registrar(forPlugin: "SignInWithApplePlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/packages/supabase_flutter/example/pubspec.yaml
+++ b/packages/supabase_flutter/example/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  supabase_flutter: ^1.10.0
+  supabase_flutter: ^2.0.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/supabase_flutter/lib/src/supabase_auth.dart
+++ b/packages/supabase_flutter/lib/src/supabase_auth.dart
@@ -248,7 +248,7 @@ extension GoTrueClientSignInProvider on GoTrueClient {
   ///
   /// ```dart
   /// await supabase.auth.signInWithOAuth(
-  ///   Provider.google,
+  ///   OAuthProvider.google,
   ///   // Use deep link to bring the user back to the app
   ///   redirectTo: 'my-scheme://my-host/callback-path',
   /// );

--- a/packages/supabase_flutter/lib/supabase_flutter.dart
+++ b/packages/supabase_flutter/lib/supabase_flutter.dart
@@ -9,3 +9,4 @@ export 'package:url_launcher/url_launcher.dart' show LaunchMode;
 export 'src/flutter_go_true_client_options.dart';
 export 'src/local_storage.dart';
 export 'src/supabase.dart';
+export 'src/supabase_auth.dart' hide SupabaseAuth;


### PR DESCRIPTION
## What kind of change does this PR introduce?

Currently `signInWithOAuth()` and `generateRawNonce()` are not exported in `supabase_auth.dart` file. This PR updates the export to make those methods available.

Fixes https://github.com/supabase/supabase-flutter/issues/762