### PR TITLE
fix(realtime): Send version when joining channel and remove jwt check

### DIFF
--- a/packages/realtime_client/test/socket_test.dart
+++ b/packages/realtime_client/test/socket_test.dart
@@ -453,7 +453,10 @@ void main() {
 
   group('setAuth', () {
     final token = generateJwt();
-    final updateJoinPayload = {'access_token': token};
+    final updateJoinPayload = {
+      'access_token': token,
+      'version': Constants.defaultHeaders['X-Client-Info'],
+    };
     final pushPayload = {'access_token': token};
 
     test(
@@ -534,7 +537,10 @@ void main() {
 
       const token = 'sb-key';
       final pushPayload = {'access_token': token};
-      final updateJoinPayload = {'access_token': token};
+      final updateJoinPayload = {
+        'access_token': token,
+        'version': Constants.defaultHeaders['X-Client-Info'],
+      };
 
       await mockedSocket.setAuth(token);
 


### PR DESCRIPTION
## What is the new behavior?

- Remove the jwt check when pushing access token
- On set auth, also send the client info for better internal reports.

## Additional context

https://github.com/supabase/realtime-js/pull/451
https://github.com/supabase/realtime-js/pull/455
