### PR TITLE
fix(postgrest): Update parameter type of `isFilter()` to only allow boolean or null

### DIFF
--- a/packages/postgrest/lib/src/postgrest_filter_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_filter_builder.dart
@@ -228,7 +228,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   ///     .isFilter('data', null);
   /// ```
   // ignore: non_constant_identifier_names
-  PostgrestFilterBuilder<T> isFilter(String column, Object? value) {
+  PostgrestFilterBuilder<T> isFilter(String column, bool? value) {
     return copyWithUrl(appendSearchParams(column, 'is.$value'));
   }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes https://github.com/supabase/supabase-flutter/issues/917

## What is the current behavior?

Currently any object can be passed as the value parameter of `isFilter()`

## What is the new behavior?

Only null and boolean values can be passed to `isFilter()`