### PR TITLE
fix(storage): use toString() for statusCode to handle non-string types

### DIFF
--- a/packages/storage_client/lib/src/types.dart
+++ b/packages/storage_client/lib/src/types.dart
@@ -309,7 +309,7 @@ class StorageException implements Exception {
       StorageException(
         json['message'] as String? ?? json.toString(),
         error: json['error'] as String?,
-        statusCode: (json['statusCode'] as String?) ?? statusCode,
+        statusCode: json['statusCode']?.toString() ?? statusCode,
       );
 
   @override

--- a/packages/storage_client/test/client_test.dart
+++ b/packages/storage_client/test/client_test.dart
@@ -415,7 +415,7 @@ void main() {
         await storage.from('bucket2').download(uploadPath);
         fail('File that does not exist was found');
       } on StorageException catch (error) {
-        expect(error.statusCode, '400');
+        expect(error.statusCode, '404');
       }
       await storage
           .from(newBucketName)
@@ -435,7 +435,7 @@ void main() {
         await storage.from('bucket2').download('$uploadPath 3');
         fail('File that does not exist was found');
       } on StorageException catch (error) {
-        expect(error.statusCode, '400');
+        expect(error.statusCode, '404');
       }
       await storage
           .from(newBucketName)
@@ -449,7 +449,7 @@ void main() {
         await storage.from(newBucketName).download(uploadPath);
         fail('File that was moved was found');
       } on StorageException catch (error) {
-        expect(error.statusCode, '400');
+        expect(error.statusCode, '404');
       }
     });
   });

--- a/packages/storage_client/test/client_test.dart
+++ b/packages/storage_client/test/client_test.dart
@@ -415,7 +415,7 @@ void main() {
         await storage.from('bucket2').download(uploadPath);
         fail('File that does not exist was found');
       } on StorageException catch (error) {
-        expect(error.statusCode, '404');
+        expect(error.statusCode, '400');
       }
       await storage
           .from(newBucketName)
@@ -435,7 +435,7 @@ void main() {
         await storage.from('bucket2').download('$uploadPath 3');
         fail('File that does not exist was found');
       } on StorageException catch (error) {
-        expect(error.statusCode, '404');
+        expect(error.statusCode, '400');
       }
       await storage
           .from(newBucketName)
@@ -449,7 +449,7 @@ void main() {
         await storage.from(newBucketName).download(uploadPath);
         fail('File that was moved was found');
       } on StorageException catch (error) {
-        expect(error.statusCode, '404');
+        expect(error.statusCode, '400');
       }
     });
   });


### PR DESCRIPTION
Fixes #1312

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

`StorageException.fromJson` uses `as String?` to cast `json['statusCode']`, which silently returns `null` when the server sends `statusCode` as an integer (e.g., `404` instead of `"404"`). This causes the `statusCode` field to be `null` instead of the actual value from the JSON response body.

## What is the new behavior?

Uses `.toString()` instead of `as String?`, which correctly converts the `statusCode` regardless of whether the server sends it as a string or integer.