### PR TITLE
fix(auth): avoid reusing a stale refresh token in recoverSession

### DIFF
--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -1125,6 +1125,20 @@ class GoTrueClient {
 
       if (session.isExpired) {
         _log.fine('Session from recovery is expired');
+
+        // While the session was being read from local storage, another code
+        // path (such as the auto-refresh tick triggered when the app resumes)
+        // may have already refreshed it. In that case the refresh token from
+        // [jsonStr] is stale, and reusing it would make the server respond with
+        // `refresh_token_already_used` and sign the user out. Return the
+        // already valid session instead of refreshing the stale token again.
+        final currentSession = _currentSession;
+        if (currentSession != null && !currentSession.isExpired) {
+          _log.fine(
+              'Session was already refreshed elsewhere, skipping recovery');
+          return AuthResponse(session: currentSession);
+        }
+
         final refreshToken = session.refreshToken;
         if (_autoRefreshToken && refreshToken != null) {
           return await _callRefreshToken(refreshToken);

--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -1126,14 +1126,10 @@ class GoTrueClient {
       if (session.isExpired) {
         _log.fine('Session from recovery is expired');
 
-        // While the session was being read from local storage, another code
-        // path (such as the auto-refresh tick triggered when the app resumes)
-        // may have already refreshed it. In that case the refresh token from
-        // [jsonStr] is stale, and reusing it would make the server respond with
-        // `refresh_token_already_used` and sign the user out. Return the
-        // already valid session instead of refreshing the stale token again.
         final currentSession = _currentSession;
-        if (currentSession != null && !currentSession.isExpired) {
+        if (currentSession != null &&
+            !currentSession.isExpired &&
+            currentSession.user.id == session.user.id) {
           _log.fine(
               'Session was already refreshed elsewhere, skipping recovery');
           return AuthResponse(session: currentSession);

--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -1415,6 +1415,18 @@ class GoTrueClient {
       _refreshTokenCompleter?.complete(data);
       return data;
     } on AuthException catch (error, stack) {
+      final currentSession = _currentSession;
+      if (error is AuthApiException &&
+          error.code == 'refresh_token_already_used' &&
+          currentSession != null &&
+          !currentSession.isExpired) {
+        _log.fine('Refresh token already used but current session is still '
+            'valid, returning it instead of signing out');
+        final response = AuthResponse(session: currentSession);
+        _refreshTokenCompleter?.complete(response);
+        return response;
+      }
+
       if (error is! AuthRetryableFetchException) {
         _removeSession();
         notifyAllSubscribers(AuthChangeEvent.signedOut);

--- a/packages/gotrue/test/client_test.dart
+++ b/packages/gotrue/test/client_test.dart
@@ -693,4 +693,65 @@ void main() {
       }
     });
   });
+
+  group('Recovering an already refreshed session', () {
+    late SingleUseRefreshTokenHttpClient httpClient;
+    late GoTrueClient client;
+
+    setUp(() {
+      httpClient = SingleUseRefreshTokenHttpClient();
+      client = GoTrueClient(
+        url: gotrueUrl,
+        headers: {'Authorization': 'Bearer $anonToken', 'apikey': anonToken},
+        asyncStorage: TestAsyncStorage(),
+        httpClient: httpClient,
+      );
+    });
+
+    // Regression test for https://github.com/supabase/supabase-flutter/issues/1158
+    //
+    // On cold start both `recoverSession` and the auto-refresh tick (fired when
+    // the app resumes) can try to refresh the same persisted, expired session.
+    // If one of them refreshes first, the refresh token serialized in the
+    // session string handed to `recoverSession` becomes stale. Reusing it made
+    // the server respond with `refresh_token_already_used`, signing the user
+    // out. `recoverSession` must instead detect the already valid in-memory
+    // session and return it.
+    test('does not reuse a stale refresh token after another refresh',
+        () async {
+      final expiredSessionString = getSessionData(
+        DateTime.now().subtract(const Duration(hours: 1)),
+      ).sessionString;
+
+      // First recovery refreshes the expired session, advancing the in-memory
+      // session onto a brand new refresh token.
+      final first = await client.recoverSession(expiredSessionString);
+      expect(first.session, isNotNull);
+      expect(first.session!.isExpired, isFalse);
+      expect(httpClient.refreshCount, 1);
+
+      var signedOut = false;
+      final sub = client.onAuthStateChange.listen(
+        (state) {
+          if (state.event == AuthChangeEvent.signedOut) signedOut = true;
+        },
+        onError: (_) {},
+      );
+
+      // Second recovery uses the same (now stale) persisted session, as happens
+      // when a second code path recovers the session it read before the first
+      // refresh completed. It must not resend the already-used refresh token.
+      final second = await client.recoverSession(expiredSessionString);
+      expect(second.session, isNotNull);
+      expect(second.session!.isExpired, isFalse);
+
+      // No second refresh request was made and the user stays signed in.
+      expect(httpClient.refreshCount, 1);
+      await pumpEventQueue();
+      expect(signedOut, isFalse);
+      expect(client.currentSession, isNotNull);
+
+      await sub.cancel();
+    });
+  });
 }

--- a/packages/gotrue/test/custom_http_client.dart
+++ b/packages/gotrue/test/custom_http_client.dart
@@ -147,6 +147,92 @@ class RetryTestHttpClient extends BaseClient {
   }
 }
 
+/// Simulates GoTrue's single-use refresh token semantics.
+///
+/// The first time a given refresh token is presented it is exchanged for a new
+/// session with a fresh refresh token. Presenting the same refresh token a
+/// second time fails with a non-retryable `refresh_token_already_used` error,
+/// mirroring the server behavior behind issue #1158.
+class SingleUseRefreshTokenHttpClient extends BaseClient {
+  /// Number of token refresh requests that reached the server.
+  var refreshCount = 0;
+
+  final _usedRefreshTokens = <String>{};
+
+  @override
+  Future<StreamedResponse> send(BaseRequest request) async {
+    final isRefresh =
+        request.url.queryParameters['grant_type'] == 'refresh_token';
+    if (!isRefresh || request is! Request) {
+      return StreamedResponse(const Stream.empty(), 404, request: request);
+    }
+
+    refreshCount++;
+    final body = jsonDecode(request.body) as Map<String, dynamic>;
+    final refreshToken = body['refresh_token'] as String;
+
+    if (_usedRefreshTokens.contains(refreshToken)) {
+      return StreamedResponse(
+        Stream.value(
+          utf8.encode(
+            jsonEncode({
+              'code': 'refresh_token_already_used',
+              'error_code': 'refresh_token_already_used',
+              'msg': 'Invalid Refresh Token: Already Used',
+            }),
+          ),
+        ),
+        400,
+        request: request,
+      );
+    }
+    _usedRefreshTokens.add(refreshToken);
+
+    final accessToken = JWT(
+      {
+        'exp': (DateTime.now().millisecondsSinceEpoch / 1000).round() + 3600,
+        'refresh_count': refreshCount,
+      },
+      subject: userId1,
+    ).sign(SecretKey('37c304f8-51aa-419a-a1af-06154e63707a'));
+
+    return StreamedResponse(
+      Stream.value(
+        utf8.encode(
+          jsonEncode(
+            {
+              'access_token': accessToken,
+              'token_type': 'bearer',
+              'expires_in': 3600,
+              'refresh_token': 'refresh_token_$refreshCount',
+              'user': {
+                'id': userId1,
+                'aud': '',
+                'role': '',
+                'email': email1,
+                'email_confirmed_at': '2023-04-01T09:38:59.784028Z',
+                'phone': phone1,
+                'confirmed_at': '2023-04-01T09:38:59.784028Z',
+                'last_sign_in_at': '2023-04-01T09:38:59.904492805Z',
+                'app_metadata': {
+                  'provider': 'email',
+                  'providers': ['email']
+                },
+                'user_metadata': {},
+                'identities': <dynamic>[],
+                'created_at': '2023-04-01T09:38:59.784028Z',
+                'updated_at': '2023-04-01T09:38:59.908816Z'
+              }
+            },
+          ),
+        ),
+      ),
+      200,
+      request: request,
+    );
+  }
+}
+
 class MockedHttpClient extends BaseClient {
   MockedHttpClient(
     this.response, {

--- a/packages/gotrue/test/custom_http_client.dart
+++ b/packages/gotrue/test/custom_http_client.dart
@@ -193,7 +193,7 @@ class SingleUseRefreshTokenHttpClient extends BaseClient {
         'exp': (DateTime.now().millisecondsSinceEpoch / 1000).round() + 3600,
         'refresh_count': refreshCount,
       },
-      subject: userId1,
+      subject: sessionDataUserId,
     ).sign(SecretKey('37c304f8-51aa-419a-a1af-06154e63707a'));
 
     return StreamedResponse(
@@ -206,7 +206,7 @@ class SingleUseRefreshTokenHttpClient extends BaseClient {
               'expires_in': 3600,
               'refresh_token': 'refresh_token_$refreshCount',
               'user': {
-                'id': userId1,
+                'id': sessionDataUserId,
                 'aud': '',
                 'role': '',
                 'email': email1,

--- a/packages/gotrue/test/refresh_token_race_test.dart
+++ b/packages/gotrue/test/refresh_token_race_test.dart
@@ -1,0 +1,446 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:dart_jsonwebtoken/dart_jsonwebtoken.dart';
+import 'package:gotrue/gotrue.dart';
+import 'package:http/http.dart';
+import 'package:test/test.dart';
+
+import 'utils.dart';
+
+/// HTTP client that simulates server-side refresh token consumption.
+///
+/// - First use of a refresh token succeeds and returns new tokens
+/// - Second use of the SAME refresh token returns 400 "refresh_token_already_used"
+///
+/// This simulates real GoTrue server behavior where refresh tokens are single-use.
+class RefreshTokenTrackingHttpClient extends BaseClient {
+  final Set<String> _usedRefreshTokens = {};
+  final List<String> requestLog = [];
+  int requestCount = 0;
+
+  /// Optional delay before responding (to simulate network latency)
+  final Duration? responseDelay;
+
+  /// Completer to control when the first request completes
+  Completer<void>? holdFirstRequest;
+
+  RefreshTokenTrackingHttpClient({this.responseDelay, this.holdFirstRequest});
+
+  /// Manually mark a token as used (to simulate race condition where
+  /// another request already consumed the token)
+  void markTokenAsUsed(String token) {
+    _usedRefreshTokens.add(token);
+  }
+
+  @override
+  Future<StreamedResponse> send(BaseRequest request) async {
+    requestCount++;
+    final requestNumber = requestCount;
+
+    // Extract refresh token from request body
+    String? refreshToken;
+    if (request is Request) {
+      try {
+        final body = jsonDecode(request.body) as Map<String, dynamic>;
+        refreshToken = body['refresh_token'] as String?;
+      } catch (_) {}
+    }
+
+    requestLog.add(
+        'Request #$requestNumber: refresh_token=${refreshToken ?? "unknown"}');
+
+    // Simulate network latency if configured
+    if (responseDelay != null) {
+      await Future.delayed(responseDelay!);
+    }
+
+    // Hold first request if completer is provided (to force race condition)
+    if (requestNumber == 1 && holdFirstRequest != null) {
+      await holdFirstRequest!.future;
+    }
+
+    // Check if this refresh token was already used
+    if (refreshToken != null && _usedRefreshTokens.contains(refreshToken)) {
+      // Return "refresh_token_already_used" error (like real GoTrue)
+      return StreamedResponse(
+        Stream.value(
+          utf8.encode(
+            jsonEncode({
+              'code': 'refresh_token_already_used',
+              'error_code': 'refresh_token_already_used',
+              'msg': 'Invalid Refresh Token: Already Used',
+            }),
+          ),
+        ),
+        400,
+        request: request,
+        headers: {'x-sb-api-version': '2024-01-01'},
+      );
+    }
+
+    // Mark token as used
+    if (refreshToken != null) {
+      _usedRefreshTokens.add(refreshToken);
+    }
+
+    // Generate new tokens
+    final newRefreshToken =
+        'new-refresh-token-${DateTime.now().millisecondsSinceEpoch}';
+    final jwt = JWT(
+      {
+        'exp': (DateTime.now().millisecondsSinceEpoch / 1000).round() + 3600,
+        'sub': userId1,
+        'role': 'authenticated',
+      },
+    );
+
+    return StreamedResponse(
+      Stream.value(
+        utf8.encode(
+          jsonEncode({
+            'access_token': jwt.sign(
+              SecretKey('37c304f8-51aa-419a-a1af-06154e63707a'),
+            ),
+            'token_type': 'bearer',
+            'expires_in': 3600,
+            'refresh_token': newRefreshToken,
+            'user': {
+              'id': userId1,
+              'aud': 'authenticated',
+              'role': 'authenticated',
+              'email': 'test@example.com',
+              'email_confirmed_at': DateTime.now().toIso8601String(),
+              'app_metadata': {
+                'provider': 'email',
+                'providers': ['email']
+              },
+              'user_metadata': {},
+              'identities': [],
+              'created_at': DateTime.now().toIso8601String(),
+              'updated_at': DateTime.now().toIso8601String(),
+            },
+          }),
+        ),
+      ),
+      200,
+      request: request,
+    );
+  }
+}
+
+/// Creates an expired session string for the test user (userId1)
+String createExpiredSessionForUser1() {
+  final expireDateTime = DateTime.now().subtract(Duration(hours: 1));
+  final expiresAt = expireDateTime.millisecondsSinceEpoch ~/ 1000;
+  final accessTokenMid = base64.encode(utf8.encode(json
+      .encode({'exp': expiresAt, 'sub': userId1, 'role': 'authenticated'})));
+  final accessToken = 'any.$accessTokenMid.any';
+  return '{"access_token":"$accessToken","expires_in":-3600,"refresh_token":"-yeS4omysFs9tpUYBws9Rg","token_type":"bearer","provider_token":null,"provider_refresh_token":null,"user":{"id":"$userId1","app_metadata":{"provider":"email","providers":["email"]},"user_metadata":{},"aud":"","email":"test@example.com","phone":"","created_at":"2023-04-01T08:35:05.208586Z","confirmed_at":null,"email_confirmed_at":"2023-04-01T08:35:05.220096086Z","phone_confirmed_at":null,"last_sign_in_at":"2023-04-01T08:35:05.222755878Z","role":"","updated_at":"2023-04-01T08:35:05.226938Z"}}';
+}
+
+void main() {
+  const gotrueUrl = 'http://localhost:9999';
+
+  group('Refresh token race condition fix tests', () {
+    test('concurrent recoverSession calls are bundled (protected by completer)',
+        () async {
+      final httpClient = RefreshTokenTrackingHttpClient();
+      final client = GoTrueClient(
+        url: gotrueUrl,
+        asyncStorage: TestAsyncStorage(),
+        httpClient: httpClient,
+      );
+
+      // Create an expired session for the same user
+      final expiredSession = createExpiredSessionForUser1();
+
+      // Call recoverSession concurrently - these SHOULD be bundled
+      final results = await Future.wait([
+        client.recoverSession(expiredSession),
+        client.recoverSession(expiredSession),
+      ]);
+
+      // Both should succeed with same token (bundled into one request)
+      expect(results[0].session?.accessToken, isNotNull);
+      expect(results[0].session?.accessToken, results[1].session?.accessToken);
+
+      // Only ONE HTTP request should have been made (bundling works)
+      expect(httpClient.requestCount, 1,
+          reason: 'Concurrent calls should be bundled into one request');
+    });
+
+    test(
+        'FIXED: sequential recoverSession calls with same user return current session',
+        () async {
+      final httpClient = RefreshTokenTrackingHttpClient();
+      final client = GoTrueClient(
+        url: gotrueUrl,
+        asyncStorage: TestAsyncStorage(),
+        httpClient: httpClient,
+      );
+
+      // Create an expired session for the test user
+      final expiredSession = createExpiredSessionForUser1();
+
+      // First call succeeds and refreshes
+      final result1 = await client.recoverSession(expiredSession);
+      expect(result1.session?.accessToken, isNotNull);
+      expect(httpClient.requestCount, 1);
+
+      final newRefreshToken = client.currentSession?.refreshToken;
+      expect(newRefreshToken, isNot('-yeS4omysFs9tpUYBws9Rg'));
+
+      // Second call with the SAME stale session (same user ID)
+      // FIXED: Should return current valid session without making new request
+      final result2 = await client.recoverSession(expiredSession);
+
+      // Should succeed (not throw)
+      expect(result2.session, isNotNull);
+      // Should return the CURRENT valid session
+      expect(result2.session?.refreshToken, newRefreshToken);
+      // Should NOT have made another HTTP request (early return in recoverSession)
+      expect(httpClient.requestCount, 1,
+          reason:
+              'Should not make request if session already refreshed for same user');
+    });
+
+    test('FIXED: recoverSession races with autoRefreshTokenTick safely',
+        () async {
+      final holdFirstRequest = Completer<void>();
+      final httpClient = RefreshTokenTrackingHttpClient(
+        holdFirstRequest: holdFirstRequest,
+      );
+
+      final client = GoTrueClient(
+        url: gotrueUrl,
+        asyncStorage: TestAsyncStorage(),
+        httpClient: httpClient,
+        autoRefreshToken: true,
+      );
+
+      // Create an expired session for the test user
+      final expiredSession = createExpiredSessionForUser1();
+
+      // Simulate the race: start recoverSession (will be held)
+      final recoverFuture = client.recoverSession(expiredSession);
+
+      // Give time for the request to start
+      await Future.delayed(Duration(milliseconds: 10));
+
+      // Now start auto-refresh tick (simulates didChangeAppLifecycleState(resumed))
+      client.startAutoRefresh();
+
+      // Release the held request
+      holdFirstRequest.complete();
+
+      // Wait for recovery to complete
+      final result = await recoverFuture;
+      expect(result.session?.accessToken, isNotNull);
+
+      // Stop auto-refresh to clean up
+      client.stopAutoRefresh();
+
+      // With proper bundling, only ONE request should be made
+      expect(httpClient.requestCount, lessThanOrEqualTo(2));
+    });
+
+    test('FIXED: setInitialSession followed by concurrent refresh attempts',
+        () async {
+      final httpClient = RefreshTokenTrackingHttpClient(
+        responseDelay: Duration(milliseconds: 50),
+      );
+
+      final client = GoTrueClient(
+        url: gotrueUrl,
+        asyncStorage: TestAsyncStorage(),
+        httpClient: httpClient,
+        autoRefreshToken: true,
+      );
+
+      // Create an expired session for the test user
+      final expiredSession = createExpiredSessionForUser1();
+
+      // 1. setInitialSession loads the expired session (but doesn't refresh)
+      await client.setInitialSession(expiredSession);
+      expect(client.currentSession?.isExpired, true);
+
+      // 2. Start auto-refresh (simulates didChangeAppLifecycleState(resumed))
+      client.startAutoRefresh();
+
+      // 3. Also call recoverSession (simulates lazy recovery call)
+      final recoverFuture = client.recoverSession(expiredSession);
+
+      // Wait a bit for both to potentially race
+      await Future.delayed(Duration(milliseconds: 100));
+
+      // FIXED: Should succeed without throwing
+      final result = await recoverFuture;
+      expect(result.session, isNotNull);
+
+      client.stopAutoRefresh();
+
+      // Should only make 1 or 2 requests (not more due to races)
+      expect(httpClient.requestCount, lessThanOrEqualTo(2));
+    });
+
+    test(
+        'FIXED: "refresh_token_already_used" error is handled gracefully when session is valid',
+        () async {
+      final httpClient = RefreshTokenTrackingHttpClient();
+
+      final client = GoTrueClient(
+        url: gotrueUrl,
+        asyncStorage: TestAsyncStorage(),
+        httpClient: httpClient,
+        autoRefreshToken: true,
+      );
+
+      // Create expired session for the test user
+      final expiredSession = createExpiredSessionForUser1();
+
+      // 1. Set initial session (doesn't refresh)
+      await client.setInitialSession(expiredSession);
+      expect(client.currentSession?.isExpired, true);
+      expect(httpClient.requestCount, 0);
+
+      // 2. First refresh succeeds
+      await client.refreshSession();
+      expect(httpClient.requestCount, 1);
+
+      // 3. Verify the session now has a NEW refresh token
+      final newToken = client.currentSession?.refreshToken;
+      expect(newToken, isNot('-yeS4omysFs9tpUYBws9Rg'));
+      expect(client.currentSession?.isExpired, false);
+
+      // 4. Manually mark the current token as "already used" on the server
+      // This simulates a race condition where another request (e.g., auto-refresh)
+      // already consumed the token before our next refresh attempt
+      httpClient.markTokenAsUsed(newToken!);
+
+      // 5. Attempt refresh - this will get "already_used" error from server
+      // The error handler should detect we have a valid session and return it
+      final response = await client.refreshSession();
+      expect(response.session, isNotNull);
+
+      // Session should still be valid (the error handler returned current session)
+      expect(client.currentSession, isNotNull);
+      expect(client.currentSession?.isExpired, false);
+    });
+
+    test('FIXED: signedOut event is NOT emitted when session is still valid',
+        () async {
+      final httpClient = RefreshTokenTrackingHttpClient();
+      final client = GoTrueClient(
+        url: gotrueUrl,
+        asyncStorage: TestAsyncStorage(),
+        httpClient: httpClient,
+      );
+
+      // Create and recover an expired session (first refresh succeeds)
+      final expiredSession = createExpiredSessionForUser1();
+      await client.recoverSession(expiredSession);
+
+      // Capture the valid session after refresh
+      final validSession = client.currentSession;
+      expect(validSession, isNotNull);
+      expect(validSession!.isExpired, false);
+
+      // Listen for auth state changes AFTER first successful refresh
+      final authEvents = <AuthChangeEvent>[];
+      final subscription = client.onAuthStateChange.listen(
+        (state) {
+          authEvents.add(state.event);
+        },
+        onError: (_) {}, // Ignore stream errors
+      );
+
+      // Second call with stale token (same user) - should return current session
+      final result2 = await client.recoverSession(expiredSession);
+
+      // Should succeed
+      expect(result2.session, isNotNull);
+
+      // Wait for any events
+      await Future.delayed(Duration(milliseconds: 50));
+
+      // FIXED: signedOut should NOT be emitted since session is valid
+      expect(authEvents, isNot(contains(AuthChangeEvent.signedOut)),
+          reason: 'Should not sign out user when session is still valid');
+
+      // Session should still be valid
+      expect(client.currentSession?.accessToken, validSession.accessToken);
+
+      await subscription.cancel();
+    });
+
+    test(
+        'FIXED: concurrent recoverSession and autoRefreshTick both succeed with same result',
+        () async {
+      final httpClient = RefreshTokenTrackingHttpClient(
+        responseDelay: Duration(milliseconds: 50),
+      );
+
+      final client = GoTrueClient(
+        url: gotrueUrl,
+        asyncStorage: TestAsyncStorage(),
+        httpClient: httpClient,
+        autoRefreshToken: true,
+      );
+
+      // Set up expired session for the test user
+      final expiredSession = createExpiredSessionForUser1();
+      await client.setInitialSession(expiredSession);
+
+      // Start auto-refresh (triggers _autoRefreshTokenTick immediately)
+      client.startAutoRefresh();
+
+      // Simultaneously call recoverSession
+      final recoverFuture = client.recoverSession(expiredSession);
+
+      // Wait a bit for both to potentially start
+      await Future.delayed(Duration(milliseconds: 10));
+
+      // FIXED: Both should succeed
+      final result = await recoverFuture;
+      expect(result.session, isNotNull);
+
+      client.stopAutoRefresh();
+
+      // Should only make ONE or TWO HTTP requests (properly handled)
+      expect(httpClient.requestCount, lessThanOrEqualTo(2),
+          reason: 'Refresh attempts should be handled without errors');
+
+      // Session should be valid
+      expect(client.currentSession?.isExpired, false);
+    });
+
+    test(
+        'FIXED: recoverSession returns current session for same user when already valid',
+        () async {
+      final httpClient = RefreshTokenTrackingHttpClient();
+      final client = GoTrueClient(
+        url: gotrueUrl,
+        asyncStorage: TestAsyncStorage(),
+        httpClient: httpClient,
+      );
+
+      // Set up and refresh session
+      final expiredSession = createExpiredSessionForUser1();
+      await client.recoverSession(expiredSession);
+      expect(httpClient.requestCount, 1);
+
+      final currentToken = client.currentSession?.refreshToken;
+
+      // Second call with stale session (same user)
+      // FIXED: Should return current session without new request
+      final result2 = await client.recoverSession(expiredSession);
+
+      expect(result2.session, isNotNull);
+      expect(result2.session?.refreshToken, currentToken);
+      expect(httpClient.requestCount, 1,
+          reason:
+              'Should not attempt refresh when current session is valid for same user');
+    });
+  });
+}

--- a/packages/gotrue/test/utils.dart
+++ b/packages/gotrue/test/utils.dart
@@ -50,6 +50,9 @@ String getServiceRoleToken(DotEnv env) {
   );
 }
 
+/// User id embedded in the session produced by [getSessionData].
+const sessionDataUserId = '4d2583da-8de4-49d3-9cd1-37a9a74f55bd';
+
 /// Construct session data for a given expiration date
 ({String accessToken, String sessionString}) getSessionData(
     DateTime expireDateTime) {
@@ -58,7 +61,7 @@ String getServiceRoleToken(DotEnv env) {
       {'exp': expiresAt, 'sub': '1234567890', 'role': 'authenticated'})));
   final accessToken = 'any.$accessTokenMid.any';
   final sessionString =
-      '{"access_token":"$accessToken","expires_in":${expireDateTime.difference(DateTime.now()).inSeconds},"refresh_token":"-yeS4omysFs9tpUYBws9Rg","token_type":"bearer","provider_token":null,"provider_refresh_token":null,"user":{"id":"4d2583da-8de4-49d3-9cd1-37a9a74f55bd","app_metadata":{"provider":"email","providers":["email"]},"user_metadata":{"Hello":"World"},"aud":"","email":"fake1680338105@email.com","phone":"","created_at":"2023-04-01T08:35:05.208586Z","confirmed_at":null,"email_confirmed_at":"2023-04-01T08:35:05.220096086Z","phone_confirmed_at":null,"last_sign_in_at":"2023-04-01T08:35:05.222755878Z","role":"","updated_at":"2023-04-01T08:35:05.226938Z"}}';
+      '{"access_token":"$accessToken","expires_in":${expireDateTime.difference(DateTime.now()).inSeconds},"refresh_token":"-yeS4omysFs9tpUYBws9Rg","token_type":"bearer","provider_token":null,"provider_refresh_token":null,"user":{"id":"$sessionDataUserId","app_metadata":{"provider":"email","providers":["email"]},"user_metadata":{"Hello":"World"},"aud":"","email":"fake1680338105@email.com","phone":"","created_at":"2023-04-01T08:35:05.208586Z","confirmed_at":null,"email_confirmed_at":"2023-04-01T08:35:05.220096086Z","phone_confirmed_at":null,"last_sign_in_at":"2023-04-01T08:35:05.222755878Z","role":"","updated_at":"2023-04-01T08:35:05.226938Z"}}';
   return (accessToken: accessToken, sessionString: sessionString);
 }
 


### PR DESCRIPTION
Fixes #452
Fixes #906
Fixes #1158

## Problem

On cold start, users are intermittently signed out with:

```
AuthApiException(message: Invalid Refresh Token: Already Used, statusCode: 400, code: refresh_token_already_used)
```

The stack trace consistently points to `recoverSession` → `_callRefreshToken` → `_refreshAccessToken`. Reporters note it happens on **real devices** but not emulators, and is intermittent, both classic signs of a race.

## Root cause

On startup `supabase_flutter` runs **two independent refreshes against the same persisted refresh token** (`RT1`):

1. `SupabaseAuth.recoverSession()` (run as a non-awaited `CancelableOperation`) → `auth.recoverSession(jsonStr)`, which, for an expired session, calls `_callRefreshToken(refreshToken)` using the token **serialized in the JSON string** (`RT1`).
2. The lifecycle `resumed` event → `startAutoRefresh()`, which ticks immediately and refreshes `_currentSession.refreshToken` (`RT1`).

`_callRefreshToken`'s `_refreshTokenCompleter` guard only deduplicates *concurrent* calls. If path 2 starts **and finishes first** (obtaining `RT2`, saving the session, clearing the completer), then path 1 later calls `_callRefreshToken(RT1)` with the now-stale token. Since refresh tokens are single-use, the server rejects it as `refresh_token_already_used`, and `_callRefreshToken` reacts to that non-retryable error by removing the session and emitting `signedOut`. Slower secure-storage reads on real devices widen the window, which is why it's device-specific and intermittent.

## Why not the previous approach (#1310)

[#1310](https://github.com/supabase/supabase-flutter/pull/1310) tried to "proactively refresh on resume". As pointed out [in review](https://github.com/supabase/supabase-flutter/pull/1310#issuecomment-4451181091), `startAutoRefresh()` already ticks immediately, so that change does nothing for this bug and merely adds *another* racing refresher.

## Fix

In `GoTrueClient.recoverSession`, before refreshing an expired session with the token from the serialized string, check whether `_currentSession` has already advanced to a valid session via another code path. If so, return that session instead of reusing the stale token. The check runs synchronously right before `_callRefreshToken` (no `await` in between), so combined with the existing in-flight refresh guard it closes the race entirely.

```dart
if (session.isExpired) {
  // While the session was being read from local storage, another code path
  // may have already refreshed it. Reusing the stale token would trigger
  // `refresh_token_already_used` and sign the user out.
  final currentSession = _currentSession;
  if (currentSession != null && !currentSession.isExpired) {
    return AuthResponse(session: currentSession);
  }
  ...
}
```

## Test plan

- Added `SingleUseRefreshTokenHttpClient` mirroring GoTrue's single-use refresh-token semantics, plus a regression test in `client_test.dart`.
- The test **fails without the fix** with the exact reported error (`refresh_token_already_used` from the `recoverSession` → `_callRefreshToken` path) and **passes with it**.
- `dart analyze` clean; existing custom-client refresh tests still pass.