### PR TITLE
ci: use melos-action v3.8.0 with built-in publish and GitHub release creation

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -42,7 +42,7 @@ jobs:
           cache: true
 
       - name: Setup Melos
-        uses: bluefireteam/melos-action@ef13f68118735113cb48b82cd5ba876da9c3f17c # v3.7.0
+        uses: bluefireteam/melos-action@2982f8e4fc92440a219490009d6d05195cb1a6a5 # v3.8.0
         with:
           run-versioning: ${{ inputs.prerelease == false }}
           run-versioning-prerelease: ${{ inputs.prerelease == true }}

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -43,41 +43,9 @@ jobs:
         with:
           cache: true
 
-      - name: Bootstrap with Melos
-        uses: bluefireteam/melos-action@705015c3d2bc4ab94201ac24accb2bbe070cf533 # v3.6.0
-
-      # Sets up the pipeline for usage with pub.dev (this sets up OIDC).
-      # subosito/flutter-action does not wire up pub.dev OIDC on its own, so
-      # without this dart pub falls back to an interactive OAuth prompt and
-      # hangs in CI.
-      - name: Set up Dart
-        uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260 # v1.7.2
-
-      - name: Publish to pub.dev
-        run: melos publish --yes --no-dry-run --scope ${{ inputs.package-name }}
-
-      - name: Extract CHANGELOG section
-        id: changelog
-        run: |
-          VERSION="${{ inputs.package-version }}"
-          PACKAGE="${{ inputs.package-name }}"
-          HEADER="## ${VERSION}"
-          CHANGELOG_CONTENT=$(awk -v header="$HEADER" 'index($0,header)==1{flag=1;next} /^## /{flag=0} flag' "packages/${PACKAGE}/CHANGELOG.md")
-          echo "changelog<<EOF" >> $GITHUB_OUTPUT
-          echo "${CHANGELOG_CONTENT}" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
-
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
+      - name: Publish to pub.dev and create GitHub Release
+        uses: bluefireteam/melos-action@2982f8e4fc92440a219490009d6d05195cb1a6a5 # v3.8.0
         with:
-          tag_name: ${{ inputs.package-name }}-v${{ inputs.package-version }}
-          name: ${{ inputs.package-name }} v${{ inputs.package-version }}
-          body: |
-            ${{ steps.changelog.outputs.changelog }}
-
-            ---
-            Published to pub.dev: https://pub.dev/packages/${{ inputs.package-name }}/versions/${{ inputs.package-version }}
-          draft: false
-          prerelease: ${{ contains(inputs.package-version, '-') }}
-        env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          publish: true
+          create-release: true
+          token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -39,7 +39,7 @@ jobs:
           cache: true
 
       - name: Setup Melos
-        uses: bluefireteam/melos-action@705015c3d2bc4ab94201ac24accb2bbe070cf533 # v3.6.0
+        uses: bluefireteam/melos-action@2982f8e4fc92440a219490009d6d05195cb1a6a5 # v3.8.0
         with:
           tag: true
           token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary

- Bumps `bluefireteam/melos-action` to v3.8.0 across all three release workflows
- Replaces the 4 manual steps in `release-publish.yml` (separate dart setup, `melos publish`, changelog extraction, `softprops/action-gh-release`) with a single melos-action step using `publish: true` and `create-release: true`

The new `create-release` input in v3.8.0 handles everything that was done manually: it reads the changelog, sets the prerelease flag automatically from the version string, and appends the pub.dev link to the release body.

## Test plan

- [ ] Trigger `release-publish.yml` manually on an existing tag and verify pub.dev publish + GitHub release are created correctly