### PR TITLE
fix: Upgrade `web_socket_channel` for supporting `web: ^1.0.0` and therefore WASM compilation on web

### DIFF
--- a/packages/functions_client/pubspec.yaml
+++ b/packages/functions_client/pubspec.yaml
@@ -13,5 +13,5 @@ dependencies:
   yet_another_json_isolate: 2.0.1
 
 dev_dependencies:
-  lints: ^2.1.1
+  lints: ^3.0.0
   test: ^1.16.4

--- a/packages/gotrue/lib/src/types/auth_exception.dart
+++ b/packages/gotrue/lib/src/types/auth_exception.dart
@@ -22,7 +22,7 @@ class AuthException implements Exception {
 }
 
 class AuthPKCEGrantCodeExchangeError extends AuthException {
-  AuthPKCEGrantCodeExchangeError(String message) : super(message);
+  AuthPKCEGrantCodeExchangeError(super.message);
 }
 
 class AuthSessionMissingException extends AuthException {
@@ -38,8 +38,7 @@ class AuthRetryableFetchException extends AuthException {
 }
 
 class AuthApiException extends AuthException {
-  AuthApiException(String message, {String? statusCode})
-      : super(message, statusCode: statusCode);
+  AuthApiException(super.message, {super.statusCode});
 }
 
 class AuthUnknownException extends AuthException {

--- a/packages/gotrue/lib/src/types/user_attributes.dart
+++ b/packages/gotrue/lib/src/types/user_attributes.dart
@@ -77,16 +77,16 @@ class AdminUserAttributes extends UserAttributes {
   final String? banDuration;
 
   AdminUserAttributes({
-    String? email,
-    String? phone,
-    String? password,
-    Object? data,
+    super.email,
+    super.phone,
+    super.password,
+    super.data,
     this.userMetadata,
     this.appMetadata,
     this.emailConfirm,
     this.phoneConfirm,
     this.banDuration,
-  }) : super(email: email, phone: phone, password: password, data: data);
+  });
 
   @override
   Map<String, dynamic> toJson() {

--- a/packages/gotrue/pubspec.yaml
+++ b/packages/gotrue/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
 dev_dependencies:
   dart_jsonwebtoken: ^2.4.1
   dotenv: ^4.1.0
-  lints: ^2.1.1
+  lints: ^3.0.0
   test: ^1.16.4
   otp: ^3.1.3
 

--- a/packages/postgrest/lib/src/postgrest_filter_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_filter_builder.dart
@@ -1,7 +1,7 @@
 part of 'postgrest_builder.dart';
 
 class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
-  PostgrestFilterBuilder(PostgrestBuilder<T, T, T> builder) : super(builder);
+  PostgrestFilterBuilder(super.builder);
 
   @override
   PostgrestFilterBuilder<T> copyWithUrl(Uri url) =>

--- a/packages/postgrest/pubspec.yaml
+++ b/packages/postgrest/pubspec.yaml
@@ -15,5 +15,5 @@ dependencies:
 
 dev_dependencies:
   collection: ^1.16.0
-  lints: ^2.1.1
+  lints: ^3.0.0
   test: ^1.21.4

--- a/packages/realtime_client/pubspec.yaml
+++ b/packages/realtime_client/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   collection: ^1.15.0
   http: '>=0.13.0 <2.0.0'
   meta: ^1.7.0
-  web_socket_channel: ^3.0.1
+  web_socket_channel: '>=2.3.0 <4.0.0'
 
 dev_dependencies:
   lints: ^4.0.0

--- a/packages/realtime_client/pubspec.yaml
+++ b/packages/realtime_client/pubspec.yaml
@@ -12,9 +12,9 @@ dependencies:
   collection: ^1.15.0
   http: '>=0.13.0 <2.0.0'
   meta: ^1.7.0
-  web_socket_channel: ^2.3.0
+  web_socket_channel: ^3.0.1
 
 dev_dependencies:
-  lints: ^2.1.1
+  lints: ^4.0.0
   mocktail: ^1.0.0
   test: ^1.16.5

--- a/packages/realtime_client/pubspec.yaml
+++ b/packages/realtime_client/pubspec.yaml
@@ -15,6 +15,6 @@ dependencies:
   web_socket_channel: '>=2.3.0 <4.0.0'
 
 dev_dependencies:
-  lints: ^4.0.0
+  lints: ^3.0.0
   mocktail: ^1.0.0
   test: ^1.16.5

--- a/packages/realtime_client/test/socket_test_stubs.dart
+++ b/packages/realtime_client/test/socket_test_stubs.dart
@@ -13,7 +13,7 @@ class MockChannel extends Mock implements RealtimeChannel {}
 class MockPush extends Mock implements Push {}
 
 class SocketWithMockedChannel extends RealtimeClient {
-  SocketWithMockedChannel(String endPoint) : super(endPoint);
+  SocketWithMockedChannel(super.endPoint);
 
   Map<String, RealtimeChannel> mockedChannelLooker = {};
 

--- a/packages/storage_client/lib/src/types.dart
+++ b/packages/storage_client/lib/src/types.dart
@@ -212,13 +212,10 @@ class SignedUploadURLResponse extends SignedUrl {
   final String token;
 
   const SignedUploadURLResponse({
-    required String signedUrl,
-    required String path,
+    required super.signedUrl,
+    required super.path,
     required this.token,
-  }) : super(
-          signedUrl: signedUrl,
-          path: path,
-        );
+  });
 }
 
 class StorageException implements Exception {

--- a/packages/storage_client/pubspec.yaml
+++ b/packages/storage_client/pubspec.yaml
@@ -17,5 +17,5 @@ dependencies:
 
 dev_dependencies:
   test: ^1.21.4
-  lints: ^2.1.1
+  lints: ^3.0.0
   path: ^1.8.2

--- a/packages/supabase/lib/src/auth_user.dart
+++ b/packages/supabase/lib/src/auth_user.dart
@@ -2,33 +2,18 @@ import 'package:gotrue/gotrue.dart' show User;
 
 class AuthUser extends User {
   AuthUser({
-    required String id,
-    required Map<String, dynamic> appMetadata,
-    required Map<String, dynamic> userMetadata,
-    required String aud,
-    required String? email,
-    required String? phone,
-    required String createdAt,
-    String? confirmedAt,
-    String? emailConfirmedAt,
-    String? phoneConfirmedAt,
-    String? lastSignInAt,
-    required String role,
-    required String updatedAt,
-  }) : super(
-          id: id,
-          appMetadata: appMetadata,
-          userMetadata: userMetadata,
-          aud: aud,
-          email: email,
-          phone: phone,
-          createdAt: createdAt,
-          // ignore: deprecated_member_use
-          confirmedAt: confirmedAt,
-          emailConfirmedAt: emailConfirmedAt,
-          phoneConfirmedAt: phoneConfirmedAt,
-          lastSignInAt: lastSignInAt,
-          role: role,
-          updatedAt: updatedAt,
-        );
+    required super.id,
+    required super.appMetadata,
+    required Map<String, dynamic> super.userMetadata,
+    required super.aud,
+    required super.email,
+    required super.phone,
+    required super.createdAt,
+    super.confirmedAt,
+    super.emailConfirmedAt,
+    super.phoneConfirmedAt,
+    super.lastSignInAt,
+    required String super.role,
+    required String super.updatedAt,
+  });
 }

--- a/packages/supabase/lib/src/auth_user.dart
+++ b/packages/supabase/lib/src/auth_user.dart
@@ -13,7 +13,7 @@ class AuthUser extends User {
     super.emailConfirmedAt,
     super.phoneConfirmedAt,
     super.lastSignInAt,
-    required String super.role,
-    required String super.updatedAt,
+    required super.role,
+    required super.updatedAt,
   });
 }

--- a/packages/supabase/lib/src/auth_user.dart
+++ b/packages/supabase/lib/src/auth_user.dart
@@ -4,7 +4,7 @@ class AuthUser extends User {
   AuthUser({
     required super.id,
     required super.appMetadata,
-    required Map<String, dynamic> super.userMetadata,
+    required super.userMetadata,
     required super.aud,
     required super.email,
     required super.phone,

--- a/packages/supabase/lib/src/supabase_query_builder.dart
+++ b/packages/supabase/lib/src/supabase_query_builder.dart
@@ -10,12 +10,12 @@ class SupabaseQueryBuilder extends PostgrestQueryBuilder {
   SupabaseQueryBuilder(
     String url,
     RealtimeClient realtime, {
-    Map<String, String> super.headers = const {},
-    required String super.schema,
+    super.headers = const {},
+    required super.schema,
     required String table,
     super.httpClient,
     required int incrementId,
-    required YAJsonIsolate super.isolate,
+    required super.isolate,
   })  : _realtime = realtime,
         _schema = schema,
         _table = table,

--- a/packages/supabase/lib/src/supabase_query_builder.dart
+++ b/packages/supabase/lib/src/supabase_query_builder.dart
@@ -1,5 +1,4 @@
 import 'package:supabase/supabase.dart';
-import 'package:yet_another_json_isolate/yet_another_json_isolate.dart';
 
 class SupabaseQueryBuilder extends PostgrestQueryBuilder {
   final RealtimeClient _realtime;
@@ -11,7 +10,7 @@ class SupabaseQueryBuilder extends PostgrestQueryBuilder {
     String url,
     RealtimeClient realtime, {
     super.headers = const {},
-    required super.schema,
+    required String super.schema,
     required String table,
     super.httpClient,
     required int incrementId,

--- a/packages/supabase/lib/src/supabase_query_builder.dart
+++ b/packages/supabase/lib/src/supabase_query_builder.dart
@@ -1,4 +1,3 @@
-import 'package:http/http.dart';
 import 'package:supabase/supabase.dart';
 import 'package:yet_another_json_isolate/yet_another_json_isolate.dart';
 
@@ -11,22 +10,18 @@ class SupabaseQueryBuilder extends PostgrestQueryBuilder {
   SupabaseQueryBuilder(
     String url,
     RealtimeClient realtime, {
-    Map<String, String> headers = const {},
-    required String schema,
+    Map<String, String> super.headers = const {},
+    required String super.schema,
     required String table,
-    Client? httpClient,
+    super.httpClient,
     required int incrementId,
-    required YAJsonIsolate isolate,
+    required YAJsonIsolate super.isolate,
   })  : _realtime = realtime,
         _schema = schema,
         _table = table,
         _incrementId = incrementId,
         super(
           url: Uri.parse(url),
-          headers: headers,
-          schema: schema,
-          httpClient: httpClient,
-          isolate: isolate,
         );
 
   /// Returns real-time data from your table as a `Stream`.

--- a/packages/supabase/pubspec.yaml
+++ b/packages/supabase/pubspec.yaml
@@ -21,4 +21,4 @@ dependencies:
 dev_dependencies:
   lints: ^3.0.0
   test: ^1.17.9
-  web_socket_channel: '>=2.3.0 <4.0.0'
+  web_socket_channel: '>=2.2.0 <4.0.0'

--- a/packages/supabase/pubspec.yaml
+++ b/packages/supabase/pubspec.yaml
@@ -19,6 +19,6 @@ dependencies:
   yet_another_json_isolate: 2.0.1
 
 dev_dependencies:
-  lints: ^4.0.0
+  lints: ^3.0.0
   test: ^1.17.9
   web_socket_channel: '>=2.3.0 <4.0.0'

--- a/packages/supabase/pubspec.yaml
+++ b/packages/supabase/pubspec.yaml
@@ -21,4 +21,4 @@ dependencies:
 dev_dependencies:
   lints: ^4.0.0
   test: ^1.17.9
-  web_socket_channel: ^3.0.1
+  web_socket_channel: '>=2.3.0 <4.0.0'

--- a/packages/supabase/pubspec.yaml
+++ b/packages/supabase/pubspec.yaml
@@ -19,6 +19,6 @@ dependencies:
   yet_another_json_isolate: 2.0.1
 
 dev_dependencies:
-  lints: ^2.1.1
+  lints: ^4.0.0
   test: ^1.17.9
-  web_socket_channel: ^2.2.0
+  web_socket_channel: ^3.0.1

--- a/packages/supabase_flutter/example/pubspec.yaml
+++ b/packages/supabase_flutter/example/pubspec.yaml
@@ -17,7 +17,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
-  flutter_lints: ^1.0.4
+  flutter_lints: ^3.0.1
 
 flutter:
   uses-material-design: true

--- a/packages/supabase_flutter/pubspec.yaml
+++ b/packages/supabase_flutter/pubspec.yaml
@@ -26,7 +26,7 @@ dev_dependencies:
   dart_jsonwebtoken: ^2.4.1
   flutter_test:
     sdk: flutter
-  flutter_lints: ^2.0.2
+  flutter_lints: ^3.0.1
   path: ^1.8.3
 
 platforms:

--- a/packages/supabase_flutter/test/widget_test_stubs.dart
+++ b/packages/supabase_flutter/test/widget_test_stubs.dart
@@ -10,7 +10,7 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 import 'utils.dart';
 
 class MockWidget extends StatefulWidget {
-  const MockWidget({Key? key}) : super(key: key);
+  const MockWidget({super.key});
 
   @override
   State<MockWidget> createState() => _MockWidgetState();

--- a/packages/supabase_flutter/test/widget_test_stubs.dart
+++ b/packages/supabase_flutter/test/widget_test_stubs.dart
@@ -127,6 +127,7 @@ void mockAppLink({
           const StandardMethodCodec().encodeSuccessEnvelope(initialLink),
           (ByteData? data) {},
         );
+        return null;
       },
     );
   }

--- a/packages/yet_another_json_isolate/pubspec.yaml
+++ b/packages/yet_another_json_isolate/pubspec.yaml
@@ -10,5 +10,5 @@ dependencies:
   async: ^2.8.0
 
 dev_dependencies:
-  lints: ^2.1.1
+  lints: ^3.0.0
   test: ^1.16.0


### PR DESCRIPTION
## What kind of change does this PR introduce?

Upgrade the  `web_socket_channel` to `^3.0.1` which mostly serves as an upgrade path for the transitive `web` dependency which otherwise causes `web_socket_channel` to downgrade and prevent WASM support on the web platform.

## What is the current behavior?

When having `supabase` or `supabase_flutter` as a project dependeny while relying on `web: ^1.0.0` the  `web_socket_channel` dependeny would downgrade and WASM compilation isn't possible anymore.

## What is the new behavior?

This behavior seems to be migrated.

## Additional context

The breaking changes don't affect the codebase. Tests passed locally. Additionally, one linting error got fixed.