### PR TITLE
fix(supabase_flutter): Safely check if conn is not null to avoid null check operator

### DIFF
--- a/packages/supabase_flutter/lib/src/supabase.dart
+++ b/packages/supabase_flutter/lib/src/supabase.dart
@@ -233,7 +233,8 @@ class Supabase with WidgetsBindingObserver {
   Future<void> onResumed() async {
     final realtime = Supabase.instance.client.realtime;
     if (realtime.channels.isNotEmpty) {
-      if (realtime.connState == SocketStates.disconnecting) {
+      if (realtime.connState == SocketStates.disconnecting &&
+          realtime.conn != null) {
         // If the socket is still disconnecting from e.g.
         // [AppLifecycleState.paused] we should wait for it to finish before
         // reconnecting.


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

After app changes its life cycle, `onResumed()` method is called to resume any open web socket connection. This code is executed 
```
 if (realtime.channels.isNotEmpty) {
      if (realtime.connState == SocketStates.disconnecting) {
        bool cancel = false;
        final connectFuture = realtime.conn!.sink.done.then(
```
So, if the `SocketStates` is `disconnecting` it will try to use `realtime.conn!` assuming is not `null` when it can be `null`, hence throwing an error **Null check operator used on a null value**

If we look inside `RealtimeClient` which holds `conn` and `connState` we can see the only time `conn` is set to `null` and the only time `connState` is set to `SocketStates.disconnection` is here, in the `disconnect` method

```
Future<void> disconnect({int? code, String? reason}) async {
    final conn = this.conn;
    if (conn != null) {
      final oldState = connState;
      connState = SocketStates.disconnecting;
      
      
      if (oldState == SocketStates.open ||
          oldState == SocketStates.connecting) {
        if (code != null) {
          await conn.sink.close(code, reason ?? '');
        } else {
          await conn.sink.close();
        }
        connState = SocketStates.disconnected;
        reconnectTimer.reset();
        
      }
      this.conn = null;

      if (heartbeatTimer != null) heartbeatTimer?.cancel();
    }
  }
```
so it is clear that `conn` can be `null` and `connState` is `disconnecting` when `oldState` is `closed`, `disconnecting` or `disconnected`

Fixes [#1176 ](https://github.com/supabase/supabase-flutter/issues/1176)

## What is the new behavior?

The new behavior just checks if `conn` is **not** `null`. 
