### PR TITLE
forward id from https://github.com/supabase/storage/pull/332

### DIFF
--- a/packages/storage_client/CHANGELOG.md
+++ b/packages/storage_client/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.0.1
+
+> Note: This release has breaking changes.
+
+ - **BREAKING** : upload response does not only return the new key, but also the new id. Forwards [supabase/storage/#332](https://github.com/supabase/storage/pull/332) PR.
+
 ## 2.0.0
 
  - Graduate package to a stable release. See pre-releases prior to this version for changelog entries.

--- a/packages/storage_client/lib/src/storage_file_api.dart
+++ b/packages/storage_client/lib/src/storage_file_api.dart
@@ -41,7 +41,7 @@ class StorageFileApi {
   /// [retryAttempts] overrides the retryAttempts parameter set across the storage client.
   ///
   /// You can pass a [retryController] and call `cancel()` to cancel the retry attempts.
-  Future<String> upload(
+  Future<UploadResponse> upload(
     String path,
     File file, {
     FileOptions fileOptions = const FileOptions(),
@@ -60,7 +60,7 @@ class StorageFileApi {
       retryController: retryController,
     );
 
-    return (response as Map)['Key'] as String;
+    return UploadResponse.fromJson(response);
   }
 
   /// Uploads a binary file to an existing bucket. Can be used on the web.
@@ -76,7 +76,7 @@ class StorageFileApi {
   /// [retryAttempts] overrides the retryAttempts parameter set across the storage client.
   ///
   /// You can pass a [retryController] and call `cancel()` to cancel the retry attempts.
-  Future<String> uploadBinary(
+  Future<UploadResponse> uploadBinary(
     String path,
     Uint8List data, {
     FileOptions fileOptions = const FileOptions(),
@@ -95,7 +95,7 @@ class StorageFileApi {
       retryController: retryController,
     );
 
-    return (response as Map)['Key'] as String;
+    return UploadResponse.fromJson(response);
   }
 
   /// Upload a file with a token generated from `createUploadSignedUrl`.
@@ -210,7 +210,7 @@ class StorageFileApi {
   /// [retryAttempts] overrides the retryAttempts parameter set across the storage client.
   ///
   /// You can pass a [retryController] and call `cancel()` to cancel the retry attempts.
-  Future<String> update(
+  Future<UploadResponse> update(
     String path,
     File file, {
     FileOptions fileOptions = const FileOptions(),
@@ -229,7 +229,7 @@ class StorageFileApi {
       retryController: retryController,
     );
 
-    return (response as Map<String, dynamic>)['Key'] as String;
+    return UploadResponse.fromJson(response);
   }
 
   /// Replaces an existing file at the specified path with a new one. Can be
@@ -246,7 +246,7 @@ class StorageFileApi {
   /// [retryAttempts] overrides the retryAttempts parameter set across the storage client.
   ///
   /// You can pass a [retryController] and call `cancel()` to cancel the retry attempts.
-  Future<String> updateBinary(
+  Future<UploadResponse> updateBinary(
     String path,
     Uint8List data, {
     FileOptions fileOptions = const FileOptions(),
@@ -265,7 +265,7 @@ class StorageFileApi {
       retryController: retryController,
     );
 
-    return (response as Map)['Key'] as String;
+    return UploadResponse.fromJson(response);
   }
 
   /// Moves an existing file.

--- a/packages/storage_client/lib/src/types.dart
+++ b/packages/storage_client/lib/src/types.dart
@@ -159,6 +159,23 @@ class SortBy {
   }
 }
 
+class UploadResponse {
+  /// the previously returned key: bucket-id/path/to/file
+  final String key;
+
+  /// the new storage.object.id of the uploaded file
+  final String id;
+
+  const UploadResponse({
+    required this.key,
+    required this.id,
+  });
+
+  UploadResponse.fromJson(Map<String, dynamic> json)
+      : key = json['Key'] as String,
+        id = json['Id'] as String;
+}
+
 class SignedUrl {
   /// The file path, including the current file name. For example `folder/image.png`.
   final String path;

--- a/packages/storage_client/pubspec.yaml
+++ b/packages/storage_client/pubspec.yaml
@@ -1,6 +1,6 @@
 name: storage_client
 description: Dart client library to interact with Supabase Storage. Supabase Storage provides an interface for managing Files stored in S3, using Postgres to manage permissions.
-version: 2.0.0
+version: 2.0.1
 homepage: 'https://supabase.com'
 repository: 'https://github.com/supabase/supabase-flutter/tree/main/packages/storage_client'
 documentation: 'https://supabase.com/docs/reference/dart/storage-createbucket'

--- a/packages/storage_client/test/basic_test.dart
+++ b/packages/storage_client/test/basic_test.dart
@@ -175,7 +175,7 @@ void main() {
 
       final response = await client.from('public').upload('a.txt', file);
       expect(response, isA<String>());
-      expect(response.endsWith('/a.txt'), isTrue);
+      expect(response.key.endsWith('/a.txt'), isTrue);
     });
 
     test('should update file', () async {
@@ -197,7 +197,7 @@ void main() {
 
       final response = await client.from('public').update('a.txt', file);
       expect(response, isA<String>());
-      expect(response.endsWith('/a.txt'), isTrue);
+      expect(response.key.endsWith('/a.txt'), isTrue);
     });
 
     test('should move file', () async {
@@ -328,7 +328,7 @@ void main() {
 
       final response = await client.from('public').upload('a.txt', file);
       expect(response, isA<String>());
-      expect(response.endsWith('/a.txt'), isTrue);
+      expect(response.key.endsWith('/a.txt'), isTrue);
     });
 
     test('aborting upload should throw', () async {
@@ -357,7 +357,7 @@ void main() {
           .from('public')
           .uploadBinary('a.txt', file.readAsBytesSync());
       expect(response, isA<String>());
-      expect(response.endsWith('/a.txt'), isTrue);
+      expect(response.key.endsWith('/a.txt'), isTrue);
     });
 
     test('should update file with few network failures', () async {
@@ -366,7 +366,7 @@ void main() {
 
       final response = await client.from('public').update('a.txt', file);
       expect(response, isA<String>());
-      expect(response.endsWith('/a.txt'), isTrue);
+      expect(response.key.endsWith('/a.txt'), isTrue);
     });
     test('should update binary with few network failures', () async {
       final file = File('a.txt');
@@ -376,7 +376,7 @@ void main() {
           .from('public')
           .updateBinary('a.txt', file.readAsBytesSync());
       expect(response, isA<String>());
-      expect(response.endsWith('/a.txt'), isTrue);
+      expect(response.key.endsWith('/a.txt'), isTrue);
     });
   });
 

--- a/packages/supabase/CHANGELOG.md
+++ b/packages/supabase/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.4
+
+ - Update a dependency to the latest release.
+
 ## 2.0.3
 
  - Update a dependency to the latest release.

--- a/packages/supabase/pubspec.yaml
+++ b/packages/supabase/pubspec.yaml
@@ -1,6 +1,6 @@
 name: supabase
 description: A dart client for Supabase. This client makes it simple for developers to build secure and scalable products.
-version: 2.0.3
+version: 2.0.4
 homepage: 'https://supabase.com'
 repository: 'https://github.com/supabase/supabase-flutter/tree/main/packages/supabase'
 documentation: 'https://supabase.com/docs/reference/dart/introduction'

--- a/packages/supabase_flutter/CHANGELOG.md
+++ b/packages/supabase_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.1
+
+ - Update a dependency to the latest release.
+
 ## 2.1.0
 
  - **FIX**: Update Provider to OAuthProvider in readme ([#778](https://github.com/supabase/supabase-flutter/issues/778)). ([0585ee96](https://github.com/supabase/supabase-flutter/commit/0585ee960c7dbd1b232fe84a169daf8b3f37170c))

--- a/packages/supabase_flutter/example/linux/flutter/generated_plugin_registrant.cc
+++ b/packages/supabase_flutter/example/linux/flutter/generated_plugin_registrant.cc
@@ -6,9 +6,13 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <gtk/gtk_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
+  g_autoptr(FlPluginRegistrar) gtk_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "GtkPlugin");
+  gtk_plugin_register_with_registrar(gtk_registrar);
   g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
   url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);

--- a/packages/supabase_flutter/example/linux/flutter/generated_plugins.cmake
+++ b/packages/supabase_flutter/example/linux/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  gtk
   url_launcher_linux
 )
 

--- a/packages/supabase_flutter/pubspec.yaml
+++ b/packages/supabase_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: supabase_flutter
 description: Flutter integration for Supabase. This package makes it simple for developers to build secure and scalable products.
-version: 2.1.0
+version: 2.1.1
 homepage: 'https://supabase.com'
 repository: 'https://github.com/supabase/supabase-flutter/tree/main/packages/supabase_flutter'
 documentation: 'https://supabase.com/docs/reference/dart/introduction'


### PR DESCRIPTION
## What kind of change does this PR introduce?

patch

## What is the current behavior?

when uploading a file a key as String is returned, the id of the new object isn't

## What is the new behavior?

the new return type includes both the key and the id

## Additional context

Simply fowards the changes introduced in https://github.com/supabase/storage/pull/332 to the dart/flutter client
