### PR TITLE
fix: Send metadata inviteUserByEmail()

### DIFF
--- a/packages/gotrue/lib/src/gotrue_admin_api.dart
+++ b/packages/gotrue/lib/src/gotrue_admin_api.dart
@@ -105,7 +105,10 @@ class GoTrueAdminApi {
     String? redirectTo,
     Map<String, dynamic>? data,
   }) async {
-    final body = {'email': email};
+    final body = {
+      'email': email,
+      if (data != null) 'data': data,
+    };
     final fetchOptions = GotrueRequestOptions(
       headers: _headers,
       body: body,


### PR DESCRIPTION
### Pull Request Description

This fix sends metadata when using `inviteUserByEmail()`

## What kind of change does this PR introduce?
- Bug fix

## What is the current behavior?
When using the `inviteUserByEmail()` function, the `user_metadata` field remains empty, even when data is provided.

**Relevant Issue:**  
[Issue #1059](https://github.com/supabase/supabase-flutter/issues/1059)

## What is the new behavior?
The `inviteUserByEmail()` function now successfully sends user metadata when provided. The `user_metadata` field will correctly include the submitted data.

## Additional context
This change ensures that any metadata passed during the invitation process is included in the request.
```dart
final UserResponse res = await supabase.client.auth.admin.inviteUserByEmail(
  'test@test.com',
  data: {
    'first_name': "test",
    'last_name': "one",
  },
);

