### PR TITLE
feat: Allow setting `timeout` of `RealtimeClient`.

### DIFF
--- a/packages/realtime_client/lib/realtime_client.dart
+++ b/packages/realtime_client/lib/realtime_client.dart
@@ -1,4 +1,4 @@
-export 'src/constants.dart' show RealtimeLogLevel;
+export 'src/constants.dart' show RealtimeConstants, RealtimeLogLevel;
 export 'src/realtime_channel.dart';
 export 'src/realtime_client.dart';
 export 'src/realtime_presence.dart';

--- a/packages/realtime_client/lib/src/constants.dart
+++ b/packages/realtime_client/lib/src/constants.dart
@@ -9,6 +9,8 @@ class Constants {
   };
 }
 
+typedef RealtimeConstants = Constants;
+
 enum SocketStates {
   /// Client attempting to establish a connection
   connecting,

--- a/packages/supabase/lib/src/realtime_client_options.dart
+++ b/packages/supabase/lib/src/realtime_client_options.dart
@@ -14,9 +14,13 @@ class RealtimeClientOptions {
   /// Level of realtime server logs to to be logged
   final RealtimeLogLevel? logLevel;
 
+  /// the timeout to trigger push timeouts
+  final Duration? timeout;
+
   /// {@macro realtime_client_options}
   const RealtimeClientOptions({
     this.eventsPerSecond,
     this.logLevel,
+    this.timeout,
   });
 }

--- a/packages/supabase/lib/src/supabase_client.dart
+++ b/packages/supabase/lib/src/supabase_client.dart
@@ -263,6 +263,7 @@ class SupabaseClient {
       headers: {'apikey': _supabaseKey, ...headers},
       logLevel: options.logLevel,
       httpClient: _authHttpClient,
+      timeout: options.timeout ?? RealtimeConstants.defaultTimeout,
     );
   }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Allow the ctor `SupabaseClient` to set `timeout` to a `RealtimeClient`.

## What is the current behavior?

Due to the fact the `timeout` is a final field in `RealtimeClient`, we cannot change its value after the `RealtimeClient` is created, and because the `RealtimeClient` is created in the ctor of `SupabaseClient`, there is no way for users to set the timeout.

## What is the new behavior?

The new behavior allow us to set the timeout of the `RealtimeClient` like this:
``` dart
final SupabaseClient supabase = SupabaseClient(
  'https://your.supabase.address/',
  'your_anon_key',
  realtimeClientOptions: RealtimeClientOptions(timeout: Duration(minutes: 1)),
);
```

## Additional context

My app is connecting Supabase through Tor proxy. It's normal to cost 10 or more seconds to build a WebSocket connection. However, the current default timeout of `RealtimeClient` is 10 seconds, which is too short, and very often leads to result of no WebSocket connection is created, and therefore no realtime feature is provided.