### PR TITLE
fix(storage): handle null signedURL in createSignedUrls response

### DIFF
--- a/packages/storage_client/lib/src/storage_file_api.dart
+++ b/packages/storage_client/lib/src/storage_file_api.dart
@@ -366,22 +366,53 @@ class StorageFileApi {
       },
       options: options,
     );
-    final signedUrlPath = (response as Map<String, dynamic>)['signedURL'];
+    final signedUrlPath =
+        (response as Map<String, dynamic>)['signedURL'] as String?;
+    if (signedUrlPath == null) {
+      throw StorageException('No signed URL returned by API');
+    }
     final signedUrl = '$url$signedUrlPath';
     return signedUrl;
+  }
+
+  // TODO(v3): Remove this deprecated overload and rename createSignedUrlsResult
+  // to createSignedUrls. Dart lacks overloading so the preferred API had to be
+  // given a temporary name. https://linear.app/supabase/issue/SDK-1002
+  /// Create signed URLs to download files without requiring permissions.
+  ///
+  /// Items for paths that do not exist are silently omitted. Use
+  /// [createSignedUrlsResult] to distinguish missing paths from successful ones.
+  ///
+  /// [paths] is the file paths to be downloaded, including the current file
+  /// names. For example: `createSignedUrls(['folder/image.png', 'folder2/image2.png'])`.
+  ///
+  /// [expiresIn] is the number of seconds until the signed URLs expire. For
+  /// example, `60` for URLs which are valid for one minute.
+  @Deprecated('Use createSignedUrlsResult to handle missing paths correctly.')
+  Future<List<SignedUrl>> createSignedUrls(
+    List<String> paths,
+    int expiresIn,
+  ) async {
+    final results = await createSignedUrlsResult(paths, expiresIn);
+    return results
+        .whereType<SignedUrlSuccess>()
+        .map((r) => SignedUrl(path: r.path, signedUrl: r.signedUrl))
+        .toList();
   }
 
   /// Create signed URLs to download files without requiring permissions. These
   /// URLs can be valid for a set number of seconds.
   ///
+  /// Returns one [SignedUrlResult] per requested path. Each result is either a
+  /// [SignedUrlSuccess] (with a ready-to-use signed URL) or a [SignedUrlFailure]
+  /// (when the server could not sign that path, e.g. the file does not exist).
+  ///
   /// [paths] is the file paths to be downloaded, including the current file
-  /// names. For example: `createdSignedUrl(['folder/image.png', 'folder2/image2.png'])`.
+  /// names. For example: `createSignedUrlsResult(['folder/image.png', 'folder2/image2.png'])`.
   ///
   /// [expiresIn] is the number of seconds until the signed URLs expire. For
   /// example, `60` for URLs which are valid for one minute.
-  ///
-  /// A list of [SignedUrl]s is returned.
-  Future<List<SignedUrl>> createSignedUrls(
+  Future<List<SignedUrlResult>> createSignedUrlsResult(
     List<String> paths,
     int expiresIn,
   ) async {
@@ -394,15 +425,18 @@ class StorageFileApi {
       },
       options: options,
     );
-    final List<SignedUrl> urls = (response as List).map((e) {
-      return SignedUrl(
-        // Prevents exceptions being thrown when null value is returned
-        // https://github.com/supabase/storage-api/issues/353
-        path: e['path'] ?? '',
-        signedUrl: '$url${e['signedURL']}',
-      );
+    return (response as List).map<SignedUrlResult>((e) {
+      final signedUrlPath = e['signedURL'] as String?;
+      final path = e['path'] as String? ?? '';
+      if (signedUrlPath != null) {
+        return SignedUrlSuccess(path: path, signedUrl: '$url$signedUrlPath');
+      } else {
+        return SignedUrlFailure(
+          path: path,
+          error: e['error'] as String? ?? 'Unknown error',
+        );
+      }
     }).toList();
-    return urls;
   }
 
   /// Downloads a file.

--- a/packages/storage_client/lib/src/types.dart
+++ b/packages/storage_client/lib/src/types.dart
@@ -284,6 +284,45 @@ class SignedUrl {
   }
 }
 
+/// Represents a per-item result from [StorageFileApi.createSignedUrlsResult].
+///
+/// Use exhaustive pattern matching to handle both outcomes:
+/// ```dart
+/// for (final result in results) {
+///   switch (result) {
+///     case SignedUrlSuccess(:final signedUrl):
+///       print('URL: $signedUrl');
+///     case SignedUrlFailure(:final error):
+///       print('Missing: $error');
+///   }
+/// }
+/// ```
+sealed class SignedUrlResult {
+  /// The requested file path.
+  final String path;
+  const SignedUrlResult({required this.path});
+}
+
+/// A successful [SignedUrlResult]: the file was found and a signed URL was generated.
+final class SignedUrlSuccess extends SignedUrlResult {
+  /// The signed URL ready for use.
+  final String signedUrl;
+  const SignedUrlSuccess({required super.path, required this.signedUrl});
+
+  @override
+  String toString() => 'SignedUrlSuccess(path: $path, signedUrl: $signedUrl)';
+}
+
+/// A failed [SignedUrlResult]: the path could not be signed (e.g. the file does not exist).
+final class SignedUrlFailure extends SignedUrlResult {
+  /// The reason the URL could not be created.
+  final String error;
+  const SignedUrlFailure({required super.path, required this.error});
+
+  @override
+  String toString() => 'SignedUrlFailure(path: $path, error: $error)';
+}
+
 class SignedUploadURLResponse extends SignedUrl {
   /// Token to be used when uploading files with the `uploadToSignedUrl` method.
   final String token;

--- a/packages/storage_client/test/basic_test.dart
+++ b/packages/storage_client/test/basic_test.dart
@@ -129,10 +129,82 @@ void main() {
     });
 
     test('should createSignedUrl file', () async {
-      customHttpClient.response = {'signedURL': 'url'};
+      customHttpClient.response = {'signedURL': '/signed/url'};
 
       final response = await client.from('public').createSignedUrl('b.txt', 60);
       expect(response, isA<String>());
+      expect(response, endsWith('/signed/url'));
+    });
+
+    test('createSignedUrl throws StorageException when signedURL is null',
+        () async {
+      customHttpClient.response = {'signedURL': null};
+
+      expect(
+        () => client.from('public').createSignedUrl('missing.txt', 60),
+        throwsA(isA<StorageException>()),
+      );
+    });
+
+    test('createSignedUrlsResult returns success and failure for mixed paths',
+        () async {
+      customHttpClient.response = [
+        {
+          'path': 'exists.txt',
+          'signedURL': '/storage/v1/object/sign/public/exists.txt?token=abc',
+        },
+        {
+          'path': 'missing.txt',
+          'signedURL': null,
+          'error': 'not_found',
+        },
+      ];
+
+      final results = await client
+          .from('public')
+          .createSignedUrlsResult(['exists.txt', 'missing.txt'], 60);
+
+      expect(results.length, 2);
+      expect(results[0], isA<SignedUrlSuccess>());
+      expect(results[1], isA<SignedUrlFailure>());
+
+      final success = results[0] as SignedUrlSuccess;
+      expect(success.path, 'exists.txt');
+      expect(
+        success.signedUrl,
+        endsWith('/storage/v1/object/sign/public/exists.txt?token=abc'),
+      );
+
+      final failure = results[1] as SignedUrlFailure;
+      expect(failure.path, 'missing.txt');
+      expect(failure.error, 'not_found');
+    });
+
+    // ignore: deprecated_member_use_from_same_package
+    test('createSignedUrls (deprecated) omits missing paths', () async {
+      customHttpClient.response = [
+        {
+          'path': 'exists.txt',
+          'signedURL': '/storage/v1/object/sign/public/exists.txt?token=abc',
+        },
+        {
+          'path': 'missing.txt',
+          'signedURL': null,
+          'error': 'not_found',
+        },
+      ];
+
+      // ignore: deprecated_member_use_from_same_package
+      final urls = await client
+          .from('public')
+          .createSignedUrls(['exists.txt', 'missing.txt'], 60);
+
+      expect(urls.length, 1);
+      expect(urls[0].path, 'exists.txt');
+      expect(
+        urls[0].signedUrl,
+        endsWith('/storage/v1/object/sign/public/exists.txt?token=abc'),
+      );
     });
 
     test('should list files', () async {


### PR DESCRIPTION
## Summary

When a requested path does not exist, the Storage API returns `"signedURL": null` for that item. The Flutter SDK was silently producing broken URLs like `"${storageUrl}null"` with no way for callers to detect the issue.

This is a backward-compatible reimplementation of #1356, using [supabase/supabase-swift#958](https://github.com/supabase/supabase-swift/pull/958) as the reference. Because Dart does not support method overloading (unlike Swift's `@_disfavoredOverload`), the new preferred API gets the name `createSignedUrlsResult` and the old one is deprecated — this will be cleaned up in v3 ([SDK-1002](https://linear.app/supabase/issue/SDK-1002)).

## Changes

- **`types.dart`**: Add `SignedUrlResult` sealed class with `SignedUrlSuccess` and `SignedUrlFailure` subtypes — mirrors Swift's `SignedURLResult` enum
- **`storage_file_api.dart`**:
  - `createSignedUrl` now throws `StorageException` when the API returns a null `signedURL` instead of producing a malformed string
  - `createSignedUrls` is deprecated; it delegates to `createSignedUrlsResult` and silently drops failures (matching Swift's `compactMap` on the deprecated overload)
  - New `createSignedUrlsResult` returns `List<SignedUrlResult>` — one entry per requested path with a clear success/failure distinction
- **`test/basic_test.dart`**: Tests for the null `signedURL` throw, mixed success/failure results, and deprecated drop behaviour

## Backward Compatibility

No breaking changes:
- `SignedUrl.signedUrl` stays `String` (non-nullable)
- `createSignedUrls` still compiles — callers get a deprecation hint pointing to `createSignedUrlsResult`
- `createSignedUrl` throwing on null is a bug fix (previously it returned a broken string)

## Testing

All 38 unit tests pass.

## Linear

Closes: [SDK-862](https://linear.app/supabase/issue/SDK-862)
v3 cleanup: [SDK-1002](https://linear.app/supabase/issue/SDK-1002)

🤖 Generated with [Claude Code](https://claude.com/claude-code)