### PR TITLE
fix(gotrue): Ensure a single `initialSession` is emitted.

### DIFF
--- a/packages/supabase_flutter/lib/src/supabase_auth.dart
+++ b/packages/supabase_flutter/lib/src/supabase_auth.dart
@@ -199,7 +199,12 @@ class SupabaseAuth with WidgetsBindingObserver {
         // Needed to keep compatible with 5.0.0 and 6.0.0
         // https://pub.dev/packages/app_links/changelog
         // after app_links 6.0.0
-        uri = await (_appLinks as dynamic).getInitialUri();
+        //
+        // app_links claims that the initial link will be included in the
+        // `uriLinkStream`, but that is not the case for web
+        if (kIsWeb) {
+          uri = await (_appLinks as dynamic).getInitialLink();
+        }
       }
       if (uri != null) {
         await _handleDeeplink(uri);

--- a/packages/supabase_flutter/lib/src/supabase_auth.dart
+++ b/packages/supabase_flutter/lib/src/supabase_auth.dart
@@ -196,9 +196,11 @@ class SupabaseAuth with WidgetsBindingObserver {
         // before app_links 6.0.0
         uri = await (_appLinks as dynamic).getInitialAppLink();
       } on NoSuchMethodError catch (_) {
-        // Needed to keep compatible with 5.0.0 and 6.0.0
-        // https://pub.dev/packages/app_links/changelog
-        // after app_links 6.0.0
+        // The AppLinks package contains the initial link in the uriLinkStream
+        // starting from version 6.0.0. Before this version, getting the
+        // initial link was done with getInitialAppLink. Being in this catch
+        // handler means we are in at least version 6.0.0, meaning we do not
+        // need to handle the initial link manually.
         //
         // app_links claims that the initial link will be included in the
         // `uriLinkStream`, but that is not the case for web


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixing a bug where two `initialSession` is emitted. Also fixing a bug where deeplink isn't handled on the web.

Closes https://github.com/supabase/supabase-flutter/issues/937
Closes https://github.com/supabase/supabase-flutter/issues/974