### PR TITLE
docs: Fix typo for RPC docs

### DIFF
--- a/packages/postgrest/lib/src/postgrest.dart
+++ b/packages/postgrest/lib/src/postgrest.dart
@@ -86,7 +86,7 @@ class PostgrestClient {
   ///
   /// [fn] is the name of the function to call.
   ///
-  /// [params] is an optinal object to pass as arguments to the function call.
+  /// [params] is an optional object to pass as arguments to the function call.
   ///
   /// When [get] is set to `true`, the function will be called with read-only
   /// access mode.


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update.

## What is the current behavior?

Typo on RPC function docs where the current docs says:
```
/// [params] is an optinal object to pass as arguments to the function call.
```

## What is the new behavior?

Typo on RPC function docs where the current docs says:
```
/// [params] is an optional object to pass as arguments to the function call.
```

## Additional context

Add any other context or screenshots.
