### PR TITLE
feat(realtime_client): Add support for authorized realtime channels with broadcast and presence.

### DIFF
--- a/packages/realtime_client/lib/src/realtime_channel.dart
+++ b/packages/realtime_client/lib/src/realtime_channel.dart
@@ -491,8 +491,7 @@ class RealtimeChannel {
     if (!canPush && type == RealtimeListenTypes.broadcast) {
       final headers = <String, String>{
         'Content-Type': 'application/json',
-        if (socket.params['apikey'] != null)
-          'apikey': socket.params['apikey']!,
+        if (socket.params['apikey'] != null) 'apikey': socket.params['apikey']!,
         ...socket.headers,
         if (socket.accessToken != null)
           'Authorization': 'Bearer ${socket.accessToken}',

--- a/packages/realtime_client/lib/src/realtime_channel.dart
+++ b/packages/realtime_client/lib/src/realtime_channel.dart
@@ -491,7 +491,8 @@ class RealtimeChannel {
     if (!canPush && type == RealtimeListenTypes.broadcast) {
       final headers = <String, String>{
         'Content-Type': 'application/json',
-        'apikey': socket.params['apikey'] ?? '',
+        if (socket.params['apikey'] != null)
+          'apikey': socket.params['apikey']!,
         ...socket.headers,
         'Authorization':
             socket.accessToken != null ? 'Bearer ${socket.accessToken}' : '',

--- a/packages/realtime_client/lib/src/realtime_channel.dart
+++ b/packages/realtime_client/lib/src/realtime_channel.dart
@@ -494,8 +494,8 @@ class RealtimeChannel {
         if (socket.params['apikey'] != null)
           'apikey': socket.params['apikey']!,
         ...socket.headers,
-        'Authorization':
-            socket.accessToken != null ? 'Bearer ${socket.accessToken}' : '',
+        if (socket.accessToken != null)
+          'Authorization': 'Bearer ${socket.accessToken}',
       };
       final body = {
         'messages': [

--- a/packages/realtime_client/lib/src/realtime_channel.dart
+++ b/packages/realtime_client/lib/src/realtime_channel.dart
@@ -32,6 +32,7 @@ class RealtimeChannel {
   @internal
   final RealtimeClient socket;
 
+  /// Defines if the channel is private or not and if RLS policies will be used to check data
   late final bool _private;
 
   RealtimeChannel(

--- a/packages/realtime_client/lib/src/realtime_client.dart
+++ b/packages/realtime_client/lib/src/realtime_client.dart
@@ -51,7 +51,7 @@ class RealtimeClient {
   String? accessToken;
   List<RealtimeChannel> channels = [];
   final String endPoint;
-  final String httpEndpoint;
+
   final Map<String, String> headers;
   final Map<String, dynamic> params;
   final Duration timeout;
@@ -117,7 +117,6 @@ class RealtimeClient {
                   logLevel == null ? null : {'log_level': logLevel.name},
             )
             .toString(),
-        httpEndpoint = httpEndpointURL(endPoint),
         headers = {
           ...Constants.defaultHeaders,
           if (headers != null) ...headers,

--- a/packages/realtime_client/lib/src/realtime_client.dart
+++ b/packages/realtime_client/lib/src/realtime_client.dart
@@ -51,6 +51,7 @@ class RealtimeClient {
   String? accessToken;
   List<RealtimeChannel> channels = [];
   final String endPoint;
+  final String httpEndpoint;
   final Map<String, String> headers;
   final Map<String, dynamic> params;
   final Duration timeout;
@@ -85,6 +86,7 @@ class RealtimeClient {
   /// Initializes the Socket
   ///
   /// `endPoint` The string WebSocket endpoint, ie, "ws://example.com/socket", "wss://example.com", "/socket" (inherited host & protocol)
+  /// `httpEndpoint` The string HTTP endpoint, ie, "https://example.com", "/" (inherited host & protocol)
   /// `transport` The Websocket Transport, for example WebSocket.
   /// `timeout` The default timeout in milliseconds to trigger push timeouts.
   /// `params` The optional params to pass when connecting.
@@ -115,6 +117,7 @@ class RealtimeClient {
                   logLevel == null ? null : {'log_level': logLevel.name},
             )
             .toString(),
+        httpEndpoint = httpEndpointURL(endPoint),
         headers = {
           ...Constants.defaultHeaders,
           if (headers != null) ...headers,

--- a/packages/realtime_client/lib/src/transformers.dart
+++ b/packages/realtime_client/lib/src/transformers.dart
@@ -332,3 +332,20 @@ Map<String, Map<String, dynamic>> getPayloadRecords(
 
   return records;
 }
+
+/// Converts a WebSocket URL to an HTTP URL.
+String httpEndpointURL(String socketUrl) {
+  var url = socketUrl;
+
+  // Replace 'ws' or 'wss' with 'http' or 'https' respectively
+  url = url.replaceFirst(RegExp(r'^ws', caseSensitive: false), 'http');
+
+  // Remove WebSocket-specific endings
+  url = url.replaceFirst(
+    RegExp(r'(/socket/websocket|/socket|/websocket)/?$', caseSensitive: false),
+    '',
+  );
+
+  // Remove trailing slashes
+  return url.replaceAll(RegExp(r'/+$'), '');
+}

--- a/packages/realtime_client/lib/src/types.dart
+++ b/packages/realtime_client/lib/src/types.dart
@@ -408,17 +408,3 @@ class SinglePresenceState {
   @override
   String toString() => 'PresenceState(key: $key, presences: $presences)';
 }
-
-class Channel {
-  final String name;
-  final String inserted_at;
-  final String updated_at;
-  final int id;
-
-  Channel({
-    required this.name,
-    required this.inserted_at,
-    required this.updated_at,
-    required this.id,
-  });
-}

--- a/packages/realtime_client/lib/src/types.dart
+++ b/packages/realtime_client/lib/src/types.dart
@@ -148,7 +148,7 @@ class RealtimeChannelConfig {
   /// [key] option is used to track presence payload across clients
   final String key;
 
-  /// defines if the channel is private or not and if RLS policies will be used to check data
+  /// Defines if the channel is private or not and if RLS policies will be used to check data
   final bool private;
 
   const RealtimeChannelConfig({

--- a/packages/realtime_client/lib/src/types.dart
+++ b/packages/realtime_client/lib/src/types.dart
@@ -148,10 +148,14 @@ class RealtimeChannelConfig {
   /// [key] option is used to track presence payload across clients
   final String key;
 
+  /// defines if the channel is private or not and if RLS policies will be used to check data
+  final bool private;
+
   const RealtimeChannelConfig({
     this.ack = false,
     this.self = false,
     this.key = '',
+    this.private = false,
   });
 
   Map<String, dynamic> toMap() {
@@ -164,6 +168,7 @@ class RealtimeChannelConfig {
         'presence': {
           'key': key,
         },
+        'private': private,
       }
     };
   }
@@ -402,4 +407,18 @@ class SinglePresenceState {
 
   @override
   String toString() => 'PresenceState(key: $key, presences: $presences)';
+}
+
+class Channel {
+  final String name;
+  final String inserted_at;
+  final String updated_at;
+  final int id;
+
+  Channel({
+    required this.name,
+    required this.inserted_at,
+    required this.updated_at,
+    required this.id,
+  });
 }

--- a/packages/realtime_client/test/socket_test.dart
+++ b/packages/realtime_client/test/socket_test.dart
@@ -287,7 +287,8 @@ void main() {
       expect(channel.params, {
         'config': {
           'broadcast': {'ack': false, 'self': false},
-          'presence': {'key': ''}
+          'presence': {'key': ''},
+          'private': false,
         }
       });
     });

--- a/packages/realtime_client/test/transformers_test.dart
+++ b/packages/realtime_client/test/transformers_test.dart
@@ -234,4 +234,19 @@ void main() {
       expect(enrichedPayload, expectedMap);
     });
   });
+
+  group('httpEndpointURL', () {
+    test('Converts a hosted Supabase WS URL', () {
+      expect(
+        httpEndpointURL('wss://example.supabase.co/realtime/v1'),
+        equals('https://example.supabase.co/realtime/v1'),
+      );
+    });
+    test('Converts a custom domain WS URL', () {
+      expect(
+        httpEndpointURL('wss://custom-domain.com/realtime/v1'),
+        equals('https://custom-domain.com/realtime/v1'),
+      );
+    });
+  });
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Adds support for authorization on broadcast and presence

## What is the current behavior?

Authorization is not supported on broadcast or presence allowing anyone to listen to its messages. 

## What is the new behavior?

Realtime channel created with `private: true` will respect RLS. Read more on the [official docs](https://supabase.com/docs/guides/realtime/authorization).

```dart
channel = supabase.channel(
  'my_channel',
  opts: const RealtimeChannelConfig(private: true),
);
```

Related JS PRs

- https://github.com/supabase/realtime-js/pull/408
- https://github.com/supabase/realtime-js/pull/414