### PR TITLE
ci(supabase_flutter): make WASM tests non-blocking

### DIFF
--- a/.github/workflows/supabase_flutter.yml
+++ b/.github/workflows/supabase_flutter.yml
@@ -88,6 +88,9 @@ jobs:
           cd example && flutter build web
 
       - name: Build and test web (WASM)
+        # WASM tests have known infrastructure flakiness (12min+ loading timeouts)
+        # Allow CI to continue while still running tests for visibility
+        continue-on-error: true
         if: ${{ matrix.os == 'ubuntu-latest' && matrix.flutter-version == '3.x'}}
         run: |
           flutter test --platform chrome --wasm


### PR DESCRIPTION
## Summary
- Make WASM tests non-blocking with `continue-on-error: true`
- WASM tests have known infrastructure flakiness (12+ minute loading timeouts)
- CI will continue while still running tests for visibility

## Context
The `flutter test --platform chrome --wasm` step has been timing out during the test **loading** phase (not execution), causing unrelated PRs to fail CI. This is an infrastructure issue with Flutter's WASM testing, not a code issue.

## Test plan
- [x] Verify workflow syntax is valid
- [ ] CI runs should now pass even if WASM tests timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipeline resilience for web platform testing to accommodate infrastructure variations while maintaining visibility into test results.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->