### PR TITLE
feat: Add third-party auth support

### DIFF
--- a/packages/supabase/lib/src/auth_http_client.dart
+++ b/packages/supabase/lib/src/auth_http_client.dart
@@ -5,7 +5,6 @@ class AuthHttpClient extends BaseClient {
 
   final String _supabaseKey;
   final Future<String?> Function() _getAccessToken;
-
   AuthHttpClient(this._supabaseKey, this._inner, this._getAccessToken);
 
   @override

--- a/packages/supabase/lib/src/auth_http_client.dart
+++ b/packages/supabase/lib/src/auth_http_client.dart
@@ -1,32 +1,17 @@
 import 'package:http/http.dart';
-import 'package:supabase/supabase.dart';
 
 class AuthHttpClient extends BaseClient {
   final Client _inner;
-  final GoTrueClient _auth;
-  final String _supabaseKey;
 
-  AuthHttpClient(this._supabaseKey, this._inner, this._auth);
+  final String _supabaseKey;
+  final Future<String?> Function() _getAccessToken;
+
+  AuthHttpClient(this._supabaseKey, this._inner, this._getAccessToken);
 
   @override
   Future<StreamedResponse> send(BaseRequest request) async {
-    if (_auth.currentSession?.isExpired ?? false) {
-      try {
-        await _auth.refreshSession();
-      } catch (error) {
-        final expiresAt = _auth.currentSession?.expiresAt;
-        if (expiresAt != null) {
-          // Failed to refresh the token.
-          final isExpiredWithoutMargin = DateTime.now()
-              .isAfter(DateTime.fromMillisecondsSinceEpoch(expiresAt * 1000));
-          if (isExpiredWithoutMargin) {
-            // Throw the error instead of making an API request with an expired token.
-            rethrow;
-          }
-        }
-      }
-    }
-    final authBearer = _auth.currentSession?.accessToken ?? _supabaseKey;
+    final accessToken = await _getAccessToken();
+    final authBearer = accessToken ?? _supabaseKey;
 
     request.headers.putIfAbsent("Authorization", () => 'Bearer $authBearer');
     request.headers.putIfAbsent("apikey", () => _supabaseKey);

--- a/packages/supabase/lib/src/supabase_client.dart
+++ b/packages/supabase/lib/src/supabase_client.dart
@@ -59,7 +59,7 @@ class SupabaseClient {
   late final SupabaseStorageClient storage;
   late final RealtimeClient realtime;
   late final PostgrestClient rest;
-  late StreamSubscription<AuthState> _authStateSubscription;
+  StreamSubscription<AuthState>? _authStateSubscription;
   late final YAJsonIsolate _isolate;
   final Future<String> Function()? accessToken;
 
@@ -247,7 +247,7 @@ class SupabaseClient {
   }
 
   Future<void> dispose() async {
-    await _authStateSubscription.cancel();
+    await _authStateSubscription?.cancel();
     await _isolate.dispose();
   }
 

--- a/packages/supabase/lib/src/supabase_client.dart
+++ b/packages/supabase/lib/src/supabase_client.dart
@@ -91,13 +91,15 @@ class SupabaseClient {
       ..clear()
       ..addAll(_headers);
 
-    auth.headers
-      ..clear()
-      ..addAll({
-        ...Constants.defaultHeaders,
-        ..._getAuthHeaders(),
-        ...headers,
-      });
+    if (accessToken == null) {
+      auth.headers
+        ..clear()
+        ..addAll({
+          ...Constants.defaultHeaders,
+          ..._getAuthHeaders(),
+          ...headers,
+        });
+    }
 
     // To apply the new headers in the realtime client,
     // manually unsubscribe and resubscribe to all channels.
@@ -142,7 +144,7 @@ class SupabaseClient {
     functions = _initFunctionsClient();
     storage = _initStorageClient(storageOptions.retryAttempts);
     realtime = _initRealtimeClient(options: realtimeClientOptions);
-    if (accessToken != null) {
+    if (accessToken == null) {
       _listenForAuthEvents();
     }
   }

--- a/packages/supabase/lib/src/supabase_client.dart
+++ b/packages/supabase/lib/src/supabase_client.dart
@@ -229,7 +229,6 @@ class SupabaseClient {
     if (_authInstance.currentSession?.isExpired ?? false) {
       try {
         await _authInstance.refreshSession();
-        return _authInstance.currentSession?.accessToken;
       } catch (error) {
         final expiresAt = _authInstance.currentSession?.expiresAt;
         if (expiresAt != null) {
@@ -243,7 +242,7 @@ class SupabaseClient {
         }
       }
     }
-    return null;
+    return _authInstance.currentSession?.accessToken;
   }
 
   Future<void> dispose() async {

--- a/packages/supabase/test/client_test.dart
+++ b/packages/supabase/test/client_test.dart
@@ -186,6 +186,16 @@ void main() {
 
       mockServer.close();
     });
+
+    test('create a client with third-party auth accessToken', () async {
+      final supabase = SupabaseClient('URL', 'KEY', accessToken: () async {
+        return 'jwt';
+      });
+      expect(
+          supabase.auth.currentUser,
+          throwsA(AuthException(
+              'Supabase Client is configured with the accessToken option, accessing supabase.auth is not possible.')));
+    });
   });
 
   group('Custom Header', () {

--- a/packages/supabase/test/client_test.dart
+++ b/packages/supabase/test/client_test.dart
@@ -192,7 +192,7 @@ void main() {
         return 'jwt';
       });
       expect(
-          supabase.auth.currentUser,
+          () => supabase.auth.currentUser,
           throwsA(AuthException(
               'Supabase Client is configured with the accessToken option, accessing supabase.auth is not possible.')));
     });

--- a/packages/supabase_flutter/lib/src/supabase.dart
+++ b/packages/supabase_flutter/lib/src/supabase.dart
@@ -75,6 +75,7 @@ class Supabase {
     PostgrestClientOptions postgrestOptions = const PostgrestClientOptions(),
     StorageClientOptions storageOptions = const StorageClientOptions(),
     FlutterAuthClientOptions authOptions = const FlutterAuthClientOptions(),
+    Future<String> Function()? accessToken,
     bool? debug,
   }) async {
     assert(
@@ -103,6 +104,7 @@ class Supabase {
       authOptions: authOptions,
       postgrestOptions: postgrestOptions,
       storageOptions: storageOptions,
+      accessToken: accessToken,
     );
     _instance._debugEnable = debug ?? kDebugMode;
     _instance.log('***** Supabase init completed $_instance');
@@ -154,6 +156,7 @@ class Supabase {
     required PostgrestClientOptions postgrestOptions,
     required StorageClientOptions storageOptions,
     required AuthClientOptions authOptions,
+    required Future<String> Function()? accessToken,
   }) {
     final headers = {
       ...Constants.defaultHeaders,
@@ -168,6 +171,7 @@ class Supabase {
       postgrestOptions: postgrestOptions,
       storageOptions: storageOptions,
       authOptions: authOptions,
+      accessToken: accessToken,
     );
     _initialized = true;
   }

--- a/packages/supabase_flutter/test/supabase_flutter_test.dart
+++ b/packages/supabase_flutter/test/supabase_flutter_test.dart
@@ -99,7 +99,7 @@ void main() {
     /// Check if the current version of AppLinks uses an explicit call to get
     /// the initial link. This is only the case before version 6.0.0, where we
     /// can find the getInitialAppLink function.
-    /// 
+    ///
     /// CI pipeline is set so that it tests both app_links newer and older than v6.0.0
     bool appLinksExposesInitialLinkInStream() {
       try {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Adds support for the accessToken option on the Supabase client which can be used to provide a third-party authentication (e.g. Auth0, Clerk, Firebase Auth, ...) access token or ID token to be used instead of Supabase Auth.

When set, supabase.auth.xyz cannot be used and an error will be thrown.

js PR here: https://github.com/supabase/supabase-js/pull/1004