### PR TITLE
fix: Allow null to be returned from accessToken function when the user is not signed in

### DIFF
--- a/packages/supabase/lib/src/supabase_client.dart
+++ b/packages/supabase/lib/src/supabase_client.dart
@@ -63,7 +63,7 @@ class SupabaseClient {
   late final PostgrestClient rest;
   StreamSubscription<AuthState>? _authStateSubscription;
   late final YAJsonIsolate _isolate;
-  final Future<String> Function()? accessToken;
+  final Future<String?> Function()? accessToken;
 
   /// Increment ID of the stream to create different realtime topic for each stream
   final _incrementId = Counter();

--- a/packages/supabase_flutter/lib/src/supabase.dart
+++ b/packages/supabase_flutter/lib/src/supabase.dart
@@ -81,7 +81,7 @@ class Supabase with WidgetsBindingObserver {
     PostgrestClientOptions postgrestOptions = const PostgrestClientOptions(),
     StorageClientOptions storageOptions = const StorageClientOptions(),
     FlutterAuthClientOptions authOptions = const FlutterAuthClientOptions(),
-    Future<String> Function()? accessToken,
+    Future<String?> Function()? accessToken,
     bool? debug,
   }) async {
     assert(
@@ -186,7 +186,7 @@ class Supabase with WidgetsBindingObserver {
     required PostgrestClientOptions postgrestOptions,
     required StorageClientOptions storageOptions,
     required AuthClientOptions authOptions,
-    required Future<String> Function()? accessToken,
+    required Future<String?> Function()? accessToken,
   }) {
     final headers = {
       ...Constants.defaultHeaders,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix. 

## What is the current behavior?

Currently `null` cannot be returned from `accessToken` function. 

## What is the new behavior?

`null` can be returned from `accessToken` when the user on the third-party auth is not signed in.

## Additional context

Related https://github.com/supabase/supabase-js/pull/1332
