### PR TITLE
fix(realtime_client): Accept an error on track when the server returns an error

### DIFF
--- a/packages/realtime_client/lib/src/realtime_channel.dart
+++ b/packages/realtime_client/lib/src/realtime_channel.dart
@@ -527,6 +527,11 @@ class RealtimeChannel {
           completer.complete(ChannelResponse.ok);
         }
       });
+      push.receive('error', (_) {
+        if (!completer.isCompleted) {
+          completer.complete(ChannelResponse.error);
+        }
+      });
       push.receive('timeout', (_) {
         if (!completer.isCompleted) {
           completer.complete(ChannelResponse.timedOut);


### PR DESCRIPTION
## What kind of change does this PR introduce?

Currently, there is a bug where the `channel.track()` method hangs indefinitely when the server returns an error. This PR fixes the issue. 

## Additional context

JS update here: https://github.com/supabase/realtime-js/pull/290/files
