### PR TITLE
feat: Add `detectSessionInUri` option to optionally disable deep link observer. 

### DIFF
--- a/packages/supabase_flutter/lib/src/flutter_go_true_client_options.dart
+++ b/packages/supabase_flutter/lib/src/flutter_go_true_client_options.dart
@@ -2,6 +2,9 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 
 class FlutterAuthClientOptions extends AuthClientOptions {
   final LocalStorage? localStorage;
+
+  /// If true, the client will start the deep link observer and obtain sessions
+  /// a valid URI comes in.
   final bool detectSessionInUri;
 
   const FlutterAuthClientOptions({
@@ -24,7 +27,7 @@ class FlutterAuthClientOptions extends AuthClientOptions {
       autoRefreshToken: autoRefreshToken ?? this.autoRefreshToken,
       localStorage: localStorage ?? this.localStorage,
       pkceAsyncStorage: pkceAsyncStorage ?? this.pkceAsyncStorage,
-      detectSessionInUri: detectSessionInUrl ?? this.detectSessionInUri,
+      detectSessionInUri: detectSessionInUrl ?? detectSessionInUri,
     );
   }
 }

--- a/packages/supabase_flutter/lib/src/flutter_go_true_client_options.dart
+++ b/packages/supabase_flutter/lib/src/flutter_go_true_client_options.dart
@@ -2,12 +2,14 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 
 class FlutterAuthClientOptions extends AuthClientOptions {
   final LocalStorage? localStorage;
+  final bool detectSessionInUri;
 
   const FlutterAuthClientOptions({
     super.authFlowType,
     super.autoRefreshToken,
     super.pkceAsyncStorage,
     this.localStorage,
+    this.detectSessionInUri = true,
   });
 
   FlutterAuthClientOptions copyWith({
@@ -15,12 +17,14 @@ class FlutterAuthClientOptions extends AuthClientOptions {
     bool? autoRefreshToken,
     LocalStorage? localStorage,
     dynamic pkceAsyncStorage,
+    bool? detectSessionInUrl,
   }) {
     return FlutterAuthClientOptions(
       authFlowType: authFlowType ?? this.authFlowType,
       autoRefreshToken: autoRefreshToken ?? this.autoRefreshToken,
       localStorage: localStorage ?? this.localStorage,
       pkceAsyncStorage: pkceAsyncStorage ?? this.pkceAsyncStorage,
+      detectSessionInUri: detectSessionInUrl ?? this.detectSessionInUri,
     );
   }
 }

--- a/packages/supabase_flutter/lib/src/flutter_go_true_client_options.dart
+++ b/packages/supabase_flutter/lib/src/flutter_go_true_client_options.dart
@@ -4,7 +4,7 @@ class FlutterAuthClientOptions extends AuthClientOptions {
   final LocalStorage? localStorage;
 
   /// If true, the client will start the deep link observer and obtain sessions
-  /// a valid URI comes in.
+  /// when a valid URI is detected.
   final bool detectSessionInUri;
 
   const FlutterAuthClientOptions({
@@ -19,15 +19,15 @@ class FlutterAuthClientOptions extends AuthClientOptions {
     AuthFlowType? authFlowType,
     bool? autoRefreshToken,
     LocalStorage? localStorage,
-    dynamic pkceAsyncStorage,
-    bool? detectSessionInUrl,
+    GotrueAsyncStorage? pkceAsyncStorage,
+    bool? detectSessionInUri,
   }) {
     return FlutterAuthClientOptions(
       authFlowType: authFlowType ?? this.authFlowType,
       autoRefreshToken: autoRefreshToken ?? this.autoRefreshToken,
       localStorage: localStorage ?? this.localStorage,
       pkceAsyncStorage: pkceAsyncStorage ?? this.pkceAsyncStorage,
-      detectSessionInUri: detectSessionInUrl ?? detectSessionInUri,
+      detectSessionInUri: detectSessionInUri ?? this.detectSessionInUri,
     );
   }
 }

--- a/packages/supabase_flutter/lib/src/supabase_auth.dart
+++ b/packages/supabase_flutter/lib/src/supabase_auth.dart
@@ -164,8 +164,10 @@ class SupabaseAuth with WidgetsBindingObserver {
   ///
   /// Automatically called on dispose().
   void _stopDeeplinkObserver() {
-    Supabase.instance.log('***** SupabaseDeepLinkingMixin stopAuthObserver');
-    _deeplinkSubscription?.cancel();
+    if (_deeplinkSubscription != null) {
+      Supabase.instance.log('***** SupabaseDeepLinkingMixin stopAuthObserver');
+      _deeplinkSubscription?.cancel();
+    }
   }
 
   /// Handle incoming links - the ones that the app will receive from the OS

--- a/packages/supabase_flutter/lib/src/supabase_auth.dart
+++ b/packages/supabase_flutter/lib/src/supabase_auth.dart
@@ -62,7 +62,9 @@ class SupabaseAuth with WidgetsBindingObserver {
     }
     _widgetsBindingInstance?.addObserver(this);
 
-    await _startDeeplinkObserver();
+    if (options.detectSessionInUri) {
+      await _startDeeplinkObserver();
+    }
 
     // Emit a null session if the user did not have persisted session
     if (shouldEmitInitialSession) {


### PR DESCRIPTION
## What kind of change does this PR introduce?

js client has [detectSessionInUrl](https://github.com/supabase/gotrue-js/blob/master/src/GoTrueClient.ts#L100) option to optionally disable obtaining sessions from URL. This PR adds the same parameter, but renames the end to `uri` from `url`.

Closes https://github.com/supabase/supabase-flutter/issues/847

We've had the following two PRs related to this, but we can finally close these too.
https://github.com/supabase/supabase-flutter/pull/669
https://github.com/supabase/supabase-flutter/pull/605