### PR TITLE
Added some data retrieval methods to fetch data easily.

### DIFF
--- a/packages/postgrest/lib/src/postgrest_filter_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_filter_builder.dart
@@ -1,7 +1,7 @@
 part of 'postgrest_builder.dart';
 
 class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
-  PostgrestFilterBuilder(PostgrestBuilder<T, T, T> builder) : super(builder);
+  PostgrestFilterBuilder(super.builder);
 
   @override
   PostgrestFilterBuilder<T> copyWithUrl(Uri url) =>
@@ -230,6 +230,42 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   // ignore: non_constant_identifier_names
   PostgrestFilterBuilder<T> isFilter(String column, Object? value) {
     return copyWithUrl(appendSearchParams(column, 'is.$value'));
+  }
+
+  /// Finds all rows whose value on the stated [column] exactly match the null.
+  /// ```dart
+  /// await supabase
+  ///     .from('users')
+  ///     .select()
+  ///     .isNull('data');
+  /// ```
+  // ignore: non_constant_identifier_names
+  PostgrestFilterBuilder<T> isNull(String column) {
+    return this.isFilter(column, null);
+  }
+
+  /// Finds all rows whose value on the stated [column] exactly match the true.
+  /// ```dart
+  /// await supabase
+  ///     .from('users')
+  ///     .select()
+  ///     .isTrue('data');
+  /// ```
+  // ignore: non_constant_identifier_names
+  PostgrestFilterBuilder<T> isTrue(String column) {
+    return this.isFilter(column, true);
+  }
+
+  /// Finds all rows whose value on the stated [column] exactly match the false.
+  /// ```dart
+  /// await supabase
+  ///     .from('users')
+  ///     .select()
+  ///     .isFalse('data');
+  /// ```
+  // ignore: non_constant_identifier_names
+  PostgrestFilterBuilder<T> isFalse(String column) {
+    return this.isFilter(column, false);
   }
 
   /// Finds all rows whose value on the stated [column] is found on the specified [values].

--- a/packages/postgrest/lib/src/postgrest_transform_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_transform_builder.dart
@@ -76,6 +76,32 @@ class PostgrestTransformBuilder<T> extends RawPostgrestBuilder<T, T, T> {
     return PostgrestTransformBuilder(copyWithUrl(url));
   }
 
+  /// finds oldest result with the default [created_at] or specified [column].
+  ///
+  /// ```dart
+  /// final data = await supabase
+  ///     .from('users')
+  ///     .select()
+  ///     .oldest();
+  /// ````
+  PostgrestTransformBuilder<Map<String, dynamic>> oldest(
+      [String column = 'created_at']) {
+    return order(column, ascending: false).single();
+  }
+
+  /// finds latest result with the default [created_at] or specified [column].
+  ///
+  /// ```dart
+  /// final data = await supabase
+  ///     .from('users')
+  ///     .select()
+  ///     .latest();
+  /// ````
+  PostgrestTransformBuilder<Map<String, dynamic>> latest(
+      [String column = 'created_at']) {
+    return order(column, ascending: true).single();
+  }
+
   /// Limits the result with the specified [count].
   ///
   /// ```dart

--- a/packages/postgrest/pubspec.yaml
+++ b/packages/postgrest/pubspec.yaml
@@ -1,19 +1,19 @@
 name: postgrest
 description: PostgREST client for Dart. This library provides an ORM interface to PostgREST.
 version: 2.1.1
-homepage: 'https://supabase.com'
-repository: 'https://github.com/supabase/supabase-flutter/tree/main/packages/postgrest'
-documentation: 'https://supabase.com/docs/reference/dart/select'
+homepage: "https://supabase.com"
+repository: "https://github.com/supabase/supabase-flutter/tree/main/packages/postgrest"
+documentation: "https://supabase.com/docs/reference/dart/select"
 
 environment:
-  sdk: '>=3.0.0 <4.0.0'
+  sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  http: '>=0.13.0 <2.0.0'
+  http: ">=0.13.0 <2.0.0"
   yet_another_json_isolate: ^2.0.0
   meta: ^1.9.1
 
 dev_dependencies:
   collection: ^1.16.0
-  lints: ^2.1.1
+  lints: ^3.0.0
   test: ^1.21.4


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the current behavior?

To fetch single latest or oldest data currently need to apply order() on created_at field and then single() method to get one also to fetch null, true or false we need to pass in isFilter.

## What is the new behavior?

### latest() and oldest()

Before

final data = await supabase.from('users').select().order('created_at, ascending: true).single();

Now

final data = await supabase.from('users').select().latest();
or
final data = await supabase.from('users').select().latest('id');

same for oldest.

### isNull() , isTrue() and isFalse()

Before

final data = await supabase.from('users').select().isFilter('data', null);

Now

final data = await supabase.from('users').select().isNull('data');
or
final data = await supabase.from('users').select().isTrue('data');
or
final data = await supabase.from('users').select().isFalse('data');

