### PR TITLE
add tiktok provider

### DIFF
--- a/packages/gotrue/lib/src/types/types.dart
+++ b/packages/gotrue/lib/src/types/types.dart
@@ -26,6 +26,7 @@ enum OAuthProvider {
   notion,
   slack,
   spotify,
+  tiktok,
   twitch,
   twitter,
   workos,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Relate: https://github.com/supabase/auth/pull/1807
Add tiktok as oauth provider

## What is the current behavior?

There is no option for tiktok

## What is the new behavior?

Option for oauth with tiktok

## Additional context

Add any other context or screenshots.
