### PR TITLE
fix: Correct the id value passed to `.unlinkIdentity()` method

### DIFF
--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -892,7 +892,7 @@ class GoTrueClient {
   /// The user will no longer be able to sign in with that identity once it's unlinked.
   Future<void> unlinkIdentity(UserIdentity identity) async {
     await _fetch.request(
-      '$_url/user/identities/${identity.id}',
+      '$_url/user/identities/${identity.identityId}',
       RequestMethodType.delete,
       options: GotrueRequestOptions(
         headers: headers,


### PR DESCRIPTION
Just implemented manual linking, and found that the unlink method just doesnt work cause the wrong id is used.
```
AuthException(message: identity_id must be an UUID, statusCode: 400)
```
Here's the fix :)