### PR TITLE
ci: pin docker imgproxy image version

### DIFF
--- a/infra/storage_client/docker-compose.yml
+++ b/infra/storage_client/docker-compose.yml
@@ -81,7 +81,7 @@ services:
       - /sql/dummy-data.sql
 
   imgproxy:
-    image: darthsim/imgproxy
+    image: darthsim/imgproxy:v3.30.1
     ports:
       - 50020:8080
     volumes:


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The storage tests fail, because the imgproxy docker image version is not pinned and it got a new major version, which seems not to be fully working with the current configuration.

## What is the new behavior?

Pin the version to the one used by the supabase selfhosting setup.

## Additional context


