### PR TITLE
fix(gotrue): Signing in does not remove the session unless the operation succeeds.

### DIFF
--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -140,8 +140,6 @@ class GoTrueClient {
     Map<String, dynamic>? data,
     String? captchaToken,
   }) async {
-    _removeSession();
-
     final response = await _fetch.request(
       '$_url/signup',
       RequestMethodType.post,
@@ -193,8 +191,6 @@ class GoTrueClient {
   }) async {
     assert((email != null && phone == null) || (email == null && phone != null),
         'You must provide either an email or phone number');
-
-    _removeSession();
 
     late final Map<String, dynamic> response;
 
@@ -261,8 +257,6 @@ class GoTrueClient {
     required String password,
     String? captchaToken,
   }) async {
-    _removeSession();
-
     late final Map<String, dynamic> response;
 
     if (email != null) {
@@ -315,7 +309,6 @@ class GoTrueClient {
     String? scopes,
     Map<String, String>? queryParams,
   }) async {
-    _removeSession();
     return _getUrlForProvider(
       provider,
       url: '$_url/authorize',
@@ -393,8 +386,6 @@ class GoTrueClient {
     String? nonce,
     String? captchaToken,
   }) async {
-    _removeSession();
-
     if (provider != OAuthProvider.google &&
         provider != OAuthProvider.apple &&
         provider != OAuthProvider.kakao) {
@@ -458,8 +449,6 @@ class GoTrueClient {
     String? captchaToken,
     OtpChannel channel = OtpChannel.sms,
   }) async {
-    _removeSession();
-
     if (email != null) {
       String? codeChallenge;
       if (_flowType == AuthFlowType.pkce) {
@@ -530,10 +519,6 @@ class GoTrueClient {
     assert((email != null && phone == null) || (email == null && phone != null),
         '`email` or `phone` needs to be specified.');
 
-    if (type != OtpType.emailChange && type != OtpType.phoneChange) {
-      _removeSession();
-    }
-
     final body = {
       if (email != null) 'email': email,
       if (phone != null) 'phone': phone,
@@ -584,7 +569,6 @@ class GoTrueClient {
       'providerId or domain has to be provided.',
     );
 
-    _removeSession();
     String? codeChallenge;
     String? codeChallengeMethod;
     if (_flowType == AuthFlowType.pkce) {
@@ -674,10 +658,6 @@ class GoTrueClient {
     if (phone != null) {
       assert([OtpType.sms, OtpType.phoneChange].contains(type),
           'phone must be provided for type ${type.name}');
-    }
-
-    if (type != OtpType.emailChange && type != OtpType.phoneChange) {
-      _removeSession();
     }
 
     final body = {
@@ -847,7 +827,6 @@ class GoTrueClient {
     final accessToken = currentSession?.accessToken;
 
     if (scope != SignOutScope.others) {
-      _removeSession();
       await _asyncStorage?.removeItem(
           key: '${Constants.defaultStorageKey}-code-verifier');
       notifyAllSubscribers(AuthChangeEvent.signedOut);
@@ -1135,11 +1114,6 @@ class GoTrueClient {
     _currentUser = session.user;
   }
 
-  void _removeSession() {
-    _currentSession = null;
-    _currentUser = null;
-  }
-
   /// Generates a new JWT.
   ///
   /// To prevent multiple simultaneous requests it catches an already ongoing request by using the global [_refreshTokenCompleter].
@@ -1174,7 +1148,6 @@ class GoTrueClient {
       return data;
     } on AuthException catch (error, stack) {
       if (error is! AuthRetryableFetchException) {
-        _removeSession();
         notifyAllSubscribers(AuthChangeEvent.signedOut);
       } else {
         _onAuthStateChangeController.addError(error, stack);

--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -827,8 +827,7 @@ class GoTrueClient {
     final accessToken = currentSession?.accessToken;
 
     if (scope != SignOutScope.others) {
-      _currentSession = null;
-      _currentUser = null;
+      _removeSession();
       await _asyncStorage?.removeItem(
           key: '${Constants.defaultStorageKey}-code-verifier');
       notifyAllSubscribers(AuthChangeEvent.signedOut);
@@ -1116,6 +1115,11 @@ class GoTrueClient {
     _currentUser = session.user;
   }
 
+  void _removeSession() {
+    _currentSession = null;
+    _currentUser = null;
+  }
+
   /// Generates a new JWT.
   ///
   /// To prevent multiple simultaneous requests it catches an already ongoing request by using the global [_refreshTokenCompleter].
@@ -1150,6 +1154,7 @@ class GoTrueClient {
       return data;
     } on AuthException catch (error, stack) {
       if (error is! AuthRetryableFetchException) {
+        _removeSession();
         notifyAllSubscribers(AuthChangeEvent.signedOut);
       } else {
         _onAuthStateChangeController.addError(error, stack);

--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -827,6 +827,8 @@ class GoTrueClient {
     final accessToken = currentSession?.accessToken;
 
     if (scope != SignOutScope.others) {
+      _currentSession = null;
+      _currentUser = null;
       await _asyncStorage?.removeItem(
           key: '${Constants.defaultStorageKey}-code-verifier');
       notifyAllSubscribers(AuthChangeEvent.signedOut);


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Currently, the SDK removes the session whenever a user tries to sign-in / sign-up. If the operation fails, the user is signed out from the original session they had. This PR fixes the behavior so that the session is not removed.

## What is the new behavior?

The user's session is not removed at the beginning of calling sign-in / sign-up methods, and they will keep the existing session if the sign-in / sign-up operation fails. 

## Additional context

JS PR: https://github.com/supabase/auth-js/pull/915
