### PR TITLE
refactor: Remove hive dependency and add instructinos to migration from v1 while persisting the auth state

### DIFF
--- a/packages/supabase_flutter/CHANGELOG.md
+++ b/packages/supabase_flutter/CHANGELOG.md
@@ -31,7 +31,7 @@
 
 ## 2.0.0
 
- - Graduate package to a stable release. See pre-releases prior to this version for changelog entries.
+ - Graduate package to a stable release. See pre-releases prior to this version for changelog entries. Upgrade guide can be found [here](https://supabase.com/docs/reference/dart/upgrade-guide).
 
 ## 2.0.0-dev.4
 

--- a/packages/supabase_flutter/README.md
+++ b/packages/supabase_flutter/README.md
@@ -583,6 +583,11 @@ Supabase.initialize(
 
 ---
 
+## Migrating Guide
+
+You can find the migration guide to migrate from v1 to v2 here:
+https://supabase.com/docs/reference/dart/upgrade-guide
+
 ## Contributing
 
 - Fork the repo on [GitHub](https://github.com/supabase/supabase-flutter)

--- a/packages/supabase_flutter/README.md
+++ b/packages/supabase_flutter/README.md
@@ -567,7 +567,7 @@ class HiveLocalStorage extends LocalStorage {
 }
 ```
 
-You can then initialize Supabase with `MigrationLocalStorage` and it will automatically migrate the sessino from Hive to SharedPreferences.
+You can then initialize Supabase with `MigrationLocalStorage` and it will automatically migrate the session from Hive to SharedPreferences.
 
 ```dart
 Supabase.initialize(

--- a/packages/supabase_flutter/README.md
+++ b/packages/supabase_flutter/README.md
@@ -429,7 +429,7 @@ Supabase.initialize(
 
 ### Persisting the user session from supabase_flutter v1
 
-supabase_flutter v1 used hive to persist the user session. In the current versino of supabase_flutter it uses shared_preferences. If you are updating your app from v1 to v2, you can use the following custom `LocalStorage` implementation to automatically migrate the user session from hive to shared_preferences.
+supabase_flutter v1 used hive to persist the user session. In the current version of supabase_flutter it uses shared_preferences. If you are updating your app from v1 to v2, you can use the following custom `LocalStorage` implementation to automatically migrate the user session from hive to shared_preferences.
 
 ```dart
 const _hiveBoxName = 'supabase_authentication';

--- a/packages/supabase_flutter/README.md
+++ b/packages/supabase_flutter/README.md
@@ -429,7 +429,7 @@ Supabase.initialize(
 
 ### Persisting the user session from supabase_flutter v1
 
-supabase_flutter v1 used hive to persist the user session. In the current version of supabase_flutter it uses shared_preferences. If you are updating your app from v1 to v2, you can use the following custom `LocalStorage` implementation to automatically migrate the user session from hive to shared_preferences.
+supabase_flutter v1 used hive to persist the user session. In the current version of supabase_flutter it uses shared_preferences. If you are updating your app from v1 to v2, you can use the following custom `LocalStorage` implementation to automatically migrate the user session from [hive](https://pub.dev/packages/hive) to [shared_preferences](https://pub.dev/packages/shared_preferences).
 
 ```dart
 const _hiveBoxName = 'supabase_authentication';

--- a/packages/supabase_flutter/lib/src/local_storage.dart
+++ b/packages/supabase_flutter/lib/src/local_storage.dart
@@ -1,17 +1,13 @@
 import 'dart:async';
-import 'dart:convert';
-import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
-import 'package:hive_flutter/hive_flutter.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 import './local_storage_stub.dart'
     if (dart.library.html) './local_storage_web.dart' as web;
 
-const _hiveBoxName = 'supabase_authentication';
 const supabasePersistSessionKey = 'SUPABASE_PERSIST_SESSION_KEY';
 
 /// LocalStorage is used to persist the user session in the device.
@@ -64,62 +60,6 @@ class EmptyLocalStorage extends LocalStorage {
   Future<void> persistSession(persistSessionString) async {}
 }
 
-/// A [LocalStorage] implementation that implements Hive as the
-/// storage method.
-class HiveLocalStorage extends LocalStorage {
-  /// Creates a LocalStorage instance that implements the Hive Database
-  const HiveLocalStorage();
-
-  /// The encryption key used by Hive. If null, the box is not encrypted
-  ///
-  /// This value should not be redefined in runtime, otherwise the user may
-  /// not be fetched correctly
-  ///
-  /// See also:
-  ///
-  ///   * <https://docs.hivedb.dev/#/advanced/encrypted_box?id=encrypted-box>
-  static String? encryptionKey;
-
-  @override
-  Future<void> initialize() async {
-    HiveCipher? encryptionCipher;
-    if (encryptionKey != null) {
-      encryptionCipher = HiveAesCipher(base64Url.decode(encryptionKey!));
-    }
-    await Hive.initFlutter('auth');
-    await Hive.openBox(_hiveBoxName, encryptionCipher: encryptionCipher)
-        .timeout(const Duration(seconds: 1));
-  }
-
-  @override
-  Future<bool> hasAccessToken() {
-    return Future.value(
-      Hive.box(_hiveBoxName).containsKey(
-        supabasePersistSessionKey,
-      ),
-    );
-  }
-
-  @override
-  Future<String?> accessToken() {
-    return Future.value(
-      Hive.box(_hiveBoxName).get(supabasePersistSessionKey) as String?,
-    );
-  }
-
-  @override
-  Future<void> removePersistedSession() {
-    return Hive.box(_hiveBoxName).delete(supabasePersistSessionKey);
-  }
-
-  @override
-  Future<void> persistSession(String persistSessionString) {
-    // Flush after X amount of writes
-    return Hive.box(_hiveBoxName)
-        .put(supabasePersistSessionKey, persistSessionString);
-  }
-}
-
 /// A [LocalStorage] implementation that implements SharedPreferences as the
 /// storage method.
 class SharedPreferencesLocalStorage extends LocalStorage {
@@ -170,82 +110,6 @@ class SharedPreferencesLocalStorage extends LocalStorage {
       return web.persistSession(persistSessionKey, persistSessionString);
     }
     return _prefs.setString(persistSessionKey, persistSessionString);
-  }
-}
-
-class MigrationLocalStorage extends LocalStorage {
-  final SharedPreferencesLocalStorage sharedPreferencesLocalStorage;
-  late final HiveLocalStorage hiveLocalStorage;
-
-  MigrationLocalStorage({required String persistSessionKey})
-      : sharedPreferencesLocalStorage =
-            SharedPreferencesLocalStorage(persistSessionKey: persistSessionKey);
-
-  @override
-  Future<void> initialize() async {
-    await Hive.initFlutter('auth');
-    hiveLocalStorage = const HiveLocalStorage();
-    await sharedPreferencesLocalStorage.initialize();
-    try {
-      await migrate();
-    } on TimeoutException {
-      // Ignore TimeoutException thrown by Hive methods
-      // https://github.com/supabase/supabase-flutter/issues/794
-    }
-  }
-
-  @visibleForTesting
-  Future<void> migrate() async {
-    // Migrate from Hive to SharedPreferences
-    if (await Hive.boxExists(_hiveBoxName)) {
-      await hiveLocalStorage.initialize();
-
-      final hasHive = await hiveLocalStorage.hasAccessToken();
-      if (hasHive) {
-        final accessToken = await hiveLocalStorage.accessToken();
-        final session =
-            Session.fromJson(jsonDecode(accessToken!)['currentSession']);
-        if (session == null) {
-          return;
-        }
-        await sharedPreferencesLocalStorage
-            .persistSession(jsonEncode(session.toJson()));
-        await hiveLocalStorage.removePersistedSession();
-      }
-      if (Hive.box(_hiveBoxName).isEmpty) {
-        final boxPath = Hive.box(_hiveBoxName).path;
-        await Hive.deleteBoxFromDisk(_hiveBoxName);
-
-        //Delete `auth` folder if it's empty
-        if (!kIsWeb && boxPath != null) {
-          final boxDir = File(boxPath).parent;
-          final dirIsEmpty = await boxDir.list().length == 0;
-          if (dirIsEmpty) {
-            await boxDir.delete();
-          }
-        }
-      }
-    }
-  }
-
-  @override
-  Future<String?> accessToken() {
-    return sharedPreferencesLocalStorage.accessToken();
-  }
-
-  @override
-  Future<bool> hasAccessToken() {
-    return sharedPreferencesLocalStorage.hasAccessToken();
-  }
-
-  @override
-  Future<void> persistSession(String persistSessionString) {
-    return sharedPreferencesLocalStorage.persistSession(persistSessionString);
-  }
-
-  @override
-  Future<void> removePersistedSession() {
-    return sharedPreferencesLocalStorage.removePersistedSession();
   }
 }
 

--- a/packages/supabase_flutter/lib/src/supabase.dart
+++ b/packages/supabase_flutter/lib/src/supabase.dart
@@ -88,7 +88,7 @@ class Supabase {
     }
     if (authOptions.localStorage == null) {
       authOptions = authOptions.copyWith(
-        localStorage: MigrationLocalStorage(
+        localStorage: SharedPreferencesLocalStorage(
           persistSessionKey:
               "sb-${Uri.parse(url).host.split(".").first}-auth-token",
         ),

--- a/packages/supabase_flutter/pubspec.yaml
+++ b/packages/supabase_flutter/pubspec.yaml
@@ -15,8 +15,6 @@ dependencies:
   crypto: ^3.0.2
   flutter:
     sdk: flutter
-  hive: ^2.2.1
-  hive_flutter: ^1.1.0
   http: '>=0.13.4 <2.0.0'
   meta: ^1.7.0
   supabase: ^2.0.7

--- a/packages/supabase_flutter/test/widget_test.dart
+++ b/packages/supabase_flutter/test/widget_test.dart
@@ -1,12 +1,7 @@
-import 'dart:convert';
-import 'dart:io';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:path/path.dart' as path;
 import 'package:supabase_flutter/supabase_flutter.dart';
 
-import 'utils.dart';
 import 'widget_test_stubs.dart';
 
 void main() {
@@ -33,28 +28,4 @@ void main() {
     await tester.pump();
     expect(find.text('You have signed out'), findsOneWidget);
   });
-
-  test(
-    "Migrates from Hive to SharedPreferences",
-    () async {
-      final hiveLocalStorage = TestHiveLocalStorage();
-      await hiveLocalStorage.initialize();
-      final (:accessToken, :sessionString) = getSessionData(DateTime.now());
-      await hiveLocalStorage
-          .persistSession('{"currentSession":$sessionString}');
-      final boxFile =
-          File("${path.current}/auth_test/supabase_authentication.hive");
-      expect(await boxFile.exists(), true);
-
-      final migrationLocalStorage = TestMigrationLocalStorage();
-      await migrationLocalStorage.initialize();
-
-      final migratedSessionString = await migrationLocalStorage.accessToken();
-      final migratedSession =
-          Session.fromJson(jsonDecode(migratedSessionString!));
-      expect(await boxFile.exists(), false);
-      expect(accessToken, migratedSession!.accessToken);
-      expect(await boxFile.parent.exists(), false);
-    },
-  );
 }

--- a/packages/supabase_flutter/test/widget_test_stubs.dart
+++ b/packages/supabase_flutter/test/widget_test_stubs.dart
@@ -4,10 +4,7 @@ import 'package:dart_jsonwebtoken/dart_jsonwebtoken.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:hive_flutter/hive_flutter.dart';
 import 'package:http/http.dart';
-import 'package:path/path.dart' as path;
-import 'package:shared_preferences/shared_preferences.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 import 'utils.dart';
@@ -82,28 +79,6 @@ class MockLocalStorage extends LocalStorage {
   Future<void> persistSession(String persistSessionString) async {}
   @override
   Future<void> removePersistedSession() async {}
-}
-
-class TestHiveLocalStorage extends HiveLocalStorage {
-  @override
-  Future<void> initialize() async {
-    Hive.init("${path.current}/auth_test");
-    await Hive.openBox("supabase_authentication");
-  }
-}
-
-class TestMigrationLocalStorage extends MigrationLocalStorage {
-  TestMigrationLocalStorage()
-      : super(persistSessionKey: "SUPABASE_PERSIST_SESSION_KEY");
-
-  @override
-  Future<void> initialize() async {
-    Hive.init("${path.current}/auth_test");
-    hiveLocalStorage = TestHiveLocalStorage();
-    SharedPreferences.setMockInitialValues({});
-    await sharedPreferencesLocalStorage.initialize();
-    await migrate();
-  }
 }
 
 class MockEmptyLocalStorage extends LocalStorage {


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR removes the Hive dependency. We said we eventually remove the Hive dependency when we first implemented the automatic migration code. I personally was thinking of keeping the migration code around longer something like 5 or 6 months, and it has only been a month and a half since v2 of supabase_fluter has been published. However, Hive is currently [working on a complete rewrite](https://pub.dev/packages/hive/versions/4.0.0-dev.2/changelog), and it might be good to remove its dependency before they release a stable version of it. I'm open to comments about this PR though. 

If this PR gets merged, I will add a similar section about migrating auth from v1 to v2 in the [upgrade guide](https://supabase.com/docs/reference/dart/upgrade-guide) as well.

Closes https://github.com/supabase/supabase-flutter/issues/812