### PR TITLE
fix(yet_another_json_isolate): Conditional export now works correctly with Dart 3.5+

### DIFF
--- a/packages/yet_another_json_isolate/CHANGELOG.md
+++ b/packages/yet_another_json_isolate/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.3
+
+ - fix: conditional export for Dart 3.5+ & dart2wasm
+
 ## 2.0.2
 
  - **FIX**: Upgrade `web_socket_channel` for supporting `web: ^1.0.0` and therefore WASM compilation on web ([#992](https://github.com/supabase/supabase-flutter/issues/992)). ([7da68565](https://github.com/supabase/supabase-flutter/commit/7da68565a7aa578305b099d7af755a7b0bcaca46))

--- a/packages/yet_another_json_isolate/CHANGELOG.md
+++ b/packages/yet_another_json_isolate/CHANGELOG.md
@@ -1,7 +1,3 @@
-## 2.0.3
-
- - fix: conditional export for Dart 3.5+ & dart2wasm
-
 ## 2.0.2
 
  - **FIX**: Upgrade `web_socket_channel` for supporting `web: ^1.0.0` and therefore WASM compilation on web ([#992](https://github.com/supabase/supabase-flutter/issues/992)). ([7da68565](https://github.com/supabase/supabase-flutter/commit/7da68565a7aa578305b099d7af755a7b0bcaca46))

--- a/packages/yet_another_json_isolate/lib/yet_another_json_isolate.dart
+++ b/packages/yet_another_json_isolate/lib/yet_another_json_isolate.dart
@@ -1,3 +1,3 @@
 library yet_another_json_isolate;
 
-export 'src/_isolates_io.dart' if (dart.library.js) 'src/_isolates_web.dart';
+export 'src/_isolates_io.dart' if (dart.library.js_interop) 'src/_isolates_web.dart';

--- a/packages/yet_another_json_isolate/lib/yet_another_json_isolate.dart
+++ b/packages/yet_another_json_isolate/lib/yet_another_json_isolate.dart
@@ -1,3 +1,5 @@
 library yet_another_json_isolate;
 
-export 'src/_isolates_io.dart' if (dart.library.js_interop) 'src/_isolates_web.dart';
+export 'src/_isolates_io.dart'
+    if (dart.library.js_interop) 'src/_isolates_web.dart' // After Dart 3.3
+    if (dart.library.js) 'src/_isolates_web.dart'; // Before Dart 3.3 (for backwards compatibility)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix

- closes #1047 
  - see Issue for more detailed information.

## What is the current behavior?

`Supabase.initialize()` doesn't work correctly on Dart 3.5+ with WASM Compiler

## What is the new behavior?

`Supabase.initialize()` works!

## Additional context

- https://github.com/supabase-community/json-isolate-dart/pull/7
