### PR TITLE
fix: enable filtering and tranformation on count with head

### DIFF
--- a/packages/postgrest/lib/src/postgrest_query_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_query_builder.dart
@@ -250,11 +250,10 @@ class PostgrestQueryBuilder<T> extends RawPostgrestBuilder<T, T, T> {
   /// ```dart
   /// int count = await supabase.from('users').count();
   /// ```
-  RawPostgrestBuilder<int, int, int> count(
-      [CountOption option = CountOption.exact]) {
-    return _copyWithType(
+  PostgrestFilterBuilder<int> count([CountOption option = CountOption.exact]) {
+    return PostgrestFilterBuilder<int>(_copyWithType(
       method: METHOD_HEAD,
       count: option,
-    );
+    ));
   }
 }

--- a/packages/postgrest/test/basic_test.dart
+++ b/packages/postgrest/test/basic_test.dart
@@ -283,12 +283,11 @@ void main() {
       await postgrest.from('users').select('*').head();
     });
 
-    test('count with head: true, filters and modifiers', () async {
+    test('count with head: true, filters', () async {
       final int count = await postgrest
           .from('users')
           .count(CountOption.exact)
-          .eq('status', 'ONLINE')
-          .limit(1);
+          .eq('status', 'ONLINE');
       expect(count, 3);
     });
 

--- a/packages/postgrest/test/basic_test.dart
+++ b/packages/postgrest/test/basic_test.dart
@@ -283,19 +283,30 @@ void main() {
       await postgrest.from('users').select('*').head();
     });
 
+    test('count with head: true, filters and modifiers', () async {
+      final int count = await postgrest
+          .from('users')
+          .count(CountOption.exact)
+          .eq('status', 'ONLINE')
+          .limit(1);
+      expect(count, 3);
+    });
+
     test('select with head:true, count: exact', () async {
-      final res = await postgrest.from('users').count(CountOption.exact);
+      final int res = await postgrest.from('users').count(CountOption.exact);
       expect(res, 4);
     });
 
     test('select with count: planned', () async {
       final res =
           await postgrest.from('users').select('*').count(CountOption.planned);
-      expect(res.count, isNotNull);
+      final int count = res.count;
+      expect(count, isNotNull);
     });
 
     test('select with head:true, count: estimated', () async {
-      final res = await postgrest.from('users').count(CountOption.estimated);
+      final int res =
+          await postgrest.from('users').count(CountOption.estimated);
       expect(res, isA<int>());
     });
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Currently when performing count with head: true, we cannot chain filters (eq, match, etc.). 

This PR will allow filters to be chained on `.count()` like this:

```dart
final int count = await supabase.from('table')
  .count() // count with head: true
  .eq('name', 'Supabase');
```

## Cons

Might not be anything to be too concerned about, but wanted to leave a note here. The change in this PR will actually allow a whole bunch of other things to be chained to `.count()` that doesn't make a whole lot of sense. 

```dart
final res = await supabase.from('table')
  .count()
  .eq('name', 'Supabase')
  .limit(1) // It's a head request, and limits and ranges are ignored for count request, so this is not doing anything
  .withConverter<List<int>>((data) => [data]); // `data` here is the count value of type int. Again, doesn't really make a whole lot of sense being able to chain this here.
```