### PR TITLE
fix(gotrue): Fix the issue where `verfiyOTP` emits `signIn` instead of `passwordRecovery` auth event.

### DIFF
--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -509,7 +509,9 @@ class GoTrueClient {
     }
 
     _saveSession(authResponse.session!);
-    notifyAllSubscribers(AuthChangeEvent.signedIn);
+    notifyAllSubscribers(type == OtpType.recovery
+        ? AuthChangeEvent.passwordRecovery
+        : AuthChangeEvent.signedIn);
 
     return authResponse;
   }


### PR DESCRIPTION
## What kind of change does this PR introduce?

This fixes issue #773

## What is the current behavior?

`verifyOTP` emits `AuthChangeEvent.signedIn` when `OtpType.recovery` is passed

## What is the new behavior?

`verifyOTP` emits `AuthChangeEvent.passwordRecovery` when `OtpType.recovery` is passed

This allows listeners to properly navigate the user to the password reset screen rather than the default home screen after verification.
