### PR TITLE
fix(gotrue, supabase_flutter): Throw error when parsing auth URL that contains an error description.

### DIFF
--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -719,14 +719,6 @@ class GoTrueClient {
     Uri originUrl, {
     bool storeSession = true,
   }) async {
-    if (_flowType == AuthFlowType.pkce) {
-      final authCode = originUrl.queryParameters['code'];
-      if (authCode == null) {
-        throw AuthPKCEGrantCodeExchangeError(
-            'No code detected in query parameters.');
-      }
-      return await exchangeCodeForSession(authCode);
-    }
     var url = originUrl;
     if (originUrl.hasQuery) {
       final decoded = originUrl.toString().replaceAll('#', '&');
@@ -739,6 +731,15 @@ class GoTrueClient {
     final errorDescription = url.queryParameters['error_description'];
     if (errorDescription != null) {
       throw AuthException(errorDescription);
+    }
+
+    if (_flowType == AuthFlowType.pkce) {
+      final authCode = originUrl.queryParameters['code'];
+      if (authCode == null) {
+        throw AuthPKCEGrantCodeExchangeError(
+            'No code detected in query parameters.');
+      }
+      return await exchangeCodeForSession(authCode);
     }
 
     final accessToken = url.queryParameters['access_token'];

--- a/packages/gotrue/test/client_test.dart
+++ b/packages/gotrue/test/client_test.dart
@@ -43,6 +43,7 @@ void main() {
           'apikey': anonToken,
         },
         asyncStorage: asyncStorage,
+        flowType: AuthFlowType.implicit,
       );
 
       adminClient = client = GoTrueClient(
@@ -62,6 +63,7 @@ void main() {
           'apikey': anonToken,
         },
         asyncStorage: asyncStorage,
+        flowType: AuthFlowType.implicit,
       );
     });
 
@@ -319,14 +321,8 @@ void main() {
       test('signIn() with Provider with redirectTo', () async {
         final res = await client.getOAuthSignInUrl(
             provider: OAuthProvider.google, redirectTo: 'https://supabase.com');
-        final expectedOutput =
-            '$gotrueUrl/authorize?provider=google&redirect_to=https%3A%2F%2Fsupabase.com';
-        final queryParameters = Uri.parse(res.url).queryParameters;
-
-        expect(res.url, startsWith(expectedOutput));
-        expect(queryParameters, containsPair('flow_type', 'pkce'));
-        expect(queryParameters, containsPair('code_challenge', isNotNull));
-        expect(queryParameters, containsPair('code_challenge_method', 's256'));
+        expect(res.url,
+            '$gotrueUrl/authorize?provider=google&redirect_to=https%3A%2F%2Fsupabase.com');
         expect(res.provider, OAuthProvider.google);
       });
 

--- a/packages/gotrue/test/client_test.dart
+++ b/packages/gotrue/test/client_test.dart
@@ -46,7 +46,7 @@ void main() {
         flowType: AuthFlowType.implicit,
       );
 
-      adminClient = client = GoTrueClient(
+      adminClient = GoTrueClient(
         url: gotrueUrl,
         headers: {
           'Authorization': 'Bearer ${getServiceRoleToken(env)}',

--- a/packages/gotrue/test/client_test.dart
+++ b/packages/gotrue/test/client_test.dart
@@ -489,5 +489,20 @@ void main() {
       expect(queryParameters['code_challenge_method'], 's256');
       expect(queryParameters['code_challenge'], isA<String>());
     });
+
+    test('Parsing invalid URL should throw', () async {
+      const errorMessage = 'auth_error_message';
+
+      final urlWithoutAccessToken = Uri.parse(
+          'http://my-callback-url.com/welcome#error_description=errorMessage');
+      try {
+        await client.getSessionFromUrl(urlWithoutAccessToken);
+        fail('getSessionFromUrl did not throw exception');
+      } on AuthException catch (error) {
+        expect(error.message, errorMessage);
+      } catch (_) {
+        fail('getSessionFromUrl did not throw exception');
+      }
+    });
   });
 }

--- a/packages/gotrue/test/client_test.dart
+++ b/packages/gotrue/test/client_test.dart
@@ -106,6 +106,23 @@ void main() {
       } catch (_) {}
     });
 
+    test('Parsing an error URL should throw', () async {
+      const errorMessage =
+          'Unverified email with spotify. A confirmation email has been sent to your spotify email';
+
+      final urlWithoutAccessToken = Uri.parse(
+          'http://my-callback-url.com/#error=unauthorized_client&error_code=401&error_description=${Uri.encodeComponent(errorMessage)}');
+      try {
+        await client.getSessionFromUrl(urlWithoutAccessToken);
+        fail('getSessionFromUrl did not throw exception');
+      } on AuthException catch (error) {
+        expect(error.message, errorMessage);
+      } catch (error) {
+        fail(
+            'getSessionFromUrl threw ${error.runtimeType} instead of AuthException');
+      }
+    });
+
     test('Subscribe a listener', () async {
       final stream = client.onAuthStateChange;
 
@@ -490,18 +507,21 @@ void main() {
       expect(queryParameters['code_challenge'], isA<String>());
     });
 
-    test('Parsing invalid URL should throw', () async {
-      const errorMessage = 'auth_error_message';
+    test('Parsing an error URL should throw', () async {
+      const errorMessage =
+          'Unverified email with spotify. A confirmation email has been sent to your spotify email';
 
+      // Supabase Auth returns a URL with `#` even when using pkce flow.
       final urlWithoutAccessToken = Uri.parse(
-          'http://my-callback-url.com/welcome#error_description=errorMessage');
+          'http://my-callback-url.com/#error=unauthorized_client&error_code=401&error_description=${Uri.encodeComponent(errorMessage)}');
       try {
         await client.getSessionFromUrl(urlWithoutAccessToken);
         fail('getSessionFromUrl did not throw exception');
       } on AuthException catch (error) {
         expect(error.message, errorMessage);
-      } catch (_) {
-        fail('getSessionFromUrl did not throw exception');
+      } catch (error) {
+        fail(
+            'getSessionFromUrl threw ${error.runtimeType} instead of AuthException');
       }
     });
   });

--- a/packages/supabase_flutter/lib/src/supabase_auth.dart
+++ b/packages/supabase_flutter/lib/src/supabase_auth.dart
@@ -147,7 +147,8 @@ class SupabaseAuth with WidgetsBindingObserver {
     return (uri.fragment.contains('access_token') &&
             _authFlowType == AuthFlowType.implicit) ||
         (uri.queryParameters.containsKey('code') &&
-            _authFlowType == AuthFlowType.pkce);
+            _authFlowType == AuthFlowType.pkce) ||
+        (uri.fragment.contains('error_description'));
   }
 
   /// Enable deep link observer to handle deep links


### PR DESCRIPTION
## What kind of change does this PR introduce?

The SDK should throw an AuthException when parsing an auth URL that contains an error description.

This PR updates the `_isAuthCallbackDeeplink` in supabase_flutter to return `true` if the URL contains `error_description`, and also makes sure proper exception is thrown when parsing auth URL containing an error description.

Related https://github.com/supabase/supabase-flutter/issues/819#issuecomment-1944364896