### PR TITLE
ci: replace deprecated IMGPROXY_ENABLE_WEBP_DETECTION with IMGPROXY_AUTO_WEBP

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -53,7 +53,7 @@ jobs:
                 if [[ "$d" == "postgrest/"* ]]; then
                   cd ../../infra/postgrest
                   docker compose down
-                  docker compose up -d
+                  docker compose up --wait --timeout 60
                   cd ../../packages/postgrest
                   dart test --coverage=coverage --concurrency=1
                   dart pub global run coverage:format_coverage --packages=.dart_tool/package_config.json --report-on=lib --lcov -o coverage/lcov.info -i coverage
@@ -64,7 +64,7 @@ jobs:
                 elif [[ "$d" == "gotrue/"* ]]; then
                   cd ../../infra/gotrue
                   docker compose down
-                  docker compose up -d
+                  docker compose up --wait --timeout 60
                   cd ../../packages/gotrue
                   dart test --coverage=coverage --concurrency=1
                   dart pub global run coverage:format_coverage --packages=.dart_tool/package_config.json --report-on=lib --lcov -o coverage/lcov.info -i coverage
@@ -75,7 +75,7 @@ jobs:
                 elif [[ "$d" == "storage_client/"* ]]; then
                   cd ../../infra/storage_client
                   docker compose down
-                  docker compose up -d
+                  docker compose up --wait --timeout 60
                   cd ../../packages/storage_client
                   dart test --coverage=coverage --concurrency=1
                   dart pub global run coverage:format_coverage --packages=.dart_tool/package_config.json --report-on=lib --lcov -o coverage/lcov.info -i coverage

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -53,7 +53,7 @@ jobs:
                 if [[ "$d" == "postgrest/"* ]]; then
                   cd ../../infra/postgrest
                   docker compose down
-                  docker compose up --wait --timeout 60
+                  docker compose up -d
                   cd ../../packages/postgrest
                   dart test --coverage=coverage --concurrency=1
                   dart pub global run coverage:format_coverage --packages=.dart_tool/package_config.json --report-on=lib --lcov -o coverage/lcov.info -i coverage
@@ -64,7 +64,7 @@ jobs:
                 elif [[ "$d" == "gotrue/"* ]]; then
                   cd ../../infra/gotrue
                   docker compose down
-                  docker compose up --wait --timeout 60
+                  docker compose up -d
                   cd ../../packages/gotrue
                   dart test --coverage=coverage --concurrency=1
                   dart pub global run coverage:format_coverage --packages=.dart_tool/package_config.json --report-on=lib --lcov -o coverage/lcov.info -i coverage
@@ -75,7 +75,7 @@ jobs:
                 elif [[ "$d" == "storage_client/"* ]]; then
                   cd ../../infra/storage_client
                   docker compose down
-                  docker compose up --wait --timeout 60
+                  docker compose up -d
                   cd ../../packages/storage_client
                   dart test --coverage=coverage --concurrency=1
                   dart pub global run coverage:format_coverage --packages=.dart_tool/package_config.json --report-on=lib --lcov -o coverage/lcov.info -i coverage

--- a/infra/storage_client/docker-compose.yml
+++ b/infra/storage_client/docker-compose.yml
@@ -81,7 +81,7 @@ services:
       - /sql/dummy-data.sql
 
   imgproxy:
-    image: darthsim/imgproxy
+    image: darthsim/imgproxy:v4.0.3
     ports:
       - 50020:8080
     volumes:

--- a/infra/storage_client/docker-compose.yml
+++ b/infra/storage_client/docker-compose.yml
@@ -81,7 +81,7 @@ services:
       - /sql/dummy-data.sql
 
   imgproxy:
-    image: darthsim/imgproxy:v3.30.1
+    image: darthsim/imgproxy
     ports:
       - 50020:8080
     volumes:
@@ -89,6 +89,6 @@ services:
     environment:
       - IMGPROXY_LOCAL_FILESYSTEM_ROOT=/
       - IMGPROXY_USE_ETAG=true
-      - IMGPROXY_ENABLE_WEBP_DETECTION=true
+      - IMGPROXY_AUTO_WEBP=true
 volumes:
   assets-volume:

--- a/infra/storage_client/docker-compose.yml
+++ b/infra/storage_client/docker-compose.yml
@@ -90,5 +90,10 @@ services:
       - IMGPROXY_LOCAL_FILESYSTEM_ROOT=/
       - IMGPROXY_USE_ETAG=true
       - IMGPROXY_ENABLE_WEBP_DETECTION=true
+    healthcheck:
+      test: ["CMD", "imgproxy", "health"]
+      interval: 3s
+      timeout: 5s
+      retries: 10
 volumes:
   assets-volume:

--- a/infra/storage_client/docker-compose.yml
+++ b/infra/storage_client/docker-compose.yml
@@ -90,10 +90,5 @@ services:
       - IMGPROXY_LOCAL_FILESYSTEM_ROOT=/
       - IMGPROXY_USE_ETAG=true
       - IMGPROXY_ENABLE_WEBP_DETECTION=true
-    healthcheck:
-      test: ["CMD", "imgproxy", "health"]
-      interval: 3s
-      timeout: 5s
-      retries: 10
 volumes:
   assets-volume:


### PR DESCRIPTION
## Summary

- `IMGPROXY_ENABLE_WEBP_DETECTION` is a deprecated alias for `IMGPROXY_AUTO_WEBP` that was removed in imgproxy v4
- When `darthsim/imgproxy:latest` pulled v4, the env var was silently ignored, WebP detection stopped working, and the test `will return the image as webp when the browser support it` returned JPEG instead of WebP ([failing run](https://github.com/supabase/supabase-flutter/actions/runs/25862754359/job/76074557749?pr=1365))
- Replace `IMGPROXY_ENABLE_WEBP_DETECTION=true` with the canonical `IMGPROXY_AUTO_WEBP=true` and unpin the imgproxy image so the version stays current

## Test plan

- [ ] Confirm the "Generate Combined Coverage" job passes and the WebP test no longer fails