### PR TITLE
chore(supabase_flutter): State that linux is supported

### DIFF
--- a/packages/supabase_flutter/pubspec.yaml
+++ b/packages/supabase_flutter/pubspec.yaml
@@ -36,5 +36,6 @@ platforms:
   macos:
   web:
   windows:
+  linux:
 
 flutter:


### PR DESCRIPTION
## What kind of change does this PR introduce?

Mark in the pubspec.yaml of the supabase_flutter package that the linux platform is supported. This was previously not marked as supported, because of missing deeplink support, with an update to the app_links package this got resolved.

## Additional context

#278