### PR TITLE
fix: Add error_code from url to AuthException

### DIFF
--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -756,8 +756,9 @@ class GoTrueClient {
     }
 
     final errorDescription = url.queryParameters['error_description'];
+    final errorCode = url.queryParameters['error_code'];
     if (errorDescription != null) {
-      throw AuthException(errorDescription);
+      throw AuthException(errorDescription, statusCode: errorCode);
     }
 
     if (_flowType == AuthFlowType.pkce) {

--- a/packages/gotrue/test/client_test.dart
+++ b/packages/gotrue/test/client_test.dart
@@ -137,6 +137,7 @@ void main() {
         fail('getSessionFromUrl did not throw exception');
       } on AuthException catch (error) {
         expect(error.message, errorMessage);
+        expect(error.statusCode, '401');
       } catch (error) {
         fail(
             'getSessionFromUrl threw ${error.runtimeType} instead of AuthException');


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The `error_code` from the url response is ignored and not passed to the `AuthException`.

## What is the new behavior?

The `error_code` field is now set to `statusCode` from `AuthExcetption`.

## Additional context

close #964
