### PR TITLE
ci: pass --yes to melos publish for non-interactive CI

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -47,10 +47,10 @@ jobs:
         uses: bluefireteam/melos-action@705015c3d2bc4ab94201ac24accb2bbe070cf533 # v3.6.0
 
       - name: Publish dry run
-        run: melos publish --scope ${{ inputs.package-name }} --dry-run
+        run: melos publish --yes --scope ${{ inputs.package-name }} --dry-run
 
       - name: Publish to pub.dev
-        run: melos publish --scope ${{ inputs.package-name }}
+        run: melos publish --yes --scope ${{ inputs.package-name }}
 
       - name: Extract CHANGELOG section
         id: changelog


### PR DESCRIPTION
## What

Add `--yes` to both `melos publish` invocations in `release-publish.yml` (dry-run and real publish).

## Why

The publish workflow failed at the dry-run step:

```
The following packages will be validated only (dry run):
storage_client    2.5.2    2.5.4
CancelledException: Operation was canceled.
```

`melos publish` prompts for interactive confirmation. CI has no TTY, so it reads EOF and cancels with `CancelledException`. Passing `--yes` makes it run unattended.