### PR TITLE
feat: Add debugName parameter to YAJsonIsolate.

### DIFF
--- a/packages/yet_another_json_isolate/lib/src/_isolates_io.dart
+++ b/packages/yet_another_json_isolate/lib/src/_isolates_io.dart
@@ -8,6 +8,13 @@ import 'package:async/async.dart';
 
 // One instance manages one isolate
 class YAJsonIsolate {
+  YAJsonIsolate({
+    this.debugName,
+  });
+
+  /// The debug name used for the isolate spawned by this instance.
+  final String? debugName;
+
   final _receivePort = ReceivePort();
   late final SendPort _sendPort;
   final _createdIsolate = Completer<void>();
@@ -26,6 +33,7 @@ class YAJsonIsolate {
       _receivePort.sendPort,
       onExit: _receivePort.sendPort,
       onError: _receivePort.sendPort,
+      debugName: debugName,
     );
     _sendPort = await _events.next;
     _createdIsolate.complete();

--- a/packages/yet_another_json_isolate/lib/src/_isolates_web.dart
+++ b/packages/yet_another_json_isolate/lib/src/_isolates_web.dart
@@ -1,6 +1,10 @@
 import 'dart:convert';
 
 class YAJsonIsolate {
+  YAJsonIsolate({
+    String? debugName,
+  });
+
   Future<void> initialize() async {}
 
   Future<void> dispose() async {}


### PR DESCRIPTION
## What kind of change does this PR introduce?

This is a new feature for `YAJsonIsolate`.

In testing environments, it's easy to have multiple clients open. Specifically, I usually have an admin client and a client for the current user, but I can't tell which is which because all isolates have the same name. When an error occurs in the isolate, it takes a lot of effort to figure out which client produced it.

I would like to be able to rename isolates, specifically for use in debugging.

## What is the current behavior?

Currently, all isolates spawned have the name `_compute`.

Here's a screenshot of what it looks like in VSCode.

![before_change](https://github.com/user-attachments/assets/114b8caa-5812-43d7-be5c-aa36e2a536a2)

## What is the new behavior?

There's now a `debugName` constructor parameter on `YAJsonIsolate`. The user can add the library to their package and instantiate an instance with their desired `debugName` if they want to access it. 

Here's a screenshot of what it looks like in VSCode, after setting the name to `my_isolate`.

![after_change](https://github.com/user-attachments/assets/f91c1da3-4cd2-444a-b412-6e14115f816c)


## Additional context

Two questions:

1. There's also a web implementation in `_isolates_web.dart`. Does this now need the same (albeit unused) constructor parameter?
2. I didn't write a test. I could store and expose the underlying `Isolate` instance to verify it gets created with the specified `debugName`, but then I have to remember to unassign it so I'd rather just not store it. If a test is required, let me know what it should do.
