### PR TITLE
fix(gotrue): Handle empty error response

### DIFF
--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -1006,8 +1006,8 @@ class GoTrueClient {
 
         return AuthResponse(session: session);
       }
-    } catch (error) {
-      notifyException(error);
+    } catch (error, stackTrace) {
+      notifyException(error, stackTrace);
       rethrow;
     }
   }

--- a/packages/gotrue/lib/src/types/auth_exception.dart
+++ b/packages/gotrue/lib/src/types/auth_exception.dart
@@ -1,4 +1,5 @@
 import 'package:gotrue/src/types/error_code.dart';
+import 'package:http/http.dart' as http;
 
 class AuthException implements Exception {
   /// Human readable error message associated with the error.
@@ -46,6 +47,9 @@ class AuthSessionMissingException extends AuthException {
           message ?? 'Auth session missing!',
           statusCode: '400',
         );
+  @override
+  String toString() =>
+      'AuthSessionMissingException(message: $message, statusCode: $statusCode)';
 }
 
 class AuthRetryableFetchException extends AuthException {
@@ -53,17 +57,37 @@ class AuthRetryableFetchException extends AuthException {
     String message = 'AuthRetryableFetchException',
     super.statusCode,
   }) : super(message);
+
+  @override
+  String toString() =>
+      'AuthRetryableFetchException(message: $message, statusCode: $statusCode)';
 }
 
 class AuthApiException extends AuthException {
   AuthApiException(super.message, {super.statusCode, super.code});
+
+  @override
+  String toString() =>
+      'AuthApiException(message: $message, statusCode: $statusCode, code: $code)';
 }
 
 class AuthUnknownException extends AuthException {
+  /// May contain a non 2xx [http.Response] object or the original thrown error.
   final Object originalError;
 
-  AuthUnknownException({required String message, required this.originalError})
-      : super(message);
+  AuthUnknownException({
+    required String message,
+    required this.originalError,
+  }) : super(
+          message,
+          statusCode: originalError is http.Response
+              ? originalError.statusCode.toString()
+              : null,
+        );
+
+  @override
+  String toString() =>
+      'AuthUnknownException(message: $message, originalError: $originalError, statusCode: $statusCode)';
 }
 
 class AuthWeakPasswordException extends AuthException {
@@ -74,4 +98,8 @@ class AuthWeakPasswordException extends AuthException {
     required super.statusCode,
     required this.reasons,
   }) : super(message, code: ErrorCode.weakPassword.code);
+
+  @override
+  String toString() =>
+      'AuthWeakPasswordException(message: $message, statusCode: $statusCode, reasons: $reasons)';
 }

--- a/packages/gotrue/lib/src/types/auth_state.dart
+++ b/packages/gotrue/lib/src/types/auth_state.dart
@@ -13,6 +13,6 @@ class AuthState {
 
   @override
   String toString() {
-    return 'AuthState{event: $event, session: $session, fromBroadcast: $fromBroadcast}';
+    return 'AuthState(event: $event, session: $session, fromBroadcast: $fromBroadcast)';
   }
 }

--- a/packages/gotrue/test/client_test.dart
+++ b/packages/gotrue/test/client_test.dart
@@ -484,8 +484,11 @@ void main() {
       try {
         await client.signInWithPassword(email: email1, password: password);
       } catch (error) {
-        expect(error, isA<AuthException>());
-        expect((error as AuthException).statusCode, '420');
+        expect(error, isA<AuthUnknownException>());
+        error as AuthUnknownException;
+        expect(error.statusCode, '420');
+        expect(error.originalError, isA<http.Response>());
+        expect(error.message, contains('empty response'));
       }
     });
   });

--- a/packages/gotrue/test/custom_http_client.dart
+++ b/packages/gotrue/test/custom_http_client.dart
@@ -10,7 +10,7 @@ class CustomHttpClient extends BaseClient {
   Future<StreamedResponse> send(BaseRequest request) async {
     //Return custom status code to check for usage of this client.
     return StreamedResponse(
-      request.finalize(),
+      Stream.empty(),
       420,
       request: request,
     );


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When receiving an error response, which doesn't contain any body, the decoding to json throws a `FormatException`. This is very misleading, because we shouldn't try to decode an empty response. This happened to me while doing some testing, but I do not exactly remember the reason for the error anymore.

## What is the new behavior?

Do not decode an empty response.

In addition, I added a `toString` for every subclass of `AuthException`.

## Additional context


