### PR TITLE
fix: Add equality to user attributes classes

### DIFF
--- a/packages/gotrue/lib/src/types/user_attributes.dart
+++ b/packages/gotrue/lib/src/types/user_attributes.dart
@@ -1,4 +1,3 @@
-// ignore_for_file: public_member_api_docs, sort_constructors_first
 import 'package:collection/collection.dart';
 
 class UserAttributes {

--- a/packages/gotrue/lib/src/types/user_attributes.dart
+++ b/packages/gotrue/lib/src/types/user_attributes.dart
@@ -1,3 +1,6 @@
+// ignore_for_file: public_member_api_docs, sort_constructors_first
+import 'package:collection/collection.dart';
+
 class UserAttributes {
   /// The user's email.
   String? email;
@@ -34,6 +37,26 @@ class UserAttributes {
       if (password != null) 'password': password,
       if (data != null) 'data': data,
     };
+  }
+
+  @override
+  bool operator ==(covariant UserAttributes other) {
+    if (identical(this, other)) return true;
+
+    return other.email == email &&
+        other.phone == phone &&
+        other.password == password &&
+        other.nonce == nonce &&
+        other.data == data;
+  }
+
+  @override
+  int get hashCode {
+    return email.hashCode ^
+        phone.hashCode ^
+        password.hashCode ^
+        nonce.hashCode ^
+        data.hashCode;
   }
 }
 
@@ -101,5 +124,26 @@ class AdminUserAttributes extends UserAttributes {
       if (phoneConfirm != null) 'phone_confirm': phoneConfirm,
       if (banDuration != null) 'ban_duration': banDuration,
     };
+  }
+
+  @override
+  bool operator ==(covariant AdminUserAttributes other) {
+    if (identical(this, other)) return true;
+    final mapEquals = const DeepCollectionEquality().equals;
+
+    return mapEquals(other.userMetadata, userMetadata) &&
+        mapEquals(other.appMetadata, appMetadata) &&
+        other.emailConfirm == emailConfirm &&
+        other.phoneConfirm == phoneConfirm &&
+        other.banDuration == banDuration;
+  }
+
+  @override
+  int get hashCode {
+    return userMetadata.hashCode ^
+        appMetadata.hashCode ^
+        emailConfirm.hashCode ^
+        phoneConfirm.hashCode ^
+        banDuration.hashCode;
   }
 }

--- a/packages/gotrue/lib/src/types/user_attributes.dart
+++ b/packages/gotrue/lib/src/types/user_attributes.dart
@@ -40,14 +40,17 @@ class UserAttributes {
   }
 
   @override
-  bool operator ==(covariant UserAttributes other) {
+  bool operator ==(Object other) {
     if (identical(this, other)) return true;
+    if (other is! UserAttributes) return false;
+
+    final mapEquals = const DeepCollectionEquality().equals;
 
     return other.email == email &&
         other.phone == phone &&
         other.password == password &&
         other.nonce == nonce &&
-        other.data == data;
+        mapEquals(other.data, data);
   }
 
   @override
@@ -127,8 +130,10 @@ class AdminUserAttributes extends UserAttributes {
   }
 
   @override
-  bool operator ==(covariant AdminUserAttributes other) {
+  bool operator ==(Object other) {
     if (identical(this, other)) return true;
+    if (other is! AdminUserAttributes) return false;
+
     final mapEquals = const DeepCollectionEquality().equals;
 
     return mapEquals(other.userMetadata, userMetadata) &&
@@ -140,7 +145,8 @@ class AdminUserAttributes extends UserAttributes {
 
   @override
   int get hashCode {
-    return userMetadata.hashCode ^
+    return super.hashCode ^
+        userMetadata.hashCode ^
         appMetadata.hashCode ^
         emailConfirm.hashCode ^
         phoneConfirm.hashCode ^

--- a/packages/gotrue/test/src/types/user_attributes_test.dart
+++ b/packages/gotrue/test/src/types/user_attributes_test.dart
@@ -1,0 +1,128 @@
+import 'package:gotrue/src/types/user_attributes.dart';
+import 'package:test/test.dart';
+
+void main() {
+  late String email;
+  late String phone;
+  late String password;
+  late String nonce;
+  late Map<String, dynamic> data;
+
+  setUp(() {
+    email = 'john@supabase.com';
+    phone = '+1234567890';
+    password = 'password';
+    nonce = 'nonce';
+    data = {'first_name': 'John', 'last_name': 'Doe'};
+  });
+
+  group('User attributes', () {
+    late UserAttributes userAttributesOne;
+    late UserAttributes userAttributesTwo;
+
+    setUp(() {
+      userAttributesOne = UserAttributes(
+        email: email,
+        phone: phone,
+        password: password,
+        nonce: nonce,
+        data: data,
+      );
+
+      userAttributesTwo = UserAttributes(
+        email: email,
+        phone: phone,
+        password: password,
+        nonce: nonce,
+        data: data,
+      );
+    });
+
+    test('Attributes are equals', () {
+      // assert
+      expect(userAttributesOne, equals(userAttributesTwo));
+    });
+
+    test('Attributes are not equals', () {
+      // arrange
+      final userAttributesThree = UserAttributes(
+        email: 'email',
+        phone: phone,
+        password: password,
+        nonce: nonce,
+        data: {'first_name': 'Jane', 'last_name': 'Doe'},
+      );
+
+      // assert
+      expect(userAttributesOne, isNot(equals(userAttributesThree)));
+    });
+  });
+
+  group('Admin user attributes', () {
+    late AdminUserAttributes adminUserAttributesOne;
+    late AdminUserAttributes adminUserAttributesTwo;
+
+    late Map<String, dynamic> userMetadata;
+    late Map<String, dynamic> appMetadata;
+    late bool emailConfirm;
+    late bool phoneConfirm;
+    late String banDuration;
+
+    setUp(() {
+      userMetadata = {'first_name': 'John', 'last_name': 'Doe'};
+      appMetadata = {
+        'roles': ['admin']
+      };
+      emailConfirm = true;
+      phoneConfirm = true;
+      banDuration = '1d';
+
+      adminUserAttributesOne = AdminUserAttributes(
+        email: email,
+        phone: phone,
+        password: password,
+        data: data,
+        userMetadata: userMetadata,
+        appMetadata: appMetadata,
+        emailConfirm: emailConfirm,
+        phoneConfirm: phoneConfirm,
+        banDuration: banDuration,
+      );
+
+      adminUserAttributesTwo = AdminUserAttributes(
+        email: email,
+        phone: phone,
+        password: password,
+        data: data,
+        userMetadata: userMetadata,
+        appMetadata: appMetadata,
+        emailConfirm: emailConfirm,
+        phoneConfirm: phoneConfirm,
+        banDuration: banDuration,
+      );
+    });
+
+    test('Attributes are equals', () {
+      // assert
+      expect(adminUserAttributesOne, equals(adminUserAttributesTwo));
+    });
+
+    test('Attributes are not equals', () {
+      // arrange
+      final adminUserAttributesThree = AdminUserAttributes(
+        email: email,
+        phone: phone,
+        password: password,
+        data: data,
+        userMetadata: {'first_name': 'Jane', 'last_name': 'Doe'},
+        appMetadata: appMetadata,
+        emailConfirm: false,
+        phoneConfirm: false,
+        banDuration: 'banDuration',
+      );
+
+      // assert
+      expect(adminUserAttributesOne, isNot(equals(adminUserAttributesThree)));
+    });
+  });
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix both `UserAttributes` and `AdminUserAttributes` classes by adding equality.

## What is the current behavior?

```dart
final attributeOne = UserAttributes(password: newPassword);
final attributeTwo = UserAttributes(password: newPassword);

attributeOne == attributeTwo // false
```

## What is the new behavior?

```dart
final attributeOne = UserAttributes(password: newPassword);
final attributeTwo = UserAttributes(password: newPassword);

attributeOne == attributeTwo // true
```

## Additional context

Encountered this behaviour when I tried to verify if my mock was called with the right values.

```dart
verify(() => mockAuthClient.updateUser(supa.UserAttributes(password: newPassword))); // failed
``` 
I then added the equality to the class in my pub cache and it worked.