### PR TITLE
fix: Remove platform check to start deep link observer on every platform including Linux

### DIFF
--- a/packages/supabase_flutter/README.md
+++ b/packages/supabase_flutter/README.md
@@ -9,10 +9,6 @@ Flutter Client library for [Supabase](https://supabase.com/).
 
 - Documentation: https://supabase.com/docs/reference/dart/introduction
 
-## Platform Support
-
-Except Linux, all platforms are fully supported. Linux only doesn't support deeplinks, because of our dependency [app_links](https://pub.dev/packages/app_links). All other features are supported.
-
 ## Getting Started
 
 Import the package:

--- a/packages/supabase_flutter/example/linux/flutter/generated_plugin_registrant.cc
+++ b/packages/supabase_flutter/example/linux/flutter/generated_plugin_registrant.cc
@@ -6,9 +6,13 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <gtk/gtk_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
+  g_autoptr(FlPluginRegistrar) gtk_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "GtkPlugin");
+  gtk_plugin_register_with_registrar(gtk_registrar);
   g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
   url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);

--- a/packages/supabase_flutter/example/linux/flutter/generated_plugins.cmake
+++ b/packages/supabase_flutter/example/linux/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  gtk
   url_launcher_linux
 )
 

--- a/packages/supabase_flutter/lib/src/supabase_auth.dart
+++ b/packages/supabase_flutter/lib/src/supabase_auth.dart
@@ -61,14 +61,8 @@ class SupabaseAuth with WidgetsBindingObserver {
       }
     }
     _widgetsBindingInstance?.addObserver(this);
-    if (kIsWeb ||
-        Platform.isAndroid ||
-        Platform.isIOS ||
-        Platform.isMacOS ||
-        Platform.isWindows ||
-        Platform.environment.containsKey('FLUTTER_TEST')) {
-      await _startDeeplinkObserver();
-    }
+
+    await _startDeeplinkObserver();
 
     // Emit a null session if the user did not have persisted session
     if (shouldEmitInitialSession) {


### PR DESCRIPTION
## What kind of change does this PR introduce?

- Support deeplink on Linux platform

## Additional context

The app_link package has supported the deep link feature since version 3.5.0.

https://github.com/llfbandit/app_links/pull/76
