### PR TITLE
fix: Store actual error in AuthException

### DIFF
--- a/packages/gotrue/lib/src/fetch.dart
+++ b/packages/gotrue/lib/src/fetch.dart
@@ -30,13 +30,16 @@ class GotrueFetch {
 
   AuthException _handleError(dynamic error) {
     if (error is! Response) {
-      throw AuthRetryableFetchException();
+      throw AuthRetryableFetchException(message: error.toString());
     }
 
     // If the status is 500 or above, it's likely a server error,
     // and can be retried.
     if (error.statusCode >= 500) {
-      throw AuthRetryableFetchException();
+      throw AuthRetryableFetchException(
+        message: error.body,
+        statusCode: error.statusCode.toString(),
+      );
     }
 
     final dynamic data;
@@ -134,7 +137,7 @@ class GotrueFetch {
       }
     } catch (e) {
       // fetch failed, likely due to a network or CORS error
-      throw AuthRetryableFetchException();
+      throw AuthRetryableFetchException(message: e.toString());
     }
 
     if (!isSuccessStatusCode(response.statusCode)) {

--- a/packages/gotrue/lib/src/types/auth_exception.dart
+++ b/packages/gotrue/lib/src/types/auth_exception.dart
@@ -31,7 +31,10 @@ class AuthSessionMissingException extends AuthException {
 }
 
 class AuthRetryableFetchException extends AuthException {
-  AuthRetryableFetchException() : super('AuthRetryableFetchError');
+  AuthRetryableFetchException({
+    String message = 'AuthRetryableFetchException',
+    super.statusCode,
+  }) : super(message);
 }
 
 class AuthApiException extends AuthException {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?
`
When e.g. an http response with status code 500 is received, an `AuthRetryableFetchException` is thrown without contaning the actual error.

## What is the new behavior?

I've added the `message` and `statusCode` to the constructor.

## Additional context

#902
