### PR TITLE
fix(storage): handle null signedURL in createSignedUrls response

### DIFF
--- a/packages/storage_client/lib/src/storage_file_api.dart
+++ b/packages/storage_client/lib/src/storage_file_api.dart
@@ -366,7 +366,11 @@ class StorageFileApi {
       },
       options: options,
     );
-    final signedUrlPath = (response as Map<String, dynamic>)['signedURL'];
+    final signedUrlPath =
+        (response as Map<String, dynamic>)['signedURL'] as String?;
+    if (signedUrlPath == null) {
+      throw StorageException('No signed URL returned by API');
+    }
     final signedUrl = '$url$signedUrlPath';
     return signedUrl;
   }
@@ -395,11 +399,11 @@ class StorageFileApi {
       options: options,
     );
     final List<SignedUrl> urls = (response as List).map((e) {
+      final signedUrlPath = e['signedURL'] as String?;
       return SignedUrl(
-        // Prevents exceptions being thrown when null value is returned
-        // https://github.com/supabase/storage-api/issues/353
         path: e['path'] ?? '',
-        signedUrl: '$url${e['signedURL']}',
+        signedUrl: signedUrlPath != null ? '$url$signedUrlPath' : null,
+        error: e['error'] as String?,
       );
     }).toList();
     return urls;

--- a/packages/storage_client/lib/src/types.dart
+++ b/packages/storage_client/lib/src/types.dart
@@ -246,16 +246,22 @@ class SignedUrl {
   /// The file path, including the current file name. For example `folder/image.png`.
   final String path;
 
-  /// Full signed URL of the files.
-  final String signedUrl;
+  /// Full signed URL of the file. Null when the path does not exist or the
+  /// server returned an error for this item; check [error] for details.
+  final String? signedUrl;
+
+  /// Per-item error message returned by the server when [signedUrl] is null.
+  final String? error;
 
   const SignedUrl({
     required this.path,
     required this.signedUrl,
+    this.error,
   });
 
   @override
-  String toString() => 'SignedUrl(path: $path, signedUrl: $signedUrl)';
+  String toString() =>
+      'SignedUrl(path: $path, signedUrl: $signedUrl, error: $error)';
 
   @override
   bool operator ==(Object other) {
@@ -263,19 +269,22 @@ class SignedUrl {
 
     return other is SignedUrl &&
         other.path == path &&
-        other.signedUrl == signedUrl;
+        other.signedUrl == signedUrl &&
+        other.error == error;
   }
 
   @override
-  int get hashCode => path.hashCode ^ signedUrl.hashCode;
+  int get hashCode => path.hashCode ^ signedUrl.hashCode ^ error.hashCode;
 
   SignedUrl copyWith({
     String? path,
     String? signedUrl,
+    String? error,
   }) {
     return SignedUrl(
       path: path ?? this.path,
       signedUrl: signedUrl ?? this.signedUrl,
+      error: error ?? this.error,
     );
   }
 }

--- a/packages/storage_client/test/basic_test.dart
+++ b/packages/storage_client/test/basic_test.dart
@@ -129,10 +129,51 @@ void main() {
     });
 
     test('should createSignedUrl file', () async {
-      customHttpClient.response = {'signedURL': 'url'};
+      customHttpClient.response = {'signedURL': '/signed/url'};
 
       final response = await client.from('public').createSignedUrl('b.txt', 60);
       expect(response, isA<String>());
+      expect(response, endsWith('/signed/url'));
+    });
+
+    test('createSignedUrl throws StorageException when signedURL is null',
+        () async {
+      customHttpClient.response = {'signedURL': null};
+
+      expect(
+        () => client.from('public').createSignedUrl('missing.txt', 60),
+        throwsA(isA<StorageException>()),
+      );
+    });
+
+    test(
+        'createSignedUrls returns null signedUrl and error for missing path',
+        () async {
+      customHttpClient.response = [
+        {
+          'path': 'exists.txt',
+          'signedURL':
+              '/storage/v1/object/sign/public/exists.txt?token=abc',
+        },
+        {
+          'path': 'missing.txt',
+          'signedURL': null,
+          'error': 'not_found',
+        },
+      ];
+
+      final urls = await client
+          .from('public')
+          .createSignedUrls(['exists.txt', 'missing.txt'], 60);
+
+      expect(urls.length, 2);
+      expect(urls[0].signedUrl, isNotNull);
+      expect(
+        urls[0].signedUrl,
+        '$supabaseUrl/storage/v1/storage/v1/object/sign/public/exists.txt?token=abc',
+      );
+      expect(urls[1].signedUrl, isNull);
+      expect(urls[1].error, 'not_found');
     });
 
     test('should list files', () async {


### PR DESCRIPTION
## Summary

When a requested path does not exist, the Storage API returns `"signedURL": null` for that item. The Flutter SDK was silently producing broken URLs like `"${storageUrl}null"` with no way for callers to detect the issue. This mirrors the fix applied to the Swift SDK in supabase/supabase-swift#958.

## Changes

- **`types.dart`**: `SignedUrl.signedUrl` is now `String?` (nullable); added optional `error: String?` field populated from the per-item server error
- **`storage_file_api.dart`**: `createSignedUrl` throws `StorageException` when the API returns null (consistent with `createSignedUploadUrl`); `createSignedUrls` sets `signedUrl` to null and populates `error` for missing-path items
- **`test/basic_test.dart`**: Added tests for both null-signedURL scenarios; updated existing `createSignedUrl` test to assert the URL suffix

## Root Cause

- `storage_file_api.dart:402` — `'$url${e['signedURL']}'` with a null value produces the literal string `"${url}null"`
- `storage_file_api.dart:370` — same issue in the single-URL variant
- `types.dart:250` — `signedUrl` was non-nullable, making it impossible for callers to detect a missing path

## Testing

### Reproduction Tests
- `createSignedUrl throws StorageException when signedURL is null` — previously returned broken URL, now throws
- `createSignedUrls returns null signedUrl and error for missing path` — previously returned broken URL, now returns `signedUrl: null, error: 'not_found'`

### Test Results
All 37 unit tests pass. Integration tests (`client_test.dart`) require a live storage server and are unaffected by this change.

## Breaking Changes

`SignedUrl.signedUrl` changes from `String` to `String?`. Callers that use this field without a null check will need to be updated. This is intentional — the previous non-null return was a false guarantee.

## Acceptance Criteria

- [x] `createSignedUrls` does not return items with `signedUrl == "${storageUrl}null"`
- [x] `createSignedUrl` throws `StorageException` when the API returns null signedURL
- [x] Unit tests added and passing for both null-signedURL scenarios
- [x] No regression in existing tests

## Linear Issue

Closes: [SDK-862](https://linear.app/supabase/issue/SDK-862)
Related: [SDK-851](https://linear.app/supabase/issue/SDK-851) (Swift), [SDK-842](https://linear.app/supabase/issue/SDK-842) (Python)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) `/take`