### PR TITLE
fix: Use per client fetch instance

### DIFF
--- a/packages/storage_client/lib/src/fetch.dart
+++ b/packages/storage_client/lib/src/fetch.dart
@@ -11,8 +11,6 @@ import 'package:storage_client/src/types.dart';
 
 import 'file_io.dart' if (dart.library.js) './file_stub.dart';
 
-Fetch storageFetch = Fetch();
-
 class Fetch {
   final Client? httpClient;
 

--- a/packages/storage_client/lib/src/storage_bucket_api.dart
+++ b/packages/storage_client/lib/src/storage_bucket_api.dart
@@ -1,10 +1,13 @@
 import 'package:http/http.dart';
+import 'package:meta/meta.dart';
 import 'package:storage_client/src/fetch.dart';
 import 'package:storage_client/src/types.dart';
 
 class StorageBucketApi {
   final String url;
   final Map<String, String> headers;
+  @internal
+  late Fetch storageFetch;
 
   StorageBucketApi(this.url, this.headers, {Client? httpClient}) {
     storageFetch = Fetch(httpClient);

--- a/packages/storage_client/lib/src/storage_client.dart
+++ b/packages/storage_client/lib/src/storage_client.dart
@@ -48,7 +48,13 @@ class SupabaseStorageClient extends StorageBucketApi {
   ///
   /// [id] The bucket id to operate on.
   StorageFileApi from(String id) {
-    return StorageFileApi(url, headers, id, _defaultRetryAttempts);
+    return StorageFileApi(
+      url,
+      headers,
+      id,
+      _defaultRetryAttempts,
+      storageFetch,
+    );
   }
 
   void setAuth(String jwt) {

--- a/packages/storage_client/lib/src/storage_file_api.dart
+++ b/packages/storage_client/lib/src/storage_file_api.dart
@@ -10,12 +10,14 @@ class StorageFileApi {
   final Map<String, String> headers;
   final String? bucketId;
   final int _retryAttempts;
+  final Fetch _storageFetch;
 
   const StorageFileApi(
     this.url,
     this.headers,
     this.bucketId,
     this._retryAttempts,
+    this._storageFetch,
   );
 
   String _getFinalPath(String path) {
@@ -51,7 +53,7 @@ class StorageFileApi {
     assert(retryAttempts == null || retryAttempts >= 0,
         'retryAttempts has to be greater or equal to 0');
     final finalPath = _getFinalPath(path);
-    final response = await storageFetch.postFile(
+    final response = await _storageFetch.postFile(
       '$url/object/$finalPath',
       file,
       fileOptions,
@@ -86,7 +88,7 @@ class StorageFileApi {
     assert(retryAttempts == null || retryAttempts >= 0,
         'retryAttempts has to be greater or equal to 0');
     final finalPath = _getFinalPath(path);
-    final response = await storageFetch.postBinaryFile(
+    final response = await _storageFetch.postBinaryFile(
       '$url/object/$finalPath',
       data,
       fileOptions,
@@ -121,7 +123,7 @@ class StorageFileApi {
     var url = Uri.parse('${this.url}/object/upload/sign/$finalPath');
     url = url.replace(queryParameters: {'token': token});
 
-    await storageFetch.putFile(
+    await _storageFetch.putFile(
       url.toString(),
       file,
       fileOptions,
@@ -155,7 +157,7 @@ class StorageFileApi {
     var url = Uri.parse('${this.url}/object/upload/sign/$path0');
     url = url.replace(queryParameters: {'token': token});
 
-    await storageFetch.putBinaryFile(
+    await _storageFetch.putBinaryFile(
       url.toString(),
       data,
       fileOptions,
@@ -175,7 +177,7 @@ class StorageFileApi {
   Future<SignedUploadURLResponse> createSignedUploadUrl(String path) async {
     final finalPath = _getFinalPath(path);
 
-    final data = await storageFetch.post(
+    final data = await _storageFetch.post(
       '$url/object/upload/sign/$finalPath',
       {},
       options: FetchOptions(headers: headers),
@@ -220,7 +222,7 @@ class StorageFileApi {
     assert(retryAttempts == null || retryAttempts >= 0,
         'retryAttempts has to be greater or equal to 0');
     final finalPath = _getFinalPath(path);
-    final response = await storageFetch.putFile(
+    final response = await _storageFetch.putFile(
       '$url/object/$finalPath',
       file,
       fileOptions,
@@ -256,7 +258,7 @@ class StorageFileApi {
     assert(retryAttempts == null || retryAttempts >= 0,
         'retryAttempts has to be greater or equal to 0');
     final finalPath = _getFinalPath(path);
-    final response = await storageFetch.putBinaryFile(
+    final response = await _storageFetch.putBinaryFile(
       '$url/object/$finalPath',
       data,
       fileOptions,
@@ -276,7 +278,7 @@ class StorageFileApi {
   /// `folder/image-new.png`.
   Future<String> move(String fromPath, String toPath) async {
     final options = FetchOptions(headers: headers);
-    final response = await storageFetch.post(
+    final response = await _storageFetch.post(
       '$url/object/move',
       {
         'bucketId': bucketId,
@@ -297,7 +299,7 @@ class StorageFileApi {
   /// `folder/image-copy.png`.
   Future<String> copy(String fromPath, String toPath) async {
     final options = FetchOptions(headers: headers);
-    final response = await storageFetch.post(
+    final response = await _storageFetch.post(
       '$url/object/copy',
       {
         'bucketId': bucketId,
@@ -326,7 +328,7 @@ class StorageFileApi {
   }) async {
     final finalPath = _getFinalPath(path);
     final options = FetchOptions(headers: headers);
-    final response = await storageFetch.post(
+    final response = await _storageFetch.post(
       '$url/object/sign/$finalPath',
       {
         'expiresIn': expiresIn,
@@ -354,7 +356,7 @@ class StorageFileApi {
     int expiresIn,
   ) async {
     final options = FetchOptions(headers: headers);
-    final response = await storageFetch.post(
+    final response = await _storageFetch.post(
       '$url/object/sign/$bucketId',
       {
         'expiresIn': expiresIn,
@@ -391,7 +393,7 @@ class StorageFileApi {
     fetchUrl = fetchUrl.replace(queryParameters: queryParams);
 
     final response =
-        await storageFetch.get(fetchUrl.toString(), options: options);
+        await _storageFetch.get(fetchUrl.toString(), options: options);
     return response as Uint8List;
   }
 
@@ -424,7 +426,7 @@ class StorageFileApi {
   /// name. For example: `remove(['folder/image.png'])`.
   Future<List<FileObject>> remove(List<String> paths) async {
     final options = FetchOptions(headers: headers);
-    final response = await storageFetch.delete(
+    final response = await _storageFetch.delete(
       '$url/object/$bucketId',
       {'prefixes': paths},
       options: options,
@@ -451,7 +453,7 @@ class StorageFileApi {
       ...searchOptions.toMap(),
     };
     final options = FetchOptions(headers: headers);
-    final response = await storageFetch.post(
+    final response = await _storageFetch.post(
       '$url/object/list/$bucketId',
       body,
       options: options,

--- a/packages/storage_client/pubspec.yaml
+++ b/packages/storage_client/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
   http_parser: ^4.0.1
   mime: ^1.0.2
   retry: ^3.1.0
+  meta: ^1.7.0
 
 dev_dependencies:
   mocktail: ^0.3.0

--- a/packages/storage_client/pubspec.yaml
+++ b/packages/storage_client/pubspec.yaml
@@ -16,7 +16,6 @@ dependencies:
   meta: ^1.7.0
 
 dev_dependencies:
-  mocktail: ^0.3.0
   test: ^1.21.4
   lints: ^2.1.1
   path: ^1.8.2

--- a/packages/storage_client/test/client_test.dart
+++ b/packages/storage_client/test/client_test.dart
@@ -1,9 +1,7 @@
 import 'dart:io';
 
 import 'package:mime/mime.dart';
-import 'package:mocktail/mocktail.dart';
 import "package:path/path.dart" show join;
-import 'package:storage_client/src/types.dart';
 import 'package:storage_client/storage_client.dart';
 import 'package:test/test.dart';
 
@@ -36,9 +34,6 @@ void main() {
       'Authorization': 'Bearer $storageKey',
     });
 
-    // Register default mock values (used by mocktail)
-    registerFallbackValue(const FileOptions());
-    registerFallbackValue(const FetchOptions());
     file = File(join(
         Directory.current.path, 'test', 'fixtures', 'upload', 'sadcat.jpg'));
   });

--- a/packages/storage_client/test/custom_http_client.dart
+++ b/packages/storage_client/test/custom_http_client.dart
@@ -1,8 +1,9 @@
 import 'dart:convert';
+import 'dart:typed_data';
 
 import 'package:http/http.dart';
 
-class CustomHttpClient extends BaseClient {
+class FailingHttpClient extends BaseClient {
   @override
   Future<StreamedResponse> send(BaseRequest request) async {
     //Return custom status code to check for usage of this client.
@@ -26,6 +27,26 @@ class RetryHttpClient extends BaseClient {
     //Return custom status code to check for usage of this client.
     return StreamedResponse(
       Stream.value(utf8.encode(jsonEncode({'Key': 'public/a.txt'}))),
+      201,
+      request: request,
+    );
+  }
+}
+
+class CustomHttpClient extends BaseClient {
+  dynamic response;
+
+  @override
+  Future<StreamedResponse> send(BaseRequest request) async {
+    final dynamic body;
+    if (response is Uint8List) {
+      body = response;
+    } else {
+      body = utf8.encode(jsonEncode(response));
+    }
+
+    return StreamedResponse(
+      Stream.value(body),
       201,
       request: request,
     );


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

One global fetch instance is used for all storage clients.

## What is the new behavior?

The fetch instance containing the custom http client is now per storage client.

## Additional context

close #771
