### PR TITLE
feat(gotrue, supabase_flutter): Add `signInWithSSO` method

### DIFF
--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -527,7 +527,7 @@ class GoTrueClient {
   /// If you have built an organization-specific login page, you can use the
   /// organization's SSO Identity Provider UUID directly instead.
   // async signInWithSSO(params: SignInWithSSO): Promise<SSOResponse> {
-  Future<void> signInWithSSO({
+  Future<String> signInWithSSO({
     String? providerId,
     String? domain,
     String? redirectTo,
@@ -552,7 +552,7 @@ class GoTrueClient {
       codeChallengeMethod = codeVerifier == codeChallenge ? 'plain' : 's256';
     }
 
-    return await _fetch.request('$_url/sso', RequestMethodType.post,
+    final res = await _fetch.request('$_url/sso', RequestMethodType.post,
         options: GotrueRequestOptions(
           body: {
             if (providerId != null) 'provider_id': providerId,
@@ -566,6 +566,8 @@ class GoTrueClient {
           },
           headers: _headers,
         ));
+
+    return res['url'] as String;
   }
 
   /// Force refreshes the session including the user data in case it was updated

--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -514,10 +514,8 @@ class GoTrueClient {
     return authResponse;
   }
 
-  /// Attempts a single-sign on using an enterprise Identity Provider. A
-  /// successful SSO attempt will redirect the current page to the identity
-  /// provider authorization page. The redirect URL is implementation and SSO
-  /// protocol specific.
+  /// Obtains a URL to perform a single-sign on using an enterprise Identity
+  /// Provider. The redirect URL is implementation and SSO protocol specific.
   ///
   /// You can use it by providing a SSO domain. Typically you can extract this
   /// domain by asking users for their email address. If this domain is
@@ -526,8 +524,7 @@ class GoTrueClient {
   ///
   /// If you have built an organization-specific login page, you can use the
   /// organization's SSO Identity Provider UUID directly instead.
-  // async signInWithSSO(params: SignInWithSSO): Promise<SSOResponse> {
-  Future<String> signInWithSSO({
+  Future<String> getSSOSignInUrl({
     String? providerId,
     String? domain,
     String? redirectTo,

--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -514,6 +514,60 @@ class GoTrueClient {
     return authResponse;
   }
 
+  /// Attempts a single-sign on using an enterprise Identity Provider. A
+  /// successful SSO attempt will redirect the current page to the identity
+  /// provider authorization page. The redirect URL is implementation and SSO
+  /// protocol specific.
+  ///
+  /// You can use it by providing a SSO domain. Typically you can extract this
+  /// domain by asking users for their email address. If this domain is
+  /// registered on the Auth instance the redirect will use that organization's
+  /// currently active SSO Identity Provider for the login.
+  ///
+  /// If you have built an organization-specific login page, you can use the
+  /// organization's SSO Identity Provider UUID directly instead.
+  // async signInWithSSO(params: SignInWithSSO): Promise<SSOResponse> {
+  Future<void> signInWithSSO({
+    String? providerId,
+    String? domain,
+    String? redirectTo,
+    String? captchaToken,
+  }) async {
+    assert(
+      providerId != null || domain != null,
+      'providerId or domain has to be provided.',
+    );
+
+    _removeSession();
+    String? codeChallenge;
+    String? codeChallengeMethod;
+    if (_flowType == AuthFlowType.pkce) {
+      assert(_asyncStorage != null,
+          'You need to provide asyncStorage to perform pkce flow.');
+      final codeVerifier = generatePKCEVerifier();
+      await _asyncStorage!.setItem(
+          key: '${Constants.defaultStorageKey}-code-verifier',
+          value: codeVerifier);
+      codeChallenge = generatePKCEChallenge(codeVerifier);
+      codeChallengeMethod = codeVerifier == codeChallenge ? 'plain' : 's256';
+    }
+
+    return await _fetch.request('$_url/sso', RequestMethodType.post,
+        options: GotrueRequestOptions(
+          body: {
+            if (providerId != null) 'provider_id': providerId,
+            if (domain != null) 'domain': domain,
+            if (redirectTo != null) 'redirect_to': redirectTo,
+            if (captchaToken != null)
+              'gotrue_meta_security': {'captcha_token': captchaToken},
+            'skip_http_redirect': true,
+            'code_challenge': codeChallenge,
+            'code_challenge_method': codeChallengeMethod,
+          },
+          headers: _headers,
+        ));
+  }
+
   /// Force refreshes the session including the user data in case it was updated
   /// in a different session.
   Future<AuthResponse> refreshSession() async {

--- a/packages/supabase_flutter/lib/src/supabase_auth.dart
+++ b/packages/supabase_flutter/lib/src/supabase_auth.dart
@@ -294,6 +294,42 @@ extension GoTrueClientSignInProvider on GoTrueClient {
     return result;
   }
 
+  /// Attempts a single-sign on using an enterprise Identity Provider. A
+  /// successful SSO attempt will redirect the current page to the identity
+  /// provider authorization page. The redirect URL is implementation and SSO
+  /// protocol specific.
+  ///
+  /// You can use it by providing a SSO domain. Typically you can extract this
+  /// domain by asking users for their email address. If this domain is
+  /// registered on the Auth instance the redirect will use that organization's
+  /// currently active SSO Identity Provider for the login.
+  ///
+  /// If you have built an organization-specific login page, you can use the
+  /// organization's SSO Identity Provider UUID directly instead.
+  ///
+  /// Returns true if the URL was launched successful, otherwise either returns
+  /// false or throws a [PlatformException] depending on the launchUrl failure.
+  ///
+  /// ```dart
+  /// await supabase.auth.signInWithSSO(
+  ///   domain: 'company.com',
+  /// );
+  /// ```
+  Future<bool> signInWithSSO({
+    String? providerId,
+    String? domain,
+    String? redirectTo,
+    String? captchaToken,
+    LaunchMode launchMode = LaunchMode.platformDefault,
+  }) async {
+    final ssoUrl = await getSSOSignInUrl();
+    return await launchUrl(
+      Uri.parse(ssoUrl),
+      mode: launchMode,
+      webOnlyWindowName: '_self',
+    );
+  }
+
   String generateRawNonce() {
     final random = Random.secure();
     return base64Url.encode(List<int>.generate(16, (_) => random.nextInt(256)));

--- a/packages/supabase_flutter/lib/src/supabase_auth.dart
+++ b/packages/supabase_flutter/lib/src/supabase_auth.dart
@@ -307,7 +307,7 @@ extension GoTrueClientSignInProvider on GoTrueClient {
   /// If you have built an organization-specific login page, you can use the
   /// organization's SSO Identity Provider UUID directly instead.
   ///
-  /// Returns true if the URL was launched successful, otherwise either returns
+  /// Returns true if the URL was launched successfully, otherwise either returns
   /// false or throws a [PlatformException] depending on the launchUrl failure.
   ///
   /// ```dart

--- a/packages/supabase_flutter/lib/src/supabase_auth.dart
+++ b/packages/supabase_flutter/lib/src/supabase_auth.dart
@@ -322,7 +322,12 @@ extension GoTrueClientSignInProvider on GoTrueClient {
     String? captchaToken,
     LaunchMode launchMode = LaunchMode.platformDefault,
   }) async {
-    final ssoUrl = await getSSOSignInUrl();
+    final ssoUrl = await getSSOSignInUrl(
+      providerId: providerId,
+      domain: domain,
+      redirectTo: redirectTo,
+      captchaToken: captchaToken,
+    );
     return await launchUrl(
       Uri.parse(ssoUrl),
       mode: launchMode,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Add `signInWithSSO()` method that can be called like the following:

```dart
await supabase.auth.signInWithSSO(
  domain: `company.com`
);
```

`signInWithSSO()` works in a similar way as `signInWithOAuth()` where `gotrue-dart` has a `getSSOSignInUrl()` that provides the sign in URL, and supabase_flutter handles the user redirect.

supabase-js implementation here: https://github.com/supabase/gotrue-js/blob/master/src/GoTrueClient.ts#L758

Closes https://github.com/supabase/supabase-flutter/issues/759

