### PR TITLE
feat(goture): Allow OAuthProvider.kakao for signInWithIdToken

### DIFF
--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -373,7 +373,7 @@ class GoTrueClient {
 
   /// Allows signing in with an ID token issued by certain supported providers.
   /// The [idToken] is verified for validity and a new session is established.
-  /// This method of signing in only supports [OAuthProvider.google] or [OAuthProvider.apple].
+  /// This method of signing in only supports [OAuthProvider.google], [OAuthProvider.apple] or [OAuthProvider.kakao].
   ///
   /// If the ID token contains an `at_hash` claim, then [accessToken] must be
   /// provided to compare its hash with the value in the ID token.
@@ -395,9 +395,11 @@ class GoTrueClient {
   }) async {
     _removeSession();
 
-    if (provider != OAuthProvider.google && provider != OAuthProvider.apple) {
-      throw AuthException('Provider must either be '
-          '${OAuthProvider.google.name} or ${OAuthProvider.apple.name}.');
+    if (provider != OAuthProvider.google &&
+        provider != OAuthProvider.apple &&
+        provider != OAuthProvider.kakao) {
+      throw AuthException('Provider must be '
+          '${OAuthProvider.google.name}, ${OAuthProvider.apple.name} or ${OAuthProvider.kakao.name}.');
     }
 
     final response = await _fetch.request(


### PR DESCRIPTION
## What kind of change does this PR introduce?

Allow OAuthProvider.kakao for signInWithIdToken in gotrue_client

## What is the current behavior?

Only google and apple are allowed.

## What is the new behavior?

https://github.com/supabase/auth/pull/1381
Since supabase.auth already allows an OIDC with kakao, the client should accept the OAuthProvider.kakao with signInWithIdToken