### PR TITLE
ci: use lowercase subject for release PR title

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -42,10 +42,11 @@ jobs:
           cache: true
 
       - name: Setup Melos
-        uses: bluefireteam/melos-action@705015c3d2bc4ab94201ac24accb2bbe070cf533 # v3.6.0
+        uses: bluefireteam/melos-action@ef13f68118735113cb48b82cd5ba876da9c3f17c # v3.7.0
         with:
           run-versioning: ${{ inputs.prerelease == false }}
           run-versioning-prerelease: ${{ inputs.prerelease == true }}
           run-versioning-graduate: ${{ inputs.graduate == true }}
           create-pr: true
+          pr-title: 'chore(release): publish packages'
           token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## What

Bumps `bluefireteam/melos-action` to **v3.7.0** and sets the new `pr-title` input so the auto-generated release-preparation PR uses a lowercase subject:

```yaml
pr-title: 'chore(release): publish packages'
```

## Why

The release PR was previously created with melos-action's hardcoded title `chore(release): Publish packages` (capital "P"). That fails our conventional PR title check in `title-validation.yml`, which requires a lowercase subject (`^(?![A-Z]).+$`), so the title had to be edited by hand on every release.

melos-action didn't expose a way to customize the title, so the `pr-title` / `pr-body` inputs were added upstream in [bluefireteam/melos-action#42](https://github.com/bluefireteam/melos-action/pull/42) (released as v3.7.0). This PR adopts it.

## Changes

- Pin bumped to `ef13f68` (`# v3.7.0`).
- Added `pr-title: 'chore(release): publish packages'`.