### PR TITLE
ci: drop standalone publish dry-run step

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -53,9 +53,6 @@ jobs:
       - name: Set up Dart
         uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260 # v1.7.2
 
-      - name: Publish dry run
-        run: melos publish --yes --scope ${{ inputs.package-name }} --dry-run
-
       - name: Publish to pub.dev
         run: melos publish --yes --no-dry-run --scope ${{ inputs.package-name }}
 


### PR DESCRIPTION
## What

Remove the dedicated "Publish dry run" step from `release-publish.yml`.

## Why

storage_client published fine, but the `supabase` publish failed at the **dry-run** step (exit code 65):

```
* Your dependency on "storage_client" should allow more than one version. For example:
    storage_client: ^2.5.4
...
Package has 6 warnings and 7 hints.
└> dart pub publish --dry-run └> FAILED (exit code 65)
```

`dart pub publish --dry-run` exits non-zero when a package has **warnings**. `supabase`/`supabase_flutter` deliberately pin **exact** sibling versions (`storage_client: 2.5.4`, `gotrue: …`, etc.) and override deps via `pubspec_overrides.yaml`, which pub flags as warnings. The standalone dry-run then failed and **skipped the real publish**.

The real publish step runs `dart pub publish --force`, which publishes despite those warnings (that's how supabase 2.10.6 shipped). So the dry-run gate added no safety the real publish doesn't already provide — it only produced false failures. Removing it.

Follow-up to #1376 / #1377; storage_client 2.5.4 is already live.