### PR TITLE
fix: Support custom access token

### DIFF
--- a/packages/supabase/lib/src/supabase_client.dart
+++ b/packages/supabase/lib/src/supabase_client.dart
@@ -52,7 +52,7 @@ class SupabaseClient {
   final Client? _httpClient;
   late final Client _authHttpClient;
 
-  late final GoTrueClient _authInstance;
+  GoTrueClient? _authInstance;
 
   /// Supabase Functions allows you to deploy and invoke edge functions.
   late final FunctionsClient functions;
@@ -160,7 +160,7 @@ class SupabaseClient {
 
   GoTrueClient get auth {
     if (accessToken == null) {
-      return _authInstance;
+      return _authInstance!;
     } else {
       throw AuthException(
         'Supabase Client is configured with the accessToken option, accessing supabase.auth is not possible.',
@@ -239,11 +239,13 @@ class SupabaseClient {
       return await accessToken!();
     }
 
-    if (_authInstance.currentSession?.isExpired ?? false) {
+    final authInstance = _authInstance!;
+
+    if (authInstance.currentSession?.isExpired ?? false) {
       try {
-        await _authInstance.refreshSession();
+        await authInstance.refreshSession();
       } catch (error, stackTrace) {
-        final expiresAt = _authInstance.currentSession?.expiresAt;
+        final expiresAt = authInstance.currentSession?.expiresAt;
         if (expiresAt != null) {
           // Failed to refresh the token.
           final isExpiredWithoutMargin = DateTime.now()
@@ -260,14 +262,14 @@ class SupabaseClient {
         }
       }
     }
-    return _authInstance.currentSession?.accessToken;
+    return authInstance.currentSession?.accessToken;
   }
 
   Future<void> dispose() async {
     _log.fine('Dispose SupabaseClient');
     await _authStateSubscription?.cancel();
     await _isolate.dispose();
-    auth.dispose();
+    _authInstance?.dispose();
   }
 
   GoTrueClient _initSupabaseAuthClient({
@@ -332,6 +334,7 @@ class SupabaseClient {
     );
   }
 
+  /// Requires the `auth` instance, so no custom `accessToken` is allowed.
   Map<String, String> _getAuthHeaders() {
     final authBearer = auth.currentSession?.accessToken ?? _supabaseKey;
     final defaultHeaders = {

--- a/packages/supabase_flutter/lib/src/supabase.dart
+++ b/packages/supabase_flutter/lib/src/supabase.dart
@@ -1,6 +1,4 @@
 import 'dart:async';
-import 'dart:developer' as dev;
-import 'dart:io';
 
 import 'package:async/async.dart';
 import 'package:flutter/foundation.dart';

--- a/packages/supabase_flutter/lib/src/supabase.dart
+++ b/packages/supabase_flutter/lib/src/supabase.dart
@@ -1,8 +1,10 @@
 import 'dart:async';
 import 'dart:developer' as dev;
+import 'dart:io';
 
 import 'package:async/async.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
 import 'package:http/http.dart';
 import 'package:logging/logging.dart';
 import 'package:supabase/supabase.dart';
@@ -32,7 +34,7 @@ final _log = Logger('supabase.supabase_flutter');
 /// See also:
 ///
 ///   * [SupabaseAuth]
-class Supabase {
+class Supabase with WidgetsBindingObserver {
   /// Gets the current supabase instance.
   ///
   /// An [AssertionError] is thrown if supabase isn't initialized yet.
@@ -126,15 +128,18 @@ class Supabase {
       accessToken: accessToken,
     );
 
-    _instance._supabaseAuth = SupabaseAuth();
-    await _instance._supabaseAuth.initialize(options: authOptions);
+    if (accessToken == null) {
+      final supabaseAuth = SupabaseAuth();
+      _instance._supabaseAuth = supabaseAuth;
+      await supabaseAuth.initialize(options: authOptions);
 
-    // Wrap `recoverSession()` in a `CancelableOperation` so that it can be canceled in dispose
-    // if still in progress
-    _instance._restoreSessionCancellableOperation =
-        CancelableOperation.fromFuture(
-      _instance._supabaseAuth.recoverSession(),
-    );
+      // Wrap `recoverSession()` in a `CancelableOperation` so that it can be canceled in dispose
+      // if still in progress
+      _instance._restoreSessionCancellableOperation =
+          CancelableOperation.fromFuture(
+        supabaseAuth.recoverSession(),
+      );
+    }
 
     _log.info('***** Supabase init completed *****');
 
@@ -144,6 +149,8 @@ class Supabase {
   Supabase._();
   static final Supabase _instance = Supabase._();
 
+  static WidgetsBinding? get _widgetsBindingInstance => WidgetsBinding.instance;
+
   bool _initialized = false;
 
   /// The supabase client for this instance
@@ -151,12 +158,14 @@ class Supabase {
   /// Throws an error if [Supabase.initialize] was not called.
   late SupabaseClient client;
 
-  late SupabaseAuth _supabaseAuth;
+  SupabaseAuth? _supabaseAuth;
 
   bool _debugEnable = false;
 
   /// Wraps the `recoverSession()` call so that it can be terminated when `dispose()` is called
   late CancelableOperation _restoreSessionCancellableOperation;
+
+  CancelableOperation<void>? _realtimeReconnectOperation;
 
   StreamSubscription? _logSubscription;
 
@@ -165,7 +174,8 @@ class Supabase {
     await _restoreSessionCancellableOperation.cancel();
     _logSubscription?.cancel();
     client.dispose();
-    _instance._supabaseAuth.dispose();
+    _instance._supabaseAuth?.dispose();
+    _widgetsBindingInstance?.removeObserver(this);
     _initialized = false;
   }
 
@@ -195,6 +205,76 @@ class Supabase {
       authOptions: authOptions,
       accessToken: accessToken,
     );
+    _widgetsBindingInstance?.addObserver(this);
     _initialized = true;
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    switch (state) {
+      case AppLifecycleState.resumed:
+        onResumed();
+      case AppLifecycleState.detached:
+      case AppLifecycleState.paused:
+        _realtimeReconnectOperation?.cancel();
+        Supabase.instance.client.realtime.disconnect();
+      default:
+    }
+  }
+
+  Future<void> onResumed() async {
+    final realtime = Supabase.instance.client.realtime;
+    if (realtime.channels.isNotEmpty) {
+      if (realtime.connState == SocketStates.disconnecting) {
+        // If the socket is still disconnecting from e.g.
+        // [AppLifecycleState.paused] we should wait for it to finish before
+        // reconnecting.
+
+        bool cancel = false;
+        final connectFuture = realtime.conn!.sink.done.then(
+          (_) async {
+            // Make this connect cancelable so that it does not connect if the
+            // disconnect took so long that the app is already in background
+            // again.
+
+            if (!cancel) {
+              // ignore: invalid_use_of_internal_member
+              await realtime.connect();
+              for (final channel in realtime.channels) {
+                // ignore: invalid_use_of_internal_member
+                if (channel.isJoined) {
+                  // ignore: invalid_use_of_internal_member
+                  channel.forceRejoin();
+                }
+              }
+            }
+          },
+          onError: (error) {},
+        );
+        _realtimeReconnectOperation = CancelableOperation.fromFuture(
+          connectFuture,
+          onCancel: () => cancel = true,
+        );
+      } else if (!realtime.isConnected) {
+        // Reconnect if the socket is currently not connected.
+        // When coming from [AppLifecycleState.paused] this should be the case,
+        // but when coming from [AppLifecycleState.inactive] no disconnect
+        // happened and therefore connection should still be intanct and we
+        // should not reconnect.
+
+        // ignore: invalid_use_of_internal_member
+        await realtime.connect();
+        for (final channel in realtime.channels) {
+          // Only rejoin channels that think they are still joined and not
+          // which were manually unsubscribed by the user while in background
+
+          // ignore: invalid_use_of_internal_member
+          if (channel.isJoined) {
+            // ignore: invalid_use_of_internal_member
+            channel.forceRejoin();
+          }
+        }
+      }
+    }
   }
 }

--- a/packages/supabase_flutter/lib/src/supabase_auth.dart
+++ b/packages/supabase_flutter/lib/src/supabase_auth.dart
@@ -4,7 +4,6 @@ import 'dart:io' show Platform;
 import 'dart:math';
 
 import 'package:app_links/app_links.dart';
-import 'package:async/async.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -30,8 +29,6 @@ class SupabaseAuth with WidgetsBindingObserver {
   StreamSubscription<AuthState>? _authSubscription;
 
   StreamSubscription<Uri?>? _deeplinkSubscription;
-
-  CancelableOperation<void>? _realtimeReconnectOperation;
 
   final _appLinks = AppLinks();
 
@@ -118,74 +115,15 @@ class SupabaseAuth with WidgetsBindingObserver {
   void didChangeAppLifecycleState(AppLifecycleState state) {
     switch (state) {
       case AppLifecycleState.resumed:
-        onResumed();
+        if (_autoRefreshToken) {
+          Supabase.instance.client.auth.startAutoRefresh();
+        }
       case AppLifecycleState.detached:
       case AppLifecycleState.paused:
         if (kIsWeb || Platform.isAndroid || Platform.isIOS) {
           Supabase.instance.client.auth.stopAutoRefresh();
-          _realtimeReconnectOperation?.cancel();
-          Supabase.instance.client.realtime.disconnect();
         }
       default:
-    }
-  }
-
-  Future<void> onResumed() async {
-    if (_autoRefreshToken) {
-      Supabase.instance.client.auth.startAutoRefresh();
-    }
-    final realtime = Supabase.instance.client.realtime;
-    if (realtime.channels.isNotEmpty) {
-      if (realtime.connState == SocketStates.disconnecting) {
-        // If the socket is still disconnecting from e.g.
-        // [AppLifecycleState.paused] we should wait for it to finish before
-        // reconnecting.
-
-        bool cancel = false;
-        final connectFuture = realtime.conn!.sink.done.then(
-          (_) async {
-            // Make this connect cancelable so that it does not connect if the
-            // disconnect took so long that the app is already in background
-            // again.
-
-            if (!cancel) {
-              // ignore: invalid_use_of_internal_member
-              await realtime.connect();
-              for (final channel in realtime.channels) {
-                // ignore: invalid_use_of_internal_member
-                if (channel.isJoined) {
-                  // ignore: invalid_use_of_internal_member
-                  channel.forceRejoin();
-                }
-              }
-            }
-          },
-          onError: (error) {},
-        );
-        _realtimeReconnectOperation = CancelableOperation.fromFuture(
-          connectFuture,
-          onCancel: () => cancel = true,
-        );
-      } else if (!realtime.isConnected) {
-        // Reconnect if the socket is currently not connected.
-        // When coming from [AppLifecycleState.paused] this should be the case,
-        // but when coming from [AppLifecycleState.inactive] no disconnect
-        // happened and therefore connection should still be intanct and we
-        // should not reconnect.
-
-        // ignore: invalid_use_of_internal_member
-        await realtime.connect();
-        for (final channel in realtime.channels) {
-          // Only rejoin channels that think they are still joined and not
-          // which were manually unsubscribed by the user while in background
-
-          // ignore: invalid_use_of_internal_member
-          if (channel.isJoined) {
-            // ignore: invalid_use_of_internal_member
-            channel.forceRejoin();
-          }
-        }
-      }
     }
   }
 

--- a/packages/supabase_flutter/test/supabase_flutter_test.dart
+++ b/packages/supabase_flutter/test/supabase_flutter_test.dart
@@ -53,6 +53,10 @@ void main() {
       url: supabaseUrl,
       anonKey: supabaseUrl,
       debug: false,
+      authOptions: FlutterAuthClientOptions(
+        localStorage: MockLocalStorage(),
+        pkceAsyncStorage: MockAsyncStorage(),
+      ),
       accessToken: () async => 'my-access-token',
     );
 

--- a/packages/supabase_flutter/test/supabase_flutter_test.dart
+++ b/packages/supabase_flutter/test/supabase_flutter_test.dart
@@ -9,7 +9,7 @@ void main() {
   const supabaseKey = '';
   tearDown(() async => await Supabase.instance.dispose());
 
-  group("Valid session", () {
+  group("Initialize", () {
     setUp(() async {
       mockAppLink();
       // Initialize the Supabase singleton
@@ -46,6 +46,23 @@ void main() {
       final newClient = Supabase.instance.client;
       expect(supabase, isNot(newClient));
     });
+  });
+
+  test('with custom access token', () async {
+    final supabase = await Supabase.initialize(
+      url: supabaseUrl,
+      anonKey: supabaseUrl,
+      debug: false,
+      accessToken: () async => 'my-access-token',
+    );
+
+    // print(supabase.client.auth.runtimeType);
+
+    void accessAuth() {
+      supabase.client.auth;
+    }
+
+    expect(accessAuth, throwsA(isA<AuthException>()));
   });
 
   group("Expired session", () {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Passing a custom access token to supabase_flutter doesn't work. I noticed that the `SupabaseClient.dispose()` method didn't work with custom access token as well.

## What is the new behavior?

The realtime reconnection logic is moved to the `Supabase` class and `SupabaseAuth` is only initialized when no custom `accessToken` is passed.

## Additional context

close #1072 
