### PR TITLE
ci: disable Flutter SDK cache for floating 3.x version

### DIFF
--- a/.github/workflows/supabase_flutter.yml
+++ b/.github/workflows/supabase_flutter.yml
@@ -59,7 +59,10 @@ jobs:
         with:
           flutter-version: ${{ matrix.flutter-version }}
           channel: 'stable'
-          cache: true
+          # Caching 3.x (latest stable) is flaky: the cached SDK contains
+          # runner-image-specific binaries that break silently when the runner
+          # image is updated. Pinned versions like 3.19.x are stable to cache.
+          cache: ${{ matrix.flutter-version != '3.x' }}
 
       - name: Show Flutter version
         run: flutter --version


### PR DESCRIPTION
## Summary

- The `supabase_flutter` CI was failing on "Test Flutter v3.x on windows-latest" at the Setup Flutter step with no visible error output.
- Root cause: `cache: true` restores a pre-compiled Flutter SDK (~1.8 GB) containing runner-image-specific binaries. When the runner image is updated, the cached binaries fail silently after extraction. The same issue can affect macOS and Linux runners.
- `3.19.x` is unaffected because it resolves to a pinned version whose cache remains stable across runner updates. Only the floating `3.x` (latest stable) is flaky.
- Fix: disable the SDK cache for all `3.x` combinations via `cache: ${{ matrix.flutter-version != '3.x' }}`.

## Test plan

- [ ] "Test Flutter v3.x on windows-latest" passes without the stale-cache failure
- [ ] "Test Flutter v3.x on ubuntu-latest" and "Test Flutter v3.x on macos-latest" are unaffected
- [ ] All `3.19.x` matrix combinations still use the cache as before