### PR TITLE
chore: Internal packages are now imported with version specified

### DIFF
--- a/packages/functions_client/pubspec.yaml
+++ b/packages/functions_client/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 
 dependencies:
   http: '>=0.13.4 <2.0.0'
-  yet_another_json_isolate: ^2.0.0
+  yet_another_json_isolate: 2.0.0
 
 dev_dependencies:
   lints: ^2.1.1

--- a/packages/postgrest/pubspec.yaml
+++ b/packages/postgrest/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 
 dependencies:
   http: '>=0.13.0 <2.0.0'
-  yet_another_json_isolate: ^2.0.0
+  yet_another_json_isolate: 2.0.0
   meta: ^1.9.1
 
 dev_dependencies:

--- a/packages/supabase/pubspec.yaml
+++ b/packages/supabase/pubspec.yaml
@@ -9,14 +9,14 @@ environment:
   sdk: '>=3.0.0 <4.0.0'
 
 dependencies:
-  functions_client: ^2.2.0
-  gotrue: ^2.7.0
+  functions_client: 2.2.0
+  gotrue: 2.7.0
   http: '>=0.13.5 <2.0.0'
-  postgrest: ^2.1.2
-  realtime_client: ^2.0.4
-  storage_client: ^2.0.1
+  postgrest: 2.1.2
+  realtime_client: 2.0.4
+  storage_client: 2.0.1
   rxdart: ^0.27.5
-  yet_another_json_isolate: ^2.0.0
+  yet_another_json_isolate: 2.0.0
 
 dev_dependencies:
   lints: ^2.1.1

--- a/packages/supabase_flutter/pubspec.yaml
+++ b/packages/supabase_flutter/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
     sdk: flutter
   http: '>=0.13.4 <2.0.0'
   meta: ^1.7.0
-  supabase: ^2.1.3
+  supabase: 2.1.3
   url_launcher: ^6.1.2
   path_provider: ^2.0.0
   shared_preferences: ^2.0.0


### PR DESCRIPTION
## What kind of change does this PR introduce?

Instead of specifying the version range like `"^2.0.0"`, the internal packages are pinned to specific versions. 

supabase-js started doing this recently as well. With this, we can now the versions of the sub-libraries just by obtaining the supabase-flutter version, and it also helps with preventing accidental breaking change affecting a wider range if there were to be one. 