### PR TITLE
fix: Weak password throws `AuthWeakPasswordException`.

### DIFF
--- a/packages/gotrue/lib/src/fetch.dart
+++ b/packages/gotrue/lib/src/fetch.dart
@@ -58,7 +58,7 @@ class GotrueFetch {
       throw AuthWeakPasswordException(
         message: _getErrorMessage(data),
         statusCode: error.statusCode.toString(),
-        reasons: data['weak_password']['reasons'],
+        reasons: List<String>.from(data['weak_password']['reasons']),
       );
     }
 

--- a/packages/gotrue/test/client_test.dart
+++ b/packages/gotrue/test/client_test.dart
@@ -102,6 +102,15 @@ void main() {
       expect(data?.user.id, isA<String>());
       expect(data?.user.userMetadata!['Hello'], 'World');
     });
+    test('signUp() with week password throws AuthWeakPasswordException',
+        () async {
+      try {
+        await client.signUp(email: newEmail, password: '123');
+        fail('signUp with week password should throw exception');
+      } catch (error) {
+        expect(error, isA<AuthWeakPasswordException>());
+      }
+    });
 
     test('Parsing invalid URL should throw', () async {
       const expiresIn = 12345;


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes a bug. 

## What is the current behavior?

Currently a format exception with message `type 'List<dynamic>' is not a subtype of type 'List<String>'` is thrown when performing signUp, password update with a week password. 

## What is the new behavior?

`AuthWeakPasswordException` is properly thrown when performing signUp/ password update with a week password. 

## Additional context

fixes https://github.com/supabase/supabase-flutter/issues/891
