### PR TITLE
chore: support mime 2.0.0

### DIFF
--- a/packages/storage_client/pubspec.yaml
+++ b/packages/storage_client/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 dependencies:
   http: '>=0.13.4 <2.0.0'
   http_parser: ^4.0.1
-  mime: ^1.0.2
+  mime: '>=1.0.2 <3.0.0'
   retry: ^3.1.0
   meta: ^1.7.0
   logging: ^1.2.0


### PR DESCRIPTION
## What kind of change does this PR introduce?

package upgrade

## What is the current behavior?

mime 2.0.0 is not supported

## What is the new behavior?

Support 1.2.0 and 2.0.0

## Additional context
[mime changelog](https://pub.dev/packages/mime/changelog) We don't use that method so the update doesn't matter.

close #1074
