### PR TITLE
fix(gotrue): Set _currentUser when setting initial session

### DIFF
--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -901,6 +901,7 @@ class GoTrueClient {
     }
 
     _currentSession = session;
+    _currentUser = _currentSession?.user;
     notifyAllSubscribers(AuthChangeEvent.initialSession);
   }
 

--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -120,6 +120,11 @@ class GoTrueClient {
   Map<String, String> get headers => _headers;
 
   /// Returns the current logged in user, if any;
+  ///
+  /// Use [currentSession] to determine whether the user has an active session,
+  /// because [currentUser] can be non-null without an active session, such as
+  /// when the user signed up using email and password but has not confirmed
+  /// their email address.
   User? get currentUser => _currentUser;
 
   /// Returns the current session, if any;
@@ -901,7 +906,7 @@ class GoTrueClient {
     }
 
     _currentSession = session;
-    _currentUser = _currentSession?.user;
+    _currentUser = session.user;
     notifyAllSubscribers(AuthChangeEvent.initialSession);
   }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Currently when the supabase_flutter SDK obtains the initial session from local storage and calls `setInitialSession()` method of gotrue, the `_currentUser` is not set causing a state where `auth.currentSession` is not null, but `auth.currentUser` being null. This PR fixes it. 

Related https://github.com/supabase/supabase-flutter/issues/805