### PR TITLE
docs(postgrest): Expand documentation for `contains` and `containedBy` methods

### DIFF
--- a/packages/postgrest/lib/src/postgrest_filter_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_filter_builder.dart
@@ -248,11 +248,25 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
 
   /// Finds all rows whose json, array, or range value on the stated [column] contains the values specified in [value].
   ///
+  /// Pass an array or use brackets in a string for an inclusive range:
   /// ```dart
   /// await supabase
   ///     .from('users')
   ///     .select()
-  ///     .contains('age_range', '[1,2)');
+  ///     .contains('age_range', [1,2]);
+  /// 
+  /// await supabase
+  ///     .from('users')
+  ///     .select()
+  ///     .contains('age_range', '[1,2]');  
+  /// ```
+  ///
+  /// Use parenthesis in a string for an exclusive range:
+  /// ```dart
+  /// await supabase
+  ///     .from('users')
+  ///     .select()
+  ///     .contains('age_range', '(1,2)');
   /// ```
   PostgrestFilterBuilder<T> contains(String column, Object value) {
     final Uri url;
@@ -272,11 +286,25 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
 
   /// Finds all rows whose json, array, or range value on the stated [column] is contained by the specified [value].
   ///
+  /// Pass an array or use brackets in a string for an inclusive range:
   /// ```dart
   /// await supabase
   ///     .from('users')
   ///     .select()
-  ///     .containedBy('age_range', '[1,2)');
+  ///     .containedBy('age_range', [1,2]);
+  /// 
+  /// await supabase
+  ///     .from('users')
+  ///     .select()
+  ///     .containedBy('age_range', '[1,2]');  
+  /// ```
+  ///
+  /// Use parenthesis in a string for an exclusive range:
+  /// ```dart
+  /// await supabase
+  ///     .from('users')
+  ///     .select()
+  ///     .containedBy('age_range', '(1,2)');
   /// ```
   PostgrestFilterBuilder<T> containedBy(String column, Object value) {
     final Uri url;

--- a/packages/postgrest/lib/src/postgrest_filter_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_filter_builder.dart
@@ -292,7 +292,6 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   /// Pass an array or use brackets in a string for an inclusive range and
   /// use parenthesis in a string for an exclusive range
   /// ```dart
-  ///
   /// // On array columns
   /// final data = await supabase
   ///   .from('classes')

--- a/packages/postgrest/lib/src/postgrest_filter_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_filter_builder.dart
@@ -248,25 +248,28 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
 
   /// Finds all rows whose json, array, or range value on the stated [column] contains the values specified in [value].
   ///
-  /// Pass an array or use brackets in a string for an inclusive range:
+  /// Pass an array or use brackets in a string for an inclusive range and
+  /// use parenthesis in a string for an exclusive range:
   /// ```dart
-  /// await supabase
-  ///     .from('users')
-  ///     .select()
-  ///     .contains('age_range', [1,2]);
-  /// 
-  /// await supabase
-  ///     .from('users')
-  ///     .select()
-  ///     .contains('age_range', '[1,2]');  
-  /// ```
+  /// // On array columns
+  /// final data = await supabase
+  ///   .from('issues')
+  ///   .select()
+  ///   .contains('tags', ['is:open', 'priority:low']);
   ///
-  /// Use parenthesis in a string for an exclusive range:
-  /// ```dart
-  /// await supabase
-  ///     .from('users')
-  ///     .select()
-  ///     .contains('age_range', '(1,2)');
+  /// // On range columns
+  /// // Finds rows where the `during` column contains the range between
+  /// // `2000-01-01 00:00` inclusive and `2000-01-01 23:59` exclusive
+  /// final data = await supabase
+  ///   .from('reservations')
+  ///   .select()
+  ///   .contains('during', '[2000-01-01 13:00, 2000-01-01 13:30)');
+  ///
+  /// //On jsonb columns
+  /// final data = await supabase
+  ///   .from('users')
+  ///   .select('name')
+  ///   .contains('address', { 'street': 'Melrose Place' });
   /// ```
   PostgrestFilterBuilder<T> contains(String column, Object value) {
     final Uri url;
@@ -286,25 +289,29 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
 
   /// Finds all rows whose json, array, or range value on the stated [column] is contained by the specified [value].
   ///
-  /// Pass an array or use brackets in a string for an inclusive range:
+  /// Pass an array or use brackets in a string for an inclusive range and
+  /// use parenthesis in a string for an exclusive range
   /// ```dart
-  /// await supabase
-  ///     .from('users')
-  ///     .select()
-  ///     .containedBy('age_range', [1,2]);
-  /// 
-  /// await supabase
-  ///     .from('users')
-  ///     .select()
-  ///     .containedBy('age_range', '[1,2]');  
-  /// ```
   ///
-  /// Use parenthesis in a string for an exclusive range:
-  /// ```dart
-  /// await supabase
-  ///     .from('users')
-  ///     .select()
-  ///     .containedBy('age_range', '(1,2)');
+  /// // On array columns
+  /// final data = await supabase
+  ///   .from('classes')
+  ///   .select('name')
+  ///   .containedBy('days', ['monday', 'tuesday', 'wednesday', 'friday']);
+  ///
+  /// // On range columns
+  /// // Finds rows where the `during` column is contained between
+  /// // `2000-01-01 00:00` inclusive and `2000-01-01 23:59` exclusive
+  /// final data = await supabase
+  ///   .from('reservations')
+  ///   .select()
+  ///   .containedBy('during', '[2000-01-01 00:00, 2000-01-01 23:59)');
+  ///
+  /// // On jsonb columns
+  /// final data = await supabase
+  ///   .from('users')
+  ///   .select('name')
+  ///   .containedBy('address', {'postcode': 90210});
   /// ```
   PostgrestFilterBuilder<T> containedBy(String column, Object value) {
     final Uri url;


### PR DESCRIPTION
## What kind of change does this PR introduce?

Previous documentation provides code examples that are syntactically incorrect and do not explain how to provide inclusive and exclusive ranges as a value.

This PR does not introduce any code changes, only code documentation changes.

## Additional context

Documentation in VS Code for `contains` and `containedBy` methods was confusing, and looked like an obvious typo. While performing a deeper dive into the methods themselves I discovered I could pass a string with parenthesis or brackets, or an array object as a value. This was not exposed in the code comments for the documentation. I felt compelled to update it.
