### PR TITLE
fix: Keep compatible with app_links 6.0.0 and 5.0.0

### DIFF
--- a/.github/workflows/supabase_flutter.yml
+++ b/.github/workflows/supabase_flutter.yml
@@ -5,25 +5,25 @@ on:
     branches:
       - main
     paths:
-      - "packages/supabase_flutter/**"
-      - ".github/workflows/supabase_flutter.yaml"
-      - "packages/functions_client/**"
-      - "packages/gotrue/**"
-      - "packages/postgrest/**"
-      - "packages/realtime_client/**"
-      - "packages/storage_client/**"
-      - "packages/supabase/**"
+      - 'packages/supabase_flutter/**'
+      - '.github/workflows/supabase_flutter.yaml'
+      - 'packages/functions_client/**'
+      - 'packages/gotrue/**'
+      - 'packages/postgrest/**'
+      - 'packages/realtime_client/**'
+      - 'packages/storage_client/**'
+      - 'packages/supabase/**'
 
   pull_request:
     paths:
-      - "packages/supabase_flutter/**"
-      - ".github/workflows/supabase_flutter.yaml"
-      - "packages/functions_client/**"
-      - "packages/gotrue/**"
-      - "packages/postgrest/**"
-      - "packages/realtime_client/**"
-      - "packages/storage_client/**"
-      - "packages/supabase/**"
+      - 'packages/supabase_flutter/**'
+      - '.github/workflows/supabase_flutter.yaml'
+      - 'packages/functions_client/**'
+      - 'packages/gotrue/**'
+      - 'packages/postgrest/**'
+      - 'packages/realtime_client/**'
+      - 'packages/storage_client/**'
+      - 'packages/supabase/**'
 
 jobs:
   test:
@@ -32,7 +32,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        flutter-version: ["3.10.x", "3.x"]
+        flutter-version: ['3.10.x', '3.x']
 
     defaults:
       run:
@@ -46,12 +46,12 @@ jobs:
 
       - uses: actions/setup-java@v1
         with:
-          java-version: "12.x"
+          java-version: '12.x'
 
       - uses: subosito/flutter-action@v2
         with:
           flutter-version: ${{ matrix.flutter-version }}
-          channel: "stable"
+          channel: 'stable'
 
       - run: flutter --version
 
@@ -72,7 +72,7 @@ jobs:
       - name: Run tests
         run: flutter test --concurrency=1
 
-      - name: Run tests with downgraded packages
+      - name: Run tests with downgraded app_links
         run: |
           flutter pub downgrade app_links
           flutter test --concurrency=1

--- a/.github/workflows/supabase_flutter.yml
+++ b/.github/workflows/supabase_flutter.yml
@@ -5,25 +5,25 @@ on:
     branches:
       - main
     paths:
-      - 'packages/supabase_flutter/**'
-      - '.github/workflows/supabase_flutter.yaml'
-      - 'packages/functions_client/**'
-      - 'packages/gotrue/**'
-      - 'packages/postgrest/**'
-      - 'packages/realtime_client/**'
-      - 'packages/storage_client/**'
-      - 'packages/supabase/**'
+      - "packages/supabase_flutter/**"
+      - ".github/workflows/supabase_flutter.yaml"
+      - "packages/functions_client/**"
+      - "packages/gotrue/**"
+      - "packages/postgrest/**"
+      - "packages/realtime_client/**"
+      - "packages/storage_client/**"
+      - "packages/supabase/**"
 
   pull_request:
     paths:
-      - 'packages/supabase_flutter/**'
-      - '.github/workflows/supabase_flutter.yaml'
-      - 'packages/functions_client/**'
-      - 'packages/gotrue/**'
-      - 'packages/postgrest/**'
-      - 'packages/realtime_client/**'
-      - 'packages/storage_client/**'
-      - 'packages/supabase/**'
+      - "packages/supabase_flutter/**"
+      - ".github/workflows/supabase_flutter.yaml"
+      - "packages/functions_client/**"
+      - "packages/gotrue/**"
+      - "packages/postgrest/**"
+      - "packages/realtime_client/**"
+      - "packages/storage_client/**"
+      - "packages/supabase/**"
 
 jobs:
   test:
@@ -32,7 +32,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        flutter-version: ['3.10.x', '3.x']
+        flutter-version: ["3.10.x", "3.x"]
 
     defaults:
       run:
@@ -46,12 +46,12 @@ jobs:
 
       - uses: actions/setup-java@v1
         with:
-          java-version: '12.x'
+          java-version: "12.x"
 
       - uses: subosito/flutter-action@v2
         with:
           flutter-version: ${{ matrix.flutter-version }}
-          channel: 'stable'
+          channel: "stable"
 
       - run: flutter --version
 
@@ -74,5 +74,5 @@ jobs:
 
       - name: Run tests with downgraded packages
         run: |
-          flutter pub downgrade
+          flutter pub downgrade app_links
           flutter test --concurrency=1

--- a/.github/workflows/supabase_flutter.yml
+++ b/.github/workflows/supabase_flutter.yml
@@ -71,3 +71,8 @@ jobs:
 
       - name: Run tests
         run: flutter test --concurrency=1
+
+      - name: Run tests with downgraded packages
+        run: |
+          flutter pub downgrade
+          flutter test --concurrency=1

--- a/packages/supabase_flutter/lib/src/supabase_auth.dart
+++ b/packages/supabase_flutter/lib/src/supabase_auth.dart
@@ -189,7 +189,16 @@ class SupabaseAuth with WidgetsBindingObserver {
     _initialDeeplinkIsHandled = true;
 
     try {
-      final uri = await _appLinks.getInitialAppLink();
+      Uri? uri;
+      try {
+        // before app_links 6.0.0
+        uri = await (_appLinks as dynamic).getInitialAppLink();
+      } on NoSuchMethodError catch (_) {
+        // Needed to keep compatible with 5.0.0 and 6.0.0
+        // https://pub.dev/packages/app_links/changelog
+        // after app_links 6.0.0
+        uri = await (_appLinks as dynamic).getInitialLink();
+      }
       if (uri != null) {
         await _handleDeeplink(uri);
       }

--- a/packages/supabase_flutter/pubspec.yaml
+++ b/packages/supabase_flutter/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   flutter: '>=3.0.0'
 
 dependencies:
-  app_links: '>=3.5.0 <6.0.0'
+  app_links: '>=3.5.0 <7.0.0'
   async: ^2.11.0
   crypto: ^3.0.2
   flutter:


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix, dependency version bump

## What is the current behavior?

app_links 6.0.0 is not supported

## What is the new behavior?

5.0.0 is still supported and 6.0.0 now as well, despite the breaking change, by trying both methods with error catching.
Additionally, the supabase_flutter packages is now tested with downgraded packages versions as well.

## Additional context

#915 wanted to drop support for 5.0.0