### PR TITLE
feat: Support MultipartRequest in functions invoke

### DIFF
--- a/packages/functions_client/lib/functions_client.dart
+++ b/packages/functions_client/lib/functions_client.dart
@@ -1,6 +1,6 @@
 library functions_client;
 
-export 'package:http/http.dart' show ByteStream;
+export 'package:http/http.dart' show ByteStream, MultipartFile;
 
 export 'src/functions_client.dart';
 export 'src/types.dart';

--- a/packages/functions_client/lib/src/constants.dart
+++ b/packages/functions_client/lib/src/constants.dart
@@ -2,7 +2,6 @@ import 'package:functions_client/src/version.dart';
 
 class Constants {
   static const defaultHeaders = {
-    'Content-Type': 'application/json',
     'X-Client-Info': 'functions-dart/$version',
   };
 }

--- a/packages/functions_client/lib/src/functions_client.dart
+++ b/packages/functions_client/lib/src/functions_client.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:typed_data';
 
 import 'package:functions_client/src/constants.dart';
 import 'package:functions_client/src/types.dart';
@@ -90,6 +91,14 @@ class FunctionsClient {
       if (headers != null) ...headers
     };
 
+    if (body != null &&
+        (headers == null || headers.containsKey("Content-Type") == false)) {
+      finalHeaders['Content-Type'] = switch (body) {
+        Uint8List() => 'application/octet-stream',
+        String() => 'text/plain',
+        _ => 'application/json',
+      };
+    }
     final http.BaseRequest request;
     if (files != null) {
       assert(

--- a/packages/functions_client/test/custom_http_client.dart
+++ b/packages/functions_client/test/custom_http_client.dart
@@ -13,6 +13,7 @@ class CustomHttpClient extends BaseClient {
   Future<StreamedResponse> send(BaseRequest request) async {
     // Add request to receivedRequests list.
     receivedRequests = receivedRequests..add(request);
+    request.finalize();
 
     if (request.url.path.endsWith("error-function")) {
       //Return custom status code to check for usage of this client.

--- a/packages/functions_client/test/custom_http_client.dart
+++ b/packages/functions_client/test/custom_http_client.dart
@@ -32,8 +32,22 @@ class CustomHttpClient extends BaseClient {
             "Content-Type": "text/event-stream",
           });
     } else {
+      final Stream<List<int>> stream;
+      if (request is MultipartRequest) {
+        stream = Stream.value(
+          utf8.encode(jsonEncode([
+            for (final file in request.files)
+              {
+                "name": file.field,
+                "content": await file.finalize().bytesToString()
+              }
+          ])),
+        );
+      } else {
+        stream = Stream.value(utf8.encode(jsonEncode({"key": "Hello World"})));
+      }
       return StreamedResponse(
-        Stream.value(utf8.encode(jsonEncode({"key": "Hello World"}))),
+        stream,
         200,
         request: request,
         headers: {

--- a/packages/functions_client/test/custom_http_client.dart
+++ b/packages/functions_client/test/custom_http_client.dart
@@ -14,7 +14,7 @@ class CustomHttpClient extends BaseClient {
     // Add request to receivedRequests list.
     receivedRequests = receivedRequests..add(request);
 
-    if (request.url.path.endsWith("function")) {
+    if (request.url.path.endsWith("error-function")) {
       //Return custom status code to check for usage of this client.
       return StreamedResponse(
         Stream.value(utf8.encode(jsonEncode({"key": "Hello World"}))),

--- a/packages/functions_client/test/functions_dart_test.dart
+++ b/packages/functions_client/test/functions_dart_test.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:functions_client/src/functions_client.dart';
 import 'package:functions_client/src/types.dart';
+import 'package:http/http.dart';
 import 'package:test/test.dart';
 import 'package:yet_another_json_isolate/yet_another_json_isolate.dart';
 
@@ -40,6 +41,26 @@ void main() {
 
       expect(request.url.queryParameters, {'key': 'value'});
       expect(res.data, {'key': 'Hello World'});
+      expect(res.status, 200);
+    });
+
+    test('function call with files', () async {
+      final fileName = "file.txt";
+      final fileContent = "Hello World";
+      final res = await functionsCustomHttpClient.invoke(
+        'function1',
+        queryParameters: {'key': 'value'},
+        files: [
+          MultipartFile.fromString(fileName, fileContent),
+        ],
+      );
+
+      final request = customHttpClient.receivedRequests.last;
+
+      expect(request.url.queryParameters, {'key': 'value'});
+      expect(res.data, [
+        {'name': fileName, 'content': fileContent}
+      ]);
       expect(res.status, 200);
     });
 

--- a/packages/functions_client/test/functions_dart_test.dart
+++ b/packages/functions_client/test/functions_dart_test.dart
@@ -29,6 +29,8 @@ void main() {
 
     test('function call', () async {
       final res = await functionsCustomHttpClient.invoke('function');
+      expect(
+          customHttpClient.receivedRequests.last.headers["Content-Type"], null);
       expect(res.data, {'key': 'Hello World'});
       expect(res.status, 200);
     });
@@ -58,6 +60,7 @@ void main() {
       final request = customHttpClient.receivedRequests.last;
 
       expect(request.url.queryParameters, {'key': 'value'});
+      expect(request.headers['Content-Type'], contains('multipart/form-data'));
       expect(res.data, [
         {'name': fileName, 'content': fileContent}
       ]);
@@ -100,6 +103,7 @@ void main() {
 
         req as Request;
         expect(req.body, '42');
+        expect(req.headers["Content-Type"], contains("application/json"));
       });
 
       test('double is properly encoded', () async {
@@ -110,6 +114,7 @@ void main() {
 
         req as Request;
         expect(req.body, '42.9');
+        expect(req.headers["Content-Type"], contains("application/json"));
       });
 
       test('string is properly encoded', () async {
@@ -120,6 +125,7 @@ void main() {
 
         req as Request;
         expect(req.body, 'ExampleText');
+        expect(req.headers["Content-Type"], contains("text/plain"));
       });
 
       test('list is properly encoded', () async {
@@ -130,6 +136,7 @@ void main() {
 
         req as Request;
         expect(req.body, '[1,2,3]');
+        expect(req.headers["Content-Type"], contains("application/json"));
       });
 
       test('map is properly encoded', () async {
@@ -143,6 +150,7 @@ void main() {
 
         req as Request;
         expect(req.body, '{"thekey":"thevalue"}');
+        expect(req.headers["Content-Type"], contains("application/json"));
       });
     });
   });


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the current behavior?

The `body` can only be of type `Map<String,dynamic>` and no files can be uploaded.

## What is the new behavior?

The `body` can be any `Object`, which is encodable to String. There's now a `files` parameter to send files with a `MultipartRequest`.

## Additional context

At the moment everything is bundled in one method like in functions-js. One could argue to create an extra method to be more type safe with `body` being `Map<String,String>`.

close #933
