### PR TITLE
fix(realtime_client): prevent sending expired tokens

### DIFF
--- a/packages/realtime_client/pubspec.yaml
+++ b/packages/realtime_client/pubspec.yaml
@@ -19,3 +19,4 @@ dev_dependencies:
   lints: ^3.0.0
   mocktail: ^1.0.0
   test: ^1.16.5
+  crypto: ^3.0.6


### PR DESCRIPTION
## What kind of change does this PR introduce?

Adds a check of whether the JWT is expired before sending it to realtime. This helps the realtime logs to be filled with bunch of expired JWT token logs. 

Equivalent of https://github.com/supabase/realtime-js/pull/437 from realtime-js