### PR TITLE
fix: Add error messages for when the session or expiresAt was missing while making API requests. 

### DIFF
--- a/packages/supabase/lib/src/auth_http_client.dart
+++ b/packages/supabase/lib/src/auth_http_client.dart
@@ -14,23 +14,15 @@ class AuthHttpClient extends BaseClient {
       try {
         await _auth.refreshSession();
       } catch (error) {
-        final session = _auth.currentSession;
-        if (session == null) {
-          // No session to refresh.
-          throw AuthException('No session to make the API request.');
-        }
-        final expiresAt = session.expiresAt;
-        if (expiresAt == null) {
-          // No expiry time to refresh.
-          throw AuthException('Session does not contain exp claim.');
-        }
-
-        // Failed to refresh the token.
-        final isExpiredWithoutMargin = DateTime.now()
-            .isAfter(DateTime.fromMillisecondsSinceEpoch(expiresAt * 1000));
-        if (isExpiredWithoutMargin) {
-          // Throw the error instead of making an API request with an expired token.
-          rethrow;
+        final expiresAt = _auth.currentSession?.expiresAt;
+        if (expiresAt != null) {
+          // Failed to refresh the token.
+          final isExpiredWithoutMargin = DateTime.now()
+              .isAfter(DateTime.fromMillisecondsSinceEpoch(expiresAt * 1000));
+          if (isExpiredWithoutMargin) {
+            // Throw the error instead of making an API request with an expired token.
+            rethrow;
+          }
         }
       }
     }

--- a/packages/supabase/lib/src/auth_http_client.dart
+++ b/packages/supabase/lib/src/auth_http_client.dart
@@ -14,10 +14,20 @@ class AuthHttpClient extends BaseClient {
       try {
         await _auth.refreshSession();
       } catch (error) {
+        final session = _auth.currentSession;
+        if (session == null) {
+          // No session to refresh.
+          throw AuthException('No session to make the API request.');
+        }
+        final expiresAt = session.expiresAt;
+        if (expiresAt == null) {
+          // No expiry time to refresh.
+          throw AuthException('Session does not contain exp claim.');
+        }
+
         // Failed to refresh the token.
-        final isExpiredWithoutMargin = DateTime.now().isAfter(
-            DateTime.fromMillisecondsSinceEpoch(
-                _auth.currentSession!.expiresAt! * 1000));
+        final isExpiredWithoutMargin = DateTime.now()
+            .isAfter(DateTime.fromMillisecondsSinceEpoch(expiresAt * 1000));
         if (isExpiredWithoutMargin) {
           // Throw the error instead of making an API request with an expired token.
           rethrow;


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR  properly handles null session and null `expiresAt` for a slim chance of them being null while making HTTP requests. 

Closes https://github.com/supabase/supabase-flutter/issues/969