### PR TITLE
ci: upgrade create-github-app-token to v3.2.0

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -21,9 +21,9 @@ jobs:
     steps:
       - name: Generate token
         id: app-token
-        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.GH_APP_CLIENT_ID }}
+          client-id: ${{ vars.GH_APP_CLIENT_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
           permission-contents: write
           permission-pull-requests: write

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -23,7 +23,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
         with:
-          client-id: ${{ vars.GH_APP_CLIENT_ID }}
+          app-id: ${{ vars.GH_APP_CLIENT_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
           permission-contents: write
           permission-pull-requests: write


### PR DESCRIPTION
## Summary

- Upgrades `actions/create-github-app-token` from v3.0.0 to v3.2.0
- In v3.2.0 `client-id` is the correct input (`app-id` is deprecated), fixing the broken "Generate token" step

Fixes https://github.com/supabase/supabase-flutter/actions/runs/27011348688/job/79715439261