### PR TITLE
fix: make auth state change callbacks available in initialisation options (and fix duplicate initial deeplink handling)

### DIFF
--- a/packages/supabase_flutter/lib/src/flutter_go_true_client_options.dart
+++ b/packages/supabase_flutter/lib/src/flutter_go_true_client_options.dart
@@ -3,6 +3,13 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 class FlutterAuthClientOptions extends AuthClientOptions {
   final LocalStorage? localStorage;
 
+  /// Callback for receiving state change updates from the auth subscription.
+  final void Function(AuthState data)? onAuthStateChange;
+
+  /// Callback for receiving errors from the auth state change subscription.
+  /// Both the error and the stacktrace will be given as arguments.
+  final Function? onAuthError;
+
   /// If true, the client will start the deep link observer and obtain sessions
   /// when a valid URI is detected.
   final bool detectSessionInUri;
@@ -12,6 +19,8 @@ class FlutterAuthClientOptions extends AuthClientOptions {
     super.autoRefreshToken,
     super.pkceAsyncStorage,
     this.localStorage,
+    this.onAuthStateChange,
+    this.onAuthError,
     this.detectSessionInUri = true,
   });
 
@@ -21,6 +30,8 @@ class FlutterAuthClientOptions extends AuthClientOptions {
     LocalStorage? localStorage,
     GotrueAsyncStorage? pkceAsyncStorage,
     bool? detectSessionInUri,
+    void Function(AuthState data)? onAuthStateChange,
+    Function? onAuthError,
   }) {
     return FlutterAuthClientOptions(
       authFlowType: authFlowType ?? this.authFlowType,
@@ -28,6 +39,8 @@ class FlutterAuthClientOptions extends AuthClientOptions {
       localStorage: localStorage ?? this.localStorage,
       pkceAsyncStorage: pkceAsyncStorage ?? this.pkceAsyncStorage,
       detectSessionInUri: detectSessionInUri ?? this.detectSessionInUri,
+      onAuthStateChange: onAuthStateChange ?? this.onAuthStateChange,
+      onAuthError: onAuthError ?? this.onAuthError,
     );
   }
 }

--- a/packages/supabase_flutter/lib/src/supabase_auth.dart
+++ b/packages/supabase_flutter/lib/src/supabase_auth.dart
@@ -194,10 +194,12 @@ class SupabaseAuth with WidgetsBindingObserver {
         // before app_links 6.0.0
         uri = await (_appLinks as dynamic).getInitialAppLink();
       } on NoSuchMethodError catch (_) {
-        // Needed to keep compatible with 5.0.0 and 6.0.0
+        // The AppLinks package contains the initial link in the uriLinkStream
+        // starting from version 6.0.0. Before this version, getting the
+        // initial link was done with getInitialAppLink. Being in this catch
+        // handler means we are in at least version 6.0.0, meaning we do not
+        // need to handle the initial link manually.
         // https://pub.dev/packages/app_links/changelog
-        // after app_links 6.0.0
-        uri = await (_appLinks as dynamic).getInitialLink();
       }
       if (uri != null) {
         await _handleDeeplink(uri);

--- a/packages/supabase_flutter/lib/src/supabase_auth.dart
+++ b/packages/supabase_flutter/lib/src/supabase_auth.dart
@@ -44,9 +44,21 @@ class SupabaseAuth with WidgetsBindingObserver {
     _authSubscription = Supabase.instance.client.auth.onAuthStateChange.listen(
       (data) {
         _onAuthStateChange(data.event, data.session);
+
+        // The options can contain a callback for auth state changes
+        final optionsStateChangeCallback = options.onAuthStateChange;
+        if (optionsStateChangeCallback != null) {
+          optionsStateChangeCallback(data);
+        }
       },
       onError: (error, stackTrace) {
         Supabase.instance.log(error.toString(), stackTrace);
+
+        // The options can contain a callback for auth state changes
+        final optionsErrorCallback = options.onAuthError;
+        if (optionsErrorCallback != null) {
+          optionsErrorCallback(error, stackTrace);
+        }
       },
     );
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

This change allows giving callbacks for both data and errors from auth state changes. These listeners are applied in the initialisation of `SupabaseAuth`. 

In practice, this allows getting state change updates that happen _during_ the initialisation of Supabase.

Secondly, this fixes handling the initial deeplink multiple times when using AppLinks >= 6.0.0. In that version a change was made such that the initial deeplink is also exposed in the subscription that was already in place here.

## What is the current behavior?

It is currently not possible to get updates from the subscription during the initialisation phase. Trying to assign a listener to the subscription fails because initialisation has not happened yet. 

See #937 for elaborate information and what issue this actually causes: failing to observe `passwordRecovery` events from the initial deeplink. 

## What is the new behavior?

This adds options for adding listeners to the initialisation, there already was a subscription, now the handlers for both `onData` and `onError` also optionally call those listeners. This is commit 1fc399e

To solve the solution of duplicate initial deeplink handling, we can simply remove the handling when we know that we are using AppLinks >= 6.0.0. This is commit 494f371

## Additional context

I don't think this is the cleanest solution, but also didn't see a good way of getting a listener attached this early in the process. I especially dislike that there are now multiple ways you can attach such as listener. However, I think disallowing the original subscribing solution is bad because, (1) it is a breaking change and (2) it seems like a legitimate use case to me to subscribe after the initialisation phase, depending on what people are trying to do. 
