### PR TITLE
chore: Allow app_links version ^3.5.0 and ^4.0.0

### DIFF
--- a/packages/supabase_flutter/pubspec.yaml
+++ b/packages/supabase_flutter/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   flutter: '>=3.0.0'
 
 dependencies:
-  app_links: ^3.5.0
+  app_links: '>=3.5.0 <5.0.0'
   async: ^2.11.0
   crypto: ^3.0.2
   flutter:


### PR DESCRIPTION
## What kind of change does this PR introduce?

dependency version bump

## What is the current behavior?

Allow app_links version ^3.5.0

## What is the new behavior?

Allow app_links version ^4.0.0 as well as ^3.5.0, because no breaking change was made in the api itself. https://pub.dev/packages/app_links/changelog#400

## Additional context

close #863
