### PR TITLE
fix: Add magiclink as authenticaiton method in mfa

### DIFF
--- a/packages/gotrue/lib/src/types/mfa.dart
+++ b/packages/gotrue/lib/src/types/mfa.dart
@@ -257,7 +257,7 @@ class AuthMFAGetAuthenticatorAssuranceLevelResponse {
   });
 }
 
-enum AMRMethod { password, otp, oauth, totp }
+enum AMRMethod { password, otp, oauth, totp, magiclink }
 
 /// An authentication method reference (AMR) entry.
 ///


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The `magiclink` mfa type is not recognized. 

## What is the new behavior?

The `magiclink` type is properly parsed.

## Additional context
I'm unsure if this is the correct way to fix this. This doesn't match with the typescript types from auth-js: https://github.com/supabase/auth-js/blob/a80f343abd133521faa07b90ccea15525b933238/src/lib/types.ts#L267 It contains `mfa/totp` which we aren't able to parse as well.

close #966
