### PR TITLE
chore: Generate coverage reports and upload them.

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,52 @@
+name: Combined Coverage Report
+
+on:
+  workflow_run:
+    workflows:
+      - 'functions_client'
+      - 'gotrue'
+      - 'postgrest'
+      - 'realtime_client'
+      - 'storage_client'
+      - 'supabase'
+      - 'supabase_flutter'
+      - 'yet_another_json_isolate'
+    types:
+      - completed
+
+jobs:
+  combine-coverage:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Dart
+        uses: dart-lang/setup-dart@v1
+        with:
+          sdk: stable
+
+      - name: Install coverage tool
+        run: dart pub global activate coverage
+
+      - name: Create coverage directory
+        run: mkdir -p coverage
+
+      - name: Download coverage artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: coverage-flutter-*
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Combine coverage reports
+        run: |
+          find coverage -name "lcov.info" -exec cat {} + > coverage/combined_lcov.info
+
+      - name: Upload combined coverage to Coveralls
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: coverage/combined_lcov.info

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -40,23 +40,28 @@ jobs:
               if [[ "$d" == "supabase_flutter/"* ]]; then
                 flutter test --coverage --concurrency=1
               else
+                # Set up Docker containers based on package
                 if [[ "$d" == "postgrest/"* ]]; then
                   cd ../../infra/postgrest
                   docker compose down
                   docker compose up -d
+                  sleep 5s
                   cd ../../packages/postgrest
                 elif [[ "$d" == "gotrue/"* ]]; then
                   cd ../../infra/gotrue
                   docker compose down
                   docker compose up -d
+                  sleep 5s
                   cd ../../packages/gotrue
                 elif [[ "$d" == "storage_client/"* ]]; then
                   cd ../../infra/storage_client
                   docker compose down
                   docker compose up -d
+                  sleep 5s
                   cd ../../packages/storage_client
                 fi
-                dart test --coverage=coverage
+                # Run tests with coverage
+                dart test --coverage=coverage --concurrency=1
                 dart pub global run coverage:format_coverage --packages=.dart_tool/package_config.json --report-on=lib --lcov -o coverage/lcov.info -i coverage
               fi
             fi

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -44,25 +44,35 @@ jobs:
                 if [[ "$d" == "postgrest/"* ]]; then
                   cd ../../infra/postgrest
                   docker compose down
-                  sleep 5s
                   docker compose up -d
                   cd ../../packages/postgrest
+                  dart test --coverage=coverage --concurrency=1
+                  dart pub global run coverage:format_coverage --packages=.dart_tool/package_config.json --report-on=lib --lcov -o coverage/lcov.info -i coverage
+                  docker compose down
+                  sleep 5s
                 elif [[ "$d" == "gotrue/"* ]]; then
                   cd ../../infra/gotrue
                   docker compose down
-                  sleep 5s
                   docker compose up -d
                   cd ../../packages/gotrue
+                  dart test --coverage=coverage --concurrency=1
+                  dart pub global run coverage:format_coverage --packages=.dart_tool/package_config.json --report-on=lib --lcov -o coverage/lcov.info -i coverage
+                  docker compose down
+                  sleep 5s
                 elif [[ "$d" == "storage_client/"* ]]; then
                   cd ../../infra/storage_client
                   docker compose down
-                  sleep 5s
                   docker compose up -d
                   cd ../../packages/storage_client
+                  dart test --coverage=coverage --concurrency=1
+                  dart pub global run coverage:format_coverage --packages=.dart_tool/package_config.json --report-on=lib --lcov -o coverage/lcov.info -i coverage
+                  docker compose down
+                  sleep 5s
+                else
+                  cd ../../packages/$d
+                  dart test --coverage=coverage --concurrency=1
+                  dart pub global run coverage:format_coverage --packages=.dart_tool/package_config.json --report-on=lib --lcov -o coverage/lcov.info -i coverage
                 fi
-                # Run tests with coverage
-                dart test --coverage=coverage --concurrency=1
-                dart pub global run coverage:format_coverage --packages=.dart_tool/package_config.json --report-on=lib --lcov -o coverage/lcov.info -i coverage
               fi
             fi
             cd ..

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -90,7 +90,7 @@ jobs:
           dart pub global run combine_coverage:combine_coverage --repo-path="./" --output-directory="coverage"
           
       - name: Upload combined coverage report
-        uses: actions/upload-artifact@v4
+        uses: coverallsapp/github-action@v2
         with:
-          name: combined-coverage-report
-          path: coverage/lcov.info
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: ./coverage/lcov.info

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,52 +1,59 @@
 name: Combined Coverage Report
 
 on:
-  workflow_run:
-    workflows:
-      - 'functions_client'
-      - 'gotrue'
-      - 'postgrest'
-      - 'realtime_client'
-      - 'storage_client'
-      - 'supabase'
-      - 'supabase_flutter'
-      - 'yet_another_json_isolate'
-    types:
-      - completed
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
-  combine-coverage:
+  coverage:
+    name: Generate Combined Coverage
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Setup Dart
-        uses: dart-lang/setup-dart@v1
+      - uses: actions/checkout@v4
+      
+      - uses: subosito/flutter-action@v2
         with:
-          sdk: stable
-
-      - name: Install coverage tool
-        run: dart pub global activate coverage
-
-      - name: Create coverage directory
-        run: mkdir -p coverage
-
-      - name: Download coverage artifacts
-        uses: actions/download-artifact@v4
-        with:
-          pattern: coverage-flutter-*
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          run-id: ${{ github.event.workflow_run.id }}
-
+          flutter-version: '3.x'
+          channel: 'stable'
+          
+      - name: Install dependencies
+        run: |
+          dart pub global activate melos
+          dart pub global activate coverage
+          dart pub global activate combine_coverage
+          melos bootstrap
+          
+      - name: Run tests with coverage for all packages
+        run: |
+          # Create directory for combined coverage
+          mkdir coverage
+          
+          # Run tests for each package and generate coverage
+          cd packages
+          for d in */ ; do
+            cd "$d"
+            if [ -f "pubspec.yaml" ]; then
+              echo "Running tests for $d"
+              if [[ "$d" == "supabase_flutter/"* ]]; then
+                flutter test --coverage --concurrency=1
+              else
+                dart test --coverage=coverage
+                dart pub global run coverage:format_coverage --packages=.dart_tool/package_config.json --report-on=lib --lcov -o coverage/lcov.info -i coverage
+              fi
+            fi
+            cd ..
+          done
+          cd ..
+          
       - name: Combine coverage reports
         run: |
-          find coverage -name "lcov.info" -exec cat {} + > coverage/combined_lcov.info
-
-      - name: Upload combined coverage to Coveralls
-        uses: coverallsapp/github-action@master
+          dart pub global run combine_coverage:combine_coverage --repo-path="./" --output-directory="coverage"
+          
+      - name: Upload combined coverage report
+        uses: actions/upload-artifact@v4
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: coverage/combined_lcov.info
+          name: combined-coverage-report
+          path: coverage/lcov.info

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -40,6 +40,22 @@ jobs:
               if [[ "$d" == "supabase_flutter/"* ]]; then
                 flutter test --coverage --concurrency=1
               else
+                if [[ "$d" == "postgrest/"* ]]; then
+                  cd ../../infra/postgrest
+                  docker compose down
+                  docker compose up -d
+                  cd ../../packages/postgrest
+                elif [[ "$d" == "gotrue/"* ]]; then
+                  cd ../../infra/gotrue
+                  docker compose down
+                  docker compose up -d
+                  cd ../../packages/gotrue
+                elif [[ "$d" == "storage_client/"* ]]; then
+                  cd ../../infra/storage_client
+                  docker compose down
+                  docker compose up -d
+                  cd ../../packages/storage_client
+                fi
                 dart test --coverage=coverage
                 dart pub global run coverage:format_coverage --packages=.dart_tool/package_config.json --report-on=lib --lcov -o coverage/lcov.info -i coverage
               fi

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -48,8 +48,10 @@ jobs:
                   cd ../../packages/postgrest
                   dart test --coverage=coverage --concurrency=1
                   dart pub global run coverage:format_coverage --packages=.dart_tool/package_config.json --report-on=lib --lcov -o coverage/lcov.info -i coverage
+                  cd ../../infra/postgrest
                   docker compose down
                   sleep 5s
+                  cd ../../packages/postgrest
                 elif [[ "$d" == "gotrue/"* ]]; then
                   cd ../../infra/gotrue
                   docker compose down
@@ -57,8 +59,10 @@ jobs:
                   cd ../../packages/gotrue
                   dart test --coverage=coverage --concurrency=1
                   dart pub global run coverage:format_coverage --packages=.dart_tool/package_config.json --report-on=lib --lcov -o coverage/lcov.info -i coverage
+                  cd ../../infra/gotrue
                   docker compose down
                   sleep 5s
+                  cd ../../packages/gotrue
                 elif [[ "$d" == "storage_client/"* ]]; then
                   cd ../../infra/storage_client
                   docker compose down
@@ -66,8 +70,10 @@ jobs:
                   cd ../../packages/storage_client
                   dart test --coverage=coverage --concurrency=1
                   dart pub global run coverage:format_coverage --packages=.dart_tool/package_config.json --report-on=lib --lcov -o coverage/lcov.info -i coverage
+                  cd ../../infra/storage_client
                   docker compose down
                   sleep 5s
+                  cd ../../packages/storage_client
                 else
                   cd ../../packages/$d
                   dart test --coverage=coverage --concurrency=1

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -44,20 +44,20 @@ jobs:
                 if [[ "$d" == "postgrest/"* ]]; then
                   cd ../../infra/postgrest
                   docker compose down
-                  docker compose up -d
                   sleep 5s
+                  docker compose up -d
                   cd ../../packages/postgrest
                 elif [[ "$d" == "gotrue/"* ]]; then
                   cd ../../infra/gotrue
                   docker compose down
-                  docker compose up -d
                   sleep 5s
+                  docker compose up -d
                   cd ../../packages/gotrue
                 elif [[ "$d" == "storage_client/"* ]]; then
                   cd ../../infra/storage_client
                   docker compose down
-                  docker compose up -d
                   sleep 5s
+                  docker compose up -d
                   cd ../../packages/storage_client
                 fi
                 # Run tests with coverage

--- a/.github/workflows/functions_client.yml
+++ b/.github/workflows/functions_client.yml
@@ -58,7 +58,6 @@ jobs:
 
       - name: Format coverage
         run: |
-          melos run format-coverage
           dart pub global activate coverage
           dart pub global run coverage:format_coverage --lcov --in="./coverage/test" --out="./coverage/lcov.info" --report-on="./lib"
 

--- a/.github/workflows/functions_client.yml
+++ b/.github/workflows/functions_client.yml
@@ -4,7 +4,16 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'packages/functions_client/**'
+      - '.github/workflows/functions_client.yml'
+      - 'packages/yet_another_json_isolate/**'
+
   pull_request:
+    paths:
+      - 'packages/functions_client/**'
+      - '.github/workflows/functions_client.yml'
+      - 'packages/yet_another_json_isolate/**'
 
 jobs:
   test:

--- a/.github/workflows/functions_client.yml
+++ b/.github/workflows/functions_client.yml
@@ -57,7 +57,10 @@ jobs:
         run: dart test --coverage=./coverage
 
       - name: Format coverage
-        run: melos run format-coverage
+        run: |
+          melos run format-coverage
+          dart pub global activate coverage
+          dart pub global run coverage:format_coverage --lcov --in="./coverage/test" --out="./coverage/lcov.info" --report-on="./lib"
 
       - name: Upload coverage results to Coveralls
         uses: coverallsapp/github-action@master

--- a/.github/workflows/functions_client.yml
+++ b/.github/workflows/functions_client.yml
@@ -57,7 +57,9 @@ jobs:
         run: dart test --coverage=./coverage
 
       - name: Format coverage
-        run: melos run format-coverage
+        run: |
+          pwd
+          melos run format-coverage
 
       - name: Upload coverage results to Coveralls
         uses: coverallsapp/github-action@master

--- a/.github/workflows/functions_client.yml
+++ b/.github/workflows/functions_client.yml
@@ -56,8 +56,8 @@ jobs:
       - name: Run tests
         run: dart test --coverage=./coverage
 
-      - name: Update coverage
-        run: melos run update-coverage
+      - name: Format coverage
+        run: melos run format-coverage
 
       - name: Upload coverage results to Coveralls
         uses: coverallsapp/github-action@master

--- a/.github/workflows/functions_client.yml
+++ b/.github/workflows/functions_client.yml
@@ -65,4 +65,4 @@ jobs:
         uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: ./coverage/lcov.info
+          path-to-lcov: ./packages/functions_client/coverage/lcov.info

--- a/.github/workflows/functions_client.yml
+++ b/.github/workflows/functions_client.yml
@@ -50,17 +50,4 @@ jobs:
         run: dart analyze
 
       - name: Run tests
-        run: dart test --coverage=./coverage
-
-      - name: Format coverage
-        if: ${{ matrix.sdk == 'stable'}}
-        run: |
-          dart pub global activate coverage
-          dart pub global run coverage:format_coverage --lcov --in="./coverage/test" --out="./coverage/lcov.info" --report-on="./lib"
-
-      - name: Upload coverage artifact
-        if: ${{ matrix.sdk == 'stable'}}
-        uses: actions/upload-artifact@v4
-        with:
-          name: coverage-flutter-functions-client
-          path: ./packages/functions_client/coverage/lcov.info
+        run: dart test

--- a/.github/workflows/functions_client.yml
+++ b/.github/workflows/functions_client.yml
@@ -57,9 +57,7 @@ jobs:
         run: dart test --coverage=./coverage
 
       - name: Format coverage
-        run: |
-          pwd
-          melos run format-coverage
+        run: melos run format-coverage
 
       - name: Upload coverage results to Coveralls
         uses: coverallsapp/github-action@master

--- a/.github/workflows/functions_client.yml
+++ b/.github/workflows/functions_client.yml
@@ -4,16 +4,7 @@ on:
   push:
     branches:
       - main
-    paths:
-      - 'packages/functions_client/**'
-      - '.github/workflows/functions_client.yml'
-      - 'packages/yet_another_json_isolate/**'
-
   pull_request:
-    paths:
-      - 'packages/functions_client/**'
-      - '.github/workflows/functions_client.yml'
-      - 'packages/yet_another_json_isolate/**'
 
 jobs:
   test:
@@ -62,12 +53,14 @@ jobs:
         run: dart test --coverage=./coverage
 
       - name: Format coverage
+        if: ${{ matrix.sdk == 'stable'}}
         run: |
           dart pub global activate coverage
           dart pub global run coverage:format_coverage --lcov --in="./coverage/test" --out="./coverage/lcov.info" --report-on="./lib"
 
-      - name: Upload coverage results to Coveralls
-        uses: coverallsapp/github-action@master
+      - name: Upload coverage artifact
+        if: ${{ matrix.sdk == 'stable'}}
+        uses: actions/upload-artifact@v4
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: ./packages/functions_client/coverage/lcov.info
+          name: coverage-flutter-functions-client
+          path: ./packages/functions_client/coverage/lcov.info

--- a/.github/workflows/functions_client.yml
+++ b/.github/workflows/functions_client.yml
@@ -58,3 +58,9 @@ jobs:
 
       - name: Update coverage
         run: melos run update-coverage
+
+      - name: Upload coverage results to Coveralls
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: ./coverage/lcov.info

--- a/.github/workflows/functions_client.yml
+++ b/.github/workflows/functions_client.yml
@@ -54,4 +54,7 @@ jobs:
         run: dart analyze --fatal-warnings --fatal-infos .
 
       - name: Run tests
-        run: dart test
+        run: dart test --coverage=./coverage
+
+      - name: Update coverage
+        run: melos run update-coverage

--- a/.github/workflows/functions_client.yml
+++ b/.github/workflows/functions_client.yml
@@ -51,7 +51,12 @@ jobs:
         run: dart format lib test -l 80 --set-exit-if-changed
 
       - name: analyzer
+        if: ${{ matrix.sdk == 'stable'}}
         run: dart analyze --fatal-warnings --fatal-infos .
+
+      - name: analyzer
+        if: ${{ matrix.sdk == 'beta' || matrix.sdk == 'dev' }}
+        run: dart analyze
 
       - name: Run tests
         run: dart test --coverage=./coverage

--- a/.github/workflows/gotrue.yml
+++ b/.github/workflows/gotrue.yml
@@ -64,8 +64,8 @@ jobs:
       - name: Run tests
         run: dart test --concurrency=1 --coverage=./coverage
 
-      - name: Update coverage
-        run: melos run update-coverage
+      - name: Format coverage
+        run: melos run format-coverage
 
       - name: Upload coverage results to Coveralls
         uses: coverallsapp/github-action@master

--- a/.github/workflows/gotrue.yml
+++ b/.github/workflows/gotrue.yml
@@ -73,4 +73,4 @@ jobs:
         uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: ./coverage/lcov.info
+          path-to-lcov: ./packages/gotrue/coverage/lcov.info

--- a/.github/workflows/gotrue.yml
+++ b/.github/workflows/gotrue.yml
@@ -4,7 +4,14 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'packages/gotrue/**'
+      - '.github/workflows/gotrue.yml'
+
   pull_request:
+    paths:
+      - 'packages/gotrue/**'
+      - '.github/workflows/gotrue.yml'
 
 jobs:
   test:

--- a/.github/workflows/gotrue.yml
+++ b/.github/workflows/gotrue.yml
@@ -62,4 +62,7 @@ jobs:
           time: '5s'
 
       - name: Run tests
-        run: dart test --concurrency=1
+        run: dart test --concurrency=1 --coverage=./coverage
+
+      - name: Update coverage
+        run: melos run update-coverage

--- a/.github/workflows/gotrue.yml
+++ b/.github/workflows/gotrue.yml
@@ -65,7 +65,9 @@ jobs:
         run: dart test --concurrency=1 --coverage=./coverage
 
       - name: Format coverage
-        run: melos run format-coverage
+        run: |
+          dart pub global activate coverage
+          dart pub global run coverage:format_coverage --lcov --in="./coverage/test" --out="./coverage/lcov.info" --report-on="./lib"
 
       - name: Upload coverage results to Coveralls
         uses: coverallsapp/github-action@master

--- a/.github/workflows/gotrue.yml
+++ b/.github/workflows/gotrue.yml
@@ -48,7 +48,12 @@ jobs:
         run: dart format lib test -l 80 --set-exit-if-changed
 
       - name: analyzer
+        if: ${{ matrix.sdk == 'stable'}}
         run: dart analyze --fatal-warnings --fatal-infos .
+
+      - name: analyzer
+        if: ${{ matrix.sdk == 'beta' || matrix.sdk == 'dev' }}
+        run: dart analyze
 
       - name: Build Docker image
         run: |

--- a/.github/workflows/gotrue.yml
+++ b/.github/workflows/gotrue.yml
@@ -60,16 +60,4 @@ jobs:
           time: '5s'
 
       - name: Run tests
-        run: dart test --concurrency=1 --coverage=./coverage
-
-      - name: Format coverage
-        run: |
-          dart pub global activate coverage
-          dart pub global run coverage:format_coverage --lcov --in="./coverage/test" --out="./coverage/lcov.info" --report-on="./lib"
-
-      - name: Upload coverage artifact
-        if: ${{ matrix.sdk == 'stable'}}
-        uses: actions/upload-artifact@v4
-        with:
-          name: coverage-flutter-gotrue
-          path: ./packages/gotrue/coverage/lcov.info
+        run: dart test --concurrency=1

--- a/.github/workflows/gotrue.yml
+++ b/.github/workflows/gotrue.yml
@@ -66,3 +66,9 @@ jobs:
 
       - name: Update coverage
         run: melos run update-coverage
+
+      - name: Upload coverage results to Coveralls
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: ./coverage/lcov.info

--- a/.github/workflows/gotrue.yml
+++ b/.github/workflows/gotrue.yml
@@ -4,14 +4,7 @@ on:
   push:
     branches:
       - main
-    paths:
-      - 'packages/gotrue/**'
-      - '.github/workflows/gotrue.yml'
-
   pull_request:
-    paths:
-      - 'packages/gotrue/**'
-      - '.github/workflows/gotrue.yml'
 
 jobs:
   test:
@@ -74,8 +67,9 @@ jobs:
           dart pub global activate coverage
           dart pub global run coverage:format_coverage --lcov --in="./coverage/test" --out="./coverage/lcov.info" --report-on="./lib"
 
-      - name: Upload coverage results to Coveralls
-        uses: coverallsapp/github-action@master
+      - name: Upload coverage artifact
+        if: ${{ matrix.sdk == 'stable'}}
+        uses: actions/upload-artifact@v4
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: ./packages/gotrue/coverage/lcov.info
+          name: coverage-flutter-gotrue
+          path: ./packages/gotrue/coverage/lcov.info

--- a/.github/workflows/postgrest.yml
+++ b/.github/workflows/postgrest.yml
@@ -60,16 +60,4 @@ jobs:
           time: '5s'
 
       - name: Run tests
-        run: dart test --concurrency=1 --coverage=./coverage
-
-      - name: Format coverage
-        run: |
-          dart pub global activate coverage
-          dart pub global run coverage:format_coverage --lcov --in="./coverage/test" --out="./coverage/lcov.info" --report-on="./lib"
-
-      - name: Upload coverage artifact
-        if: ${{ matrix.sdk == 'stable'}}
-        uses: actions/upload-artifact@v4
-        with:
-          name: coverage-flutter-postgrest
-          path: ./packages/postgrest/coverage/lcov.info
+        run: dart test --concurrency=1

--- a/.github/workflows/postgrest.yml
+++ b/.github/workflows/postgrest.yml
@@ -68,3 +68,9 @@ jobs:
 
       - name: Update coverage
         run: melos run update-coverage
+
+      - name: Upload coverage results to Coveralls
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: ./coverage/lcov.info

--- a/.github/workflows/postgrest.yml
+++ b/.github/workflows/postgrest.yml
@@ -66,8 +66,8 @@ jobs:
       - name: Run tests
         run: dart test --concurrency=1 --coverage=./coverage
 
-      - name: Update coverage
-        run: melos run update-coverage
+      - name: Format coverage
+        run: melos run format-coverage
 
       - name: Upload coverage results to Coveralls
         uses: coverallsapp/github-action@master

--- a/.github/workflows/postgrest.yml
+++ b/.github/workflows/postgrest.yml
@@ -50,7 +50,12 @@ jobs:
         run: dart format lib test -l 80 --set-exit-if-changed
 
       - name: analyzer
+        if: ${{ matrix.sdk == 'stable'}}
         run: dart analyze --fatal-warnings --fatal-infos .
+
+      - name: analyzer
+        if: ${{ matrix.sdk == 'beta' || matrix.sdk == 'dev' }}
+        run: dart analyze
 
       - name: Build Docker image
         run: |

--- a/.github/workflows/postgrest.yml
+++ b/.github/workflows/postgrest.yml
@@ -64,4 +64,7 @@ jobs:
           time: '5s'
 
       - name: Run tests
-        run: dart test --concurrency=1
+        run: dart test --concurrency=1 --coverage=./coverage
+
+      - name: Update coverage
+        run: melos run update-coverage

--- a/.github/workflows/postgrest.yml
+++ b/.github/workflows/postgrest.yml
@@ -4,16 +4,7 @@ on:
   push:
     branches:
       - main
-    paths:
-      - 'packages/postgrest/**'
-      - '.github/workflows/postgrest.yml'
-      - 'packages/yet_another_json_isolate/**'
-
   pull_request:
-    paths:
-      - 'packages/postgrest/**'
-      - '.github/workflows/postgrest.yml'
-      - 'packages/yet_another_json_isolate/**'
 
 jobs:
   test:
@@ -76,8 +67,9 @@ jobs:
           dart pub global activate coverage
           dart pub global run coverage:format_coverage --lcov --in="./coverage/test" --out="./coverage/lcov.info" --report-on="./lib"
 
-      - name: Upload coverage results to Coveralls
-        uses: coverallsapp/github-action@master
+      - name: Upload coverage artifact
+        if: ${{ matrix.sdk == 'stable'}}
+        uses: actions/upload-artifact@v4
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: ./packages/postgrest/coverage/lcov.info
+          name: coverage-flutter-postgrest
+          path: ./packages/postgrest/coverage/lcov.info

--- a/.github/workflows/postgrest.yml
+++ b/.github/workflows/postgrest.yml
@@ -4,7 +4,16 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'packages/postgrest/**'
+      - '.github/workflows/postgrest.yml'
+      - 'packages/yet_another_json_isolate/**'
+
   pull_request:
+    paths:
+      - 'packages/postgrest/**'
+      - '.github/workflows/postgrest.yml'
+      - 'packages/yet_another_json_isolate/**'
 
 jobs:
   test:

--- a/.github/workflows/postgrest.yml
+++ b/.github/workflows/postgrest.yml
@@ -75,4 +75,4 @@ jobs:
         uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: ./coverage/lcov.info
+          path-to-lcov: ./packages/postgrest/coverage/lcov.info

--- a/.github/workflows/postgrest.yml
+++ b/.github/workflows/postgrest.yml
@@ -67,7 +67,9 @@ jobs:
         run: dart test --concurrency=1 --coverage=./coverage
 
       - name: Format coverage
-        run: melos run format-coverage
+        run: |
+          dart pub global activate coverage
+          dart pub global run coverage:format_coverage --lcov --in="./coverage/test" --out="./coverage/lcov.info" --report-on="./lib"
 
       - name: Upload coverage results to Coveralls
         uses: coverallsapp/github-action@master

--- a/.github/workflows/realtime_client.yml
+++ b/.github/workflows/realtime_client.yml
@@ -51,7 +51,7 @@ jobs:
         run: dart analyze --fatal-warnings --fatal-infos .
 
       - name: Run tests
-        run: dart test --coverage=./coverage
+        run: dart test --concurrency=1 --coverage=./coverage
 
       - name: Format coverage
         run: |

--- a/.github/workflows/realtime_client.yml
+++ b/.github/workflows/realtime_client.yml
@@ -49,16 +49,4 @@ jobs:
         run: dart analyze
 
       - name: Run tests
-        run: dart test --concurrency=1 --coverage=./coverage
-
-      - name: Format coverage
-        run: |
-          dart pub global activate coverage
-          dart pub global run coverage:format_coverage --lcov --in="./coverage/test" --out="./coverage/lcov.info" --report-on="./lib"
-
-      - name: Upload coverage artifact
-        if: ${{ matrix.sdk == 'stable'}}
-        uses: actions/upload-artifact@v4
-        with:
-          name: coverage-flutter-realtime-client
-          path: ./packages/realtime_client/coverage/lcov.info
+        run: dart test --concurrency=1

--- a/.github/workflows/realtime_client.yml
+++ b/.github/workflows/realtime_client.yml
@@ -4,7 +4,14 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'packages/realtime_client/**'
+      - '.github/workflows/realtime_client.yml'
+
   pull_request:
+    paths:
+      - 'packages/realtime_client/**'
+      - '.github/workflows/realtime_client.yml'
 
 jobs:
   test:

--- a/.github/workflows/realtime_client.yml
+++ b/.github/workflows/realtime_client.yml
@@ -51,4 +51,7 @@ jobs:
         run: dart analyze --fatal-warnings --fatal-infos .
 
       - name: Run tests
-        run: dart test
+        run: dart test --coverage=./coverage
+
+      - name: Update coverage
+        run: melos run update-coverage

--- a/.github/workflows/realtime_client.yml
+++ b/.github/workflows/realtime_client.yml
@@ -62,4 +62,4 @@ jobs:
         uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: ./coverage/lcov.info
+          path-to-lcov: ./packages/realtime_client/coverage/lcov.info

--- a/.github/workflows/realtime_client.yml
+++ b/.github/workflows/realtime_client.yml
@@ -54,7 +54,9 @@ jobs:
         run: dart test --coverage=./coverage
 
       - name: Format coverage
-        run: melos run format-coverage
+        run: |
+          dart pub global activate coverage
+          dart pub global run coverage:format_coverage --lcov --in="./coverage/test" --out="./coverage/lcov.info" --report-on="./lib"
 
       - name: Upload coverage results to Coveralls
         uses: coverallsapp/github-action@master

--- a/.github/workflows/realtime_client.yml
+++ b/.github/workflows/realtime_client.yml
@@ -53,8 +53,8 @@ jobs:
       - name: Run tests
         run: dart test --coverage=./coverage
 
-      - name: Update coverage
-        run: melos run update-coverage
+      - name: Format coverage
+        run: melos run format-coverage
 
       - name: Upload coverage results to Coveralls
         uses: coverallsapp/github-action@master

--- a/.github/workflows/realtime_client.yml
+++ b/.github/workflows/realtime_client.yml
@@ -4,14 +4,7 @@ on:
   push:
     branches:
       - main
-    paths:
-      - 'packages/realtime_client/**'
-      - '.github/workflows/realtime_client.yml'
-
   pull_request:
-    paths:
-      - 'packages/realtime_client/**'
-      - '.github/workflows/realtime_client.yml'
 
 jobs:
   test:
@@ -63,8 +56,9 @@ jobs:
           dart pub global activate coverage
           dart pub global run coverage:format_coverage --lcov --in="./coverage/test" --out="./coverage/lcov.info" --report-on="./lib"
 
-      - name: Upload coverage results to Coveralls
-        uses: coverallsapp/github-action@master
+      - name: Upload coverage artifact
+        if: ${{ matrix.sdk == 'stable'}}
+        uses: actions/upload-artifact@v4
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: ./packages/realtime_client/coverage/lcov.info
+          name: coverage-flutter-realtime-client
+          path: ./packages/realtime_client/coverage/lcov.info

--- a/.github/workflows/realtime_client.yml
+++ b/.github/workflows/realtime_client.yml
@@ -48,7 +48,12 @@ jobs:
         run: dart format lib test -l 80 --set-exit-if-changed
 
       - name: analyzer
+        if: ${{ matrix.sdk == 'stable'}}
         run: dart analyze --fatal-warnings --fatal-infos .
+
+      - name: analyzer
+        if: ${{ matrix.sdk == 'beta' || matrix.sdk == 'dev' }}
+        run: dart analyze
 
       - name: Run tests
         run: dart test --concurrency=1 --coverage=./coverage

--- a/.github/workflows/realtime_client.yml
+++ b/.github/workflows/realtime_client.yml
@@ -55,3 +55,9 @@ jobs:
 
       - name: Update coverage
         run: melos run update-coverage
+
+      - name: Upload coverage results to Coveralls
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: ./coverage/lcov.info

--- a/.github/workflows/storage_client.yml
+++ b/.github/workflows/storage_client.yml
@@ -4,7 +4,13 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'packages/storage_client/**'
+      - '.github/workflows/storage_client.yml'
   pull_request:
+    paths:
+      - 'packages/storage_client/**'
+      - '.github/workflows/storage_client.yml'
 
 jobs:
   test:

--- a/.github/workflows/storage_client.yml
+++ b/.github/workflows/storage_client.yml
@@ -47,7 +47,12 @@ jobs:
         run: dart format lib test -l 80 --set-exit-if-changed
 
       - name: analyzer
+        if: ${{ matrix.sdk == 'stable'}}
         run: dart analyze --fatal-warnings --fatal-infos .
+
+      - name: analyzer
+        if: ${{ matrix.sdk == 'beta' || matrix.sdk == 'dev' }}
+        run: dart analyze
 
       - name: Build Docker image
         run: |

--- a/.github/workflows/storage_client.yml
+++ b/.github/workflows/storage_client.yml
@@ -60,16 +60,4 @@ jobs:
           time: '5s'
 
       - name: Run tests
-        run: dart test --coverage=./coverage
-
-      - name: Format coverage
-        run: |
-          dart pub global activate coverage
-          dart pub global run coverage:format_coverage --lcov --in="./coverage/test" --out="./coverage/lcov.info" --report-on="./lib"
-
-      - name: Upload coverage artifact
-        if: ${{ matrix.sdk == 'stable'}}
-        uses: actions/upload-artifact@v4
-        with:
-          name: coverage-flutter-storage-client
-          path: ./packages/storage_client/coverage/lcov.info
+        run: dart test

--- a/.github/workflows/storage_client.yml
+++ b/.github/workflows/storage_client.yml
@@ -61,4 +61,7 @@ jobs:
           time: '5s'
 
       - name: Run tests
-        run: dart test
+        run: dart test --coverage=./coverage
+
+      - name: Update coverage
+        run: melos run update-coverage

--- a/.github/workflows/storage_client.yml
+++ b/.github/workflows/storage_client.yml
@@ -65,3 +65,9 @@ jobs:
 
       - name: Update coverage
         run: melos run update-coverage
+
+      - name: Upload coverage results to Coveralls
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: ./coverage/lcov.info

--- a/.github/workflows/storage_client.yml
+++ b/.github/workflows/storage_client.yml
@@ -72,4 +72,4 @@ jobs:
         uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: ./coverage/lcov.info
+          path-to-lcov: ./packages/storage_client/coverage/lcov.info

--- a/.github/workflows/storage_client.yml
+++ b/.github/workflows/storage_client.yml
@@ -63,8 +63,8 @@ jobs:
       - name: Run tests
         run: dart test --coverage=./coverage
 
-      - name: Update coverage
-        run: melos run update-coverage
+      - name: Format coverage
+        run: melos run format-coverage
 
       - name: Upload coverage results to Coveralls
         uses: coverallsapp/github-action@master

--- a/.github/workflows/storage_client.yml
+++ b/.github/workflows/storage_client.yml
@@ -64,7 +64,9 @@ jobs:
         run: dart test --coverage=./coverage
 
       - name: Format coverage
-        run: melos run format-coverage
+        run: |
+          dart pub global activate coverage
+          dart pub global run coverage:format_coverage --lcov --in="./coverage/test" --out="./coverage/lcov.info" --report-on="./lib"
 
       - name: Upload coverage results to Coveralls
         uses: coverallsapp/github-action@master

--- a/.github/workflows/storage_client.yml
+++ b/.github/workflows/storage_client.yml
@@ -4,13 +4,7 @@ on:
   push:
     branches:
       - main
-    paths:
-      - 'packages/storage_client/**'
-      - '.github/workflows/storage_client.yml'
   pull_request:
-    paths:
-      - 'packages/storage_client/**'
-      - '.github/workflows/storage_client.yml'
 
 jobs:
   test:
@@ -73,8 +67,9 @@ jobs:
           dart pub global activate coverage
           dart pub global run coverage:format_coverage --lcov --in="./coverage/test" --out="./coverage/lcov.info" --report-on="./lib"
 
-      - name: Upload coverage results to Coveralls
-        uses: coverallsapp/github-action@master
+      - name: Upload coverage artifact
+        if: ${{ matrix.sdk == 'stable'}}
+        uses: actions/upload-artifact@v4
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: ./packages/storage_client/coverage/lcov.info
+          name: coverage-flutter-storage-client
+          path: ./packages/storage_client/coverage/lcov.info

--- a/.github/workflows/supabase.yml
+++ b/.github/workflows/supabase.yml
@@ -63,11 +63,9 @@ jobs:
       - name: Run tests
         run: dart test --concurrency=1 --coverage=./coverage
 
-      - name: Update coverage
-        run: |
-          dart pub global activate combine_coverage
-          melos run update-coverage
-          dart pub global run combine_coverage --repo-path="../../"
+      - name: Format coverage
+        run: melos run format-coverage
+
 
       - name: Upload coverage results to Coveralls
         uses: coverallsapp/github-action@master

--- a/.github/workflows/supabase.yml
+++ b/.github/workflows/supabase.yml
@@ -61,4 +61,10 @@ jobs:
         run: dart analyze --fatal-warnings --fatal-infos .
 
       - name: Run tests
-        run: dart test --concurrency=1
+        run: dart test --concurrency=1 --coverage=./coverage
+
+      - name: Update coverage
+        run: |
+          dart pub global activate combine_coverage
+          melos run update-coverage
+          dart pub global run combine_coverage --repo-path="../../"

--- a/.github/workflows/supabase.yml
+++ b/.github/workflows/supabase.yml
@@ -4,7 +4,24 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'packages/supabase/**'
+      - '.github/workflows/supabase.yml'
+      - 'packages/functions_client/**'
+      - 'packages/gotrue/**'
+      - 'packages/postgrest/**'
+      - 'packages/realtime_client/**'
+      - 'packages/storage_client/**'
+
   pull_request:
+    paths:
+      - 'packages/supabase/**'
+      - '.github/workflows/supabase.yml'
+      - 'packages/functions_client/**'
+      - 'packages/gotrue/**'
+      - 'packages/postgrest/**'
+      - 'packages/realtime_client/**'
+      - 'packages/storage_client/**'
 
 jobs:
   test:

--- a/.github/workflows/supabase.yml
+++ b/.github/workflows/supabase.yml
@@ -68,3 +68,9 @@ jobs:
           dart pub global activate combine_coverage
           melos run update-coverage
           dart pub global run combine_coverage --repo-path="../../"
+
+      - name: Upload coverage results to Coveralls
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: ./coverage/lcov.info

--- a/.github/workflows/supabase.yml
+++ b/.github/workflows/supabase.yml
@@ -64,8 +64,9 @@ jobs:
         run: dart test --concurrency=1 --coverage=./coverage
 
       - name: Format coverage
-        run: melos run format-coverage
-
+        run: |
+          dart pub global activate coverage
+          dart pub global run coverage:format_coverage --lcov --in="./coverage/test" --out="./coverage/lcov.info" --report-on="./lib"
 
       - name: Upload coverage results to Coveralls
         uses: coverallsapp/github-action@master

--- a/.github/workflows/supabase.yml
+++ b/.github/workflows/supabase.yml
@@ -4,24 +4,7 @@ on:
   push:
     branches:
       - main
-    paths:
-      - 'packages/supabase/**'
-      - '.github/workflows/supabase.yml'
-      - 'packages/functions_client/**'
-      - 'packages/gotrue/**'
-      - 'packages/postgrest/**'
-      - 'packages/realtime_client/**'
-      - 'packages/storage_client/**'
-
   pull_request:
-    paths:
-      - 'packages/supabase/**'
-      - '.github/workflows/supabase.yml'
-      - 'packages/functions_client/**'
-      - 'packages/gotrue/**'
-      - 'packages/postgrest/**'
-      - 'packages/realtime_client/**'
-      - 'packages/storage_client/**'
 
 jobs:
   test:
@@ -73,8 +56,9 @@ jobs:
           dart pub global activate coverage
           dart pub global run coverage:format_coverage --lcov --in="./coverage/test" --out="./coverage/lcov.info" --report-on="./lib"
 
-      - name: Upload coverage results to Coveralls
-        uses: coverallsapp/github-action@master
+      - name: Upload coverage artifact
+        if: ${{ matrix.sdk == 'stable'}}
+        uses: actions/upload-artifact@v4
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: ./packages/supabase/coverage/lcov.info
+          name: coverage-flutter-supabase
+          path: ./packages/supabase/coverage/lcov.info

--- a/.github/workflows/supabase.yml
+++ b/.github/workflows/supabase.yml
@@ -49,16 +49,4 @@ jobs:
         run: dart analyze
 
       - name: Run tests
-        run: dart test --concurrency=1 --coverage=./coverage
-
-      - name: Format coverage
-        run: |
-          dart pub global activate coverage
-          dart pub global run coverage:format_coverage --lcov --in="./coverage/test" --out="./coverage/lcov.info" --report-on="./lib"
-
-      - name: Upload coverage artifact
-        if: ${{ matrix.sdk == 'stable'}}
-        uses: actions/upload-artifact@v4
-        with:
-          name: coverage-flutter-supabase
-          path: ./packages/supabase/coverage/lcov.info
+        run: dart test --concurrency=1

--- a/.github/workflows/supabase.yml
+++ b/.github/workflows/supabase.yml
@@ -58,7 +58,12 @@ jobs:
         run: dart format lib test -l 80 --set-exit-if-changed
 
       - name: analyzer
+        if: ${{ matrix.sdk == 'stable'}}
         run: dart analyze --fatal-warnings --fatal-infos .
+
+      - name: analyzer
+        if: ${{ matrix.sdk == 'beta' || matrix.sdk == 'dev' }}
+        run: dart analyze
 
       - name: Run tests
         run: dart test --concurrency=1 --coverage=./coverage

--- a/.github/workflows/supabase.yml
+++ b/.github/workflows/supabase.yml
@@ -72,4 +72,4 @@ jobs:
         uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: ./coverage/lcov.info
+          path-to-lcov: ./packages/supabase/coverage/lcov.info

--- a/.github/workflows/supabase_flutter.yml
+++ b/.github/workflows/supabase_flutter.yml
@@ -80,5 +80,8 @@ jobs:
           cd example
           flutter build web
 
-      - name: Update coverage
-        run: melos run update-coverage
+      - name: Upload coverage results to Coveralls
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: ./coverage/lcov.info

--- a/.github/workflows/supabase_flutter.yml
+++ b/.github/workflows/supabase_flutter.yml
@@ -84,4 +84,4 @@ jobs:
         uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: ./coverage/lcov.info
+          path-to-lcov: ./packages/supabase_flutter/coverage/lcov.info

--- a/.github/workflows/supabase_flutter.yml
+++ b/.github/workflows/supabase_flutter.yml
@@ -68,7 +68,7 @@ jobs:
         run: flutter analyze --fatal-warnings --fatal-infos .
 
       - name: Run tests
-        run: flutter test --concurrency=1
+        run: flutter test --concurrency=1 --coverage
 
       - name: Run tests with downgraded app_links
         run: |
@@ -79,3 +79,6 @@ jobs:
         run: |
           cd example
           flutter build web
+
+      - name: Update coverage
+        run: melos run update-coverage

--- a/.github/workflows/supabase_flutter.yml
+++ b/.github/workflows/supabase_flutter.yml
@@ -4,7 +4,28 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'packages/supabase_flutter/**'
+      - '.github/workflows/supabase_flutter.yml'
+      - 'packages/functions_client/**'
+      - 'packages/gotrue/**'
+      - 'packages/postgrest/**'
+      - 'packages/realtime_client/**'
+      - 'packages/storage_client/**'
+      - 'packages/supabase/**'
+      - 'packages/yet_another_json_isolate/**'
+
   pull_request:
+    paths:
+      - 'packages/supabase_flutter/**'
+      - '.github/workflows/supabase_flutter.yml'
+      - 'packages/functions_client/**'
+      - 'packages/gotrue/**'
+      - 'packages/postgrest/**'
+      - 'packages/realtime_client/**'
+      - 'packages/storage_client/**'
+      - 'packages/supabase/**'
+      - 'packages/yet_another_json_isolate/**'
 
 jobs:
   test:

--- a/.github/workflows/supabase_flutter.yml
+++ b/.github/workflows/supabase_flutter.yml
@@ -4,28 +4,7 @@ on:
   push:
     branches:
       - main
-    paths:
-      - 'packages/supabase_flutter/**'
-      - '.github/workflows/supabase_flutter.yml'
-      - 'packages/functions_client/**'
-      - 'packages/gotrue/**'
-      - 'packages/postgrest/**'
-      - 'packages/realtime_client/**'
-      - 'packages/storage_client/**'
-      - 'packages/supabase/**'
-      - 'packages/yet_another_json_isolate/**'
-
   pull_request:
-    paths:
-      - 'packages/supabase_flutter/**'
-      - '.github/workflows/supabase_flutter.yml'
-      - 'packages/functions_client/**'
-      - 'packages/gotrue/**'
-      - 'packages/postgrest/**'
-      - 'packages/realtime_client/**'
-      - 'packages/storage_client/**'
-      - 'packages/supabase/**'
-      - 'packages/yet_another_json_isolate/**'
 
 jobs:
   test:
@@ -80,8 +59,9 @@ jobs:
           cd example
           flutter build web
 
-      - name: Upload coverage results to Coveralls
-        uses: coverallsapp/github-action@master
+      - name: Upload coverage artifact
+        if: ${{ matrix.sdk == 'stable'}}
+        uses: actions/upload-artifact@v4
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: ./packages/supabase_flutter/coverage/lcov.info
+          name: coverage-flutter-supabase-flutter
+          path: ./packages/supabase_flutter/coverage/lcov.info

--- a/.github/workflows/supabase_flutter.yml
+++ b/.github/workflows/supabase_flutter.yml
@@ -47,7 +47,7 @@ jobs:
         run: flutter analyze --fatal-warnings --fatal-infos .
 
       - name: Run tests
-        run: flutter test --concurrency=1 --coverage
+        run: flutter test --concurrency=1
 
       - name: Run tests with downgraded app_links
         run: |
@@ -58,10 +58,3 @@ jobs:
         run: |
           cd example
           flutter build web
-
-      - name: Upload coverage artifact
-        if: ${{ matrix.sdk == 'stable'}}
-        uses: actions/upload-artifact@v4
-        with:
-          name: coverage-flutter-supabase-flutter
-          path: ./packages/supabase_flutter/coverage/lcov.info

--- a/.github/workflows/yet_another_json_isolate.yml
+++ b/.github/workflows/yet_another_json_isolate.yml
@@ -51,4 +51,7 @@ jobs:
         run: dart analyze --fatal-warnings --fatal-infos .
 
       - name: Run tests
-        run: dart test
+        run: dart test --coverage=./coverage
+
+      - name: Update coverage
+        run: melos run update-coverage

--- a/.github/workflows/yet_another_json_isolate.yml
+++ b/.github/workflows/yet_another_json_isolate.yml
@@ -48,7 +48,12 @@ jobs:
         run: dart format lib test -l 80 --set-exit-if-changed
 
       - name: analyzer
+        if: ${{ matrix.sdk == 'stable'}}
         run: dart analyze --fatal-warnings --fatal-infos .
+
+      - name: analyzer
+        if: ${{ matrix.sdk == 'beta' || matrix.sdk == 'dev' }}
+        run: dart analyze
 
       - name: Run tests
         run: dart test --coverage=./coverage

--- a/.github/workflows/yet_another_json_isolate.yml
+++ b/.github/workflows/yet_another_json_isolate.yml
@@ -4,14 +4,7 @@ on:
   push:
     branches:
       - main
-    paths:
-      - 'packages/yet_another_json_isolate/**'
-      - '.github/workflows/yet_another_json_isolate.yml'
-
   pull_request:
-    paths:
-      - 'packages/yet_another_json_isolate/**'
-      - '.github/workflows/yet_another_json_isolate.yml'
 
 jobs:
   test:
@@ -63,8 +56,9 @@ jobs:
           dart pub global activate coverage
           dart pub global run coverage:format_coverage --lcov --in="./coverage/test" --out="./coverage/lcov.info" --report-on="./lib"
 
-      - name: Upload coverage results to Coveralls
-        uses: coverallsapp/github-action@master
+      - name: Upload coverage artifact
+        if: ${{ matrix.sdk == 'stable'}}
+        uses: actions/upload-artifact@v4
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: ./packages/yet_another_json_isolate/coverage/lcov.info
+          name: coverage-flutter-yet-another-json-isolate
+          path: ./packages/yet_another_json_isolate/coverage/lcov.info

--- a/.github/workflows/yet_another_json_isolate.yml
+++ b/.github/workflows/yet_another_json_isolate.yml
@@ -4,7 +4,14 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'packages/yet_another_json_isolate/**'
+      - '.github/workflows/yet_another_json_isolate.yml'
+
   pull_request:
+    paths:
+      - 'packages/yet_another_json_isolate/**'
+      - '.github/workflows/yet_another_json_isolate.yml'
 
 jobs:
   test:

--- a/.github/workflows/yet_another_json_isolate.yml
+++ b/.github/workflows/yet_another_json_isolate.yml
@@ -54,7 +54,9 @@ jobs:
         run: dart test --coverage=./coverage
 
       - name: Format coverage
-        run: melos run format-coverage
+        run: |
+          dart pub global activate coverage
+          dart pub global run coverage:format_coverage --lcov --in="./coverage/test" --out="./coverage/lcov.info" --report-on="./lib"
 
       - name: Upload coverage results to Coveralls
         uses: coverallsapp/github-action@master

--- a/.github/workflows/yet_another_json_isolate.yml
+++ b/.github/workflows/yet_another_json_isolate.yml
@@ -53,8 +53,8 @@ jobs:
       - name: Run tests
         run: dart test --coverage=./coverage
 
-      - name: Update coverage
-        run: melos run update-coverage
+      - name: Format coverage
+        run: melos run format-coverage
 
       - name: Upload coverage results to Coveralls
         uses: coverallsapp/github-action@master

--- a/.github/workflows/yet_another_json_isolate.yml
+++ b/.github/workflows/yet_another_json_isolate.yml
@@ -49,16 +49,4 @@ jobs:
         run: dart analyze
 
       - name: Run tests
-        run: dart test --coverage=./coverage
-
-      - name: Format coverage
-        run: |
-          dart pub global activate coverage
-          dart pub global run coverage:format_coverage --lcov --in="./coverage/test" --out="./coverage/lcov.info" --report-on="./lib"
-
-      - name: Upload coverage artifact
-        if: ${{ matrix.sdk == 'stable'}}
-        uses: actions/upload-artifact@v4
-        with:
-          name: coverage-flutter-yet-another-json-isolate
-          path: ./packages/yet_another_json_isolate/coverage/lcov.info
+        run: dart test

--- a/.github/workflows/yet_another_json_isolate.yml
+++ b/.github/workflows/yet_another_json_isolate.yml
@@ -62,4 +62,4 @@ jobs:
         uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: ./coverage/lcov.info
+          path-to-lcov: ./packages/yet_another_json_isolate/coverage/lcov.info

--- a/.github/workflows/yet_another_json_isolate.yml
+++ b/.github/workflows/yet_another_json_isolate.yml
@@ -55,3 +55,9 @@ jobs:
 
       - name: Update coverage
         run: melos run update-coverage
+
+      - name: Upload coverage results to Coveralls
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: ./coverage/lcov.info

--- a/melos.yaml
+++ b/melos.yaml
@@ -54,13 +54,3 @@ scripts:
       # Stage the version.dart file change
       git add packages/*/lib/src/version.dart
     description: Updates the version.dart file for each packages except yet_another_json_isolate
-
-  format-coverage:
-    description: Updates the coverage for the workspace
-    run: |
-      pwd
-      # Activate coverage
-      dart pub global activate coverage
-
-      # Format coverage
-      dart pub global run coverage:format_coverage --lcov --in="./coverage/test" --out="./coverage/lcov.info" --report-on="./lib"

--- a/melos.yaml
+++ b/melos.yaml
@@ -58,9 +58,8 @@ scripts:
   update-coverage:
     description: Updates the coverage for the workspace
     run: |
-      # Activate coverage and combine_coverage
+      # Activate coverage
       dart pub global activate coverage
-      dart pub global activate combine_coverage
 
       # Format coverage
       dart pub global run coverage:format_coverage --lcov --in="./coverage/test" --out="./coverage/lcov.info" --report-on="./lib"

--- a/melos.yaml
+++ b/melos.yaml
@@ -55,7 +55,7 @@ scripts:
       git add packages/*/lib/src/version.dart
     description: Updates the version.dart file for each packages except yet_another_json_isolate
 
-  update-coverage:
+  format-coverage:
     description: Updates the coverage for the workspace
     run: |
       # Activate coverage

--- a/melos.yaml
+++ b/melos.yaml
@@ -39,6 +39,7 @@ scripts:
     exec: dart pub outdated
 
   update-version:
+    description: Updates the version.dart file for each packages except yet_another_json_isolate
     run: |
       # Loop through the packages directory
       for d in packages/*/ ; do
@@ -53,4 +54,4 @@ scripts:
       rm packages/yet_another_json_isolate/lib/src/version.dart
       # Stage the version.dart file change
       git add packages/*/lib/src/version.dart
-    description: Updates the version.dart file for each packages except yet_another_json_isolate
+    

--- a/melos.yaml
+++ b/melos.yaml
@@ -54,3 +54,16 @@ scripts:
       # Stage the version.dart file change
       git add packages/*/lib/src/version.dart
     description: Updates the version.dart file for each packages except yet_another_json_isolate
+
+  update-coverage:
+    description: Updates the coverage for the workspace
+    run: |
+      # Activate coverage and combine_coverage
+      dart pub global activate coverage
+      dart pub global activate combine_coverage
+
+      # Format coverage
+      dart pub global run coverage:format_coverage --lcov --in="./coverage/test" --out="./coverage/lcov.info" --report-on="./lib"
+
+      # Combine coverage
+      dart pub global run combine_coverage --repo-path="../../"

--- a/melos.yaml
+++ b/melos.yaml
@@ -64,6 +64,3 @@ scripts:
 
       # Format coverage
       dart pub global run coverage:format_coverage --lcov --in="./coverage/test" --out="./coverage/lcov.info" --report-on="./lib"
-
-      # Combine coverage
-      dart pub global run combine_coverage --repo-path="../../"

--- a/melos.yaml
+++ b/melos.yaml
@@ -58,6 +58,7 @@ scripts:
   format-coverage:
     description: Updates the coverage for the workspace
     run: |
+      pwd
       # Activate coverage
       dart pub global activate coverage
 

--- a/packages/realtime_client/lib/src/realtime_client.dart
+++ b/packages/realtime_client/lib/src/realtime_client.dart
@@ -91,7 +91,7 @@ class RealtimeClient {
   int longpollerTimeout = 20000;
   SocketStates? connState;
   // This is called `accessToken` in realtime-js
-  Future<String> Function()? customAccessToken;
+  Future<String?> Function()? customAccessToken;
 
   /// Initializes the Socket
   ///

--- a/packages/realtime_client/test/socket_test.dart
+++ b/packages/realtime_client/test/socket_test.dart
@@ -394,6 +394,8 @@ void main() {
 
       when(() => mockedSocketChannel.sink).thenReturn(mockedSink);
       when(() => mockedSink.close()).thenAnswer((_) => Future.value());
+      when(() => mockedSink.close(any(), any()))
+          .thenAnswer((_) => Future.value());
     });
 
     test('sends data to connection when connected', () {

--- a/packages/realtime_client/test/socket_test.dart
+++ b/packages/realtime_client/test/socket_test.dart
@@ -393,6 +393,7 @@ void main() {
       mockedSink = MockWebSocketSink();
 
       when(() => mockedSocketChannel.sink).thenReturn(mockedSink);
+      when(() => mockedSink.close()).thenAnswer((_) => Future.value());
     });
 
     test('sends data to connection when connected', () {
@@ -575,6 +576,7 @@ void main() {
       mockedSink = MockWebSocketSink();
 
       when(() => mockedSocketChannel.sink).thenReturn(mockedSink);
+      when(() => mockedSink.close()).thenAnswer((_) => Future.value());
 
       mockedSocket.connect();
     });

--- a/packages/realtime_client/test/socket_test.dart
+++ b/packages/realtime_client/test/socket_test.dart
@@ -393,9 +393,8 @@ void main() {
       mockedSink = MockWebSocketSink();
 
       when(() => mockedSocketChannel.sink).thenReturn(mockedSink);
+      when(() => mockedSocketChannel.ready).thenAnswer((_) => Future.value());
       when(() => mockedSink.close()).thenAnswer((_) => Future.value());
-      when(() => mockedSink.close(any(), any()))
-          .thenAnswer((_) => Future.value());
     });
 
     test('sends data to connection when connected', () {
@@ -410,7 +409,7 @@ void main() {
           .called(1);
     });
 
-    test('buffers data when not connected', () {
+    test('buffers data when not connected', () async {
       mockedSocket.connect();
       mockedSocket.connState = SocketStates.connecting;
 
@@ -579,6 +578,7 @@ void main() {
 
       when(() => mockedSocketChannel.sink).thenReturn(mockedSink);
       when(() => mockedSink.close()).thenAnswer((_) => Future.value());
+      when(() => mockedSocketChannel.ready).thenAnswer((_) => Future.value());
 
       mockedSocket.connect();
     });


### PR DESCRIPTION
## What kind of change does this PR introduce?

Generate coverage reports for each package and upload them.

A new GitHub actions workflow file, `coverage.yml` is introduced, which runs the test for all the packages, generates coverage reports, combines them, and uploads them. This test is redundant as the tests are also run in each individual CI pipeline, but after struggling a bit trying to combine the coverage reports from multiple different workflows, I settled with this implementation.

This PR also includes minor type fix and test stub fix in the realtime rep.