### PR TITLE
fix(supabase_flutter): use getInitialAppLink from app_links

### DIFF
--- a/packages/supabase_flutter/lib/src/supabase_auth.dart
+++ b/packages/supabase_flutter/lib/src/supabase_auth.dart
@@ -192,23 +192,7 @@ class SupabaseAuth with WidgetsBindingObserver {
     _initialDeeplinkIsHandled = true;
 
     try {
-      Uri? uri;
-      try {
-        // before app_links 6.0.0
-        uri = await (_appLinks as dynamic).getInitialAppLink();
-      } on NoSuchMethodError catch (_) {
-        // The AppLinks package contains the initial link in the uriLinkStream
-        // starting from version 6.0.0. Before this version, getting the
-        // initial link was done with getInitialAppLink. Being in this catch
-        // handler means we are in at least version 6.0.0, meaning we do not
-        // need to handle the initial link manually.
-        //
-        // app_links claims that the initial link will be included in the
-        // `uriLinkStream`, but that is not the case for web
-        if (kIsWeb) {
-          uri = await (_appLinks as dynamic).getInitialLink();
-        }
-      }
+      final uri = await _appLinks.getInitialAppLink();
       if (uri != null) {
         await _handleDeeplink(uri);
       }

--- a/packages/supabase_flutter/pubspec.yaml
+++ b/packages/supabase_flutter/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   flutter: '>=3.19.0'
 
 dependencies:
-  app_links: '>=3.5.0 <7.0.0'
+  app_links: ^4.0.0
   async: ^2.11.0
   crypto: ^3.0.2
   flutter:


### PR DESCRIPTION
The previous implementation was trying to support multiple versions of the app_links package, but it was causing a NoSuchMethodError when using newer versions.

This commit removes the backward compatibility logic and uses the getInitialAppLink method directly, which is available in app_links ^4.0.0 and later.

## What kind of change does this PR introduce?

Bug fix, feature, docs update, ...

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
