### PR TITLE
fix(functions_client): Add `toString` to `FunctionException`

### DIFF
--- a/packages/functions_client/lib/src/types.dart
+++ b/packages/functions_client/lib/src/types.dart
@@ -32,7 +32,7 @@ class FunctionException {
   final dynamic details;
   final String? reasonPhrase;
 
-  FunctionException({required this.status, this.details, this.reasonPhrase});
+  const FunctionException({required this.status, this.details, this.reasonPhrase});
 
   @override
   String toString() =>

--- a/packages/functions_client/lib/src/types.dart
+++ b/packages/functions_client/lib/src/types.dart
@@ -1,3 +1,4 @@
+// ignore_for_file: public_member_api_docs, sort_constructors_first
 import 'dart:convert';
 import 'dart:typed_data';
 
@@ -32,4 +33,8 @@ class FunctionException {
   final String? reasonPhrase;
 
   FunctionException({required this.status, this.details, this.reasonPhrase});
+
+  @override
+  String toString() =>
+      'FunctionException(status: $status, details: $details, reasonPhrase: $reasonPhrase)';
 }

--- a/packages/functions_client/lib/src/types.dart
+++ b/packages/functions_client/lib/src/types.dart
@@ -1,4 +1,3 @@
-// ignore_for_file: public_member_api_docs, sort_constructors_first
 import 'dart:convert';
 import 'dart:typed_data';
 
@@ -32,7 +31,8 @@ class FunctionException {
   final dynamic details;
   final String? reasonPhrase;
 
-  const FunctionException({required this.status, this.details, this.reasonPhrase});
+  const FunctionException(
+      {required this.status, this.details, this.reasonPhrase});
 
   @override
   String toString() =>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Add `toString` method to FunctionException so that the exception would show some context, hence making it easier to debug. 