### PR TITLE
refactor: Remove unnecessary parentheses in Bucket.fromJson

### DIFF
--- a/packages/storage_client/lib/src/types.dart
+++ b/packages/storage_client/lib/src/types.dart
@@ -27,7 +27,7 @@ class Bucket {
   });
 
   Bucket.fromJson(Map<String, dynamic> json)
-      : id = (json)['id'] as String,
+      : id = json['id'] as String,
         name = json['name'] as String,
         owner = json['owner'] as String,
         createdAt = json['created_at'] as String,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Code cleanup / refactor

## What is the current behavior?

There are unnecessary parentheses around `json` in some `fromJson` constructors like `Bucket.fromJson`, which slightly clutters the code.

## What is the new behavior?

Removed redundant parentheses to make the code cleaner and more idiomatic Dart.

## Additional context

This is a small code cleanup contribution  to help improve readability.
