### PR TITLE
fix(gotrue): fix getClaims JWT token decoding

### DIFF
--- a/.github/workflows/dart-package-test.yml
+++ b/.github/workflows/dart-package-test.yml
@@ -20,6 +20,10 @@ on:
         required: false
         type: string
         description: 'The directory containing docker-compose.yml (e.g., infra/gotrue)'
+      docker-compose-files:
+        required: false
+        type: string
+        description: 'Optional whitespace/newline-separated list of docker compose files to pass via -f (e.g., "docker-compose.yml docker-compose.override.yml"). If omitted, runs `docker compose up` with default file discovery.'
       test-concurrency:
         required: false
         type: number
@@ -84,7 +88,16 @@ jobs:
         if: ${{ inputs.needs-docker }}
         run: |
           cd ../../${{ inputs.docker-compose-dir }}
-          docker compose up -d
+          COMPOSE_FILES='${{ inputs.docker-compose-files }}'
+          if [ -n "${COMPOSE_FILES//[[:space:]]/}" ]; then
+            COMPOSE_ARGS=""
+            for f in $COMPOSE_FILES; do
+              COMPOSE_ARGS="$COMPOSE_ARGS -f $f"
+            done
+            docker compose $COMPOSE_ARGS up -d
+          else
+            docker compose up -d
+          fi
 
       - name: Wait for services to be ready
         if: ${{ inputs.needs-docker }}
@@ -102,4 +115,13 @@ jobs:
         if: ${{ inputs.needs-docker && always() }}
         run: |
           cd ../../${{ inputs.docker-compose-dir }}
-          docker compose down
+          COMPOSE_FILES='${{ inputs.docker-compose-files }}'
+          if [ -n "${COMPOSE_FILES//[[:space:]]/}" ]; then
+            COMPOSE_ARGS=""
+            for f in $COMPOSE_FILES; do
+              COMPOSE_ARGS="$COMPOSE_ARGS -f $f"
+            done
+            docker compose $COMPOSE_ARGS down
+          else
+            docker compose down
+          fi

--- a/.github/workflows/gotrue.yml
+++ b/.github/workflows/gotrue.yml
@@ -31,3 +31,13 @@ jobs:
       needs-docker: true
       docker-compose-dir: infra/gotrue
       test-concurrency: 1
+
+  test-jwks:
+    uses: ./.github/workflows/dart-package-test.yml
+    with:
+      package-name: gotrue
+      working-directory: packages/gotrue
+      needs-docker: true
+      docker-compose-dir: infra/gotrue
+      docker-compose-files: docker-compose.yml docker-compose.jwk.yml
+      test-concurrency: 1

--- a/infra/gotrue/docker-compose.jwk.yml
+++ b/infra/gotrue/docker-compose.jwk.yml
@@ -1,0 +1,6 @@
+services:
+  gotrue:
+    # Minimal override for asymmetric JWT signing + JWKS publishing.
+    # Used with: docker compose -f docker-compose.yml -f docker-compose.jwk.yml up
+    environment:
+      GOTRUE_JWT_KEYS: '[{"kty":"EC","kid":"23203d4b-184b-4915-bb30-e70047967f88","use":"sig","key_ops":["sign","verify"],"alg":"ES256","ext":true,"d":"sVoSxECYxh-gfZFCYU3U8vbjH2cHSwtc4_uDmhMRIUo","crv":"P-256","x":"uXsLvkycPMsWg8v-8CGqbwhqCG9YNrlQKFyZL96puXo","y":"xGyOad6_Dg0UpiTmpdOP1kn9W8LNM3afTpqAv2ZHM8M"}]'

--- a/packages/gotrue/.env.example
+++ b/packages/gotrue/.env.example
@@ -1,0 +1,14 @@
+# GoTrue test environment configuration
+# Copy this file to .env and configure for your test setup
+
+# Default GoTrue URL and anon key
+GOTRUE_URL=http://localhost:9998
+GOTRUE_TOKEN=anonKey
+
+# Symmetric JWT signing (HS256) - used by default docker-compose.yml
+GOTRUE_JWT_SECRET=37c304f8-51aa-419a-a1af-06154e63707a
+
+# Asymmetric JWT signing (ES256) - used when docker-compose.jwk.yml is active
+# Uncomment this line when running tests with JWK setup:
+#   docker compose -f infra/gotrue/docker-compose.yml -f infra/gotrue/docker-compose.jwk.yml up
+# GOTRUE_JWT_KEYS=[{"kty":"EC","kid":"23203d4b-184b-4915-bb30-e70047967f88","use":"sig","key_ops":["sign","verify"],"alg":"ES256","ext":true,"d":"sVoSxECYxh-gfZFCYU3U8vbjH2cHSwtc4_uDmhMRIUo","crv":"P-256","x":"uXsLvkycPMsWg8v-8CGqbwhqCG9YNrlQKFyZL96puXo","y":"xGyOad6_Dg0UpiTmpdOP1kn9W8LNM3afTpqAv2ZHM8M"}]

--- a/packages/gotrue/lib/src/types/jwt.dart
+++ b/packages/gotrue/lib/src/types/jwt.dart
@@ -1,7 +1,3 @@
-import 'dart:convert';
-
-import 'package:dart_jsonwebtoken/dart_jsonwebtoken.dart';
-
 /// JWT Header structure
 class JwtHeader {
   /// Algorithm used to sign the JWT (e.g., 'RS256', 'ES256', 'HS256')
@@ -265,10 +261,5 @@ class JWK {
       json['kid'] = kid;
     }
     return json;
-  }
-
-  RSAPublicKey get rsaPublicKey {
-    final bytes = utf8.encode(json.encode(toJson()));
-    return RSAPublicKey.bytes(bytes);
   }
 }

--- a/packages/gotrue/pubspec.yaml
+++ b/packages/gotrue/pubspec.yaml
@@ -12,19 +12,23 @@ dependencies:
   collection: ^1.15.0
   crypto: ^3.0.2
   http: ">=0.13.0 <2.0.0"
+  jose_plus: ^0.4.7
   jwt_decode: ^0.3.1
   retry: ^3.1.0
   rxdart: ">=0.27.7 <0.29.0"
   meta: ^1.7.0
   logging: ^1.2.0
   web: ">=0.5.0 <2.0.0"
-  dart_jsonwebtoken: ">=2.17.0 <4.0.0"
 
 dev_dependencies:
   dotenv: ^4.1.0
+  dart_jsonwebtoken: ">=2.17.0 <4.0.0"
   lints: ^3.0.0
   test: ^1.16.4
   otp: ^3.1.3
 
 false_secrets:
   - /infra/docker-compose.yml
+  - /infra/gotrue/docker-compose.jwk.yml
+  - /packages/gotrue/.env
+  - /packages/gotrue/.env.example

--- a/packages/gotrue/test/src/gotrue_admin_mfa_api_test.dart
+++ b/packages/gotrue/test/src/gotrue_admin_mfa_api_test.dart
@@ -1,4 +1,3 @@
-import 'package:dart_jsonwebtoken/dart_jsonwebtoken.dart';
 import 'package:dotenv/dotenv.dart';
 import 'package:gotrue/gotrue.dart';
 import 'package:http/http.dart' as http;
@@ -12,12 +11,7 @@ void main() {
   env.load(); // Load env variables from .env file
 
   final gotrueUrl = env['GOTRUE_URL'] ?? 'http://localhost:9998';
-  final serviceRoleToken = JWT(
-    {'role': 'service_role'},
-  ).sign(
-    SecretKey(
-        env['GOTRUE_JWT_SECRET'] ?? '37c304f8-51aa-419a-a1af-06154e63707a'),
-  );
+  final serviceRoleToken = getServiceRoleToken(env);
 
   late GoTrueClient client;
 

--- a/packages/gotrue/test/src/gotrue_admin_oauth_api_test.dart
+++ b/packages/gotrue/test/src/gotrue_admin_oauth_api_test.dart
@@ -1,8 +1,9 @@
-import 'package:dart_jsonwebtoken/dart_jsonwebtoken.dart';
 import 'package:dotenv/dotenv.dart';
 import 'package:gotrue/gotrue.dart';
 import 'package:http/http.dart' as http;
 import 'package:test/test.dart';
+
+import '../utils.dart';
 
 void main() {
   final env = DotEnv();
@@ -10,12 +11,7 @@ void main() {
   env.load(); // Load env variables from .env file
 
   final gotrueUrl = env['GOTRUE_URL'] ?? 'http://localhost:9998';
-  final serviceRoleToken = JWT(
-    {'role': 'service_role'},
-  ).sign(
-    SecretKey(
-        env['GOTRUE_JWT_SECRET'] ?? '37c304f8-51aa-419a-a1af-06154e63707a'),
-  );
+  final serviceRoleToken = getServiceRoleToken(env);
 
   late GoTrueClient client;
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (fixes `GoTrueClient.getClaims()` JWT decoding for asymmetric algorithms), plus tests, CI/workflow updates, package/pubspec adjustments, and infra (JWKS docker-compose) additions.

## What is the current behavior?

`getClaims()` can throw `DartError: Unexpected null value.` when verifying JWTs signed with asymmetric algorithms (e.g., `RS256`, `ES256`) because `_jwks` is force-unwrapped before it is initialized — see supabase/supabase-flutter#1286. CI/tests may not surface this because the local test auth uses HS* signing.

## What is the new behavior?

`getClaims()` no longer force-unwraps `_jwks`; the JWKS path is handled safely by fetching and caching `/.well-known/jwks.json` on first use (or falling back appropriately), so asymmetric (RS*/ES*) JWTs with `kid` are verified without crashing. Tests updated to cover the JWKS path; CI/workflows, gotrue pubspec, and docker-compose.jwk.yml were updated to support and validate the fix.

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
