### PR TITLE
feat(ci): integrate reusable CI workflows from supabase/actions

### DIFF
--- a/.github/workflows/block-merge.yml
+++ b/.github/workflows/block-merge.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   block-merge:
-    uses: supabase/actions/.github/workflows/block-merge.yml@feat/reusable-workflows
+    uses: supabase/actions/.github/workflows/block-merge.yml@659b3cd74a64ee2f1ca0a527922f134707e54671
     with:
-      block_labels: 'do-not-merge,blocked'
-      block_keywords: 'wip,do not merge'
+      block_labels: "do-not-merge,blocked"
+      block_keywords: "wip,do not merge"

--- a/.github/workflows/label-issues.yml
+++ b/.github/workflows/label-issues.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   label:
-    uses: supabase/actions/.github/workflows/label-issues.yml@feat/reusable-workflows
+    uses: supabase/actions/.github/workflows/label-issues.yml@659b3cd74a64ee2f1ca0a527922f134707e54671
     with:
       label_mappings: |
         {

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -3,17 +3,17 @@ name: Manage Stale Issues and PRs
 on:
   schedule:
     # Run every Sunday at 00:00 UTC
-    - cron: '0 0 * * 0'
+    - cron: "0 0 * * 0"
   workflow_dispatch:
 
 jobs:
   stale:
-    uses: supabase/actions/.github/workflows/stale.yml@feat/reusable-workflows
+    uses: supabase/actions/.github/workflows/stale.yml@659b3cd74a64ee2f1ca0a527922f134707e54671
     with:
       days_before_issue_stale: 180
       days_before_issue_close: 30
       days_before_pr_stale: 90
       days_before_pr_close: 14
-      exempt_issue_labels: 'priority,security,planned,good first issue'
-      exempt_pr_labels: 'priority,security'
+      exempt_issue_labels: "priority,security,planned,good first issue"
+      exempt_pr_labels: "priority,security"
       operations_per_run: 100


### PR DESCRIPTION
## Summary

Integrates reusable CI workflows from the `supabase/actions` repository to standardize CI processes across Supabase client libraries, following the pattern established in [supabase-swift#887](https://github.com/supabase/supabase-swift/pull/887) and [supabase-js#2041](https://github.com/supabase/supabase-js/pull/2041).

## Changes

### New Workflows

1. **block-merge.yml** - Prevents accidental merging of incomplete work
   - Blocks draft PRs automatically
   - Blocks PRs with `do-not-merge` or `blocked` labels
   - Blocks PRs containing "wip" or "do not merge" in the title

2. **stale.yml** - Manages inactive issues and pull requests
   - Issues: 180 days to stale status, 30 days before closure
   - PRs: 90 days to stale status, 14 days before closure
   - Exempts `priority`, `security`, `planned`, and `good first issue` labels
   - Runs weekly on Sundays

3. **label-issues.yml** - Auto-labels issues and PRs by module
   - Extracts scope from conventional commit PR titles (e.g., `fix(auth):` → `auth` label)
   - Supports all Flutter package modules: auth, storage, realtime, postgrest, functions, auth-ui
   - Parses issue templates for affected module identification

## Benefits

- ✅ Consistent CI behavior across all Supabase client libraries
- ✅ Reduced maintenance burden through shared workflow definitions
- ✅ Automated issue triaging and management
- ✅ Better PR hygiene with WIP blocking
- ✅ Improved discoverability through automatic labeling

## Test Plan

- [ ] Verify block-merge workflow prevents merging of draft PRs
- [ ] Verify block-merge workflow blocks PRs with appropriate labels/keywords
- [ ] Verify label-issues workflow correctly labels this PR based on the `ci` scope
- [ ] Stale workflow will be tested over time with scheduled runs

## References

- Closes [SDK-624](https://linear.app/supabase/issue/SDK-624)
- Related: [supabase-swift#887](https://github.com/supabase/supabase-swift/pull/887)
- Related: [supabase-js#2041](https://github.com/supabase/supabase-js/pull/2041)
- Workflows: [supabase/actions](https://github.com/supabase/actions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)