### PR TITLE
ci: Fix app_links test

### DIFF
--- a/packages/supabase_flutter/test/supabase_flutter_test.dart
+++ b/packages/supabase_flutter/test/supabase_flutter_test.dart
@@ -145,7 +145,7 @@ void main() {
       // Wait for the initial app link to be handled, as this is an async
       // process when mocking the event channel.
       if (mockEventChannel) {
-        await AppLinks().uriLinkStream.first;
+        await Future.delayed(const Duration(milliseconds: 500));
       }
       expect(pkceHttpClient.requestCount, 1);
       expect(pkceHttpClient.lastRequestBody['auth_code'], 'my-code-verifier');


### PR DESCRIPTION
## What kind of change does this PR introduce?

ci fix

## What is the current behavior?

Since app_links v6.2.0 the test is broken.

## What is the new behavior?

I remove the exact to check when app_links received the uri, because it highly depends on the version we are testing, since we still support old 3.5.0. Instead, I just way for 500ms, which should be enough.

## Additional context

The commit, which "broke" the test: https://github.com/llfbandit/app_links/commit/bb717cc91bc85dafad4ab4c55994fbb1b4094ea8
It's because the stream is now broadcast and doesn't emit the latest event when listening.
