### PR TITLE
fix: delete toJson parser print

### DIFF
--- a/packages/realtime_client/lib/src/transformers.dart
+++ b/packages/realtime_client/lib/src/transformers.dart
@@ -227,7 +227,6 @@ dynamic toJson(dynamic value) {
     try {
       return json.decode(value);
     } catch (error) {
-      print('JSON parse error: $error');
       return value;
     }
   }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

The toJson prints "errors" while decoding json, even though those errors doesn't exist.

Example:

<img width="599" height="51" alt="image" src="https://github.com/user-attachments/assets/c1e31c50-53be-4560-8d7c-243b1f8b2775" />

<img width="264" height="189" alt="image" src="https://github.com/user-attachments/assets/71c62ec9-5861-4a40-8590-1248cb70da85" />


## What is the new behavior?

Now the toJson handles the errors as expected, with the intentional decode-and-fallback logic.

## Additional context

The toJson function correctly attempts to decode JSON strings and falls back to the raw value on failure. However, it logs every parse failure, which pollutes console output for valid use cases (e.g., jsonb columns containing unquoted strings from Postgres realtime).

This removes the unnecessary print statement while preserving the intended try-decode-or-fallback behavior.
