### PR TITLE
fix: make `defaultHeaders` unmodifiable to prevent accidental mutation

### DIFF
--- a/packages/supabase/lib/src/constants.dart
+++ b/packages/supabase/lib/src/constants.dart
@@ -6,7 +6,7 @@ class Constants {
   static String? get platformVersion => condPlatformVersion;
   static String? get runtimeVersion => condRuntimeVersion;
 
-  static final Map<String, String> defaultHeaders = {
+  static final Map<String, String> defaultHeaders = Map.unmodifiable({
     'X-Client-Info': [
       'supabase-dart/$version',
       if (platform != null) 'platform=$platform',
@@ -15,5 +15,5 @@ class Constants {
       'runtime=dart',
       if (runtimeVersion != null) 'runtime-version=$runtimeVersion',
     ].join('; '),
-  };
+  });
 }

--- a/packages/supabase_flutter/lib/src/constants.dart
+++ b/packages/supabase_flutter/lib/src/constants.dart
@@ -3,14 +3,14 @@ import 'package:supabase_flutter/src/version.dart';
 import 'platform_stub.dart' if (dart.library.io) 'platform_io.dart';
 
 class Constants {
-  static Map<String, String> get defaultHeaders => {
-        'X-Client-Info': [
-          'supabase-flutter/$version',
-          if (condPlatform != null) 'platform=$condPlatform',
-          if (condPlatformVersion != null)
-            'platform-version=${Uri.encodeFull(condPlatformVersion!).replaceAll("%20", " ")}',
-          'runtime=dart',
-          if (condRuntimeVersion != null) 'runtime-version=$condRuntimeVersion',
-        ].join('; '),
-      };
+  static final Map<String, String> defaultHeaders = Map.unmodifiable({
+    'X-Client-Info': [
+      'supabase-flutter/$version',
+      if (condPlatform != null) 'platform=$condPlatform',
+      if (condPlatformVersion != null)
+        'platform-version=${Uri.encodeFull(condPlatformVersion!).replaceAll("%20", " ")}',
+      'runtime=dart',
+      if (condRuntimeVersion != null) 'runtime-version=$condRuntimeVersion',
+    ].join('; '),
+  });
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

This makes the `defaultHeaders` immutable and makes sure that they aren't regenerated on each call.

## What is the current behavior?

Currently the headers are regenerated on each call (which doesn't matter that much, because they are only called on client initialization, but since I already made the change I thought I could just as well push it since it's still an improvement).

## What is the new behavior?

The `defaultHeaders` are now only generated once even if they would be called multiple times in the future, and the map returned is immutable.

## Additional context

Initially I thought this was called on each request, which would have had a massive performance impact, but since it isn't this PR is not that important, but it is still an improvement. It also aligns the two constants files so that they have the same behavior.
