### PR TITLE
ci: remove unnecessary imgproxy host port binding to fix port conflict

### DIFF
--- a/infra/storage_client/docker-compose.yml
+++ b/infra/storage_client/docker-compose.yml
@@ -82,8 +82,6 @@ services:
 
   imgproxy:
     image: darthsim/imgproxy:v3.30.1
-    ports:
-      - 50020:8080
     volumes:
     -   assets-volume:/tmp/storage
     environment:


### PR DESCRIPTION
## Summary

- Port `50020` was mapped from the host to the `imgproxy` container in `infra/storage_client/docker-compose.yml`, but no test code references that host port
- The `storage` service reaches imgproxy over the Docker-internal network via `IMGPROXY_URL: http://imgproxy:8080` — no host binding is needed
- On CI, the "Test SDK stable" job was failing with `failed to bind host port for 0.0.0.0:50020 ... address already in use` ([example run](https://github.com/supabase/supabase-flutter/actions/runs/27002062271/job/79684730717?pr=1323))

## Test plan

- [ ] Confirm "Test SDK stable" job passes in CI without the port conflict error