### PR TITLE
fix: Returning multiple rows on a query with `.single()` throws the proper error.

### DIFF
--- a/infra/postgrest/docker-compose.yml
+++ b/infra/postgrest/docker-compose.yml
@@ -3,7 +3,7 @@
 version: '3'
 services:
   rest:
-    image: postgrest/postgrest:v11.2.2
+    image: postgrest/postgrest:v12.0.2
     ports:
       - '3000:3000'
     environment:

--- a/packages/postgrest/test/transforms_test.dart
+++ b/packages/postgrest/test/transforms_test.dart
@@ -222,6 +222,18 @@ void main() {
     expect(res['status'], 'ONLINE');
   });
 
+  test('Adding single() should throw if multiple rows are returned.', () async {
+    try {
+      await postgrest.from('users').select().single();
+      fail('.single() with multiple rows returned did not throw.');
+    } on PostgrestException catch (error) {
+      expect(error.code, 'PGRST116');
+    } catch (error) {
+      fail(
+          '.single() with multiple rows returned threw ${error.runtimeType} instead of PostgrestException.');
+    }
+  });
+
   test('single with count', () async {
     final res = await postgrest
         .from('users')


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes https://github.com/supabase/supabase-flutter/issues/921

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
