### PR TITLE
fix(auth): Validate uuid params in admin methods

### DIFF
--- a/packages/gotrue/lib/src/gotrue_admin_api.dart
+++ b/packages/gotrue/lib/src/gotrue_admin_api.dart
@@ -1,5 +1,6 @@
 import 'package:gotrue/gotrue.dart';
 import 'package:gotrue/src/fetch.dart';
+import 'package:gotrue/src/helper.dart';
 import 'package:gotrue/src/types/auth_response.dart';
 import 'package:gotrue/src/types/fetch_options.dart';
 import 'package:http/http.dart';
@@ -70,6 +71,7 @@ class GoTrueAdminApi {
   ///
   /// This function should only be called on a server. Never expose your `service_role` key on the client.
   Future<void> deleteUser(String id) async {
+    validateUuid(id);
     final options = GotrueRequestOptions(headers: _headers);
     await _fetch.request(
       '$_url/admin/users/$id',
@@ -173,6 +175,7 @@ class GoTrueAdminApi {
 
   /// Gets the user by their id.
   Future<UserResponse> getUserById(String uid) async {
+    validateUuid(uid);
     final options = GotrueRequestOptions(headers: _headers);
     final response = await _fetch.request(
       '$_url/admin/users/$uid',
@@ -187,6 +190,7 @@ class GoTrueAdminApi {
     String uid, {
     required AdminUserAttributes attributes,
   }) async {
+    validateUuid(uid);
     final body = attributes.toJson();
     final options = GotrueRequestOptions(headers: _headers, body: body);
     final response = await _fetch.request(

--- a/packages/gotrue/lib/src/gotrue_admin_mfa_api.dart
+++ b/packages/gotrue/lib/src/gotrue_admin_mfa_api.dart
@@ -1,4 +1,5 @@
 import 'fetch.dart';
+import 'helper.dart';
 import 'types/fetch_options.dart';
 import 'types/mfa.dart';
 
@@ -17,6 +18,8 @@ class GoTrueAdminMFAApi {
 
   Future<AuthMFAAdminListFactorsResponse> listFactors(
       {required String userId}) async {
+    validateUuid(userId);
+
     final data = await _fetch.request(
       '$_url/admin/users/$userId/factors',
       RequestMethodType.get,
@@ -33,6 +36,9 @@ class GoTrueAdminMFAApi {
     required String userId,
     required String factorId,
   }) async {
+    validateUuid(userId);
+    validateUuid(factorId);
+
     final data = await _fetch.request(
       '$_url/admin/users/$userId/factors/$factorId',
       RequestMethodType.delete,

--- a/packages/gotrue/lib/src/helper.dart
+++ b/packages/gotrue/lib/src/helper.dart
@@ -21,3 +21,12 @@ String generatePKCEChallenge(String verifier) {
   return base64UrlEncode(sha256.convert(ascii.encode(verifier)).bytes)
       .split('=')[0];
 }
+
+final uuidRegex =
+    RegExp(r'^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$');
+
+void validateUuid(String id) {
+  if (!uuidRegex.hasMatch(id)) {
+    throw ArgumentError('Invalid id: $id, must be a valid UUID');
+  }
+}

--- a/packages/gotrue/test/admin_test.dart
+++ b/packages/gotrue/test/admin_test.dart
@@ -111,4 +111,41 @@ void main() {
       expect(userLengthBefore - 1, userLengthAfter);
     });
   });
+
+  group('validates ids', () {
+    test('deleteUser() validates ids', () {
+      expect(() => client.admin.deleteUser('invalid-id'),
+          throwsA(isA<ArgumentError>()));
+    });
+
+    test('getUserById() validates ids', () {
+      expect(() => client.admin.getUserById('invalid-id'),
+          throwsA(isA<ArgumentError>()));
+    });
+
+    test('updateUserById() validates ids', () {
+      expect(
+          () => client.admin.updateUserById('invalid-id',
+              attributes: AdminUserAttributes(email: 'test@test.com')),
+          throwsA(isA<ArgumentError>()));
+    });
+
+    test('listFactors() validates ids', () {
+      expect(() => client.admin.mfa.listFactors(userId: 'invalid-id'),
+          throwsA(isA<ArgumentError>()));
+    });
+
+    test('deleteFactor() validates ids', () {
+      expect(
+          () => client.admin
+            ..mfa.deleteFactor(
+                userId: 'invalid-id', factorId: 'invalid-factor-id'),
+          throwsA(isA<ArgumentError>()));
+
+      expect(
+          () => client.admin
+            ..mfa.deleteFactor(userId: userId1, factorId: 'invalid-factor-id'),
+          throwsA(isA<ArgumentError>()));
+    });
+  });
 }

--- a/packages/gotrue/test/admin_test.dart
+++ b/packages/gotrue/test/admin_test.dart
@@ -137,14 +137,13 @@ void main() {
 
     test('deleteFactor() validates ids', () {
       expect(
-          () => client.admin
-            ..mfa.deleteFactor(
-                userId: 'invalid-id', factorId: 'invalid-factor-id'),
+          () => client.admin.mfa.deleteFactor(
+              userId: 'invalid-id', factorId: 'invalid-factor-id'),
           throwsA(isA<ArgumentError>()));
 
       expect(
-          () => client.admin
-            ..mfa.deleteFactor(userId: userId1, factorId: 'invalid-factor-id'),
+          () => client.admin.mfa
+              .deleteFactor(userId: userId1, factorId: 'invalid-factor-id'),
           throwsA(isA<ArgumentError>()));
     });
   });


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix https://github.com/supabase/supabase-flutter/issues/1170

## What is the current behavior?

Admin methods currently accept ids of any format

## What is the new behavior?

Admin methods now validates if id is a uuid

## Additional context

Add any other context or screenshots.
