### PR TITLE
chore(style): remove trailing_commas lint rule

### DIFF
--- a/packages/supabase_flutter/analysis_options.yaml
+++ b/packages/supabase_flutter/analysis_options.yaml
@@ -3,4 +3,3 @@ include: package:flutter_lints/flutter.yaml
 linter:
   rules:
     avoid_print: false
-    trailing_commas: preserve


### PR DESCRIPTION
## What kind of change does this PR introduce?

I think latest flutter version removed the `trailing_commas` lint rule as CI started to fail: https://github.com/supabase/supabase-flutter/actions/runs/19325526766/job/55588812938