### PR TITLE
ci: authenticate release tag push with GitHub App token

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -23,8 +23,10 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ vars.GH_APP_CLIENT_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -29,6 +29,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup Flutter
         uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
@@ -39,6 +40,7 @@ jobs:
         uses: bluefireteam/melos-action@705015c3d2bc4ab94201ac24accb2bbe070cf533 # v3.6.0
         with:
           tag: true
+          token: ${{ steps.app-token.outputs.token }}
       - name: Trigger publish workflows
         run: |
           melos exec -c 1 --no-published --no-private --order-dependents -- \


### PR DESCRIPTION
## What

Pass the GitHub App token (`steps.app-token.outputs.token`) to the `checkout` and `melos-action` steps in `release-tag.yml`.

## Why

The latest release-tag run [failed](https://github.com/supabase/supabase-flutter/actions/runs/26871273275/job/79246944666) when pushing new tags:

```
remote: error: GH013: Repository rule violations found for refs/tags/storage_client-v2.5.4.
remote: - Cannot create ref due to creations being restricted.
 ! [remote rejected] storage_client-v2.5.4 (push declined due to repository rule violations)
```

A GitHub App token is generated in the workflow, but it was only passed to the final `Trigger publish workflows` step. The `checkout` and `melos-action` steps fell back to the default `GITHUB_TOKEN` (`github-actions[bot]`), which is not on the bypass list for the tag-creation repository ruleset, so the tag push was rejected.

Routing the App token to both steps makes the tag push authenticate as the App identity.

> **Note:** This only works if the GitHub App is added to the bypass list of the tag ruleset at https://github.com/supabase/supabase-flutter/rules.