### PR TITLE
feat(gotrue, supabase, supabase_flutter, realtime_client): Use web package to access web APIs

### DIFF
--- a/.github/workflows/supabase_flutter.yml
+++ b/.github/workflows/supabase_flutter.yml
@@ -34,7 +34,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        flutter-version: ['3.13.x', '3.x']
+        flutter-version: ['3.16.x', '3.x']
 
     defaults:
       run:

--- a/.github/workflows/supabase_flutter.yml
+++ b/.github/workflows/supabase_flutter.yml
@@ -34,7 +34,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        flutter-version: ['3.16.x', '3.x']
+        flutter-version: ['3.19.x', '3.x']
 
     defaults:
       run:

--- a/.github/workflows/supabase_flutter.yml
+++ b/.github/workflows/supabase_flutter.yml
@@ -34,7 +34,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        flutter-version: ['3.10.x', '3.x']
+        flutter-version: ['3.13.x', '3.x']
 
     defaults:
       run:

--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -11,10 +11,10 @@ import 'package:gotrue/src/types/auth_response.dart';
 import 'package:gotrue/src/types/fetch_options.dart';
 import 'package:http/http.dart';
 import 'package:jwt_decode/jwt_decode.dart';
+import 'package:logging/logging.dart';
 import 'package:meta/meta.dart';
 import 'package:retry/retry.dart';
 import 'package:rxdart/subjects.dart';
-import 'package:logging/logging.dart';
 
 import 'broadcast_stub.dart' if (dart.library.html) './broadcast_web.dart'
     as web;
@@ -363,8 +363,8 @@ class GoTrueClient {
       ),
     );
 
-    await _asyncStorage!
-        .removeItem(key: '${Constants.defaultStorageKey}-code-verifier');
+    await _asyncStorage.removeItem(
+        key: '${Constants.defaultStorageKey}-code-verifier');
 
     final authSessionUrlResponse = AuthSessionUrlResponse(
         session: Session.fromJson(response)!, redirectType: redirectType?.name);

--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -16,7 +16,7 @@ import 'package:meta/meta.dart';
 import 'package:retry/retry.dart';
 import 'package:rxdart/subjects.dart';
 
-import 'broadcast_stub.dart' if (dart.library.html) './broadcast_web.dart'
+import 'broadcast_stub.dart' if (dart.library.js_interop) './broadcast_web.dart'
     as web;
 import 'version.dart';
 
@@ -1163,7 +1163,7 @@ class GoTrueClient {
   }
 
   void _mayStartBroadcastChannel() {
-    if (const bool.fromEnvironment('dart.library.html')) {
+    if (const bool.fromEnvironment('dart.library.js_interop')) {
       // Used by the js library as well
       final broadcastKey =
           "sb-${Uri.parse(_url).host.split(".").first}-auth-token";

--- a/packages/gotrue/lib/src/types/auth_state.dart
+++ b/packages/gotrue/lib/src/types/auth_state.dart
@@ -5,7 +5,7 @@ class AuthState {
   final AuthChangeEvent event;
   final Session? session;
 
-  /// Whether this state was broadcasted via `html.ChannelBroadcast` on web from
+  /// Whether this state was broadcasted via `web.BroadcastChannel` on web from
   /// another tab or window.
   final bool fromBroadcast;
 

--- a/packages/gotrue/pubspec.yaml
+++ b/packages/gotrue/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
   rxdart: '>=0.27.7 <0.29.0'
   meta: ^1.7.0
   logging: ^1.2.0
+  web: ^1.0.0
 
 dev_dependencies:
   dart_jsonwebtoken: ^2.4.1

--- a/packages/gotrue/pubspec.yaml
+++ b/packages/gotrue/pubspec.yaml
@@ -6,7 +6,7 @@ repository: 'https://github.com/supabase/supabase-flutter/tree/main/packages/got
 documentation: 'https://supabase.com/docs/reference/dart/auth-signup'
 
 environment:
-  sdk: '>=3.0.0 <4.0.0'
+  sdk: '>=3.3.0 <4.0.0'
 
 dependencies:
   collection: ^1.15.0

--- a/packages/gotrue/pubspec.yaml
+++ b/packages/gotrue/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   rxdart: '>=0.27.7 <0.29.0'
   meta: ^1.7.0
   logging: ^1.2.0
-  web: ^1.0.0
+  web: '>=0.5.0 <2.0.0'
 
 dev_dependencies:
   dart_jsonwebtoken: ^2.4.1

--- a/packages/gotrue/test/src/broadcast_web_test.dart
+++ b/packages/gotrue/test/src/broadcast_web_test.dart
@@ -1,0 +1,57 @@
+@TestOn('browser')
+import 'dart:async';
+
+import 'package:gotrue/src/broadcast_web.dart';
+import 'package:gotrue/src/types/types.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('getBroadcastChannel', () {
+    late BroadcastChannel channel1;
+    late BroadcastChannel channel2;
+
+    setUp(() {
+      channel1 = getBroadcastChannel('test-channel');
+      channel2 = getBroadcastChannel('test-channel');
+    });
+
+    tearDown(() {
+      channel1.close();
+      channel2.close();
+    });
+
+    test('can send and receive messages between channels', () async {
+      final completer = Completer<Map<String, dynamic>>();
+
+      // Listen for messages on channel2
+      final subscription = channel2.onMessage.listen((message) {
+        completer.complete(message);
+      });
+
+      // Send message from channel1
+      final testMessage = {
+        'event': 'test-event',
+        'data': {'foo': 'bar'}
+      };
+      channel1.postMessage(testMessage);
+
+      // Wait for the message to be received
+      final receivedMessage = await completer.future;
+
+      expect(receivedMessage['event'], equals('test-event'));
+      expect(receivedMessage['data']['foo'], equals('bar'));
+
+      await subscription.cancel();
+    });
+
+    test('can close channels', () async {
+      channel1.close();
+
+      // Verify that sending messages after closing throws
+      expect(
+        () => channel1.postMessage({'event': 'test'}),
+        throwsA(anything),
+      );
+    });
+  });
+}

--- a/packages/realtime_client/lib/src/websocket/websocket.dart
+++ b/packages/realtime_client/lib/src/websocket/websocket.dart
@@ -1,3 +1,3 @@
 export 'websocket_stub.dart'
     if (dart.library.io) 'websocket_io.dart'
-    if (bool.fromEnvironment) 'websocket_web.dart';
+    if (dart.library.js_interop) 'websocket_web.dart';

--- a/packages/realtime_client/lib/src/websocket/websocket.dart
+++ b/packages/realtime_client/lib/src/websocket/websocket.dart
@@ -1,3 +1,3 @@
 export 'websocket_stub.dart'
     if (dart.library.io) 'websocket_io.dart'
-    if (dart.library.html) 'websocket_web.dart';
+    if (bool.fromEnvironment) 'websocket_web.dart';

--- a/packages/supabase/pubspec.yaml
+++ b/packages/supabase/pubspec.yaml
@@ -6,7 +6,7 @@ repository: 'https://github.com/supabase/supabase-flutter/tree/main/packages/sup
 documentation: 'https://supabase.com/docs/reference/dart/introduction'
 
 environment:
-  sdk: '>=3.0.0 <4.0.0'
+  sdk: '>=3.3.0 <4.0.0'
 
 dependencies:
   functions_client: 2.4.1

--- a/packages/supabase_flutter/lib/src/local_storage.dart
+++ b/packages/supabase_flutter/lib/src/local_storage.dart
@@ -6,7 +6,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 import './local_storage_stub.dart'
-    if (dart.library.html) './local_storage_web.dart' as web;
+    if (dart.library.js_interop) './local_storage_web.dart' as web;
 
 /// Only used for migration from Hive to SharedPreferences. Not actually in use.
 const supabasePersistSessionKey = 'SUPABASE_PERSIST_SESSION_KEY';
@@ -70,7 +70,7 @@ class SharedPreferencesLocalStorage extends LocalStorage {
 
   final String persistSessionKey;
   static const _useWebLocalStorage =
-      kIsWeb && bool.fromEnvironment("dart.library.html");
+      kIsWeb && bool.fromEnvironment("dart.library.js_interop");
 
   @override
   Future<void> initialize() async {

--- a/packages/supabase_flutter/pubspec.yaml
+++ b/packages/supabase_flutter/pubspec.yaml
@@ -6,8 +6,8 @@ repository: 'https://github.com/supabase/supabase-flutter/tree/main/packages/sup
 documentation: 'https://supabase.com/docs/reference/dart/introduction'
 
 environment:
-  sdk: '>=3.0.0 <4.0.0'
-  flutter: '>=3.0.0'
+  sdk: '>=3.3.0 <4.0.0'
+  flutter: '>=3.19.0'
 
 dependencies:
   app_links: '>=3.5.0 <7.0.0'


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR [migrates gotrue to package:web](https://dart.dev/interop/js-interop/package-web).

Because of version constraints issues, this bumps the minimum Dart version to 3.3.0 and Flutter version to 3.19.0, which has been released in Feb 16, 2024.

## What is the current behavior?

Uses the old html API, which causes analysis issue, and is not recommended to keep by the Flutter team.

## What is the new behavior?

The new web package is used. 