### PR TITLE
feat: add support for broadcast replay configuration

### DIFF
--- a/packages/realtime_client/lib/src/types.dart
+++ b/packages/realtime_client/lib/src/types.dart
@@ -138,12 +138,38 @@ extension ToType on RealtimeListenTypes {
   }
 }
 
+/// Configuration for broadcast replay feature.
+/// Allows replaying broadcast messages from a specific timestamp.
+class ReplayOption {
+  /// Unix timestamp (in milliseconds) from which to start replaying messages
+  final int since;
+
+  /// Optional limit on the number of messages to replay
+  final int? limit;
+
+  const ReplayOption({
+    required this.since,
+    this.limit,
+  });
+
+  Map<String, dynamic> toMap() {
+    final map = <String, dynamic>{'since': since};
+    if (limit != null) {
+      map['limit'] = limit;
+    }
+    return map;
+  }
+}
+
 class RealtimeChannelConfig {
   /// [ack] option instructs server to acknowlege that broadcast message was received
   final bool ack;
 
   /// [self] option enables client to receive message it broadcasted
   final bool self;
+
+  /// [replay] option configures broadcast replay from a specific timestamp
+  final ReplayOption? replay;
 
   /// [key] option is used to track presence payload across clients
   final String key;
@@ -157,18 +183,24 @@ class RealtimeChannelConfig {
   const RealtimeChannelConfig({
     this.ack = false,
     this.self = false,
+    this.replay,
     this.key = '',
     this.enabled = false,
     this.private = false,
   });
 
   Map<String, dynamic> toMap() {
+    final broadcastConfig = <String, dynamic>{
+      'ack': ack,
+      'self': self,
+    };
+    if (replay != null) {
+      broadcastConfig['replay'] = replay!.toMap();
+    }
+
     return {
       'config': {
-        'broadcast': {
-          'ack': ack,
-          'self': self,
-        },
+        'broadcast': broadcastConfig,
         'presence': {
           'key': key,
           'enabled': enabled,


### PR DESCRIPTION
## Summary
- Added `ReplayOption` class for configuring broadcast replay
- Added `replay` field to `RealtimeChannelConfig`
- Updated `toMap()` method to include replay configuration in broadcast config

## Changes
This PR implements broadcast replay support following the pattern from realtime-js PR #540:

1. **ReplayOption**: New class with `since` (int) and optional `limit` (int?)
2. **RealtimeChannelConfig**: Added optional `replay` field
3. **toMap()**: Updated to serialize replay configuration

## Usage
```dart
// Configure broadcast with replay
final channel = supabase.channel(
  'my-channel',
  RealtimeChannelConfig(
    self: true,
    ack: true,
    replay: ReplayOption(
      since: 1234567890,
      limit: 100,
    ),
  ),
);

// Broadcast callback receives meta field
channel.onBroadcast(
  event: 'position',
  callback: (payload) {
    final meta = payload['meta'] as Map<String, dynamic>?;
    if (meta?['replayed'] == true) {
      print('Replayed message: ${meta?['id']}');
    }
  },
).subscribe();
```

## Test plan
- [ ] Verify type checking passes
- [ ] Test broadcast replay configuration
- [ ] Verify meta field is properly included in callbacks

🤖 Generated with [Claude Code](https://claude.com/claude-code)