### PR TITLE
fix(realtime_client): suppress InvalidJWTToken from setAuth in joinPush 'ok' handler

### DIFF
--- a/packages/realtime_client/lib/src/realtime_channel.dart
+++ b/packages/realtime_client/lib/src/realtime_channel.dart
@@ -176,7 +176,19 @@ class RealtimeChannel {
         (response) async {
           final serverPostgresFilters = response['postgres_changes'];
           if (socket.accessToken != null) {
-            await socket.setAuth(socket.accessToken);
+            try {
+              await socket.setAuth(socket.accessToken);
+            } on FormatException catch (e) {
+              // The cached access token may have expired by the time the
+              // channel rejoins (e.g. after the device wakes from a long
+              // sleep). Auth state listeners will re-call setAuth with a
+              // fresh token shortly after, so swallow this specific error
+              // to avoid surfacing it as an uncaught exception. The same
+              // filter is applied in `SupabaseClient._handleTokenChanged`.
+              if (!e.message.contains('InvalidJWTToken')) {
+                rethrow;
+              }
+            }
           }
 
           if (serverPostgresFilters == null) {

--- a/packages/realtime_client/test/channel_test.dart
+++ b/packages/realtime_client/test/channel_test.dart
@@ -99,6 +99,76 @@ void main() {
     });
   });
 
+  group("joinPush 'ok' setAuth error handling", () {
+    // Re-authorizing the channel on rejoin can throw `FormatException`
+    // ('InvalidJWTToken: ...') when the cached access token has expired
+    // by the time the server responds with 'ok'. The handler must swallow
+    // that specific message so it does not escape as an unhandled async
+    // error (which Sentry/Crashlytics surface as a fatal). See
+    // https://github.com/supabase/supabase-flutter/issues/1363.
+    test(
+        "swallows FormatException with 'InvalidJWTToken' from setAuth and "
+        "still emits 'subscribed' status", () async {
+      final socket = _SetAuthThrowingSocket(
+        '/socket',
+        thrown: const FormatException(
+          'InvalidJWTToken: Invalid value for JWT claim "exp" with value 0',
+        ),
+      );
+      socket.accessToken = 'expired-token';
+
+      final channel = socket.channel('topic');
+
+      RealtimeSubscribeStatus? status;
+      channel.subscribe((s, _) => status = s);
+      channel.joinPush.trigger('ok', {});
+
+      // Drain the microtask queue so the async 'ok' callback completes.
+      await Future<void>.value();
+      await Future<void>.value();
+
+      expect(socket.setAuthCalls, 1);
+      expect(
+        status,
+        RealtimeSubscribeStatus.subscribed,
+        reason:
+            "If the catch is missing the 'ok' callback aborts at setAuth "
+            "and the subscribed status is never emitted.",
+      );
+    });
+
+    test(
+        "non-InvalidJWTToken FormatExceptions from setAuth still abort the "
+        "rejoin handler", () async {
+      final socket = _SetAuthThrowingSocket(
+        '/socket',
+        thrown: const FormatException('some other parsing failure'),
+      );
+      socket.accessToken = 'some-token';
+
+      final channel = socket.channel('topic');
+
+      RealtimeSubscribeStatus? status;
+      // Use runZonedGuarded so the rethrown async error does not pollute
+      // the test runner zone.
+      await runZonedGuarded(() async {
+        channel.subscribe((s, _) => status = s);
+        channel.joinPush.trigger('ok', {});
+        await Future<void>.value();
+        await Future<void>.value();
+      }, (_, __) {/* expected: rethrown FormatException */});
+
+      expect(socket.setAuthCalls, 1);
+      expect(
+        status,
+        isNull,
+        reason:
+            'A non-InvalidJWTToken FormatException should propagate out of '
+            'the callback before subscribed is emitted.',
+      );
+    });
+  });
+
   group('onError', () {
     setUp(() {
       socket = RealtimeClient('/socket');
@@ -766,4 +836,23 @@ void main() {
       );
     });
   });
+}
+
+class _SetAuthThrowingSocket extends RealtimeClient {
+  _SetAuthThrowingSocket(super.endPoint, {required this.thrown});
+
+  final FormatException thrown;
+  int setAuthCalls = 0;
+
+  @override
+  Future<void> connect() async {
+    // No-op: avoid opening a real WebSocket so async transport failures
+    // don't leak into the test runner zone.
+  }
+
+  @override
+  Future<void> setAuth(String? token) async {
+    setAuthCalls++;
+    throw thrown;
+  }
 }

--- a/packages/realtime_client/test/channel_test.dart
+++ b/packages/realtime_client/test/channel_test.dart
@@ -131,8 +131,7 @@ void main() {
       expect(
         status,
         RealtimeSubscribeStatus.subscribed,
-        reason:
-            "If the catch is missing the 'ok' callback aborts at setAuth "
+        reason: "If the catch is missing the 'ok' callback aborts at setAuth "
             "and the subscribed status is never emitted.",
       );
     });
@@ -162,8 +161,7 @@ void main() {
       expect(
         status,
         isNull,
-        reason:
-            'A non-InvalidJWTToken FormatException should propagate out of '
+        reason: 'A non-InvalidJWTToken FormatException should propagate out of '
             'the callback before subscribed is emitted.',
       );
     });


### PR DESCRIPTION
## Summary

Fixes #1363.

`RealtimeChannel.subscribe()` registers an `async` `'ok'` callback on `joinPush` that calls `socket.setAuth(socket.accessToken)` without a `try`/`catch`. When the cached access token has expired by the time the server replies `'ok'` (e.g. the device woke from a long background sleep and the channel rejoined before the auth refresh fired), `setAuth` throws:

```
FormatException: InvalidJWTToken: Invalid value for JWT claim "exp" with value …
```

Because `Push.trigger` invokes the callback as a `void`-returning function, the resulting `Future`'s error is discarded and surfaces in the zone error handler. Sentry / Crashlytics report it as a fatal even though the app keeps running and the next `tokenRefreshed` event recovers normally.

`SupabaseClient._handleTokenChanged` already filters this exact exception on the auth-state-change path:

https://github.com/supabase/supabase-flutter/blob/main/packages/supabase/lib/src/supabase_client.dart#L379-L389

This PR mirrors that filter on the rejoin path so the two re-auth code paths behave consistently.

## Change

`packages/realtime_client/lib/src/realtime_channel.dart` — wrap the rejoin `setAuth` call in the same `FormatException` / `InvalidJWTToken` filter that `SupabaseClient._handleTokenChanged` uses. Other `FormatException`s still propagate.

```dart
if (socket.accessToken != null) {
  try {
    await socket.setAuth(socket.accessToken);
  } on FormatException catch (e) {
    if (!e.message.contains('InvalidJWTToken')) {
      rethrow;
    }
  }
}
```

## Tests

Added two unit tests in `packages/realtime_client/test/channel_test.dart`:

1. **Positive case** — when `setAuth` throws `FormatException('InvalidJWTToken: …')` on rejoin, the `'ok'` handler still runs to completion and emits `RealtimeSubscribeStatus.subscribed`. Without the fix this test fails (the callback aborts at `setAuth` and the subscribed status is never emitted), confirming it genuinely validates the fix.
2. **Rethrow case** — non-`InvalidJWTToken` `FormatException`s still abort the rejoin handler (subscribed is not emitted).

Both tests use a `RealtimeClient` subclass that overrides `setAuth` to throw a controlled exception and overrides `connect` to a no-op so transport-level async errors do not pollute the test runner zone.

## Test plan

- [x] `dart test packages/realtime_client/test/channel_test.dart` — both new tests pass; pre-existing tests unchanged
- [x] `dart analyze` clean for `realtime_client`, `supabase`, and `supabase_flutter`
- [x] Verified the positive test fails when the source change is reverted (confirming it tests the right thing)

> Note: `httpSend throws error on non-202 status` is flaky on `main` independently of this change (~40% fail rate locally on a clean checkout). Out of scope for this PR.