### PR TITLE
feat(postgrest): Add `toJson()` method to `PostgrestException` to allow serialization

### DIFF
--- a/packages/postgrest/lib/src/types.dart
+++ b/packages/postgrest/lib/src/types.dart
@@ -33,6 +33,15 @@ class PostgrestException implements Exception {
     );
   }
 
+  Map<String, dynamic> toJson() {
+    return {
+      'message': message,
+      'code': code,
+      'details': details,
+      'hint': hint,
+    };
+  }
+
   @override
   String toString() {
     return 'PostgrestException(message: $message, code: $code, details: $details, hint: $hint)';


### PR DESCRIPTION
## What kind of change does this PR introduce?

Make PostgrestException serialisable by implementing the toJson method.

## What is the current behavior?

I was having some issues due to PostgrestException, since I keep track of errors in the Redux store, and persist it.  TBH, I was thinking I do not really want to store an exception as is or display it to the user directly, but I would like not to lose the information, maybe embed it in a user-friendly error, but keep the option to send it to the backend (e.g. via Sentry). So serialisation would be nice to have!

```
Converting object to an encodable object failed: Instance of 'PostgrestException'
```

## What is the new behavior?

It just implements the toJson. I feel this didn't really need a test, but I can add serialisation/deserialisation roundtrip if you like ✌️ 

Thanks!
