### PR TITLE
fix: Updated gotrue types.dart to include slackOidc

### DIFF
--- a/packages/gotrue/lib/src/types/types.dart
+++ b/packages/gotrue/lib/src/types/types.dart
@@ -25,6 +25,7 @@ enum OAuthProvider {
   linkedinOidc,
   notion,
   slack,
+  slackOidc,
   spotify,
   twitch,
   twitter,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix

## What is the current behavior?

Trying to pass OAuthProvider.slack to sign in will set the `provider` url parameter value to `"slack"`, though `"slack_oidc"` is needed to authenticate properly with Slack OIDC authentication option.

## What is the new behavior?

You're able to pass `OAuthProvider.slackOidc` giving you the correct url param in the authentication request url.

## Additional context

Gotrue exported `OAuthProvider` doesn't currently include Slack OIDC provider option.

I had this verified by Supabase support when trying to figure out what was wrong with my auth setup (big thanks to Jenny Kibiri)