### PR TITLE
fix(functions_client): use uppercase HTTP method in requests

### DIFF
--- a/packages/functions_client/lib/src/functions_client.dart
+++ b/packages/functions_client/lib/src/functions_client.dart
@@ -132,11 +132,11 @@ class FunctionsClient {
       );
       final fields = body as Map<String, String>?;
 
-      request = http.MultipartRequest(method.name, uri)
+      request = http.MultipartRequest(method.name.toUpperCase(), uri)
         ..fields.addAll(fields ?? {})
         ..files.addAll(files);
     } else {
-      final bodyRequest = http.Request(method.name, uri);
+      final bodyRequest = http.Request(method.name.toUpperCase(), uri);
 
       if (body == null) {
         // No body to set

--- a/packages/functions_client/test/functions_dart_test.dart
+++ b/packages/functions_client/test/functions_dart_test.dart
@@ -186,7 +186,7 @@ void main() {
         );
 
         final req = customHttpClient.receivedRequests.last;
-        expect(req.method, 'get');
+        expect(req.method, 'GET');
       });
 
       test('PUT method', () async {
@@ -196,7 +196,7 @@ void main() {
         );
 
         final req = customHttpClient.receivedRequests.last;
-        expect(req.method, 'put');
+        expect(req.method, 'PUT');
       });
 
       test('DELETE method', () async {
@@ -206,7 +206,7 @@ void main() {
         );
 
         final req = customHttpClient.receivedRequests.last;
-        expect(req.method, 'delete');
+        expect(req.method, 'DELETE');
       });
 
       test('PATCH method', () async {
@@ -216,7 +216,7 @@ void main() {
         );
 
         final req = customHttpClient.receivedRequests.last;
-        expect(req.method, 'patch');
+        expect(req.method, 'PATCH');
       });
     });
 


### PR DESCRIPTION
## Summary

- `FunctionsClient.invoke()` uses `HttpMethod.name` to set the HTTP method on requests, which returns lowercase (`"post"`, `"get"`, etc.)
- While `IOClient` and `CupertinoClient` normalize methods to uppercase internally, `CronetClient` (recommended Android HTTP client from `cronet_http`) sends the method verbatim
- The Supabase relay rejects lowercase methods with **400 Bad Request**
- Fix: call `.toUpperCase()` on `method.name` for both `http.Request` and `http.MultipartRequest`

Fixes #1352

## Test plan

- [ ] Call `supabase.functions.invoke()` with `CronetClient` as httpClient on Android — should no longer return 400
- [ ] Verify existing behavior unchanged with `IOClient` and `CupertinoClient`