### PR TITLE
feat(postgrest): Implement maxAffected method

### DIFF
--- a/packages/postgrest/lib/src/postgrest_transform_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_transform_builder.dart
@@ -246,6 +246,38 @@ class PostgrestTransformBuilder<T> extends RawPostgrestBuilder<T, T, T> {
     return ResponsePostgrestBuilder(_copyWithType(headers: newHeaders));
   }
 
+  /// Sets the maximum number of rows that can be affected by the query.
+  ///
+  /// Only available with PATCH and DELETE operations. Requires PostgREST v13 or higher.
+  /// When the limit is exceeded, the query will fail with an error.
+  ///
+  /// ```dart
+  /// supabase.from('users').update({'active': false}).eq('status', 'inactive').maxAffected(5);
+  /// ```
+  ///
+  /// ```dart
+  /// supabase.from('users').delete().eq('active', false).maxAffected(10);
+  /// ```
+  PostgrestTransformBuilder<T> maxAffected(int value) {
+    final newHeaders = {..._headers};
+
+    // Add handling=strict and max-affected headers
+    if (newHeaders['Prefer'] != null) {
+      var preferHeader = newHeaders['Prefer']!;
+      if (!preferHeader.contains('handling=strict')) {
+        preferHeader += ',handling=strict';
+      }
+      if (!preferHeader.contains('max-affected=')) {
+        preferHeader += ',max-affected=$value';
+      }
+      newHeaders['Prefer'] = preferHeader;
+    } else {
+      newHeaders['Prefer'] = 'handling=strict,max-affected=$value';
+    }
+
+    return PostgrestTransformBuilder(_copyWith(headers: newHeaders));
+  }
+
   /// Obtains the EXPLAIN plan for this request.
   ///
   /// Before using this method, you need to enable `explain()` on your

--- a/packages/postgrest/test/transforms_test.dart
+++ b/packages/postgrest/test/transforms_test.dart
@@ -359,11 +359,7 @@ void main() {
 
     test('maxAffected method can be called on delete operations', () {
       expect(
-        () => postgrest
-            .from('channels')
-            .delete()
-            .eq('id', 999)
-            .maxAffected(5),
+        () => postgrest.from('channels').delete().eq('id', 999).maxAffected(5),
         returnsNormally,
       );
     });
@@ -377,10 +373,8 @@ void main() {
 
     test('maxAffected method can be called on insert operations', () {
       expect(
-        () => postgrest
-            .from('users')
-            .insert({'username': 'test'})
-            .maxAffected(1),
+        () =>
+            postgrest.from('users').insert({'username': 'test'}).maxAffected(1),
         returnsNormally,
       );
     });
@@ -423,8 +417,10 @@ void main() {
 
       expect(customHttpClient.lastRequest, isNotNull);
       expect(customHttpClient.lastRequest!.headers['Prefer'], isNotNull);
-      expect(customHttpClient.lastRequest!.headers['Prefer'], contains('handling=strict'));
-      expect(customHttpClient.lastRequest!.headers['Prefer'], contains('max-affected=5'));
+      expect(customHttpClient.lastRequest!.headers['Prefer'],
+          contains('handling=strict'));
+      expect(customHttpClient.lastRequest!.headers['Prefer'],
+          contains('max-affected=5'));
     });
 
     test('maxAffected sets correct headers for delete', () async {
@@ -440,8 +436,10 @@ void main() {
 
       expect(customHttpClient.lastRequest, isNotNull);
       expect(customHttpClient.lastRequest!.headers['Prefer'], isNotNull);
-      expect(customHttpClient.lastRequest!.headers['Prefer'], contains('handling=strict'));
-      expect(customHttpClient.lastRequest!.headers['Prefer'], contains('max-affected=10'));
+      expect(customHttpClient.lastRequest!.headers['Prefer'],
+          contains('handling=strict'));
+      expect(customHttpClient.lastRequest!.headers['Prefer'],
+          contains('max-affected=10'));
     });
 
     test('maxAffected preserves existing Prefer headers', () async {
@@ -463,20 +461,21 @@ void main() {
       expect(preferHeader, contains('max-affected=3'));
     });
 
-    test('maxAffected works with select operations (sets headers but likely ineffective)', () async {
+    test(
+        'maxAffected works with select operations (sets headers but likely ineffective)',
+        () async {
       try {
-        await postgrestCustomHttpClient
-            .from('users')
-            .select()
-            .maxAffected(2);
+        await postgrestCustomHttpClient.from('users').select().maxAffected(2);
       } catch (_) {
         // Expected to fail with custom client, we just want to check headers
       }
 
       expect(customHttpClient.lastRequest, isNotNull);
       expect(customHttpClient.lastRequest!.headers['Prefer'], isNotNull);
-      expect(customHttpClient.lastRequest!.headers['Prefer'], contains('handling=strict'));
-      expect(customHttpClient.lastRequest!.headers['Prefer'], contains('max-affected=2'));
+      expect(customHttpClient.lastRequest!.headers['Prefer'],
+          contains('handling=strict'));
+      expect(customHttpClient.lastRequest!.headers['Prefer'],
+          contains('max-affected=2'));
     });
   });
 }


### PR DESCRIPTION
## Summary
- Implement `maxAffected` method equivalent to postgrest-js library
- Sets maximum number of rows that can be affected by update and delete operations
- Adds `handling=strict` and `max-affected={value}` to Prefer header

## Implementation Details
- Added `maxAffected(int value)` method to `PostgrestTransformBuilder` class
- Preserves existing Prefer headers when adding maxAffected
- Supports method chaining with other transform methods
- No runtime validation - relies on documentation for proper usage guidance

## Usage Examples
```dart
// Update with max affected rows limit
supabase.from('users').update({'active': false}).eq('status', 'inactive').maxAffected(5);

// Delete with max affected rows limit  
supabase.from('users').delete().eq('active', false).maxAffected(10);

// Method chaining
supabase.from('users').update({'status': 'INACTIVE'}).eq('id', 1).maxAffected(1).select();
```

## Test Coverage
- ✅ Unit tests for method availability and chaining
- ✅ Integration tests validating HTTP headers using custom client
- ✅ Tests for preserving existing Prefer headers
- ✅ All existing tests continue to pass

## Notes
- Requires PostgREST v13 or higher
- Only effective with PATCH and DELETE operations (documented in method docs)
- When limit is exceeded, PostgREST will return an error

🤖 Generated with [Claude Code](https://claude.ai/code)