### PR TITLE
fix(auth): fix verifyOTP parameter validation for OtpType.recovery with tokenHash

### DIFF
--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -518,17 +518,28 @@ class GoTrueClient {
     String? captchaToken,
     String? tokenHash,
   }) async {
-    assert(
-        ((email != null && phone == null) ||
-                (email == null && phone != null)) ||
-            (tokenHash != null),
-        '`email` or `phone` needs to be specified.');
-    assert(token != null || tokenHash != null,
-        '`token` or `tokenHash` needs to be specified.');
+    // For recovery type with tokenHash, only tokenHash and type are required
+    final isRecoveryWithTokenHash =
+        type == OtpType.recovery && tokenHash != null;
+
+    if (!isRecoveryWithTokenHash) {
+      assert(
+          ((email != null && phone == null) ||
+                  (email == null && phone != null)) ||
+              (tokenHash != null),
+          '`email` or `phone` needs to be specified.');
+      assert(token != null || tokenHash != null,
+          '`token` or `tokenHash` needs to be specified.');
+    } else {
+      // For recovery with tokenHash, email/phone should not be provided
+      assert(email == null && phone == null,
+          'For recovery type with tokenHash, only tokenHash and type should be provided.');
+    }
 
     final body = {
-      if (email != null) 'email': email,
-      if (phone != null) 'phone': phone,
+      // For recovery type with tokenHash, exclude email/phone
+      if (!isRecoveryWithTokenHash && email != null) 'email': email,
+      if (!isRecoveryWithTokenHash && phone != null) 'phone': phone,
       if (token != null) 'token': token,
       'type': type.snakeCase,
       'redirect_to': redirectTo,

--- a/packages/gotrue/test/otp_mock_test.dart
+++ b/packages/gotrue/test/otp_mock_test.dart
@@ -130,6 +130,41 @@ void main() {
       expect(client.currentUser, isNotNull);
     });
 
+    test('verifyOTP() with recovery type and tokenHash', () async {
+      // Recovery type with tokenHash should only include tokenHash and type
+      final response = await client.verifyOTP(
+        tokenHash: 'mock-token-hash',
+        type: OtpType.recovery,
+      );
+
+      expect(response.session, isNotNull);
+      expect(response.user, isNotNull);
+
+      // Verify session was set
+      expect(client.currentSession, isNotNull);
+      expect(client.currentUser, isNotNull);
+    });
+
+    test(
+        'verifyOTP() with recovery type and tokenHash should reject email/phone',
+        () async {
+      // Recovery type with tokenHash should not accept email/phone
+      try {
+        await client.verifyOTP(
+          email: testEmail,
+          tokenHash: 'mock-token-hash',
+          type: OtpType.recovery,
+        );
+        fail('Should have thrown an assertion error');
+      } catch (e) {
+        expect(e, isA<AssertionError>());
+        expect(
+            e.toString(),
+            contains(
+                'For recovery type with tokenHash, only tokenHash and type should be provided'));
+      }
+    });
+
     test('verifyOTP() without token should throw', () async {
       try {
         await client.verifyOTP(


### PR DESCRIPTION
## Description

Fixes #1159

The `verifyOTP` method was incorrectly requiring `email` or `phone` parameters when using `OtpType.recovery` with `tokenHash`. According to the backend API, when using recovery type with tokenHash, only `token_hash` and `type` should be provided.

## Changes

- Updated `verifyOTP` method to handle `OtpType.recovery` with `tokenHash` correctly
- Added validation to ensure email/phone are not provided when using recovery type with tokenHash
- Updated request body construction to exclude email/phone for recovery type with tokenHash
- Added test cases to verify the fix works correctly

## Testing

- Added test case for recovery type with tokenHash (no email/phone)
- Added test case to ensure recovery type with tokenHash rejects email/phone parameters

## Related Issue

Closes #1159