### PR TITLE
fix(postgrest): Update parameter type of `match()` filter so that null values cannot be passed. 

### DIFF
--- a/packages/postgrest/lib/src/postgrest_filter_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_filter_builder.dart
@@ -66,6 +66,8 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   ///     .select()
   ///     .eq('username', 'supabot');
   /// ```
+  ///
+  /// If you want to filter with null equality, use [isFilter] instead.
   PostgrestFilterBuilder<T> eq(String column, Object value) {
     final Uri url;
     if (value is List) {
@@ -477,9 +479,9 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   ///   'status': 'ONLINE',
   /// });
   /// ```
-  PostgrestFilterBuilder<T> match(Map query) {
+  PostgrestFilterBuilder<T> match(Map<String, Object> query) {
     var url = _url;
-    query.forEach((k, v) => url = appendSearchParams('$k', 'eq.$v', url));
+    query.forEach((k, v) => url = appendSearchParams(k, 'eq.$v', url));
     return copyWithUrl(url);
   }
 }

--- a/packages/postgrest/lib/src/postgrest_filter_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_filter_builder.dart
@@ -479,9 +479,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   ///   'status': 'ONLINE',
   /// });
   /// ```
-  PostgrestFilterBuilder<T> match(Map query) {
-    assert(!query.values.contains(null),
-        '`null` equality does not work with match. Use isFilter instead.');
+  PostgrestFilterBuilder<T> match(Map<String, Object> query) {
     var url = _url;
     query.forEach((k, v) => url = appendSearchParams(k, 'eq.$v', url));
     return copyWithUrl(url);

--- a/packages/postgrest/lib/src/postgrest_filter_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_filter_builder.dart
@@ -67,7 +67,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   ///     .eq('username', 'supabot');
   /// ```
   ///
-  /// If you want to filter with null equality, use [isFilter] instead.
+  /// For `null` equality, use [isFilter] instead.
   PostgrestFilterBuilder<T> eq(String column, Object value) {
     final Uri url;
     if (value is List) {
@@ -479,7 +479,9 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   ///   'status': 'ONLINE',
   /// });
   /// ```
-  PostgrestFilterBuilder<T> match(Map<String, Object> query) {
+  PostgrestFilterBuilder<T> match(Map query) {
+    assert(!query.values.contains(null),
+        '`null` equality does not work with match. Use isFilter instead.');
     var url = _url;
     query.forEach((k, v) => url = appendSearchParams(k, 'eq.$v', url));
     return copyWithUrl(url);


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes https://github.com/supabase/supabase-flutter/issues/917

## What is the current behavior?

Currently, users can pass `null` to `match()` filter. 

## What is the new behavior?

Users will not be able to pass `null` to `match()`. 