### PR TITLE
fix(gotrue): AuthException .toString method

### DIFF
--- a/packages/gotrue/lib/src/types/auth_exception.dart
+++ b/packages/gotrue/lib/src/types/auth_exception.dart
@@ -20,7 +20,7 @@ class AuthException implements Exception {
 
   @override
   String toString() =>
-      'AuthException(message: $message, statusCode: $statusCode, errorCode: $code)';
+      'AuthException(message: $message, statusCode: $statusCode, code: $code)';
 
   @override
   bool operator ==(Object other) {


### PR DESCRIPTION
## What kind of change does this PR introduce?

I was a little bit confused by the logs because the AuthException doesn't contain a variable `errorCode`.

## What is the current behavior?

The `toString` output is not aligned with the variable name

## What is the new behavior?

The `toString` output is aligned with the variable name

## Additional context

_None_
