### PR TITLE
fix(storage): avoid duplicate Content-Type headers and header mutation

### DIFF
--- a/packages/storage_client/lib/src/fetch.dart
+++ b/packages/storage_client/lib/src/fetch.dart
@@ -71,8 +71,8 @@ class Fetch {
   ) async {
     final headers = Map<String, String>.from(options?.headers ?? {});
     if (method != 'GET') {
-      final hasContentType = headers.keys
-          .any((key) => key.toLowerCase() == 'content-type');
+      final hasContentType =
+          headers.keys.any((key) => key.toLowerCase() == 'content-type');
       if (!hasContentType) {
         headers['Content-Type'] = 'application/json';
       }

--- a/packages/storage_client/lib/src/fetch.dart
+++ b/packages/storage_client/lib/src/fetch.dart
@@ -69,9 +69,13 @@ class Fetch {
     Map<String, dynamic>? body,
     FetchOptions? options,
   ) async {
-    final headers = options?.headers ?? {};
+    final headers = Map<String, String>.from(options?.headers ?? {});
     if (method != 'GET') {
-      headers['Content-Type'] = 'application/json';
+      final hasContentType = headers.keys
+          .any((key) => key.toLowerCase() == 'content-type');
+      if (!hasContentType) {
+        headers['Content-Type'] = 'application/json';
+      }
     }
 
     final request = http.Request(method, Uri.parse(url))

--- a/packages/storage_client/lib/src/fetch.dart
+++ b/packages/storage_client/lib/src/fetch.dart
@@ -69,7 +69,7 @@ class Fetch {
     Map<String, dynamic>? body,
     FetchOptions? options,
   ) async {
-    final headers = Map<String, String>.from(options?.headers ?? {});
+    final headers = {...?options?.headers};
     if (method != 'GET') {
       final hasContentType =
           headers.keys.any((key) => key.toLowerCase() == 'content-type');

--- a/packages/storage_client/test/client_test.dart
+++ b/packages/storage_client/test/client_test.dart
@@ -608,4 +608,58 @@ void main() {
       );
     });
   });
+
+  group('Content-Type header handling', () {
+    late CustomHttpClient customHttpClient;
+    late SupabaseStorageClient client;
+
+    setUp(() {
+      customHttpClient = CustomHttpClient();
+      client = SupabaseStorageClient(
+        storageUrl,
+        {'Authorization': 'Bearer $storageKey'},
+        httpClient: customHttpClient,
+      );
+    });
+
+    test('defaults to application/json for non-GET requests', () async {
+      customHttpClient.response = {'message': 'Emptied'};
+      customHttpClient.statusCode = 200;
+
+      await client.emptyBucket('bucket1');
+
+      expect(customHttpClient.receivedRequests.length, 1);
+      expect(
+        customHttpClient.receivedRequests.first.headers['content-type'],
+        contains('application/json'),
+      );
+    });
+
+    test('preserves custom Content-Type set via setHeader', () async {
+      customHttpClient.response = {'message': 'Emptied'};
+      customHttpClient.statusCode = 200;
+
+      client.setHeader('Content-Type', 'application/octet-stream');
+      await client.emptyBucket('bucket1');
+
+      expect(customHttpClient.receivedRequests.length, 1);
+      expect(
+        customHttpClient.receivedRequests.first.headers['content-type'],
+        startsWith('application/octet-stream'),
+      );
+    });
+
+    test('does not mutate the stored headers map after a non-GET request',
+        () async {
+      customHttpClient.response = [];
+      customHttpClient.statusCode = 200;
+
+      final fileApi = client.from('test-bucket');
+      final headersBefore = Map<String, String>.from(fileApi.headers);
+
+      await fileApi.list();
+
+      expect(fileApi.headers, equals(headersBefore));
+    });
+  });
 }


### PR DESCRIPTION
## Summary

- Fixed `_handleRequest` in the storage fetch layer mutating the caller's headers map, which caused `Content-Type: application/json` to accumulate in the shared `_headers` map across requests.
- Added case-insensitive check before setting the default `Content-Type: application/json`, so callers that set a custom `Content-Type` (e.g. via `setHeader()`) have it respected.

## Root Cause

In `packages/storage_client/lib/src/fetch.dart`, `_handleRequest` did:

```dart
final headers = options?.headers ?? {};  // same reference, no copy
if (method != 'GET') {
  headers['Content-Type'] = 'application/json';  // mutates original map
}
```

This had two bugs:
- **Mutation**: `headers` was the same object as `options.headers` (which points to `_headers` on `StorageFileApi`), so every non-GET request permanently added `Content-Type` to the stored headers.
- **Override**: Any custom `Content-Type` set via `setHeader()` was unconditionally overwritten.

## Fix

Copy the headers map before modifying, and only set the default `Content-Type` if no `Content-Type` header already exists (checked case-insensitively):

```dart
final headers = Map<String, String>.from(options?.headers ?? {});
if (method != 'GET') {
  final hasContentType = headers.keys.any((key) => key.toLowerCase() == 'content-type');
  if (!hasContentType) {
    headers['Content-Type'] = 'application/json';
  }
}
```

## Testing

- Unit test: default `application/json` still applied for non-GET requests without a custom Content-Type
- Unit test: custom Content-Type set via `setHeader()` is preserved
- Unit test: the stored `_headers` map is not mutated after a request

All existing `setHeader` tests continue to pass.

## Acceptance Criteria

- [x] Case-insensitive Content-Type detection in storage fetch layer
- [x] Custom Content-Type headers are preserved
- [x] Default application/json still applied when no custom Content-Type
- [x] Unit tests for default and custom Content-Type scenarios
- [x] No breaking changes

Closes: [SDK-881](https://linear.app/supabase/issue/SDK-881/paritystorage-avoid-duplicate-content-type-headers-in-requests-from)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) `/take`