### PR TITLE
feat: Add Keycloak Provider on signInWithIdToken

### DIFF
--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -382,7 +382,7 @@ class GoTrueClient {
 
   /// Allows signing in with an ID token issued by certain supported providers.
   /// The [idToken] is verified for validity and a new session is established.
-  /// This method of signing in only supports [OAuthProvider.keycloak], [OAuthProvider.google], [OAuthProvider.apple] or [OAuthProvider.kakao].
+  /// This method of signing in only supports [OAuthProvider.google], [OAuthProvider.apple], [OAuthProvider.kakao] or [OAuthProvider.keycloak].
   ///
   /// If the ID token contains an `at_hash` claim, then [accessToken] must be
   /// provided to compare its hash with the value in the ID token.
@@ -402,12 +402,12 @@ class GoTrueClient {
     String? nonce,
     String? captchaToken,
   }) async {
-    if (provider != OAuthProvider.keycloak &&
-        provider != OAuthProvider.google &&
+    if (provider != OAuthProvider.google &&
         provider != OAuthProvider.apple &&
-        provider != OAuthProvider.kakao) {
+        provider != OAuthProvider.kakao &&
+        provider != OAuthProvider.keycloak) {
       throw AuthException('Provider must be '
-          '${OAuthProvider.keycloak.name}, ${OAuthProvider.google.name}, ${OAuthProvider.apple.name} or ${OAuthProvider.kakao.name}.');
+          '${OAuthProvider.google.name}, ${OAuthProvider.apple.name}, ${OAuthProvider.kakao.name} or ${OAuthProvider.keycloak.name}.');
     }
 
     final response = await _fetch.request(

--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -382,7 +382,7 @@ class GoTrueClient {
 
   /// Allows signing in with an ID token issued by certain supported providers.
   /// The [idToken] is verified for validity and a new session is established.
-  /// This method of signing in only supports [OAuthProvider.google], [OAuthProvider.apple] or [OAuthProvider.kakao].
+  /// This method of signing in only supports [OAuthProvider.keycloak], [OAuthProvider.google], [OAuthProvider.apple] or [OAuthProvider.kakao].
   ///
   /// If the ID token contains an `at_hash` claim, then [accessToken] must be
   /// provided to compare its hash with the value in the ID token.
@@ -402,11 +402,12 @@ class GoTrueClient {
     String? nonce,
     String? captchaToken,
   }) async {
-    if (provider != OAuthProvider.google &&
+    if (provider != OAuthProvider.keycloak &&
+        provider != OAuthProvider.google &&
         provider != OAuthProvider.apple &&
         provider != OAuthProvider.kakao) {
       throw AuthException('Provider must be '
-          '${OAuthProvider.google.name}, ${OAuthProvider.apple.name} or ${OAuthProvider.kakao.name}.');
+          '${OAuthProvider.keycloak.name}, ${OAuthProvider.google.name}, ${OAuthProvider.apple.name} or ${OAuthProvider.kakao.name}.');
     }
 
     final response = await _fetch.request(


### PR DESCRIPTION
## What kind of change does this PR introduce?

Relate: https://github.com/supabase/supabase-flutter/issues/1045
Add Keycloak Provider on signInWithIdToken

## What is the current behavior?

signInWithIdToken are only available for Google, Apple or Kakao

## What is the new behavior?

Authorize Keycloak to use signInWithIdToken

## Additional context
We need a transparent connection that uses the accessToken and idToken that provides us with keycloak authentication.
As the connection has already been established through our systems, we need to provide the authentication information to gotrue directly using the signInWithIdToken method.

