### PR TITLE
docs(gotrue): require onError handler in onAuthStateChange

### DIFF
--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -78,14 +78,26 @@ class GoTrueClient {
 
   /// Receive a notification every time an auth event happens.
   ///
+  /// Network errors (e.g. when the device is offline) are emitted as stream
+  /// errors. You **must** supply an `onError` handler when calling `.listen()`,
+  /// otherwise Dart will rethrow the error as an unhandled zone exception and
+  /// crash the app.
+  ///
   /// ```dart
-  /// supabase.auth.onAuthStateChange.listen((data) {
-  ///   final AuthChangeEvent event = data.event;
-  ///   final Session? session = data.session;
-  ///   if(event == AuthChangeEvent.signedIn) {
-  ///     // handle signIn event
-  ///   }
-  /// });
+  /// supabase.auth.onAuthStateChange.listen(
+  ///   (data) {
+  ///     final AuthChangeEvent event = data.event;
+  ///     final Session? session = data.session;
+  ///     if (event == AuthChangeEvent.signedIn) {
+  ///       // handle signIn event
+  ///     }
+  ///   },
+  ///   onError: (error, stackTrace) {
+  ///     // Handle or log network / auth errors here.
+  ///     // Omitting this handler causes an unhandled exception when the
+  ///     // device has no connectivity and a token refresh is attempted.
+  ///   },
+  /// );
   /// ```
   Stream<AuthState> get onAuthStateChange =>
       _onAuthStateChangeController.stream;

--- a/packages/supabase_flutter/example/lib/main.dart
+++ b/packages/supabase_flutter/example/lib/main.dart
@@ -37,11 +37,18 @@ class _MyWidgetState extends State<MyWidget> {
     setState(() {
       _user = Supabase.instance.client.auth.currentUser;
     });
-    Supabase.instance.client.auth.onAuthStateChange.listen((data) {
-      setState(() {
-        _user = data.session?.user;
-      });
-    });
+    Supabase.instance.client.auth.onAuthStateChange.listen(
+      (data) {
+        setState(() {
+          _user = data.session?.user;
+        });
+      },
+      onError: (error, stackTrace) {
+        // Network errors (e.g. offline) are emitted as stream errors.
+        // Handle or log them here; omitting this handler causes an unhandled
+        // exception when the device has no connectivity.
+      },
+    );
   }
 
   @override


### PR DESCRIPTION
## Summary

- Updates `onAuthStateChange` doc comment in `GoTrueClient` with an explicit warning that `onError` is required, plus a corrected usage example
- Fixes the example app which was missing `onError` and would crash when the device had no connectivity

## Background

Closes #1281.

Network errors (e.g. a token refresh while offline) are emitted as stream errors on `onAuthStateChange`. Without an `onError` handler, Dart rethrows them as unhandled zone exceptions, crashing the app. The SDK's own internal listener in `supabase_auth.dart` already handles this correctly — the gap was in documentation and the example app.

A companion PR in the reference docs repo updates all code examples on supabase.com: supabase/supabase#44946

## Changes

**`packages/gotrue/lib/src/gotrue_client.dart`**
- Rewrote the `onAuthStateChange` doc comment to warn that `onError` is required
- Updated the inline code example to show correct usage with `onError`

**`packages/supabase_flutter/example/lib/main.dart`**
- Added `onError` handler to the `.listen()` call that was missing it

## Test plan

- [ ] Confirm example app no longer crashes when device goes offline during a token refresh
- [ ] Confirm doc comment renders correctly in IDE tooling

🤖 Generated with [Claude Code](https://claude.com/claude-code)