### PR TITLE
docs: update facebook native login docs

### DIFF
--- a/packages/supabase_flutter/README.md
+++ b/packages/supabase_flutter/README.md
@@ -184,6 +184,48 @@ Future<AuthResponse> _googleSignIn() async {
 ...
 ```
 
+### Native Facebook Login
+
+You can also use the `signInWithIdToken` method to perform a native Facebook login using the `flutter_facebook_auth` package. Facebook provides the required OIDC ID Token via its Limited Login feature or when the `openid` permission is requested.
+
+Depending on the configuration, `flutter_facebook_auth` will return a `ClassicToken` or a `LimitedToken`. You must extract the `authenticationToken` or `tokenString` respectively to pass to the `idToken` parameter.
+
+```dart
+import 'package:flutter_facebook_auth/flutter_facebook_auth.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+Future<AuthResponse> _facebookSignIn() async {
+  // Perform the sign in with Facebook
+  final LoginResult result = await FacebookAuth.instance.login(
+    permissions: ['public_profile', 'email'],
+    // Note: Android requires LoginBehavior.webOnly to return an OIDC ID Token.
+    loginBehavior: LoginBehavior.webOnly,
+  );
+
+  if (result.status != LoginStatus.success) {
+    throw 'Facebook sign in failed: ${result.message}';
+  }
+
+  // Extract the OIDC ID Token from the result
+  String? idToken;
+  if (result.accessToken is ClassicToken) {
+    idToken = (result.accessToken as ClassicToken).authenticationToken;
+  } else if (result.accessToken is LimitedToken) {
+    idToken = result.accessToken!.tokenString;
+  }
+
+  if (idToken == null) {
+    throw 'No ID Token found. Make sure you use LoginBehavior.webOnly on Android.';
+  }
+
+  // Sign in to Supabase
+  return Supabase.instance.client.auth.signInWithIdToken(
+    provider: OAuthProvider.facebook,
+    idToken: idToken,
+  );
+}
+```
+
 ### <a id="oauth-login"></a>OAuth login
 
 The `signInWithIdToken()` method supports providers like Apple, Google, Facebook, Kakao, and Keycloak. For other providers, you need to use the `signInWithOAuth()` method to perform OAuth login. This will open the web browser to perform the OAuth login.

--- a/packages/supabase_flutter/README.md
+++ b/packages/supabase_flutter/README.md
@@ -226,6 +226,19 @@ Future<AuthResponse> _facebookSignIn() async {
 }
 ```
 
+Alternatively, if you do not want to use the native Facebook SDK, you can use the web-based `signInWithOAuth()` method. This will open the device's web browser to perform the classic Facebook OAuth 2.0 login flow.
+
+```dart
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+Future<void> _facebookSignInWeb() async {
+  await Supabase.instance.client.auth.signInWithOAuth(
+    OAuthProvider.facebook,
+    redirectTo: 'io.supabase.flutterdemo://login-callback',
+  );
+}
+```
+
 ### <a id="oauth-login"></a>OAuth login
 
 The `signInWithIdToken()` method supports providers like Apple, Google, Facebook, Kakao, and Keycloak. For other providers, you need to use the `signInWithOAuth()` method to perform OAuth login. This will open the web browser to perform the OAuth login.


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

Currently, there is no official documentation for Facebook native login using signInWithIdToken in the Flutter SDK. Many developers refer to external tutorials or guess the implementation and mistakenly pass the Facebook Graph API access token (e.g., result.accessToken!.tokenString) as the idToken parameter.

Because the Supabase GoTrue backend strictly expects an OpenID Connect (OIDC) ID token (Facebook Limited Login JWT), passing the Graph API access token throws a 400 Bad ID token error. Furthermore, developers don't know they need to request OIDC tokens by using LoginBehavior.webOnly on Android or extracting the authenticationToken field properly.

Resolves #1287 Resolves #987 (Addresses problems seen in PR #1297)

## What is the new behavior?

This PR updates packages/supabase_flutter/README.md to include:

Native Facebook Login Example: A complete, robust example of using the flutter_facebook_auth package to perform native login. It shows how to correctly enforce OIDC token generation (LoginBehavior.webOnly on Android) and how to safely extract the OIDC token by checking if the result is a ClassicToken (extracting authenticationToken) or a LimitedToken (extracting tokenString).
Web-based OAuth Alternative: Adds a secondary snippet showing how to use signInWithOAuth as a simpler web-based fallback if developers choose not to use the native Facebook SDK.

##Additional context

This is a documentation-only update. It provides the necessary context and exact implementation details to avoid backend validation errors related to Facebook's dual-token system (Graph API vs Limited Login OIDC).
The [website docs](https://supabase.com/docs/reference/dart/auth-signinwithidtoken) also needs to be updated to reflect this docs.