### PR TITLE
fix: Adds support for SharedPreferencesAsync

### DIFF
--- a/packages/supabase_flutter/lib/src/local_storage.dart
+++ b/packages/supabase_flutter/lib/src/local_storage.dart
@@ -61,66 +61,12 @@ class EmptyLocalStorage extends LocalStorage {
   Future<void> persistSession(persistSessionString) async {}
 }
 
-/// A [LocalStorage] implementation that implements SharedPreferences as the
-/// storage method.
-class SharedPreferencesLocalStorage extends LocalStorage {
-  late final SharedPreferences _prefs;
-
-  SharedPreferencesLocalStorage({required this.persistSessionKey});
-
-  final String persistSessionKey;
-
-  static const _useWebLocalStorage =
-      kIsWeb && bool.fromEnvironment("dart.library.js_interop");
-
-  @override
-  Future<void> initialize() async {
-    if (!_useWebLocalStorage) {
-      WidgetsFlutterBinding.ensureInitialized();
-      _prefs = await SharedPreferences.getInstance();
-    }
-  }
-
-  @override
-  Future<bool> hasAccessToken() async {
-    if (_useWebLocalStorage) {
-      return web.hasAccessToken(persistSessionKey);
-    }
-    return _prefs.containsKey(persistSessionKey);
-  }
-
-  @override
-  Future<String?> accessToken() async {
-    if (_useWebLocalStorage) {
-      return web.accessToken(persistSessionKey);
-    }
-    return _prefs.getString(persistSessionKey);
-  }
-
-  @override
-  Future<void> removePersistedSession() async {
-    if (_useWebLocalStorage) {
-      web.removePersistedSession(persistSessionKey);
-    } else {
-      await _prefs.remove(persistSessionKey);
-    }
-  }
-
-  @override
-  Future<void> persistSession(String persistSessionString) {
-    if (_useWebLocalStorage) {
-      return web.persistSession(persistSessionKey, persistSessionString);
-    }
-    return _prefs.setString(persistSessionKey, persistSessionString);
-  }
-}
-
 /// A [LocalStorage] implementation that implements SharedPreferencesAsync as the
 /// storage method.
-class SharedPreferencesAsyncLocalStorage extends LocalStorage {
+class SharedPreferencesLocalStorage extends LocalStorage {
   late final SharedPreferencesAsync _prefs;
 
-  SharedPreferencesAsyncLocalStorage({required this.persistSessionKey});
+  SharedPreferencesLocalStorage({required this.persistSessionKey});
 
   final String persistSessionKey;
 

--- a/packages/supabase_flutter/lib/src/local_storage.dart
+++ b/packages/supabase_flutter/lib/src/local_storage.dart
@@ -78,6 +78,21 @@ class SharedPreferencesLocalStorage extends LocalStorage {
     if (!_useWebLocalStorage) {
       WidgetsFlutterBinding.ensureInitialized();
       _prefs = SharedPreferencesAsync();
+
+      await _maybeMigrateAccessToken();
+    }
+  }
+
+  Future<void> _maybeMigrateAccessToken() async {
+    final legacyPrefs = await SharedPreferences.getInstance();
+
+    if (legacyPrefs.containsKey(persistSessionKey)) {
+      final accessToken = legacyPrefs.getString(persistSessionKey);
+
+      if (accessToken != null) {
+        await legacyPrefs.remove(persistSessionKey);
+        await _prefs.setString(persistSessionKey, accessToken);
+      }
     }
   }
 

--- a/packages/supabase_flutter/pubspec.yaml
+++ b/packages/supabase_flutter/pubspec.yaml
@@ -6,8 +6,8 @@ repository: 'https://github.com/supabase/supabase-flutter/tree/main/packages/sup
 documentation: 'https://supabase.com/docs/reference/dart/introduction'
 
 environment:
-  sdk: '>=3.3.0 <4.0.0'
-  flutter: '>=3.19.0'
+  sdk: '>=3.4.0 <4.0.0'
+  flutter: '>=3.22.0'
 
 dependencies:
   app_links: '>=6.2.0 <8.0.0'

--- a/packages/supabase_flutter/pubspec.yaml
+++ b/packages/supabase_flutter/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   supabase: 2.10.2
   url_launcher: ^6.1.2
   path_provider: ^2.0.0
-  shared_preferences: ^2.0.0
+  shared_preferences: ^2.3.0
   logging: ^1.2.0
   web: '>=0.5.0 <2.0.0'
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

It's both a bug fix and feature.

9 months ago with version 2.3.0, `shared_preferences` package added `SharedPreferencesAsync` and `SharedPreferencesWithCache` to replace the legacy (and deprecated in future) `SharedPreferences`. [See here](https://pub.dev/packages/shared_preferences#sharedpreferences-vs-sharedpreferencesasync-vs-sharedpreferenceswithcache)

Supabase flutter uses by default the legacy one with `SharedPreferencesLocalStorage`.

Problem is that on some platform like Windows, the legacy one and new one are not compatible. If the developer made the migration to `SharedPreferencesAsync` then the supabase's local storage is broken.

_Example :_
I'm using `SharedPreferencesAsync` in my app. After sign in, the `sb-x-auth-token` is saved in `saved-preferences.json` by supabase's `SharedPreferences`. After that, any call to my app's `SharedPreferencesAsync` will overwrite the token and user have to sign in on next app launch. In practice it can lead to sign in every time he opens the app if you use shared preferences frequently in your code.

## What is the new behavior?

I added a boolean flag `useSharedPreferencesAsync` to `SharedPreferencesLocalStorage`. There wasn't very much changes as every methods are already async in LocalStorage interface.

If you prefer two distinct classes `SharedPreferencesLocalStorage` and `SharedPreferencesAsyncLocalStorage` I can do this