### PR TITLE
fix(auth): fix getClaims() crash with asymmetric JWTs on first call

### DIFF
--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -1397,6 +1397,11 @@ class GoTrueClient {
   ///
   /// If the project is not using an asymmetric JWT signing key (like ECC or
   /// RSA) it always sends a request to the Auth server (similar to [getUser]) to verify the JWT.
+  ///
+  /// For JWTs signed with asymmetric algorithms (RS256, ES256, etc.), the JWKS
+  /// is fetched from the server on the first call and cached for subsequent calls.
+  /// The cache is refreshed automatically after 10 minutes.
+  ///
   /// [jwt] An optional specific JWT you wish to verify, not the one you
   ///       can obtain from [currentSession].
   /// [options] Various additional options that allow you to customize the
@@ -1428,7 +1433,7 @@ class GoTrueClient {
     final signingKey =
         (decoded.header.alg.startsWith('HS') || decoded.header.kid == null)
             ? null
-            : await _fetchJwk(decoded.header.kid!, _jwks!);
+            : await _fetchJwk(decoded.header.kid!, _jwks ?? JWKSet(keys: []));
 
     // If symmetric algorithm, fallback to getUser()
     if (signingKey == null) {


### PR DESCRIPTION
## Summary

Fixes a crash in `getClaims()` that occurred when verifying JWTs signed with asymmetric algorithms (RS256, ES256, etc.) on the first call.

## Problem

`GoTrueClient.getClaims()` would crash with `Null check operator used on a null value` when called for the first time with a JWT that:
- Uses an asymmetric signing algorithm (RS256, ES256, etc.)
- Contains a `kid` (key ID) in the JWT header

### Root Cause

In `gotrue_client.dart:1431`, the code force-unwrapped `_jwks!` before it was initialized:

```dart
final signingKey =
    (decoded.header.alg.startsWith('HS') || decoded.header.kid == null)
        ? null
        : await _fetchJwk(decoded.header.kid!, _jwks!);  // ❌ Crashes here
```

The `_jwks` cache is declared as nullable and is only populated inside `_fetchJwk()` after fetching from `/.well-known/jwks.json`. This created a circular dependency:
- Need `_jwks` to call `_fetchJwk`
- `_fetchJwk` is responsible for initializing `_jwks`

### Why CI Tests Passed

The existing tests use a GoTrue instance configured with symmetric JWT signing (HS256 via `GOTRUE_JWT_SECRET`). In that case:
- `decoded.header.alg.startsWith('HS')` returns `true`
- `signingKey` becomes `null`
- The code falls back to `getUser(token)` for server verification
- The JWKS code path (and `_jwks!`) is never executed

## Solution

Replace the force-unwrap with a null-coalescing operator:

```dart
final signingKey =
    (decoded.header.alg.startsWith('HS') || decoded.header.kid == null)
        ? null
        : await _fetchJwk(decoded.header.kid!, _jwks ?? JWKSet(keys: []));  // ✅ Fixed
```

When `_jwks` is null on the first call, an empty `JWKSet` is passed to `_fetchJwk()`. The method then:
1. Tries to find the key in the empty supplied set (won't find it)
2. Checks the cache (still null)
3. Fetches from `/.well-known/jwks.json` and populates `_jwks`
4. Returns the found key or null

## Changes

- **Fixed**: `getClaims()` now handles null `_jwks` cache gracefully (lib/src/gotrue_client.dart:1436)
- **Added**: Test case that reproduces and verifies the fix (test/get_claims_test.dart:210-256)
- **Enhanced**: Documentation to clarify JWKS caching behavior for asymmetric JWTs

## Testing

### New Test
Added `getClaims() with RS256 JWT on first call should not crash (SDK-627)` that:
- Creates a JWT with RS256 algorithm and `kid` header
- Calls `getClaims()` on a fresh client (null `_jwks` cache)
- Verifies it does NOT crash with null error
- Before fix: Crashed with "Null check operator used on a null value"
- After fix: Fails gracefully with network/auth error (expected behavior)

### Verification
```bash
flutter test test/get_claims_test.dart --plain-name "getClaims() with RS256 JWT on first call should not crash"
# ✅ Test passes
```

## Impact

Apps using Supabase Auth with asymmetric JWT signing (RS256, ES256) will no longer crash when calling `getClaims()` for the first time. This is a critical bug fix with no breaking changes.

## Related

- Linear: [SDK-627](https://linear.app/supabase/issue/SDK-627/flutter-sdk-getclaims-crashes-on-first-use-with-asymmetric-jwts)
- GitHub: [#1286](https://github.com/supabase/supabase-flutter/issues/1286)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)