### PR TITLE
fix(gotrue): replace assert with AuthException for PKCE asyncStorage check

### DIFF
--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -1069,7 +1069,14 @@ class GoTrueClient {
         jwt: _currentSession?.accessToken,
       ),
     );
-    return OAuthResponse(provider: provider, url: res['url']);
+    final url = res['url'] as String?;
+    if (url == null) {
+      throw AuthException(
+        'OAuth provider did not return a URL. '
+        'Ensure the provider is enabled in your Supabase project.',
+      );
+    }
+    return OAuthResponse(provider: provider, url: url);
   }
 
   /// Unlinks an identity from a user by deleting it.
@@ -1254,12 +1261,15 @@ class GoTrueClient {
       urlParams.addAll(queryParams);
     }
     if (_flowType == AuthFlowType.pkce) {
-      assert(
-        _asyncStorage != null,
-        'You need to provide asyncStorage to perform pkce flow.',
-      );
+      final storage = _asyncStorage;
+      if (storage == null) {
+        throw AuthException(
+          'asyncStorage is required for PKCE flow. '
+          'Provide a GotrueAsyncStorage implementation when initializing GoTrueClient.',
+        );
+      }
       final codeVerifier = generatePKCEVerifier();
-      await _asyncStorage!.setItem(
+      await storage.setItem(
         key: '${Constants.defaultStorageKey}-code-verifier',
         value: codeVerifier,
       );


### PR DESCRIPTION
Fixes #1319

## Problem

When `flowType` is `AuthFlowType.pkce` (the default) and no `asyncStorage`
is provided, calling `getOAuthSignInUrl()` or `getLinkIdentityUrl()` crashes
in **release mode** with a cryptic `Null check operator used on a null value`
error. The existing `assert()` only runs in debug builds and is silently
stripped in release.

## Changes

- `_getUrlForProvider`: replace `assert` + `_asyncStorage!` with an explicit
  null check that throws a descriptive `AuthException` in all build modes.
- `getLinkIdentityUrl`: add null check on `res['url']` before casting,
  throwing a descriptive `AuthException` if the provider returns no URL.

## Before / After

```dart
// Before (crashes silently in release)
assert(_asyncStorage != null, 'You need to provide asyncStorage...');
await _asyncStorage!.setItem(...);

// After (throws clear error in all build modes)
final storage = _asyncStorage;
if (storage == null) {
  throw AuthException('asyncStorage is required for PKCE flow...');
}
await storage.setItem(...);