### PR TITLE
fix(ci): use package tag ref in publish workflow instead of inputs

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -2,18 +2,9 @@ name: Publish Packages
 
 on:
   workflow_dispatch:
-    inputs:
-      package-name:
-        description: 'Name of the package to publish'
-        required: true
-        type: string
-      package-version:
-        description: 'Version to publish (without v prefix, e.g. 2.18.0)'
-        required: true
-        type: string
 
 concurrency:
-  group: release-publish-${{ inputs.package-name }}
+  group: release-publish-${{ github.ref }}
   cancel-in-progress: false
 
 permissions:
@@ -36,7 +27,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-          ref: ${{ inputs.package-name }}-v${{ inputs.package-version }}
 
       - name: Setup Flutter
         uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -45,15 +45,8 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
       - name: Trigger publish workflows
         run: |
-          melos exec -c 1 --no-private --order-dependents -- \
-          bash -c "
-            if git tag --points-at HEAD | grep -qx \"\$MELOS_PACKAGE_NAME-v\$MELOS_PACKAGE_VERSION\"; then
-              gh workflow run release-publish.yml \
-                --ref \$MELOS_PACKAGE_NAME-v\$MELOS_PACKAGE_VERSION \
-                --field package-name=\$MELOS_PACKAGE_NAME \
-                --field package-version=\$MELOS_PACKAGE_VERSION
-              sleep 30
-            fi
-          "
+          melos exec -c 1 --no-published --no-private --order-dependents -- \
+          gh workflow run release-publish.yml \
+          --ref \$MELOS_PACKAGE_NAME-v\$MELOS_PACKAGE_VERSION
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -45,11 +45,18 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
       - name: Trigger publish workflows
         run: |
-          melos exec -c 1 --no-published --no-private --order-dependents -- \
-          bash -c "gh workflow run release-publish.yml \
-            --ref \$MELOS_PACKAGE_NAME-v\$MELOS_PACKAGE_VERSION \
-            --field package-name=\$MELOS_PACKAGE_NAME \
-            --field package-version=\$MELOS_PACKAGE_VERSION && \
-          sleep 30"
+          # --no-published silently excludes all established packages because it
+          # filters to packages that have NEVER been on pub.dev. Instead, check
+          # inside each package whether a new tag was created on HEAD for it.
+          melos exec -c 1 --no-private --order-dependents -- \
+          bash -c "
+            if git tag --points-at HEAD | grep -qx \"\$MELOS_PACKAGE_NAME-v\$MELOS_PACKAGE_VERSION\"; then
+              gh workflow run release-publish.yml \
+                --ref \$MELOS_PACKAGE_NAME-v\$MELOS_PACKAGE_VERSION \
+                --field package-name=\$MELOS_PACKAGE_NAME \
+                --field package-version=\$MELOS_PACKAGE_VERSION
+              sleep 30
+            fi
+          "
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -45,9 +45,6 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
       - name: Trigger publish workflows
         run: |
-          # --no-published silently excludes all established packages because it
-          # filters to packages that have NEVER been on pub.dev. Instead, check
-          # inside each package whether a new tag was created on HEAD for it.
           melos exec -c 1 --no-private --order-dependents -- \
           bash -c "
             if git tag --points-at HEAD | grep -qx \"\$MELOS_PACKAGE_NAME-v\$MELOS_PACKAGE_VERSION\"; then


### PR DESCRIPTION
## Summary

The publish workflow (`release-publish.yml`) required explicit `package-name` and `package-version` inputs, which forced the tag workflow to wrap the `gh workflow run` call in `bash -c` with `--field` params and a `sleep 30` between dispatches. This complexity broke `--no-published` filtering in melos, causing publish workflows to not be triggered after release commits.

Instead, drop the inputs and let the workflow dispatch `--ref` (the package tag) drive the checkout. The melos-action with `publish: true` uses `--no-published` at that ref to determine what to publish, and `create-release: true` handles GitHub releases — the same approach used in the Flame monorepo.

## Changes

- `release-publish.yml`: removed `workflow_dispatch` inputs and explicit `ref:` override in checkout
- `release-tag.yml`: restored `--no-published`, removed `bash -c` wrapper, `--field` params, and `sleep 30`

## Test plan

- [ ] Verify the next release commit triggers publish workflows for all newly tagged packages
- [ ] Verify each triggered `release-publish.yml` run checks out at the correct package tag and publishes only the unpublished package(s)