### PR TITLE
fix: Don't send access token  in rest broadcast

### DIFF
--- a/packages/realtime_client/lib/src/realtime_channel.dart
+++ b/packages/realtime_client/lib/src/realtime_channel.dart
@@ -483,11 +483,7 @@ class RealtimeChannel {
     }
 
     if (!canPush && type == RealtimeListenTypes.broadcast) {
-      final headers = {
-        'Content-Type': 'application/json',
-        'apikey': socket.accessToken ?? '',
-        ...socket.headers
-      };
+      final headers = {'Content-Type': 'application/json', ...socket.headers};
       final body = {
         'messages': [
           {

--- a/packages/realtime_client/test/channel_test.dart
+++ b/packages/realtime_client/test/channel_test.dart
@@ -248,6 +248,7 @@ void main() {
       mockServer = await HttpServer.bind('localhost', 0);
       socket = RealtimeClient(
         'ws://${mockServer.address.host}:${mockServer.port}/realtime/v1',
+        headers: {'apikey': 'supabaseKey'},
         params: {'apikey': 'supabaseKey'},
       );
 

--- a/packages/supabase/lib/src/supabase_client.dart
+++ b/packages/supabase/lib/src/supabase_client.dart
@@ -260,7 +260,7 @@ class SupabaseClient {
       params: {
         'apikey': _supabaseKey,
       },
-      headers: headers,
+      headers: {'apikey': _supabaseKey, ...headers},
       logLevel: options.logLevel,
       httpClient: _authHttpClient,
     );


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The access token is sent as `apikey`, but from what I see it doesn't need/take authorization at all.

## What is the new behavior?

The `apikey` passed in the default header in realtime client initialization in the supabase package is used. That's the anon apikey and not the user's one. 

## Additional context

I noticed that it was enough to remove the apikey field in the send method, because the `apikey` field gets also set in the `AuthHttpClient` if it's not already set, but I thought it's either way good to add it to the headers directly as well. realtime-js does this as well.

close #867
