### PR TITLE
fix(supabase_flutter): Add timeout to Hive.openBox to fix hanging issue

### DIFF
--- a/packages/supabase_flutter/lib/src/local_storage.dart
+++ b/packages/supabase_flutter/lib/src/local_storage.dart
@@ -87,7 +87,8 @@ class HiveLocalStorage extends LocalStorage {
       encryptionCipher = HiveAesCipher(base64Url.decode(encryptionKey!));
     }
     await Hive.initFlutter('auth');
-    await Hive.openBox(_hiveBoxName, encryptionCipher: encryptionCipher);
+    await Hive.openBox(_hiveBoxName, encryptionCipher: encryptionCipher)
+        .timeout(const Duration(seconds: 1));
   }
 
   @override
@@ -185,7 +186,13 @@ class MigrationLocalStorage extends LocalStorage {
     await Hive.initFlutter('auth');
     hiveLocalStorage = const HiveLocalStorage();
     await sharedPreferencesLocalStorage.initialize();
-    await migrate();
+    try {
+      await migrate();
+    } on TimeoutException {
+      print('TimeoutException');
+      // Ignore TimeoutException thrown by Hive methods
+      // https://github.com/supabase/supabase-flutter/issues/794
+    }
   }
 
   @visibleForTesting

--- a/packages/supabase_flutter/lib/src/local_storage.dart
+++ b/packages/supabase_flutter/lib/src/local_storage.dart
@@ -189,7 +189,6 @@ class MigrationLocalStorage extends LocalStorage {
     try {
       await migrate();
     } on TimeoutException {
-      print('TimeoutException');
       // Ignore TimeoutException thrown by Hive methods
       // https://github.com/supabase/supabase-flutter/issues/794
     }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Currently when initializing Supabase within Safari while dev tool is opened, `Supabase.initialize()` hangs leaving the user with just a white screen.

This is caused by `await Hive.openBox(_hiveBoxName, encryptionCipher: encryptionCipher);` hanging. Although the reason for why the function does not complete is unknown, we could at least add a timeout so that when it does hang, we can at least catch the `TimeoutException` and proceed. 

Fixes https://github.com/supabase/supabase-flutter/issues/794