### PR TITLE
feat(supabase_flutter): Make `Supabase.initialize()` idempotent

### DIFF
--- a/packages/supabase_flutter/lib/src/supabase.dart
+++ b/packages/supabase_flutter/lib/src/supabase.dart
@@ -42,7 +42,7 @@ class Supabase with WidgetsBindingObserver {
   /// Call [Supabase.initialize] to initialize it.
   static Supabase get instance {
     assert(
-      _instance._initialized,
+      _instance._isInitialized,
       'You must initialize the supabase instance before calling Supabase.instance',
     );
     return _instance;
@@ -87,10 +87,11 @@ class Supabase with WidgetsBindingObserver {
     Future<String?> Function()? accessToken,
     bool? debug,
   }) async {
-    assert(
-      !_instance._initialized,
-      'This instance is already initialized',
-    );
+    if (_instance._isInitialized) {
+      _log.info('Supabase is already initialized. Skipping reinitialization.');
+      return _instance;
+    }
+
     _instance._debugEnable = debug ?? kDebugMode;
 
     if (_instance._debugEnable) {
@@ -152,7 +153,10 @@ class Supabase with WidgetsBindingObserver {
 
   static WidgetsBinding? get _widgetsBindingInstance => WidgetsBinding.instance;
 
-  bool _initialized = false;
+  bool _isInitialized = false;
+
+  /// Whether the Supabase instance has been initialized. Useful for debugging.
+  bool get isInitialized => _isInitialized;
 
   /// The supabase client for this instance
   ///
@@ -177,7 +181,7 @@ class Supabase with WidgetsBindingObserver {
     client.dispose();
     _instance._supabaseAuth?.dispose();
     _widgetsBindingInstance?.removeObserver(this);
-    _initialized = false;
+    _isInitialized = false;
   }
 
   void _init(
@@ -214,7 +218,7 @@ class Supabase with WidgetsBindingObserver {
       markClientToDispose(client);
     }
     _widgetsBindingInstance?.addObserver(this);
-    _initialized = true;
+    _isInitialized = true;
   }
 
   @override


### PR DESCRIPTION
This PR introduces a minor update to the `initialize()` method to avoid throwing when called multiple times. Instead, it logs an informational message and returns the existing instance, making initialization idempotent and smoother for production use.

- Replaced `assert(!_instance.isInitialized)` with a runtime check to prevent throwing.
- Added `_log.info()` when a reinitialization attempt occurs.
- Exposed `isInitialized` as a public read-only getter for improved observability.
- Avoids throwing errors in release mode by gracefully handling repeated initialization.

Closes https://github.com/supabase/supabase-flutter/issues/1163

