### PR TITLE
feat: Add setHeader method on postgrest builder

### DIFF
--- a/packages/postgrest/lib/src/postgrest_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_builder.dart
@@ -93,6 +93,12 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
     );
   }
 
+  PostgrestBuilder<T, S, R> setHeader(String key, String value) {
+    return _copyWith(
+      headers: {..._headers, key: value},
+    );
+  }
+
   Future<T> _execute() async {
     final String? method = _method;
 

--- a/packages/postgrest/lib/src/postgrest_filter_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_filter_builder.dart
@@ -484,4 +484,10 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
     query.forEach((k, v) => url = appendSearchParams(k, 'eq.$v', url));
     return copyWithUrl(url);
   }
+
+  PostgrestFilterBuilder<T> setHeader(String key, String value) {
+    return PostgrestFilterBuilder(
+      _copyWith(headers: {..._headers, key: value}),
+    );
+  }
 }

--- a/packages/postgrest/lib/src/postgrest_filter_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_filter_builder.dart
@@ -485,6 +485,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
     return copyWithUrl(url);
   }
 
+  @override
   PostgrestFilterBuilder<T> setHeader(String key, String value) {
     return PostgrestFilterBuilder(
       _copyWith(headers: {..._headers, key: value}),

--- a/packages/postgrest/lib/src/postgrest_query_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_query_builder.dart
@@ -257,6 +257,7 @@ class PostgrestQueryBuilder<T> extends RawPostgrestBuilder<T, T, T> {
     ));
   }
 
+  @override
   PostgrestQueryBuilder<T> setHeader(String key, String value) {
     return PostgrestQueryBuilder(
       url: _url,

--- a/packages/postgrest/lib/src/postgrest_query_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_query_builder.dart
@@ -256,4 +256,15 @@ class PostgrestQueryBuilder<T> extends RawPostgrestBuilder<T, T, T> {
       count: option,
     ));
   }
+
+  PostgrestQueryBuilder<T> setHeader(String key, String value) {
+    return PostgrestQueryBuilder(
+      url: _url,
+      headers: {..._headers, key: value},
+      httpClient: _httpClient,
+      method: _method,
+      schema: _schema,
+      isolate: _isolate,
+    );
+  }
 }

--- a/packages/postgrest/lib/src/postgrest_transform_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_transform_builder.dart
@@ -6,6 +6,13 @@ class PostgrestTransformBuilder<T> extends RawPostgrestBuilder<T, T, T> {
   PostgrestTransformBuilder<T> copyWithUrl(Uri url) =>
       PostgrestTransformBuilder(_copyWith(url: url));
 
+  @override
+  PostgrestTransformBuilder<T> setHeader(String key, String value) {
+    return PostgrestTransformBuilder(
+      _copyWith(headers: {..._headers, key: value}),
+    );
+  }
+
   /// Performs horizontal filtering with SELECT.
   ///
   /// ```dart

--- a/packages/postgrest/lib/src/raw_postgrest_builder.dart
+++ b/packages/postgrest/lib/src/raw_postgrest_builder.dart
@@ -41,6 +41,13 @@ class RawPostgrestBuilder<T, S, R> extends PostgrestBuilder<T, S, R> {
     ));
   }
 
+  @override
+  RawPostgrestBuilder<T, S, R> setHeader(String key, String value) {
+    return PostgrestFilterBuilder(
+      _copyWithType(headers: {..._headers, key: value}),
+    );
+  }
+
   /// Converts any response that comes from the server into a type-safe response.
   ///
   /// ```dart

--- a/packages/postgrest/lib/src/response_postgrest_builder.dart
+++ b/packages/postgrest/lib/src/response_postgrest_builder.dart
@@ -16,6 +16,13 @@ class ResponsePostgrestBuilder<T, S, R> extends PostgrestBuilder<T, S, R> {
           converter: builder._converter,
         );
 
+  @override
+  ResponsePostgrestBuilder<T, S, R> setHeader(String key, String value) {
+    return ResponsePostgrestBuilder(
+      _copyWith(headers: {..._headers, key: value}),
+    );
+  }
+
   /// Converts any response that comes from the server into a type-safe response.
   ///
   /// ```dart

--- a/packages/postgrest/test/basic_test.dart
+++ b/packages/postgrest/test/basic_test.dart
@@ -91,11 +91,15 @@ void main() {
       final httpClient = CustomHttpClient();
       final postgrest = PostgrestClient(rootUrl, httpClient: httpClient);
 
-      await postgrest.rpc('func').setHeader("myKey", "myValue").select();
+      await postgrest
+          .rpc('empty-succ')
+          .setHeader("myKey", "myValue")
+          .select()
+          .head();
       expect(httpClient.lastRequest!.headers, containsPair("myKey", "myValue"));
 
       // Other following requests should not have the header
-      await postgrest.rpc('func').select();
+      await postgrest.rpc('empty-succ').select().head();
       expect(httpClient.lastRequest!.headers,
           isNot(containsPair("myKey", "myValue")));
     });
@@ -104,11 +108,15 @@ void main() {
       final httpClient = CustomHttpClient();
       final postgrest = PostgrestClient(rootUrl, httpClient: httpClient);
 
-      await postgrest.from('users').setHeader("myKey", "myValue").select();
+      await postgrest
+          .from('empty-succ')
+          .setHeader("myKey", "myValue")
+          .select()
+          .head();
       expect(httpClient.lastRequest!.headers, containsPair("myKey", "myValue"));
 
       // Other following requests should not have the header
-      await postgrest.from('users').select();
+      await postgrest.from('empty-succ').select().head();
       expect(httpClient.lastRequest!.headers,
           isNot(containsPair("myKey", "myValue")));
     });

--- a/packages/postgrest/test/basic_test.dart
+++ b/packages/postgrest/test/basic_test.dart
@@ -87,6 +87,32 @@ void main() {
       );
     });
 
+    test('set header on rpc', () async {
+      final httpClient = CustomHttpClient();
+      final postgrest = PostgrestClient(rootUrl, httpClient: httpClient);
+
+      await postgrest.rpc('func').setHeader("myKey", "myValue").select();
+      expect(httpClient.lastRequest!.headers, containsPair("myKey", "myValue"));
+
+      // Other following requests should not have the header
+      await postgrest.rpc('func').select();
+      expect(httpClient.lastRequest!.headers,
+          isNot(containsPair("myKey", "myValue")));
+    });
+
+    test('set header on query builder', () async {
+      final httpClient = CustomHttpClient();
+      final postgrest = PostgrestClient(rootUrl, httpClient: httpClient);
+
+      await postgrest.from('users').setHeader("myKey", "myValue").select();
+      expect(httpClient.lastRequest!.headers, containsPair("myKey", "myValue"));
+
+      // Other following requests should not have the header
+      await postgrest.from('users').select();
+      expect(httpClient.lastRequest!.headers,
+          isNot(containsPair("myKey", "myValue")));
+    });
+
     test('switch schema', () async {
       final postgrest = PostgrestClient(rootUrl, schema: 'personal');
       final res = await postgrest.from('users').select();

--- a/packages/postgrest/test/custom_http_client.dart
+++ b/packages/postgrest/test/custom_http_client.dart
@@ -1,8 +1,11 @@
 import 'package:http/http.dart';
 
 class CustomHttpClient extends BaseClient {
+  BaseRequest? lastRequest;
   @override
   Future<StreamedResponse> send(BaseRequest request) async {
+    lastRequest = request;
+
     //Return custom status code to check for usage of this client.
     return StreamedResponse(
       request.finalize(),

--- a/packages/postgrest/test/custom_http_client.dart
+++ b/packages/postgrest/test/custom_http_client.dart
@@ -6,6 +6,13 @@ class CustomHttpClient extends BaseClient {
   Future<StreamedResponse> send(BaseRequest request) async {
     lastRequest = request;
 
+    if (request.url.path.endsWith("empty-succ")) {
+      return StreamedResponse(
+        Stream.empty(),
+        200,
+        request: request,
+      );
+    }
     //Return custom status code to check for usage of this client.
     return StreamedResponse(
       request.finalize(),


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the current behavior?

To change the headers for one rpc or query call the instance wide headers objects needs to be changed.

## What is the new behavior?

After calling `.rpc` or `.from` individual header fields can be set with `.setHeader(key, value)`

## Additional context

js-pr: https://github.com/supabase/postgrest-js/pull/550
issue: #179