### PR TITLE
fix(gotrue): allow refreshSession with refreshToken when no current session exists

### DIFF
--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -607,19 +607,16 @@ class GoTrueClient {
   }
 
   /// Returns a new session, regardless of expiry status.
-  /// Takes in an optional current session. If not passed in, then refreshSession() will attempt to retrieve it from getSession().
-  /// If the current session's refresh token is invalid, an error will be thrown.
+  /// Takes in an optional [refreshToken]. If not provided, then refreshSession() will attempt to retrieve it from the current session.
+  /// If no refresh token is available (neither provided nor in current session), an error will be thrown.
   Future<AuthResponse> refreshSession([String? refreshToken]) async {
-    if (currentSession?.accessToken == null) {
-      _log.warning("Can't refresh session, no current session found.");
-      throw AuthSessionMissingException();
-    }
     _log.info('Refresh session');
 
     final currentSessionRefreshToken =
         refreshToken ?? _currentSession?.refreshToken;
 
     if (currentSessionRefreshToken == null) {
+      _log.warning("Can't refresh session, no refresh token found.");
       throw AuthSessionMissingException();
     }
 

--- a/packages/gotrue/test/client_test.dart
+++ b/packages/gotrue/test/client_test.dart
@@ -291,6 +291,30 @@ void main() {
       }
     });
 
+    test('Refresh session with refreshToken when no current session exists',
+        () async {
+      await client.signInWithPassword(email: email1, password: password);
+
+      final refreshToken = client.currentSession?.refreshToken ?? '';
+      expect(refreshToken, isNotEmpty);
+
+      final newClient = GoTrueClient(
+        url: gotrueUrl,
+        headers: {
+          'apikey': anonToken,
+        },
+      );
+
+      expect(newClient.currentSession, isNull);
+
+      // This should work even though there's no current session,
+      // because we're providing a refreshToken parameter
+      final response = await newClient.refreshSession(refreshToken);
+      expect(response.session, isNotNull);
+      expect(response.session?.accessToken, isNotEmpty);
+      expect(newClient.currentSession?.accessToken, isNotEmpty);
+    });
+
     test('Update user', () async {
       await client.signInWithPassword(email: email1, password: password);
 


### PR DESCRIPTION
## Description

Fixes #1261

This PR removes the redundant check that required `currentSession.accessToken` to exist before allowing a session refresh. 

### Problem
The `refreshSession` method was throwing an `AuthSessionMissingException` when there was no current session, even if a valid `refreshToken` was provided as a parameter. This blocked a valid use case where you might have a refresh token but no current session.

### Solution
- Removed the redundant check for `currentSession?.accessToken == null`
- The existing null check for the refresh token (`currentSessionRefreshToken == null`) is sufficient to handle both cases:
  - When a `refreshToken` parameter is provided
  - When falling back to `_currentSession?.refreshToken`
- Updated documentation to clarify the behavior
- Improved error message to be more accurate
- Added test to verify the fix works correctly

### Changes
- `packages/gotrue/lib/src/gotrue_client.dart`: Removed redundant check, updated docs
- `packages/gotrue/test/client_test.dart`: Added test for refreshSession with refreshToken when no current session exists

### Testing
- ✅ Added unit test that verifies `refreshSession(refreshToken)` works when `currentSession` is null
- ✅ All existing tests should continue to pass (backward compatible)
- ✅ No linter errors