### PR TITLE
feat(supabase_flutter): Update app_links dependency to v6.0.1

### DIFF
--- a/packages/supabase_flutter/lib/src/supabase_auth.dart
+++ b/packages/supabase_flutter/lib/src/supabase_auth.dart
@@ -189,7 +189,7 @@ class SupabaseAuth with WidgetsBindingObserver {
     _initialDeeplinkIsHandled = true;
 
     try {
-      final uri = await _appLinks.getInitialAppLink();
+      final uri = await _appLinks.getInitialLink();
       if (uri != null) {
         await _handleDeeplink(uri);
       }

--- a/packages/supabase_flutter/pubspec.yaml
+++ b/packages/supabase_flutter/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   flutter: '>=3.0.0'
 
 dependencies:
-  app_links: '>=3.5.0 <6.0.0'
+  app_links: '^6.0.1'
   async: ^2.11.0
   crypto: ^3.0.2
   flutter:


### PR DESCRIPTION
## What kind of change does this PR introduce?

With app_links version 6.0.0 there are breaking changes in the app_links api ([https://pub.dev/packages/app_links/changelog](https://pub.dev/packages/app_links/changelog)):

`Breaking: Renamed getInitialApp* and getLatestApp* methods to getInitialLink* and getLatestLink*.`

I adjusted this in the PR and bumped the app_links package to ^6.0.1

## Additional context

I don't know whether you directly want to bump the app_links version, as there were multiple breaking version releases in the last 2 months. Just wanted to make this small PR as I personally bumped the version for myself.
