### PR TITLE
Offline Support for Refreshing Sessions

### DIFF
--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -1067,10 +1067,12 @@ class GoTrueClient {
         (value) => null,
         onError: (error, stack) => null,
       );
-      _refreshTokenCompleter!.future.timeout(const Duration(seconds: 10), onTimeout: () {
+       (_refreshTokenCompleter!.future as Future<void>).timeout(const Duration(seconds: 10), onTimeout: () {
         if (!_refreshTokenCompleter!.isCompleted) {
           _refreshTokenCompleter!.completeError(TimeoutException(), StackTrace.current);
         }
+
+        throw TimeoutException();
       });
     } else if (!ignorePendingRequest) {
       print("🦁 RETURNING EXISTING FUTURE 🦁");

--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -1067,6 +1067,11 @@ class GoTrueClient {
         (value) => null,
         onError: (error, stack) => null,
       );
+      _refreshTokenCompleter!.future.timeout(const Duration(seconds: 10), onTimeout: () {
+        if (!_refreshTokenCompleter!.isCompleted) {
+          _refreshTokenCompleter!.completeError(TimeoutException(), StackTrace.current);
+        }
+      });
     } else if (!ignorePendingRequest) {
       print("🦁 RETURNING EXISTING FUTURE 🦁");
       return _refreshTokenCompleter!.future;

--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -1130,7 +1130,7 @@ class GoTrueClient {
       if (!_refreshTokenCompleter!.isCompleted) {
         _refreshTokenCompleter!.completeError(e, stack);
       }
-      rethrow;
+      //rethrow;
     } catch (error, stack) {
       print("🦁 OTHER EXCEPTION 🦁: $error $stack");
 

--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -55,7 +55,7 @@ class GoTrueClient {
   int _refreshTokenRetryCount = 0;
 
   /// Completer to combine multiple simultaneous token refresh requests.
-  Completer<AuthResponse>? _refreshTokenCompleter;
+  Completer<AuthResponse?>? _refreshTokenCompleter;
 
   final _onAuthStateChangeController = BehaviorSubject<AuthState>();
   final _onAuthStateChangeControllerSync =
@@ -1065,7 +1065,7 @@ class GoTrueClient {
     print("🦁 CALLING REFRESH TOKEN 🦁");
     if (_refreshTokenCompleter?.isCompleted ?? true) {
       print("🦁 CREATING NEW FUTURE 🦁");
-      _refreshTokenCompleter = Completer<AuthResponse>();
+      _refreshTokenCompleter = Completer<AuthResponse?>();
       // Catch any error in case nobody awaits the future
       _refreshTokenCompleter!.future.then(
         (value) => null,
@@ -1074,14 +1074,14 @@ class GoTrueClient {
       try {
         (_refreshTokenCompleter!.future as Future<void>).timeout(const Duration(seconds: 10), onTimeout: () {
           if (!_refreshTokenCompleter!.isCompleted) {
-            _refreshTokenCompleter!.completeError(TimeoutException("Timeout"), StackTrace.current);
+            _refreshTokenCompleter!.complete(null);
           }
 
           throw TimeoutException("Timeout");
         });
       } catch (error, stackTrace) {
         print("🦁 TIMED OUT SELF FUTURE 🦁");
-        return Future.error(error, stackTrace);
+        return null;
       }
      } else if (!ignorePendingRequest) {
       print("🦁 RETURNING EXISTING FUTURE 🦁");
@@ -1128,8 +1128,9 @@ class GoTrueClient {
         accessToken: accessToken,
       );
       if (!_refreshTokenCompleter!.isCompleted) {
-        _refreshTokenCompleter!.completeError(e, stack);
+        _refreshTokenCompleter!.complete(null);
       }
+      return null;
     } catch (error, stack) {
       print("🦁 OTHER EXCEPTION 🦁: $error $stack");
 

--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -1069,10 +1069,10 @@ class GoTrueClient {
       );
        (_refreshTokenCompleter!.future as Future<void>).timeout(const Duration(seconds: 10), onTimeout: () {
         if (!_refreshTokenCompleter!.isCompleted) {
-          _refreshTokenCompleter!.completeError(TimeoutException(), StackTrace.current);
+          _refreshTokenCompleter!.completeError(TimeoutException("Timeout"), StackTrace.current);
         }
 
-        throw TimeoutException();
+        throw TimeoutException("Timeout");
       });
     } else if (!ignorePendingRequest) {
       print("🦁 RETURNING EXISTING FUTURE 🦁");

--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -1067,14 +1067,19 @@ class GoTrueClient {
         (value) => null,
         onError: (error, stack) => null,
       );
-       (_refreshTokenCompleter!.future as Future<void>).timeout(const Duration(seconds: 10), onTimeout: () {
-        if (!_refreshTokenCompleter!.isCompleted) {
-          _refreshTokenCompleter!.completeError(TimeoutException("Timeout"), StackTrace.current);
-        }
+      try {
+        (_refreshTokenCompleter!.future as Future<void>).timeout(const Duration(seconds: 10), onTimeout: () {
+          if (!_refreshTokenCompleter!.isCompleted) {
+            _refreshTokenCompleter!.completeError(TimeoutException("Timeout"), StackTrace.current);
+          }
 
-        throw TimeoutException("Timeout");
-      });
-    } else if (!ignorePendingRequest) {
+          throw TimeoutException("Timeout");
+        });
+      } catch (error, stackTrace) {
+        print("🦁 TIMED OUT SELF FUTURE 🦁");
+        return Future.error(error, stackTrace);
+      }
+     } else if (!ignorePendingRequest) {
       print("🦁 RETURNING EXISTING FUTURE 🦁");
       return _refreshTokenCompleter!.future;
     }

--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -1071,19 +1071,12 @@ class GoTrueClient {
         (value) => null,
         onError: (error, stack) => null,
       );
-      try {
-        (_refreshTokenCompleter!.future as Future<void>).timeout(const Duration(seconds: 10), onTimeout: () {
-          if (!_refreshTokenCompleter!.isCompleted) {
-            _refreshTokenCompleter!.complete(null);
-          }
-
-          throw TimeoutException("Timeout");
-        });
-      } catch (error, stackTrace) {
-        print("🦁 TIMED OUT SELF FUTURE 🦁");
-        return null;
-      }
-     } else if (!ignorePendingRequest) {
+      (_refreshTokenCompleter!.future as Future<void>).timeout(const Duration(seconds: 10), onTimeout: () {
+        if (!_refreshTokenCompleter!.isCompleted) {
+          _refreshTokenCompleter!.complete(null);
+        }
+      });
+    } else if (!ignorePendingRequest) {
       print("🦁 RETURNING EXISTING FUTURE 🦁");
       return _refreshTokenCompleter!.future;
     }

--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -581,7 +581,7 @@ class GoTrueClient {
 
   /// Force refreshes the session including the user data in case it was updated
   /// in a different session.
-  Future<AuthResponse> refreshSession() async {
+  Future<AuthResponse?> refreshSession() async {
     if (currentSession?.accessToken == null) {
       throw AuthException('Not logged in.');
     }
@@ -707,7 +707,7 @@ class GoTrueClient {
   }
 
   /// Sets the session data from refresh_token and returns the current session.
-  Future<AuthResponse> setSession(String refreshToken) async {
+  Future<AuthResponse?> setSession(String refreshToken) async {
     if (refreshToken.isEmpty) {
       throw AuthException('No current session.');
     }
@@ -916,7 +916,7 @@ class GoTrueClient {
   }
 
   /// Recover session from stringified [Session].
-  Future<AuthResponse> recoverSession(String jsonStr) async {
+  Future<AuthResponse?> recoverSession(String jsonStr) async {
     final session = Session.fromJson(json.decode(jsonStr));
     if (session == null) {
       await signOut();
@@ -1057,7 +1057,7 @@ class GoTrueClient {
   /// To call [_callRefreshToken] during a running request [ignorePendingRequest] is used to bypass that check.
   ///
   /// When a [ClientException] occurs [_setTokenRefreshTimer] is used to schedule a retry in the background, which emits the result via [onAuthStateChange].
-  Future<AuthResponse> _callRefreshToken({
+  Future<AuthResponse?> _callRefreshToken({
     String? refreshToken,
     String? accessToken,
     bool ignorePendingRequest = false,
@@ -1130,7 +1130,6 @@ class GoTrueClient {
       if (!_refreshTokenCompleter!.isCompleted) {
         _refreshTokenCompleter!.completeError(e, stack);
       }
-      //rethrow;
     } catch (error, stack) {
       print("🦁 OTHER EXCEPTION 🦁: $error $stack");
 

--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -1018,18 +1018,22 @@ class GoTrueClient {
     String? refreshToken,
     String? accessToken,
   }) {
+    print("🦁 SET TIMER REFRESH TOKEN 🦁");
     _refreshTokenTimer?.cancel();
     _refreshTokenRetryCount++;
     if (_refreshTokenRetryCount < Constants.maxRetryCount) {
       _refreshTokenTimer = Timer(timerDuration, () async {
+        print("🦁 CALL TIMER REFRESH TOKEN 🦁");
         try {
           await _callRefreshToken(
             refreshToken: refreshToken,
             accessToken: accessToken,
             ignorePendingRequest: true,
           );
-        } catch (_) {
+          print("🦁 SUCCESS TIMER REFRESH TOKEN 🦁");
+        } catch (err, stack) {
           // Catch any error, because in this case they should be handled by listening to [onAuthStateChange]
+          print("🦁 ERROR TIMER REFRESH TOKEN 🦁: $err #stack");
         }
       });
     } else {

--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -1058,7 +1058,9 @@ class GoTrueClient {
     String? accessToken,
     bool ignorePendingRequest = false,
   }) async {
+    print("🦁 CALLING REFRESH TOKEN 🦁");
     if (_refreshTokenCompleter?.isCompleted ?? true) {
+      print("🦁 CREATING NEW FUTURE 🦁");
       _refreshTokenCompleter = Completer<AuthResponse>();
       // Catch any error in case nobody awaits the future
       _refreshTokenCompleter!.future.then(
@@ -1066,8 +1068,10 @@ class GoTrueClient {
         onError: (error, stack) => null,
       );
     } else if (!ignorePendingRequest) {
+      print("🦁 RETURNING EXISTING FUTURE 🦁");
       return _refreshTokenCompleter!.future;
     }
+    print("🦁 REFRESHING SESSION 🦁");
     final token = refreshToken ?? currentSession?.refreshToken;
     if (token == null) {
       throw AuthException('No current session.');
@@ -1100,6 +1104,8 @@ class GoTrueClient {
       notifyAllSubscribers(AuthChangeEvent.tokenRefreshed);
       return authResponse;
     } on ClientException catch (e, stack) {
+      print("🦁 CLIENT EXCEPTION 🦁: $e $stack");
+      
       _setTokenRefreshTimer(
         Constants.retryInterval * pow(2, _refreshTokenRetryCount),
         refreshToken: token,
@@ -1110,6 +1116,8 @@ class GoTrueClient {
       }
       rethrow;
     } catch (error, stack) {
+      print("🦁 OTHER EXCEPTION 🦁: $error $stack");
+
       if (error is AuthException) {
         if (error.message.startsWith('Invalid Refresh Token:')) {
           await signOut();


### PR DESCRIPTION
Won't error out or freeze if refreshing a session fails, will just return null.

Flutter can watch Connectivity for a change, and then call refreshSession.