### PR TITLE
refactor(gotrue): Remove unused _currentUser field and update currentUser getter logic. 

### DIFF
--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -43,9 +43,6 @@ class GoTrueClient {
   /// Namespace for the GoTrue MFA API methods.
   late final GoTrueMFAApi mfa;
 
-  /// The currently logged in user or null.
-  User? _currentUser;
-
   /// The session object for the currently logged in user or null.
   Session? _currentSession;
 
@@ -140,10 +137,10 @@ class GoTrueClient {
   /// Returns the current logged in user, if any;
   ///
   /// Use [currentSession] to determine whether the user has an active session,
-  /// because [currentUser] can be non-null without an active session, such as
+  /// because [currentUser] can be null with an active session, such as
   /// when the user signed up using email and password but has not confirmed
   /// their email address.
-  User? get currentUser => _currentUser;
+  User? get currentUser => _currentSession?.user;
 
   /// Returns the current session, if any;
   Session? get currentSession => _currentSession;
@@ -748,8 +745,7 @@ class GoTrueClient {
         options: options);
     final userResponse = UserResponse.fromJson(response);
 
-    _currentUser = userResponse.user;
-    _currentSession = currentSession?.copyWith(user: userResponse.user);
+    _currentSession = currentSession!.copyWith(user: userResponse.user);
     notifyAllSubscribers(AuthChangeEvent.userUpdated);
 
     return userResponse;
@@ -970,7 +966,6 @@ class GoTrueClient {
     }
 
     _currentSession = session;
-    _currentUser = session.user;
     notifyAllSubscribers(AuthChangeEvent.initialSession);
   }
 
@@ -997,7 +992,7 @@ class GoTrueClient {
         }
       } else {
         final shouldEmitEvent = _currentSession == null ||
-            _currentSession?.user.id != session.user.id;
+            _currentSession!.user.id != session.user.id;
         _saveSession(session);
 
         if (shouldEmitEvent) {
@@ -1153,13 +1148,11 @@ class GoTrueClient {
     _log.finest('Saving session: $session');
     _log.fine('Saving session');
     _currentSession = session;
-    _currentUser = session.user;
   }
 
   void _removeSession() {
     _log.fine('Removing session');
     _currentSession = null;
-    _currentUser = null;
   }
 
   void _mayStartBroadcastChannel() {

--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -134,12 +134,7 @@ class GoTrueClient {
   /// Getter for the headers
   Map<String, String> get headers => _headers;
 
-  /// Returns the current logged in user, if any;
-  ///
-  /// Use [currentSession] to determine whether the user has an active session,
-  /// because [currentUser] can be null with an active session, such as
-  /// when the user signed up using email and password but has not confirmed
-  /// their email address.
+  /// Returns the current logged in user, asociated to [currentSession] if any;
   User? get currentUser => _currentSession?.user;
 
   /// Returns the current session, if any;
@@ -745,7 +740,7 @@ class GoTrueClient {
         options: options);
     final userResponse = UserResponse.fromJson(response);
 
-    _currentSession = currentSession!.copyWith(user: userResponse.user);
+    _currentSession = currentSession?.copyWith(user: userResponse.user);
     notifyAllSubscribers(AuthChangeEvent.userUpdated);
 
     return userResponse;


### PR DESCRIPTION
## What kind of change does this PR introduce?

Refactor

## What is the current behavior?

_currentUser variable is just being stored as a copy of _currentSession.user

## What is the new behavior?

The currentUser getter is handling the indirection correctly, no need to duplicate values and assign both each time they change.

## Additional context

I have simplified a comment (it was a double negation).
I have added some bang operators in cases where null-aware operator where not needed
