### PR TITLE
ci: Upgrade actions to remove deprecations

### DIFF
--- a/.github/workflows/functions_client.yml
+++ b/.github/workflows/functions_client.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Checks-out repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Dart
         uses: dart-lang/setup-dart@v1

--- a/.github/workflows/functions_client.yml
+++ b/.github/workflows/functions_client.yml
@@ -6,13 +6,13 @@ on:
       - main
     paths:
       - 'packages/functions_client/**'
-      - '.github/workflows/functions_client.yaml'
+      - '.github/workflows/functions_client.yml'
       - 'packages/yet_another_json_isolate/**'
 
   pull_request:
     paths:
       - 'packages/functions_client/**'
-      - '.github/workflows/functions_client.yaml'
+      - '.github/workflows/functions_client.yml'
       - 'packages/yet_another_json_isolate/**'
 
 jobs:

--- a/.github/workflows/gotrue.yml
+++ b/.github/workflows/gotrue.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Checks-out repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Dart
         uses: dart-lang/setup-dart@v1

--- a/.github/workflows/gotrue.yml
+++ b/.github/workflows/gotrue.yml
@@ -6,12 +6,12 @@ on:
       - main
     paths:
       - 'packages/gotrue/**'
-      - '.github/workflows/gotrue.yaml'
+      - '.github/workflows/gotrue.yml'
 
   pull_request:
     paths:
       - 'packages/gotrue/**'
-      - '.github/workflows/gotrue.yaml'
+      - '.github/workflows/gotrue.yml'
 
 jobs:
   test:

--- a/.github/workflows/postgrest.yml
+++ b/.github/workflows/postgrest.yml
@@ -6,13 +6,13 @@ on:
       - main
     paths:
       - 'packages/postgrest/**'
-      - '.github/workflows/postgrest.yaml'
+      - '.github/workflows/postgrest.yml'
       - 'packages/yet_another_json_isolate/**'
 
   pull_request:
     paths:
       - 'packages/postgrest/**'
-      - '.github/workflows/postgrest.yaml'
+      - '.github/workflows/postgrest.yml'
       - 'packages/yet_another_json_isolate/**'
 
 jobs:

--- a/.github/workflows/postgrest.yml
+++ b/.github/workflows/postgrest.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Checks-out repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Dart
         uses: dart-lang/setup-dart@v1

--- a/.github/workflows/realtime_client.yml
+++ b/.github/workflows/realtime_client.yml
@@ -6,12 +6,12 @@ on:
       - main
     paths:
       - 'packages/realtime_client/**'
-      - '.github/workflows/realtime_client.yaml'
+      - '.github/workflows/realtime_client.yml'
 
   pull_request:
     paths:
       - 'packages/realtime_client/**'
-      - '.github/workflows/realtime_client.yaml'
+      - '.github/workflows/realtime_client.yml'
 
 jobs:
   test:

--- a/.github/workflows/realtime_client.yml
+++ b/.github/workflows/realtime_client.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Checks-out repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Dart
         uses: dart-lang/setup-dart@v1

--- a/.github/workflows/storage_client.yml
+++ b/.github/workflows/storage_client.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checks-out repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Dart
         uses: dart-lang/setup-dart@v1

--- a/.github/workflows/storage_client.yml
+++ b/.github/workflows/storage_client.yml
@@ -6,11 +6,11 @@ on:
       - main
     paths:
       - 'packages/storage_client/**'
-      - '.github/workflows/storage_client.yaml'
+      - '.github/workflows/storage_client.yml'
   pull_request:
     paths:
       - 'packages/storage_client/**'
-      - '.github/workflows/storage_client.yaml'
+      - '.github/workflows/storage_client.yml'
 
 jobs:
   test:

--- a/.github/workflows/supabase.yml
+++ b/.github/workflows/supabase.yml
@@ -40,7 +40,7 @@ jobs:
 
     steps:
       - name: Checks-out repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Dart
         uses: dart-lang/setup-dart@v1

--- a/.github/workflows/supabase.yml
+++ b/.github/workflows/supabase.yml
@@ -6,7 +6,7 @@ on:
       - main
     paths:
       - 'packages/supabase/**'
-      - '.github/workflows/supabase.yaml'
+      - '.github/workflows/supabase.yml'
       - 'packages/functions_client/**'
       - 'packages/gotrue/**'
       - 'packages/postgrest/**'
@@ -16,7 +16,7 @@ on:
   pull_request:
     paths:
       - 'packages/supabase/**'
-      - '.github/workflows/supabase.yaml'
+      - '.github/workflows/supabase.yml'
       - 'packages/functions_client/**'
       - 'packages/gotrue/**'
       - 'packages/postgrest/**'

--- a/.github/workflows/supabase_flutter.yml
+++ b/.github/workflows/supabase_flutter.yml
@@ -6,7 +6,7 @@ on:
       - main
     paths:
       - 'packages/supabase_flutter/**'
-      - '.github/workflows/supabase_flutter.yaml'
+      - '.github/workflows/supabase_flutter.yml'
       - 'packages/functions_client/**'
       - 'packages/gotrue/**'
       - 'packages/postgrest/**'
@@ -18,7 +18,7 @@ on:
   pull_request:
     paths:
       - 'packages/supabase_flutter/**'
-      - '.github/workflows/supabase_flutter.yaml'
+      - '.github/workflows/supabase_flutter.yml'
       - 'packages/functions_client/**'
       - 'packages/gotrue/**'
       - 'packages/postgrest/**'

--- a/.github/workflows/supabase_flutter.yml
+++ b/.github/workflows/supabase_flutter.yml
@@ -44,11 +44,7 @@ jobs:
 
     steps:
       - name: Checks-out repo
-        uses: actions/checkout@v2
-
-      - uses: actions/setup-java@v1
-        with:
-          java-version: '12.x'
+        uses: actions/checkout@v4
 
       - uses: subosito/flutter-action@v2
         with:

--- a/.github/workflows/yet_another_json_isolate.yml
+++ b/.github/workflows/yet_another_json_isolate.yml
@@ -6,12 +6,12 @@ on:
       - main
     paths:
       - 'packages/yet_another_json_isolate/**'
-      - '.github/workflows/yet_another_json_isolate.yaml'
+      - '.github/workflows/yet_another_json_isolate.yml'
 
   pull_request:
     paths:
       - 'packages/yet_another_json_isolate/**'
-      - '.github/workflows/yet_another_json_isolate.yaml'
+      - '.github/workflows/yet_another_json_isolate.yml'
 
 jobs:
   test:

--- a/.github/workflows/yet_another_json_isolate.yml
+++ b/.github/workflows/yet_another_json_isolate.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Checks-out repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Dart
         uses: dart-lang/setup-dart@v1


### PR DESCRIPTION
## What kind of change does this PR introduce?

ci update

## What is the current behavior?

We still use `checkout@v2`, which uses an old node version.

## What is the new behavior?

Upgrade to `checkout@v4` and remove the java checkout.

## Additional context


