### PR TITLE
fix: Rename logger from gotrue to auth

### DIFF
--- a/packages/gotrue/lib/src/broadcast_web.dart
+++ b/packages/gotrue/lib/src/broadcast_web.dart
@@ -5,7 +5,7 @@ import 'dart:js_util' as js_util;
 import 'package:gotrue/src/types/types.dart';
 import 'package:logging/logging.dart';
 
-final _log = Logger('supabase.gotrue');
+final _log = Logger('supabase.auth');
 
 BroadcastChannel getBroadcastChannel(String broadcastKey) {
   final broadcast = html.BroadcastChannel(broadcastKey);

--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -89,7 +89,7 @@ class GoTrueClient {
 
   final AuthFlowType _flowType;
 
-  final _log = Logger('supabase.gotrue');
+  final _log = Logger('supabase.auth');
 
   /// Proxy to the web BroadcastChannel API. Should be null on non-web platforms.
   BroadcastChannel? _broadcastChannel;

--- a/packages/supabase_flutter/README.md
+++ b/packages/supabase_flutter/README.md
@@ -52,6 +52,7 @@ final supabase = Supabase.instance.client;
 * [Edge Functions](#edge-functions)
 * [Deep Links](#deep-links)
 * [Custom LocalStorage](#custom-localstorage)
+- [Logging](#logging)
 
 
 ### <a id="authentication"></a>[Authentication](https://supabase.com/docs/guides/auth)
@@ -621,7 +622,7 @@ supabaseLogger.onRecord.listen((record) {
 - `supabase_flutter`: `Logger('supabase.supabase_flutter')`
 - `supabase`: `Logger('supabase.supabase')`
 - `postgrest`: `Logger('supabase.postgrest')`
-- `gotrue`: `Logger('supabase.gotrue')`
+- `gotrue`: `Logger('supabase.auth')`
 - `realtime_client`: `Logger('supabase.realtime')`
 - `storage_client`: `Logger('supabase.storage')`
 - `functions_client`: `Logger('supabase.functions')`


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The logger from the gotrue package is named `supabase.gotrue`

## What is the new behavior?

Renamed the logger from the gotrue package to `supabase.auth`

## Additional context

I've missed pushing this commit in #1042 
