### PR TITLE
fix(realtime): Lower heartbeat interval to 25s

### DIFF
--- a/packages/realtime_client/lib/src/constants.dart
+++ b/packages/realtime_client/lib/src/constants.dart
@@ -3,6 +3,7 @@ import 'package:realtime_client/src/version.dart';
 class Constants {
   static const String vsn = '1.0.0';
   static const Duration defaultTimeout = Duration(milliseconds: 10000);
+  static const Duration defaultHeartbeatInterval = Duration(seconds: 25);
   static const int wsCloseNormal = 1000;
   static const Map<String, String> defaultHeaders = {
     'X-Client-Info': 'realtime-dart/$version',

--- a/packages/realtime_client/lib/src/constants.dart
+++ b/packages/realtime_client/lib/src/constants.dart
@@ -3,7 +3,7 @@ import 'package:realtime_client/src/version.dart';
 class Constants {
   static const String vsn = '1.0.0';
   static const Duration defaultTimeout = Duration(milliseconds: 10000);
-  static const Duration defaultHeartbeatInterval = Duration(seconds: 25);
+  static const int defaultHeartbeatIntervalMs = 25000;
   static const int wsCloseNormal = 1000;
   static const Map<String, String> defaultHeaders = {
     'X-Client-Info': 'realtime-dart/$version',

--- a/packages/realtime_client/lib/src/realtime_client.dart
+++ b/packages/realtime_client/lib/src/realtime_client.dart
@@ -65,7 +65,7 @@ class RealtimeClient {
   final WebSocketTransport transport;
   final Client? httpClient;
   final _log = Logger('supabase.realtime');
-  int heartbeatIntervalMs = 30000;
+  final Duration heartbeatInterval;
   Timer? heartbeatTimer;
 
   /// reference ID of the most recently sent heartbeat.
@@ -122,7 +122,7 @@ class RealtimeClient {
     String endPoint, {
     WebSocketTransport? transport,
     this.timeout = Constants.defaultTimeout,
-    this.heartbeatIntervalMs = 30000,
+    this.heartbeatInterval = Constants.defaultHeartbeatInterval,
     this.logger,
     RealtimeEncode? encode,
     RealtimeDecode? decode,
@@ -145,7 +145,7 @@ class RealtimeClient {
         },
         transport = transport ?? createWebSocketClient {
     _log.config(
-        'Initialize RealtimeClient with endpoint: $endPoint, timeout: $timeout, heartbeatIntervalMs: $heartbeatIntervalMs, longpollerTimeout: $longpollerTimeout, logLevel: $logLevel');
+        'Initialize RealtimeClient with endpoint: $endPoint, timeout: $timeout, heartbeatInterval: $heartbeatInterval, longpollerTimeout: $longpollerTimeout, logLevel: $logLevel');
     _log.finest('Initialize with headers: $headers, params: $params');
     final customJWT = this.headers['Authorization']?.split(' ').last;
     accessToken = customJWT ?? params['apikey'];
@@ -467,7 +467,7 @@ class RealtimeClient {
     reconnectTimer.reset();
     if (heartbeatTimer != null) heartbeatTimer!.cancel();
     heartbeatTimer = Timer.periodic(
-      Duration(milliseconds: heartbeatIntervalMs),
+      heartbeatInterval,
       (Timer t) async => await sendHeartbeat(),
     );
     for (final callback in stateChangeCallbacks['open']!) {

--- a/packages/realtime_client/lib/src/realtime_client.dart
+++ b/packages/realtime_client/lib/src/realtime_client.dart
@@ -65,7 +65,7 @@ class RealtimeClient {
   final WebSocketTransport transport;
   final Client? httpClient;
   final _log = Logger('supabase.realtime');
-  final Duration heartbeatInterval;
+  int heartbeatIntervalMs = Constants.defaultHeartbeatIntervalMs;
   Timer? heartbeatTimer;
 
   /// reference ID of the most recently sent heartbeat.
@@ -122,7 +122,7 @@ class RealtimeClient {
     String endPoint, {
     WebSocketTransport? transport,
     this.timeout = Constants.defaultTimeout,
-    this.heartbeatInterval = Constants.defaultHeartbeatInterval,
+    this.heartbeatIntervalMs = Constants.defaultHeartbeatIntervalMs,
     this.logger,
     RealtimeEncode? encode,
     RealtimeDecode? decode,
@@ -145,7 +145,7 @@ class RealtimeClient {
         },
         transport = transport ?? createWebSocketClient {
     _log.config(
-        'Initialize RealtimeClient with endpoint: $endPoint, timeout: $timeout, heartbeatInterval: $heartbeatInterval, longpollerTimeout: $longpollerTimeout, logLevel: $logLevel');
+        'Initialize RealtimeClient with endpoint: $endPoint, timeout: $timeout, heartbeatIntervalMs: $heartbeatIntervalMs, longpollerTimeout: $longpollerTimeout, logLevel: $logLevel');
     _log.finest('Initialize with headers: $headers, params: $params');
     final customJWT = this.headers['Authorization']?.split(' ').last;
     accessToken = customJWT ?? params['apikey'];
@@ -467,7 +467,7 @@ class RealtimeClient {
     reconnectTimer.reset();
     if (heartbeatTimer != null) heartbeatTimer!.cancel();
     heartbeatTimer = Timer.periodic(
-      heartbeatInterval,
+      Duration(milliseconds: heartbeatIntervalMs),
       (Timer t) async => await sendHeartbeat(),
     );
     for (final callback in stateChangeCallbacks['open']!) {

--- a/packages/realtime_client/test/socket_test.dart
+++ b/packages/realtime_client/test/socket_test.dart
@@ -79,7 +79,7 @@ void main() {
       });
       expect(socket.timeout, const Duration(milliseconds: 10000));
       expect(socket.longpollerTimeout, 20000);
-      expect(socket.heartbeatInterval, Constants.defaultHeartbeatInterval);
+      expect(socket.heartbeatIntervalMs, Constants.defaultHeartbeatIntervalMs);
       expect(
         socket.logger is void Function(
           String? kind,
@@ -100,7 +100,7 @@ void main() {
         'wss://example.com/socket',
         timeout: const Duration(milliseconds: 40000),
         longpollerTimeout: 50000,
-        heartbeatInterval: const Duration(seconds: 60),
+        heartbeatIntervalMs: 60000,
         // ignore: avoid_print
         logger: (kind, msg, data) => print('[$kind] $msg $data'),
         headers: {'X-Client-Info': 'supabase-dart/0.0.0'},
@@ -117,7 +117,7 @@ void main() {
       });
       expect(socket.timeout, const Duration(milliseconds: 40000));
       expect(socket.longpollerTimeout, 50000);
-      expect(socket.heartbeatInterval, const Duration(seconds: 60));
+      expect(socket.heartbeatIntervalMs, 60000);
       expect(
         socket.logger is void Function(
           String? kind,

--- a/packages/realtime_client/test/socket_test.dart
+++ b/packages/realtime_client/test/socket_test.dart
@@ -79,7 +79,7 @@ void main() {
       });
       expect(socket.timeout, const Duration(milliseconds: 10000));
       expect(socket.longpollerTimeout, 20000);
-      expect(socket.heartbeatIntervalMs, 30000);
+      expect(socket.heartbeatInterval, Constants.defaultHeartbeatInterval);
       expect(
         socket.logger is void Function(
           String? kind,
@@ -100,7 +100,7 @@ void main() {
         'wss://example.com/socket',
         timeout: const Duration(milliseconds: 40000),
         longpollerTimeout: 50000,
-        heartbeatIntervalMs: 60000,
+        heartbeatInterval: const Duration(seconds: 60),
         // ignore: avoid_print
         logger: (kind, msg, data) => print('[$kind] $msg $data'),
         headers: {'X-Client-Info': 'supabase-dart/0.0.0'},
@@ -117,7 +117,7 @@ void main() {
       });
       expect(socket.timeout, const Duration(milliseconds: 40000));
       expect(socket.longpollerTimeout, 50000);
-      expect(socket.heartbeatIntervalMs, 60000);
+      expect(socket.heartbeatInterval, const Duration(seconds: 60));
       expect(
         socket.logger is void Function(
           String? kind,


### PR DESCRIPTION
## What is the current behavior?

Heartbeat interval is 30s

## What is the new behavior?

Change heartbeat interval to 25s

## Additional context

The change on heartbeat stems from what we've seen from user feedback that 30s might hit the limits of socket connections and we end up with a weird timing issue where the socket gets closed just as we are sending heartbeat.
