### PR TITLE
fix: Support all mfa auth methods

### DIFF
--- a/packages/gotrue/lib/src/types/mfa.dart
+++ b/packages/gotrue/lib/src/types/mfa.dart
@@ -1,4 +1,3 @@
-import 'package:collection/collection.dart';
 import 'package:gotrue/gotrue.dart';
 
 class AuthMFAEnrollResponse {

--- a/packages/gotrue/lib/src/types/mfa.dart
+++ b/packages/gotrue/lib/src/types/mfa.dart
@@ -1,3 +1,4 @@
+import 'package:collection/collection.dart';
 import 'package:gotrue/gotrue.dart';
 
 class AuthMFAEnrollResponse {
@@ -270,7 +271,8 @@ enum AMRMethod {
   emailChange('email_change'),
   tokenRefresh('token_refresh'),
   anonymous('anonymous'),
-  mfaPhone('mfa/phone');
+  mfaPhone('mfa/phone'),
+  unknown('unknown');
 
   final String code;
   const AMRMethod(this.code);
@@ -294,9 +296,10 @@ class AMREntry {
 
   factory AMREntry.fromJson(Map<String, dynamic> json) {
     return AMREntry(
-      method: AMRMethod.values.firstWhere(
-        (e) => e.code == json['method'],
-      ),
+      method: AMRMethod.values.firstWhereOrNull(
+            (e) => e.code == json['method'],
+          ) ??
+          AMRMethod.unknown,
       timestamp: DateTime.fromMillisecondsSinceEpoch(json['timestamp'] * 1000),
     );
   }

--- a/packages/gotrue/lib/src/types/mfa.dart
+++ b/packages/gotrue/lib/src/types/mfa.dart
@@ -296,10 +296,10 @@ class AMREntry {
 
   factory AMREntry.fromJson(Map<String, dynamic> json) {
     return AMREntry(
-      method: AMRMethod.values.firstWhereOrNull(
-            (e) => e.code == json['method'],
-          ) ??
-          AMRMethod.unknown,
+      method: AMRMethod.values.firstWhere(
+        (e) => e.code == json['method'],
+        orElse: () => AMRMethod.unknown,
+      ),
       timestamp: DateTime.fromMillisecondsSinceEpoch(json['timestamp'] * 1000),
     );
   }

--- a/packages/gotrue/lib/src/types/mfa.dart
+++ b/packages/gotrue/lib/src/types/mfa.dart
@@ -257,7 +257,24 @@ class AuthMFAGetAuthenticatorAssuranceLevelResponse {
   });
 }
 
-enum AMRMethod { password, otp, oauth, totp, magiclink }
+enum AMRMethod {
+  password('password'),
+  otp('otp'),
+  oauth('oauth'),
+  totp('totp'),
+  magiclink('magiclink'),
+  recovery('recovery'),
+  invite('invite'),
+  ssoSaml('sso/saml'),
+  emailSignUp('email/signup'),
+  emailChange('email_change'),
+  tokenRefresh('token_refresh'),
+  anonymous('anonymous'),
+  mfaPhone('mfa/phone');
+
+  final String code;
+  const AMRMethod(this.code);
+}
 
 /// An authentication method reference (AMR) entry.
 ///
@@ -278,7 +295,7 @@ class AMREntry {
   factory AMREntry.fromJson(Map<String, dynamic> json) {
     return AMREntry(
       method: AMRMethod.values.firstWhere(
-        (e) => e.name == json['method'],
+        (e) => e.code == json['method'],
       ),
       timestamp: DateTime.fromMillisecondsSinceEpoch(json['timestamp'] * 1000),
     );


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?
Not all mfa auth methods can be parsed.

## What is the new behavior?

Add the rest of methods from [here](https://github.com/supabase/auth/blob/a6c18243b92b74798b6317e1c35c8a73bc3fd6e1/internal/models/factor.go#L54)

## Additional context

Just in case, is the auth team aware that the `MFAPhone` has different string values? :sweat_smile:

https://github.com/supabase/auth/blob/a6c18243b92b74798b6317e1c35c8a73bc3fd6e1/internal/models/factor.go#L81

and

https://github.com/supabase/auth/blob/a6c18243b92b74798b6317e1c35c8a73bc3fd6e1/internal/models/factor.go#L113

I have chosen `mfa/phone` for now.

#966
