### PR TITLE
fix: Update app_links dependency to accept v5.0.0

### DIFF
--- a/packages/supabase_flutter/pubspec.yaml
+++ b/packages/supabase_flutter/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   flutter: '>=3.0.0'
 
 dependencies:
-  app_links: '>=3.5.0 <5.0.0'
+  app_links: '>=3.5.0 <6.0.0'
   async: ^2.11.0
   crypto: ^3.0.2
   flutter:


### PR DESCRIPTION
## What kind of change does this PR introduce?

Update the dependencies of app_links so that it can use the latest version.

app_links v5.0.0 contains the following update, which shouldn't collide with any of its feature that are being used in supabase_flutter. 
>Breaking iOs: Application Delegate now returns true for both Universal Links and Custom URL schemes. If you have other packages which could conflict with it, report to the README.md for custom handling. This change is motived by the basic deep linking provided by Flutter and the fact that there is now a workaround for such cases.

## What is the current behavior?

app_links v5.0.0 cannot be used with supabase_flutter

## What is the new behavior?

app_links v5.0.0 can be used with supabase_flutter