### PR TITLE
docs: Fixed imprecision in Custom Local Storage README.md

### DIFF
--- a/packages/supabase_flutter/README.md
+++ b/packages/supabase_flutter/README.md
@@ -388,12 +388,12 @@ class MySecureStorage extends LocalStorage {
 
   @override
   Future<String?> accessToken() async {
-    return storage.containsKey(key: supabasePersistSessionKey);
+    return storage.read(key: supabasePersistSessionKey);
   }
 
   @override
   Future<bool> hasAccessToken() async {
-    return storage.read(key: supabasePersistSessionKey);
+    return storage.containsKey(key: supabasePersistSessionKey);
   }
 
   @override


### PR DESCRIPTION
The README.md is not completely precise when providing an example of a Custom Local Storage. 

To check if it hasAccessToken it should return a bool (and so should return storage.containsKey(key: supabasePersistSessionKey) ).

And when retrieving the accessToken it should return a string (so the correct code would be: storage.read(key: supabasePersistSessionKey) )

## What kind of change does this PR introduce?
Docs update

## What is the current behavior?
The two functions accessToken() and hasAccessToken() return the wrong type. It's probably simply an oversight when copy-pasting this code.

## What is the new behavior?
I swapped the two return lines so that it behaves correctly.

## Additional context
When trying to understand how to create a custom local storage I spent some time figuring out why my code was not behaving correctly, but then saw the wrong return type.

Im new to the open source community so I don't know if Im contributing correctly and if I explained myself correctly in this PR.