### PR TITLE
refactor: Deprecate `eventsPerSecond` on Realtime

### DIFF
--- a/packages/realtime_client/lib/src/push.dart
+++ b/packages/realtime_client/lib/src/push.dart
@@ -17,7 +17,6 @@ class Push {
   Map<String, dynamic>? _receivedResp;
   final List<Hook> _recHooks = [];
   String? _refEvent;
-  bool rateLimited = false;
 
   /// The channel
   final RealtimeChannel _channel;
@@ -59,7 +58,7 @@ class Push {
     }
     startTimeout();
     sent = true;
-    final status = _channel.socket.push(
+    _channel.socket.push(
       Message(
         topic: _channel.topic,
         event: _event,
@@ -68,9 +67,6 @@ class Push {
         joinRef: _channel.joinRef,
       ),
     );
-    if (status == 'rate limited') {
-      rateLimited = true;
-    }
   }
 
   void updatePayload(Map<String, dynamic> payload) {

--- a/packages/realtime_client/lib/src/realtime_channel.dart
+++ b/packages/realtime_client/lib/src/realtime_channel.dart
@@ -518,10 +518,6 @@ class RealtimeChannel {
         opts['timeout'] ?? _timeout,
       );
 
-      if (push.rateLimited) {
-        completer.complete(ChannelResponse.rateLimited);
-      }
-
       if (payload['type'] == 'broadcast' &&
           (params['config']?['broadcast']?['ack'] == null ||
               params['config']?['broadcast']?['ack'] == false)) {

--- a/packages/realtime_client/lib/src/types.dart
+++ b/packages/realtime_client/lib/src/types.dart
@@ -101,7 +101,14 @@ class ChannelFilter {
   }
 }
 
-enum ChannelResponse { ok, timedOut, error }
+enum ChannelResponse {
+  ok,
+  timedOut,
+  @Deprecated(
+      'Client side rate limiting has been removed, and this enum value will never be returned.')
+  rateLimited,
+  error
+}
 
 enum RealtimeListenTypes { postgresChanges, broadcast, presence }
 

--- a/packages/realtime_client/lib/src/types.dart
+++ b/packages/realtime_client/lib/src/types.dart
@@ -101,7 +101,7 @@ class ChannelFilter {
   }
 }
 
-enum ChannelResponse { ok, timedOut, rateLimited, error }
+enum ChannelResponse { ok, timedOut, error }
 
 enum RealtimeListenTypes { postgresChanges, broadcast, presence }
 

--- a/packages/supabase/lib/src/realtime_client_options.dart
+++ b/packages/supabase/lib/src/realtime_client_options.dart
@@ -7,6 +7,8 @@ class RealtimeClientOptions {
   /// How many events the RealtimeClient can push in a second
   ///
   /// Defaults to 10 events per second
+  @Deprecated(
+      'Client side rate limit has been removed. This option will be ignored.')
   final int? eventsPerSecond;
 
   /// Level of realtime server logs to to be logged

--- a/packages/supabase/lib/src/supabase_client.dart
+++ b/packages/supabase/lib/src/supabase_client.dart
@@ -255,12 +255,10 @@ class SupabaseClient {
   RealtimeClient _initRealtimeClient({
     required RealtimeClientOptions options,
   }) {
-    final eventsPerSecond = options.eventsPerSecond;
     return RealtimeClient(
       _realtimeUrl,
       params: {
         'apikey': _supabaseKey,
-        if (eventsPerSecond != null) 'eventsPerSecond': '$eventsPerSecond'
       },
       headers: headers,
       logLevel: options.logLevel,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Client-side Realtime rate-limiting was causing confusion among developers when they saw that some of their Realtime events were not being reflected. After some discussions by the Realtime team, they concluded that the client side rate limiting behavior is not ideal, and decided to drop it. There is a server side rate limiting feature in place.

This PR deprecates the `eventsPerSecond` and removes client-side rate limiting.

JS implementation: https://github.com/supabase/realtime-js/pull/260
Closes https://github.com/supabase/supabase-flutter/issues/837