### PR TITLE
feat: Add linkedin_oidc OAuthProvider

### DIFF
--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -366,7 +366,7 @@ class GoTrueClient {
       options: GotrueRequestOptions(
         headers: _headers,
         body: {
-          'provider': provider.name,
+          'provider': provider.snakeCase,
           'id_token': idToken,
           'nonce': nonce,
           'gotrue_meta_security': {'captcha_token': captchaToken},
@@ -889,7 +889,7 @@ class GoTrueClient {
     required Map<String, String>? queryParams,
     bool skipBrowserRedirect = false,
   }) async {
-    final urlParams = {'provider': provider.name};
+    final urlParams = {'provider': provider.snakeCase};
     if (scopes != null) {
       urlParams['scopes'] = scopes;
     }

--- a/packages/gotrue/lib/src/types/o_auth_provider.dart
+++ b/packages/gotrue/lib/src/types/o_auth_provider.dart
@@ -1,5 +1,3 @@
-// ignore_for_file: constant_identifier_names
-
 enum OAuthProvider {
   apple,
   azure,
@@ -13,7 +11,7 @@ enum OAuthProvider {
   kakao,
   keycloak,
   linkedin,
-  linkedin_oidc,
+  linkedinOidc,
   notion,
   slack,
   spotify,

--- a/packages/gotrue/lib/src/types/o_auth_provider.dart
+++ b/packages/gotrue/lib/src/types/o_auth_provider.dart
@@ -11,6 +11,7 @@ enum OAuthProvider {
   kakao,
   keycloak,
   linkedin,
+  linkedin_oidc,
   notion,
   slack,
   spotify,

--- a/packages/gotrue/lib/src/types/o_auth_provider.dart
+++ b/packages/gotrue/lib/src/types/o_auth_provider.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: constant_identifier_names
+
 enum OAuthProvider {
   apple,
   azure,


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature


## What is the new behavior?

Adds the `linkedin_oidc` OAuthProvider.

## Additional context
- [js pr](https://github.com/supabase/gotrue-js/pull/796)
- close #779
