### PR TITLE
fix: FunctionException implements Exception

### DIFF
--- a/packages/functions_client/lib/src/types.dart
+++ b/packages/functions_client/lib/src/types.dart
@@ -26,7 +26,7 @@ class FunctionResponse {
   });
 }
 
-class FunctionException {
+class FunctionException implements Exception {
   final int status;
   final dynamic details;
   final String? reasonPhrase;


### PR DESCRIPTION
`FunctionException` should implement `Exception`

close #1127 