### PR TITLE
fix: Ignore email and phone assertions when token hash is being verified

### DIFF
--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -533,7 +533,10 @@ class GoTrueClient {
     String? captchaToken,
     String? tokenHash,
   }) async {
-    assert(((email != null && phone == null) || (email == null && phone != null)) || (tokenHash != null),
+    assert(
+        ((email != null && phone == null) ||
+                (email == null && phone != null)) ||
+            (tokenHash != null),
         '`email` or `phone` needs to be specified.');
     assert(token != null || tokenHash != null,
         '`token` or `tokenHash` needs to be specified.');

--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -533,7 +533,7 @@ class GoTrueClient {
     String? captchaToken,
     String? tokenHash,
   }) async {
-    assert((email != null && phone == null) || (email == null && phone != null),
+    assert(((email != null && phone == null) || (email == null && phone != null)) || (tokenHash != null),
         '`email` or `phone` needs to be specified.');
     assert(token != null || tokenHash != null,
         '`token` or `tokenHash` needs to be specified.');


### PR DESCRIPTION
[Supabase Docs](https://supabase.com/docs/guides/auth/auth-email-passwordless?queryGroups=language&language=dart#with-magic-link
)

Following the above link, verifying token hash from magic link doesn't require email or phone in request body
(only 'token hash' and 'type' is required in the js example)

Pre commit state of the code threw assertion error if neither email nor phone is present in verifyOtp call preventing users to verify token hash without passing email or phone in request body ("auth/verify" endpoint called inside this function throws an error as well if email or phone is passed in request body along with token hash and type)

Hence have added a condition that will ignore the first email and phone assertion if token hash is populate