### PR TITLE
docs: update signInWithIdToken provider documentation

### DIFF
--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -376,7 +376,8 @@ class GoTrueClient {
     return authSessionUrlResponse;
   }
 
-  /// Allows signing in with an ID token issued by certain supported providers.
+  /// Allows signing in with an ID token issued by supported providers.
+  /// Common supported providers include Apple, Google, Facebook, Kakao, and Keycloak.
   /// The [idToken] is verified for validity and a new session is established.
   ///
   /// If the ID token contains an `at_hash` claim, then [accessToken] must be

--- a/packages/supabase_flutter/README.md
+++ b/packages/supabase_flutter/README.md
@@ -186,7 +186,7 @@ Future<AuthResponse> _googleSignIn() async {
 
 ### <a id="oauth-login"></a>OAuth login
 
-For providers other than Apple or Google, you need to use the `signInWithOAuth()` method to perform OAuth login. This will open the web browser to perform the OAuth login.
+The `signInWithIdToken()` method supports providers like Apple, Google, Facebook, Kakao, and Keycloak. For other providers, you need to use the `signInWithOAuth()` method to perform OAuth login. This will open the web browser to perform the OAuth login.
 
 Use the `redirectTo` parameter to redirect the user to a deep link to bring the user back to the app. Learn more about setting up deep links in [Deep link config](#deep-link-config).
 


### PR DESCRIPTION
This PR updates the documentation to clarify that `signInWithIdToken` supports Facebook, Kakao, and Keycloak in addition to Apple and Google.

## Changes
- Updated README.md to clarify which providers are supported by `signInWithIdToken`
- Updated `signInWithIdToken` method docstring to list common supported providers

## Context
The client-side provider validation was removed in gotrue v2.14.0 (via #1209), allowing more providers to work with `signInWithIdToken`. This documentation update clarifies the current state of provider support.

Closes #1259