### PR TITLE
chore: bump app_links to ` '>=6.2.0 <8.0.0'`

### DIFF
--- a/packages/supabase_flutter/pubspec.yaml
+++ b/packages/supabase_flutter/pubspec.yaml
@@ -6,11 +6,11 @@ repository: 'https://github.com/supabase/supabase-flutter/tree/main/packages/sup
 documentation: 'https://supabase.com/docs/reference/dart/introduction'
 
 environment:
-  sdk: '>=3.5.0 <4.0.0'
-  flutter: '>=3.24.0'
+  sdk: '>=3.3.0 <4.0.0'
+  flutter: '>=3.19.0'
 
 dependencies:
-  app_links: ^7.0.0
+  app_links: '>=6.2.0 <8.0.0'
   async: ^2.11.0
   crypto: ^3.0.2
   flutter:


### PR DESCRIPTION
## What kind of change does this PR introduce?

This updates `app_links` to ^7.0.0 so that users with this as a direct dependency aren't stuck on an old version.

## What is the current behavior?

Users can't use the newest `app_links` version.

## What is the new behavior?

Users can use the newest `app_links` version.

