### PR TITLE
fix: Passing `null` to `not()` filter is now allowed

### DIFF
--- a/packages/postgrest/lib/src/postgrest_filter_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_filter_builder.dart
@@ -24,7 +24,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   ///     .select()
   ///     .not('status', 'eq', 'OFFLINE');
   /// ```
-  PostgrestFilterBuilder<T> not(String column, String operator, Object value) {
+  PostgrestFilterBuilder<T> not(String column, String operator, Object? value) {
     final Uri url;
     if (value is List) {
       if (operator == "in") {

--- a/packages/postgrest/test/filter_test.dart
+++ b/packages/postgrest/test/filter_test.dart
@@ -51,11 +51,6 @@ void main() {
         .select('username')
         .not('username', 'is', null);
     expect(res.length, 4);
-
-    for (final item in res) {
-      expect(item['username'] != ('supabot'), true);
-      expect(item['username'] != ('kiwicopple'), true);
-    }
   });
 
   test('not with List of values', () async {

--- a/packages/postgrest/test/filter_test.dart
+++ b/packages/postgrest/test/filter_test.dart
@@ -45,6 +45,19 @@ void main() {
     }
   });
 
+  test('not with is null', () async {
+    final res = await postgrest
+        .from('users')
+        .select('username')
+        .not('username', 'is', null);
+    expect(res.length, 4);
+
+    for (final item in res) {
+      expect(item['username'] != ('supabot'), true);
+      expect(item['username'] != ('kiwicopple'), true);
+    }
+  });
+
   test('not with List of values', () async {
     final res = await postgrest
         .from('users')


### PR DESCRIPTION
## What kind of change does this PR introduce?

Currently passing `null` to `not()` filter is not allowed. This PR makes it possible. 

Fixes https://github.com/supabase/supabase-flutter/issues/772