### PR TITLE
ci: set up pub.dev OIDC via dart-lang/setup-dart

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -50,7 +50,16 @@ jobs:
         run: melos publish --yes --scope ${{ inputs.package-name }} --dry-run
 
       - name: Publish to pub.dev
-        run: melos publish --yes --no-dry-run --scope ${{ inputs.package-name }}
+        run: |
+          # subosito/flutter-action does not wire up pub.dev OIDC, so dart pub
+          # falls back to an interactive OAuth prompt and hangs in CI. Exchange
+          # the GitHub Actions OIDC token explicitly and hand it to pub.
+          PUB_TOKEN=$(curl -sSL \
+            -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=https://pub.dev" | jq -r '.value')
+          export PUB_TOKEN
+          dart pub token add https://pub.dev --env-var PUB_TOKEN
+          melos publish --yes --no-dry-run --scope ${{ inputs.package-name }}
 
       - name: Extract CHANGELOG section
         id: changelog

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -46,20 +46,18 @@ jobs:
       - name: Bootstrap with Melos
         uses: bluefireteam/melos-action@705015c3d2bc4ab94201ac24accb2bbe070cf533 # v3.6.0
 
+      # Sets up the pipeline for usage with pub.dev (this sets up OIDC).
+      # subosito/flutter-action does not wire up pub.dev OIDC on its own, so
+      # without this dart pub falls back to an interactive OAuth prompt and
+      # hangs in CI.
+      - name: Set up Dart
+        uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260 # v1.7.2
+
       - name: Publish dry run
         run: melos publish --yes --scope ${{ inputs.package-name }} --dry-run
 
       - name: Publish to pub.dev
-        run: |
-          # subosito/flutter-action does not wire up pub.dev OIDC, so dart pub
-          # falls back to an interactive OAuth prompt and hangs in CI. Exchange
-          # the GitHub Actions OIDC token explicitly and hand it to pub.
-          PUB_TOKEN=$(curl -sSL \
-            -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
-            "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=https://pub.dev" | jq -r '.value')
-          export PUB_TOKEN
-          dart pub token add https://pub.dev --env-var PUB_TOKEN
-          melos publish --yes --no-dry-run --scope ${{ inputs.package-name }}
+        run: melos publish --yes --no-dry-run --scope ${{ inputs.package-name }}
 
       - name: Extract CHANGELOG section
         id: changelog


### PR DESCRIPTION
## What

Add a `dart-lang/setup-dart` step before publishing, matching the mechanism used by `bluefireteam/melos-action` and [Flame's release workflow](https://github.com/flame-engine/flame/blob/main/.github/workflows/release-publish.yml).

## Why

Follow-up to #1376. With `--no-dry-run` the publish step finally attempted an upload, but it **hung on interactive OAuth** and timed out:

```
Pub needs your authorization to upload packages on your behalf.
In a web browser, go to https://accounts.google.com/o/oauth2/auth?...
Waiting for your authorization...
```

`subosito/flutter-action` does **not** wire up pub.dev OIDC, so `dart pub` had no token and fell back to the browser OAuth flow, which never completes in CI. `dart-lang/setup-dart` sets up the pipeline for pub.dev OIDC (the same step `melos-action` runs internally for `publish: true`), so `melos publish --no-dry-run` uploads non-interactively.

## Notes

- Requires `id-token: write` (already set) and pub.dev automated publishing enabled for each package.
- The workflow must be dispatched on the release **tag** so the OIDC token's ref matches the configured tag pattern on pub.dev.