### PR TITLE
fix: parse json error response

### DIFF
--- a/packages/storage_client/lib/src/fetch.dart
+++ b/packages/storage_client/lib/src/fetch.dart
@@ -30,12 +30,6 @@ class Fetch {
     FetchOptions? options,
   ) {
     if (error is http.Response) {
-      if (options?.noResolveJson == true) {
-        return StorageException(
-          error.body.isEmpty ? (error.reasonPhrase ?? '') : error.body,
-          statusCode: '${error.statusCode}',
-        );
-      }
       try {
         final data = json.decode(error.body) as Map<String, dynamic>;
 
@@ -48,7 +42,7 @@ class Fetch {
       } on FormatException catch (_) {
         _log.fine('StorageException for $url', error.body, stack);
         return StorageException(
-          error.body,
+          error.body.isEmpty ? (error.reasonPhrase ?? '') : error.body,
           statusCode: '${error.statusCode}',
         );
       }

--- a/packages/storage_client/test/client_test.dart
+++ b/packages/storage_client/test/client_test.dart
@@ -569,7 +569,7 @@ void main() {
           isA<StorageException>().having(
             (e) => e.statusCode,
             'statusCode',
-            '400',
+            '404',
           ),
         ),
       );
@@ -594,7 +594,7 @@ void main() {
           isA<StorageException>().having(
             (e) => e.statusCode,
             'statusCode',
-            '400',
+            '404',
           ),
         ),
       );
@@ -612,7 +612,7 @@ void main() {
           isA<StorageException>().having(
             (e) => e.statusCode,
             'statusCode',
-            '400',
+            '404',
           ),
         ),
       );


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix!

## What is the current behavior?

For head requests or downlaods the `noResolveJson` attribute is set to true, which makes sense for successful responses, but errors still contain the error code and message in json format, which should be parsed and properly reported.

## What is the new behavior?

Always try to parse an error response as json.

## Additional context

From what I can tell, the js sdk works the same way.

Since this can produce different status codes than before, I would merge this in v3.


close #1312


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for failed storage requests, including clearer fallback messages.
  * Standardized missing-object responses to return HTTP 404 errors during download, copy, and move operations.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->