### PR TITLE
feat(gotrue): Remove client-side provider validation for signInWithIdToken

### DIFF
--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -374,7 +374,6 @@ class GoTrueClient {
 
   /// Allows signing in with an ID token issued by certain supported providers.
   /// The [idToken] is verified for validity and a new session is established.
-  /// This method of signing in only supports [OAuthProvider.google], [OAuthProvider.apple], [OAuthProvider.kakao] or [OAuthProvider.keycloak].
   ///
   /// If the ID token contains an `at_hash` claim, then [accessToken] must be
   /// provided to compare its hash with the value in the ID token.
@@ -384,9 +383,6 @@ class GoTrueClient {
   ///
   /// [captchaToken] is the verification token received when the user
   /// completes the captcha on the app.
-  ///
-  /// This method is experimental.
-  @experimental
   Future<AuthResponse> signInWithIdToken({
     required OAuthProvider provider,
     required String idToken,
@@ -394,14 +390,6 @@ class GoTrueClient {
     String? nonce,
     String? captchaToken,
   }) async {
-    if (provider != OAuthProvider.google &&
-        provider != OAuthProvider.apple &&
-        provider != OAuthProvider.kakao &&
-        provider != OAuthProvider.keycloak) {
-      throw AuthException('Provider must be '
-          '${OAuthProvider.google.name}, ${OAuthProvider.apple.name}, ${OAuthProvider.kakao.name} or ${OAuthProvider.keycloak.name}.');
-    }
-
     final response = await _fetch.request(
       '$_url/token',
       RequestMethodType.post,


### PR DESCRIPTION
## Summary
- Facebook is now supported as an OIDC provider.
- Remove experimental annotation from `signInWithIdToken` method
- Remove client-side validation restricting providers to Google, Apple, Kakao, and Keycloak
- Backend will now handle provider validation, allowing for more flexible provider support

## Test plan
- [ ] Verify existing tests still pass
- [ ] Test signInWithIdToken with previously restricted providers
- [ ] Confirm backend properly handles unsupported providers

🤖 Generated with [Claude Code](https://claude.ai/code)