### PR TITLE
fix: Typos in gotrue_client.dart

### DIFF
--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -793,7 +793,7 @@ class GoTrueClient {
 
   /// Signs out the current user, if there is a logged in user.
   ///
-  /// [scope] dtermines which sessions should be logged out.
+  /// [scope] determines which sessions should be logged out.
   ///
   /// If using [SignOutScope.others] scope, no [AuthChangeEvent.signedOut] event is fired!
   Future<void> signOut({


### PR DESCRIPTION
## What kind of change does this PR introduce?

Just a small typo I found while reading the docs.

## What is the current behavior?

signOut says `dtermines`

## What is the new behavior?

signOut says `determines`

## Additional context

💙