### PR TITLE
getUser is also refresh the user reference in the currentSession

### DIFF
--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -717,7 +717,15 @@ class GoTrueClient {
       RequestMethodType.get,
       options: options,
     );
-    return UserResponse.fromJson(response);
+    final userResponse = UserResponse.fromJson(response);
+
+    if (userResponse.user == _currentSession?.user) return userResponse;
+
+    _currentSession = currentSession?.copyWith(user: userResponse.user);
+
+    notifyAllSubscribers(AuthChangeEvent.userUpdated);
+
+    return userResponse;
   }
 
   /// Updates user data, if there is a logged in user.

--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -719,6 +719,8 @@ class GoTrueClient {
     );
     final userResponse = UserResponse.fromJson(response);
 
+    if (userResponse.user == null) return userResponse;
+
     // np need to update the local user when the user is the same
     if (userResponse.user == _currentSession?.user) return userResponse;
 

--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -719,10 +719,10 @@ class GoTrueClient {
     );
     final userResponse = UserResponse.fromJson(response);
 
+    // np need to update the local user when the user is the same
     if (userResponse.user == _currentSession?.user) return userResponse;
 
     _currentSession = currentSession?.copyWith(user: userResponse.user);
-
     notifyAllSubscribers(AuthChangeEvent.userUpdated);
 
     return userResponse;


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix/feature -> Depending on who you ask 😅

## What is the current behavior?

The `getUser` call only gets the user without doing anything with the user 

## What is the new behavior?

The old user object is also updated in the `currentSession` 

## Additional context

We update the user object in an edgefunction and want to refresh the user afterwards. 