### PR TITLE
docs: clarify Facebook not supported for signInWithIdToke

### DIFF
--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -387,6 +387,8 @@ class GoTrueClient {
   ///
   /// [captchaToken] is the verification token received when the user
   /// completes the captcha on the app.
+  /// Note: Supported providers for signInWithIdToken are Google, Apple, Kakao, Keycloak. Facebook is NOT supported (see issue #1259 and OAuthProvider enum for details).
+
   Future<AuthResponse> signInWithIdToken({
     required OAuthProvider provider,
     required String idToken,


### PR DESCRIPTION
Clarifies in the signInWithIdToken function docstring that only Google, Apple, Kakao, and Keycloak are supported as providers; Facebook is NOT supported.

## What kind of change does this PR introduce?
Docs update (clarification)

## What is the current behavior?
Docs do not specify which providers are actually supported for signInWithIdToken; Facebook is not supported but this is unclear.

Relevant issue: #1259

## What is the new behavior?
Readers and developers will not be confused—supported providers are now explicitly listed in the docstring, preventing misuse.

## Additional context
Inspected OAuthProvider enum and actual code—Facebook is not implemented as a provider for signInWithIdToken.


