### PR TITLE
feat(gotrue): Add phone mfa enrollment

### DIFF
--- a/infra/gotrue/docker-compose.yml
+++ b/infra/gotrue/docker-compose.yml
@@ -2,7 +2,7 @@
 version: '3'
 services:
   gotrue: # Signup enabled, autoconfirm on
-    image: supabase/auth:v2.151.0
+    image: supabase/auth:v2.175.0
     ports:
       - '9998:9998'
     environment:
@@ -27,6 +27,8 @@ services:
       GOTRUE_EXTERNAL_GOOGLE_REDIRECT_URI: http://localhost:9998/callback
       GOTRUE_SECURITY_MANUAL_LINKING_ENABLED: 'true'
       GOTRUE_EXTERNAL_ANONYMOUS_USERS_ENABLED: 'true'
+      GOTRUE_MFA_PHONE_ENROLL_ENABLED: 'true'
+      GOTRUE_MFA_PHONE_VERIFY_ENABLED: 'true'
 
     depends_on:
       - db

--- a/packages/gotrue/lib/src/gotrue_mfa_api.dart
+++ b/packages/gotrue/lib/src/gotrue_mfa_api.dart
@@ -28,7 +28,7 @@ class GoTrueMFAApi {
 
   /// Starts the enrollment process for a new Multi-Factor Authentication (MFA) factor.
   /// This method creates a new `unverified` factor.
-  /// 
+  ///
   /// For TOTP: To verify a factor, present the QR code or secret to the user and ask them to add it to their authenticator app.
   /// For Phone: The user will receive an SMS with a verification code.
   ///
@@ -50,12 +50,12 @@ class GoTrueMFAApi {
     String? phone,
   }) async {
     final session = _client.currentSession;
-    
+
     final body = <String, dynamic>{
       'friendly_name': friendlyName,
       'factor_type': factorType.name,
     };
-    
+
     if (factorType == FactorType.totp) {
       body['issuer'] = issuer;
     } else if (factorType == FactorType.phone) {
@@ -64,7 +64,7 @@ class GoTrueMFAApi {
       }
       body['phone'] = phone;
     }
-    
+
     final data = await _fetch.request(
       '${_client._url}/factors',
       RequestMethodType.post,

--- a/packages/gotrue/lib/src/gotrue_mfa_api.dart
+++ b/packages/gotrue/lib/src/gotrue_mfa_api.dart
@@ -56,13 +56,12 @@ class GoTrueMFAApi {
       'factor_type': factorType.name,
     };
 
-    if (factorType == FactorType.totp) {
+    if (factorType == FactorType.totp && issuer != null) {
       body['issuer'] = issuer;
-    } else if (factorType == FactorType.phone) {
-      if (phone == null) {
-        throw ArgumentError('Phone number is required for phone factor type');
-      }
+    } else if (factorType == FactorType.phone && phone != null) {
       body['phone'] = phone;
+    } else {
+      throw ArgumentError('Invalid arguments, expected an issuer for totp factor type or phone for phone factor. type');
     }
 
     final data = await _fetch.request(

--- a/packages/gotrue/lib/src/gotrue_mfa_api.dart
+++ b/packages/gotrue/lib/src/gotrue_mfa_api.dart
@@ -61,7 +61,8 @@ class GoTrueMFAApi {
     } else if (factorType == FactorType.phone && phone != null) {
       body['phone'] = phone;
     } else {
-      throw ArgumentError('Invalid arguments, expected an issuer for totp factor type or phone for phone factor. type');
+      throw ArgumentError(
+          'Invalid arguments, expected an issuer for totp factor type or phone for phone factor. type');
     }
 
     final data = await _fetch.request(

--- a/packages/gotrue/lib/src/types/mfa.dart
+++ b/packages/gotrue/lib/src/types/mfa.dart
@@ -29,7 +29,7 @@ class AuthMFAEnrollResponse {
           ? TOTPEnrollment.fromJson(json['totp'])
           : null,
       phone: type == FactorType.phone && json['phone'] != null
-          ? PhoneEnrollment.fromJson(json['phone'])
+          ? PhoneEnrollment._fromJsonValue(json['phone'])
           : null,
     );
   }
@@ -76,6 +76,19 @@ class PhoneEnrollment {
     return PhoneEnrollment(
       phone: json['phone'],
     );
+  }
+
+  factory PhoneEnrollment._fromJsonValue(dynamic value) {
+    if (value is String) {
+      // Server returns phone number as a string directly
+      return PhoneEnrollment(phone: value);
+    } else if (value is Map<String, dynamic>) {
+      // Server returns phone data as an object
+      return PhoneEnrollment.fromJson(value);
+    } else {
+      throw ArgumentError(
+          'Invalid phone enrollment data type: ${value.runtimeType}');
+    }
   }
 }
 

--- a/packages/gotrue/test/src/gotrue_mfa_api_test.dart
+++ b/packages/gotrue/test/src/gotrue_mfa_api_test.dart
@@ -33,16 +33,42 @@ void main() {
     );
   });
 
-  test('enroll', () async {
+  test('enroll totp', () async {
     await client.signInWithPassword(password: password, email: email1);
 
     final res = await client.mfa
         .enroll(issuer: 'MyFriend', friendlyName: 'MyFriendName');
-    final uri = Uri.parse(res.totp.uri);
+    final uri = Uri.parse(res.totp!.uri);
 
     expect(res.type, FactorType.totp);
     expect(uri.queryParameters['issuer'], 'MyFriend');
     expect(uri.scheme, 'otpauth');
+  });
+
+  test('enroll phone', () async {
+    await client.signInWithPassword(password: password, email: email1);
+
+    final res = await client.mfa.enroll(
+      factorType: FactorType.phone,
+      phone: '+1234567890',
+      friendlyName: 'MyPhone',
+    );
+
+    expect(res.type, FactorType.phone);
+    expect(res.phone?.phone, '+1234567890');
+    expect(res.totp, isNull);
+  });
+
+  test('enroll phone requires phone number', () async {
+    await client.signInWithPassword(password: password, email: email1);
+
+    expect(
+      () async => await client.mfa.enroll(
+        factorType: FactorType.phone,
+        friendlyName: 'MyPhone',
+      ),
+      throwsArgumentError,
+    );
   });
 
   test('challenge', () async {
@@ -95,6 +121,7 @@ void main() {
     final res = await client.mfa.listFactors();
 
     expect(res.totp.length, 1);
+    expect(res.phone.length, 0);
     expect(res.all.length, 1);
     expect(res.all.first.id, factorId2);
     expect(res.all.first.status, FactorStatus.verified);
@@ -106,6 +133,43 @@ void main() {
         res.all.first.updatedAt.difference(DateTime.now()) <
             Duration(seconds: 2),
         true);
+  });
+
+  test('list factors with phone enrollment', () async {
+    await client.signInWithPassword(password: password, email: email1);
+
+    // First, enroll a phone factor
+    final enrollRes = await client.mfa.enroll(
+      factorType: FactorType.phone,
+      phone: '+1234567890',
+      friendlyName: 'TestPhone',
+    );
+
+    // Verify enrollment worked
+    expect(enrollRes.type, FactorType.phone);
+    expect(enrollRes.phone?.phone, '+1234567890');
+
+    // Now list factors and check that phone factor appears
+    final listRes = await client.mfa.listFactors();
+
+    // Should have 1 phone factor (unverified) and 0 verified phone factors
+    expect(listRes.all.length, greaterThanOrEqualTo(1));
+    
+    // Find the phone factor we just enrolled
+    final phoneFactor = listRes.all.firstWhere(
+      (factor) => factor.factorType == FactorType.phone,
+    );
+    
+    expect(phoneFactor.id, enrollRes.id);
+    expect(phoneFactor.factorType, FactorType.phone);
+    expect(phoneFactor.friendlyName, 'TestPhone');
+    expect(phoneFactor.status, FactorStatus.unverified);
+    
+    // Verified phone factors should be empty since we haven't verified yet
+    expect(listRes.phone.length, 0);
+    
+    // But the factor should appear in the all list
+    expect(listRes.all.any((f) => f.factorType == FactorType.phone), true);
   });
 
   test('aal1 for only password', () async {

--- a/packages/gotrue/test/src/gotrue_mfa_api_test.dart
+++ b/packages/gotrue/test/src/gotrue_mfa_api_test.dart
@@ -85,8 +85,8 @@ void main() {
     // Create a challenge first
     final challengeRes = await client.mfa.challenge(factorId: factorId1);
 
-    final res = await client.mfa
-        .verify(factorId: factorId1, challengeId: challengeRes.id, code: getTOTP());
+    final res = await client.mfa.verify(
+        factorId: factorId1, challengeId: challengeRes.id, code: getTOTP());
 
     expect(client.currentSession?.accessToken, res.accessToken);
     expect(client.currentUser, res.user);
@@ -155,20 +155,20 @@ void main() {
 
     // Should have 1 phone factor (unverified) and 0 verified phone factors
     expect(listRes.all.length, greaterThanOrEqualTo(1));
-    
+
     // Find the phone factor we just enrolled
     final phoneFactor = listRes.all.firstWhere(
       (factor) => factor.factorType == FactorType.phone,
     );
-    
+
     expect(phoneFactor.id, enrollRes.id);
     expect(phoneFactor.factorType, FactorType.phone);
     expect(phoneFactor.friendlyName, 'TestPhone');
     expect(phoneFactor.status, FactorStatus.unverified);
-    
+
     // Verified phone factors should be empty since we haven't verified yet
     expect(listRes.phone.length, 0);
-    
+
     // But the factor should appear in the all list
     expect(listRes.all.any((f) => f.factorType == FactorType.phone), true);
   });

--- a/packages/gotrue/test/src/gotrue_mfa_api_test.dart
+++ b/packages/gotrue/test/src/gotrue_mfa_api_test.dart
@@ -82,10 +82,11 @@ void main() {
   test('verify', () async {
     await client.signInWithPassword(password: password, email: email1);
 
-    final challengeId = 'b824ca10-cc13-4250-adba-20ee6e5e7dcd';
+    // Create a challenge first
+    final challengeRes = await client.mfa.challenge(factorId: factorId1);
 
     final res = await client.mfa
-        .verify(factorId: factorId1, challengeId: challengeId, code: getTOTP());
+        .verify(factorId: factorId1, challengeId: challengeRes.id, code: getTOTP());
 
     expect(client.currentSession?.accessToken, res.accessToken);
     expect(client.currentUser, res.user);


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature of adding phone support for MFA enrollment

JS PR here: https://github.com/supabase/auth-js/pull/932

## What is the current behavior?

Enrolling in MFA via SMS is supported .

## What is the new behavior?

SMS MFA is not supported. 
