### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @supabase/sdk


### PR DESCRIPTION
## Summary

- Adds `.github/CODEOWNERS` with `@supabase/sdk` as the global owner of the entire repository.

## What changed

Created `.github/CODEOWNERS` so that all PRs automatically request a review from the `@supabase/sdk` team.

## Reviewer notes

Kept intentionally minimal — a single wildcard rule, no per-package overrides.