### PR TITLE
fix: Add await to setInitialSession during initialization

### DIFF
--- a/packages/supabase_flutter/lib/src/supabase_auth.dart
+++ b/packages/supabase_flutter/lib/src/supabase_auth.dart
@@ -54,7 +54,7 @@ class SupabaseAuth with WidgetsBindingObserver {
       final persistedSession = await _localStorage.accessToken();
       if (persistedSession != null) {
         try {
-          Supabase.instance.client.auth.setInitialSession(persistedSession);
+          await Supabase.instance.client.auth.setInitialSession(persistedSession);
         } catch (error, stackTrace) {
           Supabase.instance.log(error.toString(), stackTrace);
         }


### PR DESCRIPTION
Fixes #831

In case there are no reasons why it shouldn't be awaited, I think we should await it.
