### PR TITLE
chore(supabase_flutter): remove unused dependencies

### DIFF
--- a/packages/supabase_flutter/pubspec.yaml
+++ b/packages/supabase_flutter/pubspec.yaml
@@ -12,14 +12,12 @@ environment:
 dependencies:
   app_links: '>=6.2.0 <8.0.0'
   async: ^2.11.0
-  crypto: ^3.0.2
   flutter:
     sdk: flutter
   http: '>=0.13.4 <2.0.0'
   meta: ^1.7.0
   supabase: 2.12.2
   url_launcher: ^6.1.2
-  path_provider: ^2.0.0
   shared_preferences: ^2.0.0
   logging: ^1.2.0
   web: '>=0.5.0 <2.0.0'
@@ -29,7 +27,6 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^3.0.1
-  path: ^1.8.3
   web_socket_channel: '>=2.3.0 <4.0.0'
 
 platforms:


### PR DESCRIPTION
## Summary

- Remove `crypto` (regular dep) — was used for `generateRawNonce` in Apple Sign-In, removed in #650 but pubspec entry was never cleaned up
- Remove `path_provider` (regular dep) — no import ever found in source history, leftover from the Hive era
- Remove `path` (dev dep) — added in #608 for token storage path helpers, code removed in #823 but pubspec entry was never cleaned up

Closes https://linear.app/supabase/issue/SDK-1046

## Test plan

- [ ] `flutter pub get` succeeds in `packages/supabase_flutter`
- [ ] CI passes