### PR TITLE
fix: Better stream and access token management

### DIFF
--- a/packages/realtime_client/lib/realtime_client.dart
+++ b/packages/realtime_client/lib/realtime_client.dart
@@ -1,4 +1,5 @@
-export 'src/constants.dart' show RealtimeConstants, RealtimeLogLevel;
+export 'src/constants.dart'
+    show RealtimeConstants, RealtimeLogLevel, SocketStates;
 export 'src/realtime_channel.dart';
 export 'src/realtime_client.dart';
 export 'src/realtime_presence.dart';

--- a/packages/realtime_client/lib/src/constants.dart
+++ b/packages/realtime_client/lib/src/constants.dart
@@ -18,8 +18,8 @@ enum SocketStates {
   /// Connection is live and connected
   open,
 
-  /// Socket is closing.
-  closing,
+  /// Socket is closing by the user
+  disconnecting,
 
   /// Socket being close not by the user. Realtime should attempt to reconnect.
   closed,

--- a/packages/realtime_client/lib/src/realtime_channel.dart
+++ b/packages/realtime_client/lib/src/realtime_channel.dart
@@ -70,7 +70,7 @@ class RealtimeChannel {
       socket.remove(this);
     });
 
-    _onError((String? reason) {
+    _onError((reason) {
       if (isLeaving || isClosed) {
         return;
       }
@@ -260,9 +260,9 @@ class RealtimeChannel {
   }
 
   /// Registers a callback that will be executed when the channel encounteres an error.
-  void _onError(void Function(String?) callback) {
+  void _onError(Function callback) {
     onEvents(ChannelEvents.error.eventName(), ChannelFilter(),
-        (reason, [ref]) => callback(reason?.toString()));
+        (reason, [ref]) => callback(reason));
   }
 
   /// Sets up a listener on your Supabase database.

--- a/packages/realtime_client/lib/src/realtime_channel.dart
+++ b/packages/realtime_client/lib/src/realtime_channel.dart
@@ -646,11 +646,15 @@ class RealtimeChannel {
     joinPush.resend(timeout ?? _timeout);
   }
 
-  /// Usually a rejoin only happens when the channel timeouts or errors out.
+  /// Resends [joinPush] to tell the server we join this channel again and marks
+  /// the channel as [ChannelStates.joining].
+  ///
+  /// Usually [rejoin] only happens when the channel timeouts or errors out.
   /// When manually disconnecting, the channel is still marked as
   /// [ChannelStates.joined]. Calling [RealtimeClient.leaveOpenTopic] will
   /// unsubscribe itself, which causes issues when trying to rejoin. This method
   /// therefore doesn't call [RealtimeClient.leaveOpenTopic].
+  @internal
   void forceRejoin([Duration? timeout]) {
     if (isLeaving) {
       return;

--- a/packages/realtime_client/lib/src/realtime_channel.dart
+++ b/packages/realtime_client/lib/src/realtime_channel.dart
@@ -646,6 +646,19 @@ class RealtimeChannel {
     joinPush.resend(timeout ?? _timeout);
   }
 
+  /// Usually a rejoin only happens when the channel timeouts or errors out.
+  /// When manually disconnecting, the channel is still marked as
+  /// [ChannelStates.joined]. Calling [RealtimeClient.leaveOpenTopic] will
+  /// unsubscribe itself, which causes issues when trying to rejoin. This method
+  /// therefore doesn't call [RealtimeClient.leaveOpenTopic].
+  void forceRejoin([Duration? timeout]) {
+    if (isLeaving) {
+      return;
+    }
+    _state = ChannelStates.joining;
+    joinPush.resend(timeout ?? _timeout);
+  }
+
   void trigger(String type, [dynamic payload, String? ref]) {
     final typeLower = type.toLowerCase();
 

--- a/packages/realtime_client/lib/src/realtime_client.dart
+++ b/packages/realtime_client/lib/src/realtime_client.dart
@@ -48,7 +48,7 @@ class RealtimeCloseEvent {
 
   @override
   String toString() {
-    return 'RealtimeCloseEvent{code: $code, reason: $reason}';
+    return 'RealtimeCloseEvent(code: $code, reason: $reason)';
   }
 }
 

--- a/packages/realtime_client/lib/src/realtime_client.dart
+++ b/packages/realtime_client/lib/src/realtime_client.dart
@@ -45,6 +45,11 @@ class RealtimeCloseEvent {
     required this.code,
     required this.reason,
   });
+
+  @override
+  String toString() {
+    return 'RealtimeCloseEvent{code: $code, reason: $reason}';
+  }
 }
 
 class RealtimeClient {

--- a/packages/realtime_client/lib/src/realtime_client.dart
+++ b/packages/realtime_client/lib/src/realtime_client.dart
@@ -353,7 +353,7 @@ class RealtimeClient {
 
     for (final channel in channels) {
       if (token != null) {
-        channel.updateJoinPayload({'user_token': token});
+        channel.updateJoinPayload({'access_token': token});
       }
       if (channel.joinedOnce && channel.isJoined) {
         channel.push(ChannelEvents.accessToken, {'access_token': token});

--- a/packages/realtime_client/test/mock_test.dart
+++ b/packages/realtime_client/test/mock_test.dart
@@ -268,7 +268,9 @@ void main() {
       final subscribeCallback =
           expectAsync2((RealtimeSubscribeStatus event, error) {
         if (event == RealtimeSubscribeStatus.channelError) {
-          expect(error, isNull);
+          expect(error, isA<RealtimeCloseEvent>());
+          error as RealtimeCloseEvent;
+          expect(error.reason, "heartbeat timeout");
         } else {
           expect(event, RealtimeSubscribeStatus.closed);
         }
@@ -285,6 +287,7 @@ void main() {
 
       channel.subscribe(subscribeCallback);
 
+      await Future.delayed(Duration(milliseconds: 200));
       await client.conn!.sink
           .close(Constants.wsCloseNormal, "heartbeat timeout");
     });

--- a/packages/realtime_client/test/mock_test.dart
+++ b/packages/realtime_client/test/mock_test.dart
@@ -288,8 +288,7 @@ void main() {
       channel.subscribe(subscribeCallback);
 
       await Future.delayed(Duration(milliseconds: 200));
-      await client.conn!.sink
-          .close(Constants.wsCloseNormal, "heartbeat timeout");
+      await webSocket?.close(Constants.wsCloseNormal, "heartbeat timeout");
     });
   });
 

--- a/packages/realtime_client/test/socket_test.dart
+++ b/packages/realtime_client/test/socket_test.dart
@@ -215,8 +215,8 @@ void main() {
     });
 
     test('removes existing connection', () async {
-      socket.connect();
-      socket.disconnect();
+      await socket.connect();
+      await socket.disconnect();
 
       expect(socket.conn, null);
     });

--- a/packages/realtime_client/test/socket_test.dart
+++ b/packages/realtime_client/test/socket_test.dart
@@ -423,7 +423,7 @@ void main() {
   });
 
   group('setAuth', () {
-    final updateJoinPayload = {'user_token': 'token123'};
+    final updateJoinPayload = {'acess_token': 'token123'};
     final pushPayload = {'access_token': 'token123'};
 
     test(

--- a/packages/realtime_client/test/socket_test.dart
+++ b/packages/realtime_client/test/socket_test.dart
@@ -171,6 +171,7 @@ void main() {
       });
 
       socket.connect();
+      await Future.delayed(const Duration(milliseconds: 200));
       expect(opens, 1);
 
       socket.sendHeartbeat();
@@ -229,7 +230,7 @@ void main() {
       expect(closes, 1);
     });
 
-    test('calls connection close callback', () {
+    test('calls connection close callback', () async {
       final mockedSocketChannel = MockIOWebSocketChannel();
       final mockedSocket = RealtimeClient(
         socketEndpoint,
@@ -247,7 +248,10 @@ void main() {
       const tReason = 'reason';
 
       mockedSocket.connect();
+      mockedSocket.connState = SocketStates.open;
+      await Future.delayed(const Duration(milliseconds: 200));
       mockedSocket.disconnect(code: tCode, reason: tReason);
+      await Future.delayed(const Duration(milliseconds: 200));
 
       verify(
         () => mockedSink.close(

--- a/packages/realtime_client/test/socket_test.dart
+++ b/packages/realtime_client/test/socket_test.dart
@@ -423,7 +423,7 @@ void main() {
   });
 
   group('setAuth', () {
-    final updateJoinPayload = {'acess_token': 'token123'};
+    final updateJoinPayload = {'access_token': 'token123'};
     final pushPayload = {'access_token': 'token123'};
 
     test(

--- a/packages/supabase/lib/src/supabase_query_builder.dart
+++ b/packages/supabase/lib/src/supabase_query_builder.dart
@@ -23,11 +23,16 @@ class SupabaseQueryBuilder extends PostgrestQueryBuilder {
           url: Uri.parse(url),
         );
 
-  /// Returns real-time data from your table as a `Stream`.
+  /// Combines the current state of your table from PostgREST with changes from the realtime server to return real-time data from your table as a [Stream].
   ///
   /// Realtime is disabled by default for new tables. You can turn it on by [managing replication](https://supabase.com/docs/guides/realtime/extensions/postgres-changes#replication-setup).
   ///
-  /// Pass the list of primary key column names to [primaryKey], which will be used to updating and deleting the proper records internally as the library receives real-time updates.
+  /// Pass the list of primary key column names to [primaryKey], which will be used to update and delete the proper records internally as the stream receives real-time updates.
+  ///
+  /// It handles the lifecycle of the realtime connection and automatically refetches data from PostgREST when needed.
+  ///
+  /// Make sure to provide `onError` and `onDone` callbacks to [Stream.listen] to handle errors and completion of the stream.
+  /// The stream gets closed when the realtime connection is closed.
   ///
   /// ```dart
   /// supabase.from('chats').stream(primaryKey: ['id']).listen(_onChatsReceived);

--- a/packages/supabase/lib/src/supabase_stream_builder.dart
+++ b/packages/supabase/lib/src/supabase_stream_builder.dart
@@ -76,8 +76,8 @@ class SupabaseStreamBuilder extends Stream<SupabaseStreamEvent> {
   /// Count of record to be returned
   int? _limit;
 
-  /// Flag if the stream has at least one time been subscribed to realtime
-  bool _gotSubscribed = false;
+  /// Flag that the stream has at least one time been subscribed to realtime
+  bool _wasSubscribed = false;
 
   SupabaseStreamBuilder({
     required PostgrestQueryBuilder queryBuilder,
@@ -214,10 +214,10 @@ class SupabaseStreamBuilder extends Stream<SupabaseStreamEvent> {
         case RealtimeSubscribeStatus.subscribed:
           // Reload all data after a reconnect from postgrest
           // First data from postgrest gets loaded before the realtime connect
-          if (_gotSubscribed) {
+          if (_wasSubscribed) {
             _getPostgrestData();
           }
-          _gotSubscribed = true;
+          _wasSubscribed = true;
           break;
         case RealtimeSubscribeStatus.closed:
           _streamController?.close();

--- a/packages/supabase/test/mock_test.dart
+++ b/packages/supabase/test/mock_test.dart
@@ -165,7 +165,7 @@ void main() {
           webSocket!.add(replyString);
 
           // Send an insert event
-          await Future.delayed(Duration(milliseconds: 10));
+          await Future.delayed(Duration(milliseconds: 100));
           final insertString = jsonEncode({
             'topic': topic,
             'event': 'postgres_changes',

--- a/packages/supabase/test/mock_test.dart
+++ b/packages/supabase/test/mock_test.dart
@@ -165,7 +165,7 @@ void main() {
           webSocket!.add(replyString);
 
           // Send an insert event
-          await Future.delayed(Duration(milliseconds: 100));
+          await Future.delayed(Duration(milliseconds: 10));
           final insertString = jsonEncode({
             'topic': topic,
             'event': 'postgres_changes',

--- a/packages/supabase_flutter/lib/src/supabase.dart
+++ b/packages/supabase_flutter/lib/src/supabase.dart
@@ -107,7 +107,7 @@ class Supabase {
       accessToken: accessToken,
     );
     _instance._debugEnable = debug ?? kDebugMode;
-    _instance.log('***** Supabase init completed $_instance');
+    _instance.log('***** Supabase init completed *****');
 
     _instance._supabaseAuth = SupabaseAuth();
     await _instance._supabaseAuth.initialize(options: authOptions);

--- a/packages/supabase_flutter/lib/src/supabase_auth.dart
+++ b/packages/supabase_flutter/lib/src/supabase_auth.dart
@@ -119,6 +119,9 @@ class SupabaseAuth with WidgetsBindingObserver {
       case AppLifecycleState.detached:
       case AppLifecycleState.inactive:
       case AppLifecycleState.paused:
+        // Realtime channels are kept alive in the background for some amount
+        // of time after the app is paused. If we stop refreshing the token
+        // here, the channels will be closed.
         if (Supabase.instance.client.realtime.getChannels().isEmpty) {
           Supabase.instance.client.auth.stopAutoRefresh();
         }

--- a/packages/supabase_flutter/lib/src/supabase_auth.dart
+++ b/packages/supabase_flutter/lib/src/supabase_auth.dart
@@ -119,7 +119,9 @@ class SupabaseAuth with WidgetsBindingObserver {
       case AppLifecycleState.detached:
       case AppLifecycleState.inactive:
       case AppLifecycleState.paused:
-        Supabase.instance.client.auth.stopAutoRefresh();
+        if (Supabase.instance.client.realtime.getChannels().isEmpty) {
+          Supabase.instance.client.auth.stopAutoRefresh();
+        }
       default:
     }
   }

--- a/packages/supabase_flutter/lib/src/supabase_auth.dart
+++ b/packages/supabase_flutter/lib/src/supabase_auth.dart
@@ -141,13 +141,21 @@ class SupabaseAuth with WidgetsBindingObserver {
 
         bool cancel = false;
         final connectFuture = realtime.conn!.sink.done.then(
-          (_) {
+          (_) async {
             // Make this connect cancelable so that it does not connect if the
             // disconnect took so long that the app is already in background
             // again.
 
-            // ignore: invalid_use_of_internal_member
-            if (!cancel) return realtime.connect();
+            if (!cancel) {
+              // ignore: invalid_use_of_internal_member
+              await realtime.connect();
+              for (final channel in realtime.channels) {
+                // ignore: invalid_use_of_internal_member
+                if (channel.isJoined) {
+                  channel.forceRejoin();
+                }
+              }
+            }
           },
           onError: (error) {},
         );


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The behavior of the app in background depends on the platform, but by always stopping the access token refreshing, the realtime connection may keep an invalid access token and therefore the connection get closed by server. When the realtime connection gets interrupted, it gets automatically reconnected as long as it never sent some expired access token.

## What is the new behavior?

~~When a realtime channel is open, the access token keeps refreshing while the app is in background.~~

In addition, I did more management to keep realtiem and postgrest in sync for the stream method. If the postgrest request fails, I unsubscribe the realtime connection and close the stream as I see no benefit in leaving it open, as it would just be a realtime connection by then. The dev using the stream method should handle such cases. One could also argue about doing a few retries as well, though.
When the realtime connection gets a channel error, but gets resubscribed, I reload the postgrest data to ensure the data is up to date and didn't miss any updates due to the interrupted realtime connection. 

## Additional context

#1012 #705 #579
