### PR TITLE
fix: use private Realtime channel for .stream()

### DIFF
--- a/packages/supabase/lib/src/supabase_stream_builder.dart
+++ b/packages/supabase/lib/src/supabase_stream_builder.dart
@@ -167,7 +167,10 @@ class SupabaseStreamBuilder extends Stream<SupabaseStreamEvent> {
       );
     }
 
-    _channel = _realtimeClient.channel(_realtimeTopic);
+    _channel = _realtimeClient.channel(
+      _realtimeTopic,
+      const RealtimeChannelConfig(private: true),
+    );
 
     _channel!
         .onPostgresChanges(


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix. 

## What is the current behavior?

When public channels are disabled in a Supabase project ("Allow public access to channels" is false), attempting to use `.stream()` results in an Exception: "PrivateOnly: This project only allows private channels". This happens because `.stream()` creates a Realtime channel without specifying it as private. By explicitly configuring the `RealtimeChannelConfig` with `private: true`, `.stream()` bypasses this restriction and instead relies on Row Level Security (RLS) policies, effectively allowing users to track Postgres changes on tables with private realtime channel settings.

## What is the new behavior?

Fixes an issue where `supabase.from('table').stream(...)` throws a `RealtimeSubscribeException` ("PrivateOnly: This project only allows private channels") when the "Allow public access to channels" setting is disabled in the Supabase project.

This changes `_realtimeClient.channel(...)` inside `SupabaseStreamBuilder` to use `RealtimeChannelConfig(private: true)`, ensuring the stream function respects table RLS policies and successfully connects even if public channels are disabled.

## Additional context

This resolves #1311
