### PR TITLE
chore: upgrade to flutter_lints/lints 4.0.0 and fix all analysis warnings

### DIFF
--- a/packages/functions_client/analysis_options.yaml
+++ b/packages/functions_client/analysis_options.yaml
@@ -1,1 +1,4 @@
 include: package:lints/recommended.yaml
+
+formatter:
+  trailing_commas: preserve

--- a/packages/functions_client/lib/functions_client.dart
+++ b/packages/functions_client/lib/functions_client.dart
@@ -1,4 +1,4 @@
-library functions_client;
+library;
 
 export 'package:http/http.dart' show ByteStream, MultipartFile;
 

--- a/packages/functions_client/lib/functions_client.dart
+++ b/packages/functions_client/lib/functions_client.dart
@@ -1,3 +1,4 @@
+/// A dart client library for Supabase Edge Functions.
 library;
 
 export 'package:http/http.dart' show ByteStream, MultipartFile;

--- a/packages/functions_client/pubspec.yaml
+++ b/packages/functions_client/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: '>=3.3.0 <4.0.0'
 
 dependencies:
-  http: ^1.6.0
+  http: ^1.2.2
   logging: ^1.2.0
   yet_another_json_isolate: 2.1.0
 

--- a/packages/functions_client/pubspec.yaml
+++ b/packages/functions_client/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: '>=3.3.0 <4.0.0'
 
 dependencies:
-  http: '>=0.13.4 <2.0.0'
+  http: '>=1.0.0 <2.0.0'
   logging: ^1.2.0
   yet_another_json_isolate: 2.1.0
 

--- a/packages/functions_client/pubspec.yaml
+++ b/packages/functions_client/pubspec.yaml
@@ -14,5 +14,5 @@ dependencies:
   yet_another_json_isolate: 2.1.0
 
 dev_dependencies:
-  lints: ^3.0.0
+  lints: ^6.1.0
   test: ^1.16.4

--- a/packages/functions_client/pubspec.yaml
+++ b/packages/functions_client/pubspec.yaml
@@ -14,5 +14,5 @@ dependencies:
   yet_another_json_isolate: 2.1.0
 
 dev_dependencies:
-  lints: ^6.1.0
+  lints: ^4.0.0
   test: ^1.16.4

--- a/packages/functions_client/pubspec.yaml
+++ b/packages/functions_client/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: '>=3.3.0 <4.0.0'
 
 dependencies:
-  http: ^1.0.0
+  http: ^1.6.0
   logging: ^1.2.0
   yet_another_json_isolate: 2.1.0
 

--- a/packages/functions_client/pubspec.yaml
+++ b/packages/functions_client/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: '>=3.3.0 <4.0.0'
 
 dependencies:
-  http: '>=1.0.0 <2.0.0'
+  http: ^1.0.0
   logging: ^1.2.0
   yet_another_json_isolate: 2.1.0
 

--- a/packages/gotrue/analysis_options.yaml
+++ b/packages/gotrue/analysis_options.yaml
@@ -1,7 +1,4 @@
 include: package:lints/recommended.yaml
 
-
-linter:
-  rules:
-    prefer_single_quotes: true
-
+formatter:
+  trailing_commas: preserve

--- a/packages/gotrue/lib/gotrue.dart
+++ b/packages/gotrue/lib/gotrue.dart
@@ -1,5 +1,3 @@
-library gotrue;
-
 export 'src/constants.dart'
     hide Constants, GenerateLinkTypeExtended, AuthChangeEventExtended;
 export 'src/gotrue_admin_api.dart';

--- a/packages/gotrue/lib/gotrue.dart
+++ b/packages/gotrue/lib/gotrue.dart
@@ -1,4 +1,4 @@
-/// A dart client library for the GoTrue API.
+/// A dart client library for the GoTrue API (Supabase Auth).
 library;
 
 export 'src/constants.dart'

--- a/packages/gotrue/lib/gotrue.dart
+++ b/packages/gotrue/lib/gotrue.dart
@@ -1,3 +1,5 @@
+library;
+
 export 'src/constants.dart'
     hide Constants, GenerateLinkTypeExtended, AuthChangeEventExtended;
 export 'src/gotrue_admin_api.dart';

--- a/packages/gotrue/lib/gotrue.dart
+++ b/packages/gotrue/lib/gotrue.dart
@@ -1,3 +1,4 @@
+/// A dart client library for the GoTrue API.
 library;
 
 export 'src/constants.dart'

--- a/packages/gotrue/lib/src/broadcast_web.dart
+++ b/packages/gotrue/lib/src/broadcast_web.dart
@@ -12,11 +12,9 @@ BroadcastChannel getBroadcastChannel(String broadcastKey) {
   final broadcast = web.BroadcastChannel(broadcastKey);
   final controller = StreamController<Map<String, dynamic>>();
 
-  void onMessage(web.Event event) {
-    if (event is web.MessageEvent) {
-      final dataMap = event.data.dartify();
-      controller.add(json.decode(json.encode(dataMap)));
-    }
+  void onMessage(web.MessageEvent event) {
+    final dataMap = event.data.dartify();
+    controller.add(json.decode(json.encode(dataMap)));
   }
 
   broadcast.onmessage = onMessage.toJS;

--- a/packages/gotrue/pubspec.yaml
+++ b/packages/gotrue/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 dependencies:
   collection: ^1.15.0
   crypto: ^3.0.2
-  http: '>=1.0.0 <2.0.0'
+  http: ^1.0.0
   jwt_decode: ^0.3.1
   retry: ^3.1.0
   rxdart: ">=0.27.7 <0.29.0"

--- a/packages/gotrue/pubspec.yaml
+++ b/packages/gotrue/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 dependencies:
   collection: ^1.15.0
   crypto: ^3.0.2
-  http: ">=0.13.0 <2.0.0"
+  http: '>=1.0.0 <2.0.0'
   jwt_decode: ^0.3.1
   retry: ^3.1.0
   rxdart: ">=0.27.7 <0.29.0"

--- a/packages/gotrue/pubspec.yaml
+++ b/packages/gotrue/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
 
 dev_dependencies:
   dotenv: ^4.1.0
-  lints: ^6.1.0
+  lints: ^4.0.0
   test: ^1.16.4
   otp: ^3.1.3
 

--- a/packages/gotrue/pubspec.yaml
+++ b/packages/gotrue/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 dependencies:
   collection: ^1.15.0
   crypto: ^3.0.2
-  http: ^1.0.0
+  http: ^1.6.0
   jwt_decode: ^0.3.1
   retry: ^3.1.0
   rxdart: ">=0.27.7 <0.29.0"

--- a/packages/gotrue/pubspec.yaml
+++ b/packages/gotrue/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 dependencies:
   collection: ^1.15.0
   crypto: ^3.0.2
-  http: ^1.6.0
+  http: ^1.2.2
   jwt_decode: ^0.3.1
   retry: ^3.1.0
   rxdart: ">=0.27.7 <0.29.0"

--- a/packages/gotrue/pubspec.yaml
+++ b/packages/gotrue/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
 
 dev_dependencies:
   dotenv: ^4.1.0
-  lints: ^3.0.0
+  lints: ^6.1.0
   test: ^1.16.4
   otp: ^3.1.3
 

--- a/packages/gotrue/test/src/broadcast_web_test.dart
+++ b/packages/gotrue/test/src/broadcast_web_test.dart
@@ -1,4 +1,5 @@
 @TestOn('browser')
+/// Tests for the web BroadcastChannel implementation.
 library;
 
 import 'dart:async';

--- a/packages/gotrue/test/src/broadcast_web_test.dart
+++ b/packages/gotrue/test/src/broadcast_web_test.dart
@@ -1,4 +1,6 @@
 @TestOn('browser')
+library;
+
 import 'dart:async';
 
 import 'package:gotrue/src/broadcast_web.dart';

--- a/packages/gotrue/test/src/broadcast_web_test.dart
+++ b/packages/gotrue/test/src/broadcast_web_test.dart
@@ -1,4 +1,5 @@
 @TestOn('browser')
+
 /// Tests for the web BroadcastChannel implementation.
 library;
 

--- a/packages/postgrest/analysis_options.yaml
+++ b/packages/postgrest/analysis_options.yaml
@@ -1,5 +1,4 @@
 include: package:lints/recommended.yaml
 
-linter:
-  rules:
-    avoid_print: false 
+formatter:
+  trailing_commas: preserve

--- a/packages/postgrest/lib/postgrest.dart
+++ b/packages/postgrest/lib/postgrest.dart
@@ -1,3 +1,5 @@
+library;
+
 export 'src/postgrest.dart';
 export 'src/postgrest_builder.dart';
 export 'src/types.dart';

--- a/packages/postgrest/lib/postgrest.dart
+++ b/packages/postgrest/lib/postgrest.dart
@@ -1,3 +1,4 @@
+/// PostgREST client for Dart. Provides an ORM interface to PostgREST.
 library;
 
 export 'src/postgrest.dart';

--- a/packages/postgrest/lib/src/postgrest_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_builder.dart
@@ -17,7 +17,7 @@ part 'postgrest_transform_builder.dart';
 part 'raw_postgrest_builder.dart';
 part 'response_postgrest_builder.dart';
 
-enum _HttpMethod {
+enum HttpMethod {
   get,
   head,
   post,
@@ -41,7 +41,7 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
   final Object? _body;
   final Headers _headers;
   final bool _maybeSingle;
-  final _HttpMethod? _method;
+  final HttpMethod? _method;
   final String? _schema;
   final Uri _url;
   final PostgrestConverter<S, R>? _converter;
@@ -59,8 +59,7 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
     required Uri url,
     required Headers headers,
     String? schema,
-    // ignore: library_private_types_in_public_api
-    _HttpMethod? method,
+    HttpMethod? method,
     Object? body,
     Client? httpClient,
     YAJsonIsolate? isolate,
@@ -86,7 +85,7 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
     Uri? url,
     Headers? headers,
     String? schema,
-    _HttpMethod? method,
+    HttpMethod? method,
     Object? body,
     Client? httpClient,
     YAJsonIsolate? isolate,
@@ -128,7 +127,7 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
   }
 
   Future<T> _execute() async {
-    final _HttpMethod? method = _method;
+    final HttpMethod? method = _method;
     // Work with a local copy so repeated awaits and shared-map siblings are
     // not affected by per-execution header mutations (Prefer, schema headers,
     // X-Retry-Count, etc.).
@@ -152,42 +151,42 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
 
       if (_schema == null) {
         // skip
-      } else if (method == _HttpMethod.get || method == _HttpMethod.head) {
+      } else if (method == HttpMethod.get || method == HttpMethod.head) {
         execHeaders['Accept-Profile'] = _schema;
       } else {
         execHeaders['Content-Profile'] = _schema;
       }
-      if (method != _HttpMethod.get && method != _HttpMethod.head) {
+      if (method != HttpMethod.get && method != HttpMethod.head) {
         execHeaders['Content-Type'] = 'application/json';
       }
       final bodyStr = jsonEncode(_body);
       _log.finest("Request: ${method.value} $_url");
 
       final Future<http.Response> Function() send;
-      if (method == _HttpMethod.get) {
+      if (method == HttpMethod.get) {
         send = () => (_httpClient?.get ?? http.get)(_url, headers: execHeaders);
-      } else if (method == _HttpMethod.post) {
+      } else if (method == HttpMethod.post) {
         send = () => (_httpClient?.post ?? http.post)(
               _url,
               headers: execHeaders,
               body: bodyStr,
             );
-      } else if (method == _HttpMethod.put) {
+      } else if (method == HttpMethod.put) {
         send = () => (_httpClient?.put ?? http.put)(
               _url,
               headers: execHeaders,
               body: bodyStr,
             );
-      } else if (method == _HttpMethod.patch) {
+      } else if (method == HttpMethod.patch) {
         send = () => (_httpClient?.patch ?? http.patch)(
               _url,
               headers: execHeaders,
               body: bodyStr,
             );
-      } else if (method == _HttpMethod.delete) {
+      } else if (method == HttpMethod.delete) {
         send = () =>
             (_httpClient?.delete ?? http.delete)(_url, headers: execHeaders);
-      } else if (method == _HttpMethod.head) {
+      } else if (method == HttpMethod.head) {
         send =
             () => (_httpClient?.head ?? http.head)(_url, headers: execHeaders);
       } else {
@@ -203,14 +202,14 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
 
   Future<http.Response> _executeWithRetry(
     Future<http.Response> Function() send,
-    _HttpMethod method,
+    HttpMethod method,
     Map<String, String> execHeaders,
   ) async {
     const maxRetries = 3;
     const retryableStatusCodes = {503, 520};
 
     final isRetryableMethod =
-        method == _HttpMethod.get || method == _HttpMethod.head;
+        method == HttpMethod.get || method == HttpMethod.head;
 
     if (!_retryEnabled || !isRetryableMethod) {
       return send();
@@ -238,12 +237,12 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
   }
 
   /// Parse request response to json object if possible
-  Future<T> _parseResponse(http.Response response, _HttpMethod method) async {
+  Future<T> _parseResponse(http.Response response, HttpMethod method) async {
     if (response.statusCode >= 200 && response.statusCode <= 299) {
       Object? body;
       int? count;
 
-      if (response.request!.method != _HttpMethod.head.value) {
+      if (response.request!.method != HttpMethod.head.value) {
         if (response.bodyBytes.isEmpty) {
           body = null;
         } else if (response.request!.headers['Accept'] == 'text/csv') {
@@ -265,7 +264,7 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
       }
 
       // Workaround for https://github.com/supabase/supabase-flutter/issues/560
-      if (_maybeSingle && method == _HttpMethod.get && body is List) {
+      if (_maybeSingle && method == HttpMethod.get && body is List) {
         if (body.length > 1) {
           final exception = PostgrestException(
             // https://github.com/PostgREST/postgrest/blob/a867d79c42419af16c18c3fb019eba8df992626f/src/PostgREST/Error.hs#L553
@@ -314,7 +313,7 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
         converted = body as S;
       }
 
-      if (_count != null && method != _HttpMethod.head) {
+      if (_count != null && method != HttpMethod.head) {
         return PostgrestResponse<S>(
           data: converted,
           count: count!,
@@ -324,7 +323,7 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
       }
     } else {
       late PostgrestException error;
-      if (response.request!.method != _HttpMethod.head.value) {
+      if (response.request!.method != HttpMethod.head.value) {
         try {
           final errorJson = jsonDecode(response.body) as Map<String, dynamic>;
           error = PostgrestException.fromJson(
@@ -369,8 +368,7 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
   ) {
     if (error.details is String &&
         error.details.toString().contains('Results contain 0 rows')) {
-      if (_count != null &&
-          response.request!.method != _HttpMethod.head.value) {
+      if (_count != null && response.request!.method != HttpMethod.head.value) {
         if (_converter != null) {
           return PostgrestResponse<S>(data: _converter(null as R), count: 0)
               as T;

--- a/packages/postgrest/lib/src/postgrest_filter_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_filter_builder.dart
@@ -220,7 +220,6 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   ///     .select()
   ///     .isFilter('data', null);
   /// ```
-  // ignore: non_constant_identifier_names
   PostgrestFilterBuilder<T> isFilter(String column, bool? value) {
     return copyWithUrl(appendSearchParams(column, 'is.$value'));
   }
@@ -233,7 +232,6 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   ///     .select()
   ///     .inFilter('status', ['ONLINE', 'OFFLINE']);
   /// ```
-  // ignore: non_constant_identifier_names
   PostgrestFilterBuilder<T> inFilter(String column, List values) {
     return copyWithUrl(
         appendSearchParams(column, 'in.(${_cleanFilterArray(values)})'));
@@ -510,7 +508,6 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   ///     .select()
   ///     .isDistinct('age', null);
   /// ```
-  // ignore: non_constant_identifier_names
   PostgrestFilterBuilder<T> isDistinct(String column, Object? value) {
     return copyWithUrl(appendSearchParams(column, 'isdistinct.$value'));
   }

--- a/packages/postgrest/lib/src/postgrest_query_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_query_builder.dart
@@ -14,8 +14,7 @@ class PostgrestQueryBuilder<T> extends RawPostgrestBuilder<T, T, T> {
   /// {@macro postgrest_query_builder}
   PostgrestQueryBuilder({
     required Uri url,
-    // ignore: library_private_types_in_public_api
-    _HttpMethod? method,
+    HttpMethod? method,
     Map<String, String>? headers,
     String? schema,
     Client? httpClient,
@@ -62,7 +61,7 @@ class PostgrestQueryBuilder<T> extends RawPostgrestBuilder<T, T, T> {
     final url = overrideSearchParams('select', cleanedColumns);
     return PostgrestFilterBuilder(_copyWithType(
       url: url,
-      method: _HttpMethod.get,
+      method: HttpMethod.get,
     ));
   }
 
@@ -107,7 +106,7 @@ class PostgrestQueryBuilder<T> extends RawPostgrestBuilder<T, T, T> {
     }
 
     return PostgrestFilterBuilder(_copyWith(
-      method: _HttpMethod.post,
+      method: HttpMethod.post,
       headers: newHeaders,
       body: values,
       url: url,
@@ -175,7 +174,7 @@ class PostgrestQueryBuilder<T> extends RawPostgrestBuilder<T, T, T> {
     }
 
     return PostgrestFilterBuilder<T>(_copyWith(
-      method: _HttpMethod.post,
+      method: HttpMethod.post,
       headers: newHeaders,
       body: values,
       url: url,
@@ -207,7 +206,7 @@ class PostgrestQueryBuilder<T> extends RawPostgrestBuilder<T, T, T> {
     newHeaders['Prefer'] = '';
 
     return PostgrestFilterBuilder<T>(_copyWith(
-      method: _HttpMethod.patch,
+      method: HttpMethod.patch,
       headers: newHeaders,
       body: values,
     ));
@@ -237,7 +236,7 @@ class PostgrestQueryBuilder<T> extends RawPostgrestBuilder<T, T, T> {
     final newHeaders = {..._headers};
     newHeaders['Prefer'] = '';
     return PostgrestFilterBuilder<T>(_copyWith(
-      method: _HttpMethod.delete,
+      method: HttpMethod.delete,
       headers: newHeaders,
     ));
   }
@@ -259,7 +258,7 @@ class PostgrestQueryBuilder<T> extends RawPostgrestBuilder<T, T, T> {
   /// ```
   PostgrestFilterBuilder<int> count([CountOption option = CountOption.exact]) {
     return PostgrestFilterBuilder<int>(_copyWithType(
-      method: _HttpMethod.head,
+      method: HttpMethod.head,
       count: option,
     ));
   }

--- a/packages/postgrest/lib/src/postgrest_rpc_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_rpc_builder.dart
@@ -27,9 +27,9 @@ class PostgrestRpcBuilder extends RawPostgrestBuilder {
     bool get = false,
   ]) {
     var newUrl = _url;
-    final _HttpMethod method;
+    final HttpMethod method;
     if (get) {
-      method = _HttpMethod.get;
+      method = HttpMethod.get;
       if (params is Map) {
         for (final entry in params.entries) {
           assert(entry.key is String,
@@ -45,7 +45,7 @@ class PostgrestRpcBuilder extends RawPostgrestBuilder {
         throw ArgumentError.value(params, 'params', 'argument must be a Map');
       }
     } else {
-      method = _HttpMethod.post;
+      method = HttpMethod.post;
     }
 
     return PostgrestFilterBuilder(_copyWithType(

--- a/packages/postgrest/lib/src/postgrest_transform_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_transform_builder.dart
@@ -169,7 +169,7 @@ class PostgrestTransformBuilder<T> extends RawPostgrestBuilder<T, T, T> {
     // Issue persists e.g. for `.insert([...]).select().maybeSingle()`
     final newHeaders = {..._headers};
 
-    if (_method == _HttpMethod.get) {
+    if (_method == HttpMethod.get) {
       newHeaders['Accept'] = 'application/json';
     } else {
       newHeaders['Accept'] = 'application/vnd.pgrst.object+json';
@@ -235,7 +235,7 @@ class PostgrestTransformBuilder<T> extends RawPostgrestBuilder<T, T, T> {
   /// supabase.rpc("function").head();
   ///```
   PostgrestBuilder<void, void, void> head() {
-    return _copyWithType(method: _HttpMethod.head);
+    return _copyWithType(method: HttpMethod.head);
   }
 
   /// Enables support for GeoJSON for use with PostGIS data types

--- a/packages/postgrest/lib/src/raw_postgrest_builder.dart
+++ b/packages/postgrest/lib/src/raw_postgrest_builder.dart
@@ -23,7 +23,7 @@ class RawPostgrestBuilder<T, S, R> extends PostgrestBuilder<T, S, R> {
     Uri? url,
     Headers? headers,
     String? schema,
-    _HttpMethod? method,
+    HttpMethod? method,
     Object? body,
     Client? httpClient,
     YAJsonIsolate? isolate,

--- a/packages/postgrest/pubspec.yaml
+++ b/packages/postgrest/pubspec.yaml
@@ -16,5 +16,5 @@ dependencies:
 
 dev_dependencies:
   collection: ^1.16.0
-  lints: ^3.0.0
+  lints: ^6.1.0
   test: ^1.21.4

--- a/packages/postgrest/pubspec.yaml
+++ b/packages/postgrest/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: '>=3.3.0 <4.0.0'
 
 dependencies:
-  http: ^1.6.0
+  http: ^1.2.2
   yet_another_json_isolate: 2.1.0
   meta: ^1.9.1
   logging: ^1.2.0

--- a/packages/postgrest/pubspec.yaml
+++ b/packages/postgrest/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: '>=3.3.0 <4.0.0'
 
 dependencies:
-  http: ^1.0.0
+  http: ^1.6.0
   yet_another_json_isolate: 2.1.0
   meta: ^1.9.1
   logging: ^1.2.0

--- a/packages/postgrest/pubspec.yaml
+++ b/packages/postgrest/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: '>=3.3.0 <4.0.0'
 
 dependencies:
-  http: '>=0.13.0 <2.0.0'
+  http: '>=1.0.0 <2.0.0'
   yet_another_json_isolate: 2.1.0
   meta: ^1.9.1
   logging: ^1.2.0

--- a/packages/postgrest/pubspec.yaml
+++ b/packages/postgrest/pubspec.yaml
@@ -16,5 +16,5 @@ dependencies:
 
 dev_dependencies:
   collection: ^1.16.0
-  lints: ^6.1.0
+  lints: ^4.0.0
   test: ^1.21.4

--- a/packages/postgrest/pubspec.yaml
+++ b/packages/postgrest/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: '>=3.3.0 <4.0.0'
 
 dependencies:
-  http: '>=1.0.0 <2.0.0'
+  http: ^1.0.0
   yet_another_json_isolate: 2.1.0
   meta: ^1.9.1
   logging: ^1.2.0

--- a/packages/realtime_client/analysis_options.yaml
+++ b/packages/realtime_client/analysis_options.yaml
@@ -1,10 +1,4 @@
 include: package:lints/recommended.yaml
 
-linter:
-  rules:
-    avoid_print: false
-    # TODO: need proper fix
-    avoid_dynamic_calls: false
-analyzer:
-  errors:
-    todo: ignore
+formatter:
+  trailing_commas: preserve

--- a/packages/realtime_client/lib/realtime_client.dart
+++ b/packages/realtime_client/lib/realtime_client.dart
@@ -1,3 +1,4 @@
+/// Listens to changes in a PostgreSQL database via websockets using Supabase Realtime.
 library;
 
 export 'src/constants.dart'

--- a/packages/realtime_client/lib/realtime_client.dart
+++ b/packages/realtime_client/lib/realtime_client.dart
@@ -1,3 +1,5 @@
+library;
+
 export 'src/constants.dart'
     show RealtimeConstants, RealtimeLogLevel, SocketStates;
 export 'src/realtime_channel.dart';

--- a/packages/realtime_client/lib/src/realtime_channel.dart
+++ b/packages/realtime_client/lib/src/realtime_channel.dart
@@ -869,7 +869,7 @@ class RealtimeChannel {
   @internal
   bool get isLeaving => _state == ChannelStates.leaving;
 
-  static _isEqual(Map<String, String> obj1, Map<String, String> obj2) {
+  static bool _isEqual(Map<String, String> obj1, Map<String, String> obj2) {
     if (obj1.keys.length != obj2.keys.length) {
       return false;
     }

--- a/packages/realtime_client/pubspec.yaml
+++ b/packages/realtime_client/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 
 dependencies:
   collection: ^1.15.0
-  http: ^1.6.0
+  http: ^1.2.2
   logging: ^1.2.0
   meta: ^1.7.0
   web_socket_channel: '>=2.3.0 <4.0.0'

--- a/packages/realtime_client/pubspec.yaml
+++ b/packages/realtime_client/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 
 dependencies:
   collection: ^1.15.0
-  http: '>=0.13.0 <2.0.0'
+  http: '>=1.0.0 <2.0.0'
   logging: ^1.2.0
   meta: ^1.7.0
   web_socket_channel: '>=2.3.0 <4.0.0'

--- a/packages/realtime_client/pubspec.yaml
+++ b/packages/realtime_client/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 
 dependencies:
   collection: ^1.15.0
-  http: ^1.0.0
+  http: ^1.6.0
   logging: ^1.2.0
   meta: ^1.7.0
   web_socket_channel: '>=2.3.0 <4.0.0'

--- a/packages/realtime_client/pubspec.yaml
+++ b/packages/realtime_client/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   web_socket_channel: '>=2.3.0 <4.0.0'
 
 dev_dependencies:
-  lints: ^3.0.0
+  lints: ^6.1.0
   mocktail: ^1.0.0
   test: ^1.16.5
   crypto: ^3.0.0

--- a/packages/realtime_client/pubspec.yaml
+++ b/packages/realtime_client/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   web_socket_channel: '>=2.3.0 <4.0.0'
 
 dev_dependencies:
-  lints: ^6.1.0
+  lints: ^4.0.0
   mocktail: ^1.0.0
   test: ^1.16.5
   crypto: ^3.0.0

--- a/packages/realtime_client/pubspec.yaml
+++ b/packages/realtime_client/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 
 dependencies:
   collection: ^1.15.0
-  http: '>=1.0.0 <2.0.0'
+  http: ^1.0.0
   logging: ^1.2.0
   meta: ^1.7.0
   web_socket_channel: '>=2.3.0 <4.0.0'

--- a/packages/storage_client/analysis_options.yaml
+++ b/packages/storage_client/analysis_options.yaml
@@ -1,6 +1,4 @@
 include: package:lints/recommended.yaml
 
-linter:
-  rules:
-    # avoid_print: false  # Uncomment to disable the `avoid_print` rule
-    # prefer_single_quotes: true  # Uncomment to enable the `prefer_single_quotes` rule
+formatter:
+  trailing_commas: preserve

--- a/packages/storage_client/lib/src/fetch.dart
+++ b/packages/storage_client/lib/src/fetch.dart
@@ -4,7 +4,6 @@ import 'dart:typed_data';
 
 import 'package:http/http.dart' as http;
 import 'package:http/http.dart';
-import 'package:http_parser/http_parser.dart' show MediaType;
 import 'package:logging/logging.dart';
 import 'package:mime/mime.dart';
 import 'package:retry/retry.dart';

--- a/packages/storage_client/lib/src/fetch.dart
+++ b/packages/storage_client/lib/src/fetch.dart
@@ -4,6 +4,8 @@ import 'dart:typed_data';
 
 import 'package:http/http.dart' as http;
 import 'package:http/http.dart';
+// ignore: unnecessary_import — needed for http < 1.6.0 which doesn't re-export MediaType
+import 'package:http_parser/http_parser.dart';
 import 'package:logging/logging.dart';
 import 'package:mime/mime.dart';
 import 'package:retry/retry.dart';

--- a/packages/storage_client/lib/storage_client.dart
+++ b/packages/storage_client/lib/storage_client.dart
@@ -1,4 +1,4 @@
-library storage_client;
+library;
 
 export 'src/storage_client.dart';
 export 'src/storage_file_api.dart';

--- a/packages/storage_client/lib/storage_client.dart
+++ b/packages/storage_client/lib/storage_client.dart
@@ -1,3 +1,4 @@
+/// Dart client library for Supabase Storage.
 library;
 
 export 'src/storage_client.dart';

--- a/packages/storage_client/pubspec.yaml
+++ b/packages/storage_client/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: '>=3.3.0 <4.0.0'
 
 dependencies:
-  http: ^1.0.0
+  http: ^1.6.0
   mime: '>=1.0.2 <3.0.0'
   retry: ^3.1.0
   meta: ^1.7.0

--- a/packages/storage_client/pubspec.yaml
+++ b/packages/storage_client/pubspec.yaml
@@ -9,7 +9,8 @@ environment:
   sdk: '>=3.3.0 <4.0.0'
 
 dependencies:
-  http: ^1.6.0
+  http: ^1.2.2
+  http_parser: ^4.0.1
   mime: '>=1.0.2 <3.0.0'
   retry: ^3.1.0
   meta: ^1.7.0

--- a/packages/storage_client/pubspec.yaml
+++ b/packages/storage_client/pubspec.yaml
@@ -9,8 +9,7 @@ environment:
   sdk: '>=3.3.0 <4.0.0'
 
 dependencies:
-  http: '>=0.13.4 <2.0.0'
-  http_parser: ^4.0.1
+  http: '>=1.0.0 <2.0.0'
   mime: '>=1.0.2 <3.0.0'
   retry: ^3.1.0
   meta: ^1.7.0

--- a/packages/storage_client/pubspec.yaml
+++ b/packages/storage_client/pubspec.yaml
@@ -18,5 +18,5 @@ dependencies:
 
 dev_dependencies:
   test: ^1.21.4
-  lints: ^3.0.0
+  lints: ^6.1.0
   path: ^1.8.2

--- a/packages/storage_client/pubspec.yaml
+++ b/packages/storage_client/pubspec.yaml
@@ -18,5 +18,5 @@ dependencies:
 
 dev_dependencies:
   test: ^1.21.4
-  lints: ^6.1.0
+  lints: ^4.0.0
   path: ^1.8.2

--- a/packages/storage_client/pubspec.yaml
+++ b/packages/storage_client/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: '>=3.3.0 <4.0.0'
 
 dependencies:
-  http: '>=1.0.0 <2.0.0'
+  http: ^1.0.0
   mime: '>=1.0.2 <3.0.0'
   retry: ^3.1.0
   meta: ^1.7.0

--- a/packages/supabase/analysis_options.yaml
+++ b/packages/supabase/analysis_options.yaml
@@ -1,5 +1,4 @@
 include: package:lints/recommended.yaml
 
-linter:
-  rules:
-    avoid_print: false
+formatter:
+  trailing_commas: preserve

--- a/packages/supabase/lib/supabase.dart
+++ b/packages/supabase/lib/supabase.dart
@@ -5,7 +5,7 @@ library;
 
 export 'package:functions_client/functions_client.dart';
 export 'package:gotrue/gotrue.dart';
-export 'package:postgrest/postgrest.dart';
+export 'package:postgrest/postgrest.dart' hide HttpMethod;
 export 'package:realtime_client/realtime_client.dart';
 export 'package:storage_client/storage_client.dart';
 

--- a/packages/supabase/lib/supabase.dart
+++ b/packages/supabase/lib/supabase.dart
@@ -1,8 +1,7 @@
 /// A dart client for Supabase. It supports database query, authenticate users
 /// and listen for realtime changes. This client makes it simple for developers
 /// to build secure and scalable products.
-///
-library supabase;
+library;
 
 export 'package:functions_client/functions_client.dart';
 export 'package:gotrue/gotrue.dart';

--- a/packages/supabase/pubspec.yaml
+++ b/packages/supabase/pubspec.yaml
@@ -20,6 +20,6 @@ dependencies:
   logging: ^1.2.0
 
 dev_dependencies:
-  lints: ^6.1.0
+  lints: ^4.0.0
   test: ^1.17.9
   web_socket_channel: '>=2.2.0 <4.0.0'

--- a/packages/supabase/pubspec.yaml
+++ b/packages/supabase/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 dependencies:
   functions_client: 2.6.0
   gotrue: 2.21.0
-  http: '>=0.13.5 <2.0.0'
+  http: '>=1.0.0 <2.0.0'
   postgrest: 2.7.1
   realtime_client: 2.7.4
   storage_client: 2.5.6

--- a/packages/supabase/pubspec.yaml
+++ b/packages/supabase/pubspec.yaml
@@ -20,6 +20,6 @@ dependencies:
   logging: ^1.2.0
 
 dev_dependencies:
-  lints: ^3.0.0
+  lints: ^6.1.0
   test: ^1.17.9
   web_socket_channel: '>=2.2.0 <4.0.0'

--- a/packages/supabase/pubspec.yaml
+++ b/packages/supabase/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 dependencies:
   functions_client: 2.6.0
   gotrue: 2.21.0
-  http: ^1.0.0
+  http: ^1.6.0
   postgrest: 2.7.1
   realtime_client: 2.7.4
   storage_client: 2.5.6

--- a/packages/supabase/pubspec.yaml
+++ b/packages/supabase/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 dependencies:
   functions_client: 2.6.0
   gotrue: 2.21.0
-  http: '>=1.0.0 <2.0.0'
+  http: ^1.0.0
   postgrest: 2.7.1
   realtime_client: 2.7.4
   storage_client: 2.5.6

--- a/packages/supabase/pubspec.yaml
+++ b/packages/supabase/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 dependencies:
   functions_client: 2.6.0
   gotrue: 2.21.0
-  http: ^1.6.0
+  http: ^1.2.2
   postgrest: 2.7.1
   realtime_client: 2.7.4
   storage_client: 2.5.6

--- a/packages/supabase_flutter/analysis_options.yaml
+++ b/packages/supabase_flutter/analysis_options.yaml
@@ -1,5 +1,4 @@
 include: package:flutter_lints/flutter.yaml
 
-linter:
-  rules:
-    avoid_print: false
+formatter:
+  trailing_commas: preserve

--- a/packages/supabase_flutter/example/analysis_options.yaml
+++ b/packages/supabase_flutter/example/analysis_options.yaml
@@ -30,3 +30,6 @@ analyzer:
     - lib/generated_plugin_registrant.dart
 # Additional information about this file can be found at
 # https://dart.dev/guides/language/analysis-options
+
+formatter:
+  trailing_commas: preserve

--- a/packages/supabase_flutter/example/pubspec.yaml
+++ b/packages/supabase_flutter/example/pubspec.yaml
@@ -17,7 +17,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
-  flutter_lints: ^6.0.0
+  flutter_lints: ^4.0.0
 
 flutter:
   uses-material-design: true

--- a/packages/supabase_flutter/example/pubspec.yaml
+++ b/packages/supabase_flutter/example/pubspec.yaml
@@ -17,7 +17,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
-  flutter_lints: ^3.0.1
+  flutter_lints: ^6.0.0
 
 flutter:
   uses-material-design: true

--- a/packages/supabase_flutter/lib/src/local_storage_stub.dart
+++ b/packages/supabase_flutter/lib/src/local_storage_stub.dart
@@ -1,9 +1,10 @@
 // coverage:ignore-file
-Future<bool> hasAccessToken(_) => throw UnimplementedError();
+Future<bool> hasAccessToken(String _) => throw UnimplementedError();
 
-Future<String?> accessToken(_) async => throw UnimplementedError();
+Future<String?> accessToken(String _) async => throw UnimplementedError();
 
-Future<void> removePersistedSession(_) async => throw UnimplementedError();
+Future<void> removePersistedSession(String _) async =>
+    throw UnimplementedError();
 
-Future<void> persistSession(_, persistSessionString) async =>
+Future<void> persistSession(String _, String persistSessionString) async =>
     throw UnimplementedError();

--- a/packages/supabase_flutter/lib/supabase_flutter.dart
+++ b/packages/supabase_flutter/lib/supabase_flutter.dart
@@ -1,3 +1,4 @@
+/// Flutter integration for Supabase.
 library;
 
 export 'package:supabase/supabase.dart';

--- a/packages/supabase_flutter/lib/supabase_flutter.dart
+++ b/packages/supabase_flutter/lib/supabase_flutter.dart
@@ -1,7 +1,4 @@
-/// Supabase Client Library for Flutter.
-///
-/// See <https://github.com/supabase/supabase-flutter> to learn more
-library supabase_flutter;
+library;
 
 export 'package:supabase/supabase.dart';
 export 'package:url_launcher/url_launcher.dart' show LaunchMode;

--- a/packages/supabase_flutter/pubspec.yaml
+++ b/packages/supabase_flutter/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   async: ^2.11.0
   flutter:
     sdk: flutter
-  http: ^1.6.0
+  http: ^1.2.2
   meta: ^1.7.0
   supabase: 2.12.2
   url_launcher: ^6.1.2

--- a/packages/supabase_flutter/pubspec.yaml
+++ b/packages/supabase_flutter/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   async: ^2.11.0
   flutter:
     sdk: flutter
-  http: '>=1.0.0 <2.0.0'
+  http: ^1.0.0
   meta: ^1.7.0
   supabase: 2.12.2
   url_launcher: ^6.1.2

--- a/packages/supabase_flutter/pubspec.yaml
+++ b/packages/supabase_flutter/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   async: ^2.11.0
   flutter:
     sdk: flutter
-  http: ^1.0.0
+  http: ^1.6.0
   meta: ^1.7.0
   supabase: 2.12.2
   url_launcher: ^6.1.2

--- a/packages/supabase_flutter/pubspec.yaml
+++ b/packages/supabase_flutter/pubspec.yaml
@@ -26,7 +26,7 @@ dev_dependencies:
   dart_jsonwebtoken: ">=2.17.0 <4.0.0"
   flutter_test:
     sdk: flutter
-  flutter_lints: ^6.0.0
+  flutter_lints: ^4.0.0
   web_socket_channel: '>=2.3.0 <4.0.0'
 
 platforms:

--- a/packages/supabase_flutter/pubspec.yaml
+++ b/packages/supabase_flutter/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   async: ^2.11.0
   flutter:
     sdk: flutter
-  http: '>=0.13.4 <2.0.0'
+  http: '>=1.0.0 <2.0.0'
   meta: ^1.7.0
   supabase: 2.12.2
   url_launcher: ^6.1.2

--- a/packages/supabase_flutter/pubspec.yaml
+++ b/packages/supabase_flutter/pubspec.yaml
@@ -28,7 +28,7 @@ dev_dependencies:
   dart_jsonwebtoken: ">=2.17.0 <4.0.0"
   flutter_test:
     sdk: flutter
-  flutter_lints: ^3.0.1
+  flutter_lints: ^6.0.0
   path: ^1.8.3
   web_socket_channel: '>=2.3.0 <4.0.0'
 

--- a/packages/supabase_flutter/test/deep_link_test.dart
+++ b/packages/supabase_flutter/test/deep_link_test.dart
@@ -1,4 +1,5 @@
 @TestOn('!browser')
+library;
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';

--- a/packages/supabase_flutter/test/deep_link_test.dart
+++ b/packages/supabase_flutter/test/deep_link_test.dart
@@ -1,4 +1,5 @@
 @TestOn('!browser')
+/// Tests for deep link handling on non-browser platforms.
 library;
 
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/supabase_flutter/test/deep_link_test.dart
+++ b/packages/supabase_flutter/test/deep_link_test.dart
@@ -1,4 +1,5 @@
 @TestOn('!browser')
+
 /// Tests for deep link handling on non-browser platforms.
 library;
 

--- a/packages/yet_another_json_isolate/analysis_options.yaml
+++ b/packages/yet_another_json_isolate/analysis_options.yaml
@@ -1,30 +1,4 @@
-# This file configures the static analysis results for your project (errors,
-# warnings, and lints).
-#
-# This enables the 'recommended' set of lints from `package:lints`.
-# This set helps identify many issues that may lead to problems when running
-# or consuming Dart code, and enforces writing Dart using a single, idiomatic
-# style and format.
-#
-# If you want a smaller set of lints you can change this to specify
-# 'package:lints/core.yaml'. These are just the most critical lints
-# (the recommended set includes the core lints).
-# The core lints are also what is used by pub.dev for scoring packages.
-
 include: package:lints/recommended.yaml
 
-# Uncomment the following section to specify additional rules.
-
-# linter:
-#   rules:
-#     - camel_case_types
-
-# analyzer:
-#   exclude:
-#     - path/to/excluded/files/**
-
-# For more information about the core and recommended set of lints, see
-# https://dart.dev/go/core-lints
-
-# For additional information about configuring this file, see
-# https://dart.dev/guides/language/analysis-options
+formatter:
+  trailing_commas: preserve

--- a/packages/yet_another_json_isolate/lib/yet_another_json_isolate.dart
+++ b/packages/yet_another_json_isolate/lib/yet_another_json_isolate.dart
@@ -1,4 +1,4 @@
-library yet_another_json_isolate;
+library;
 
 export 'src/_isolates_io.dart'
     if (dart.library.js_interop) 'src/_isolates_web.dart' // After Dart 3.3

--- a/packages/yet_another_json_isolate/lib/yet_another_json_isolate.dart
+++ b/packages/yet_another_json_isolate/lib/yet_another_json_isolate.dart
@@ -1,3 +1,4 @@
+/// Simplifies JSON parsing in isolates by keeping one isolate running per instance.
 library;
 
 export 'src/_isolates_io.dart'

--- a/packages/yet_another_json_isolate/pubspec.yaml
+++ b/packages/yet_another_json_isolate/pubspec.yaml
@@ -10,5 +10,5 @@ dependencies:
   async: ^2.8.0
 
 dev_dependencies:
-  lints: ^3.0.0
+  lints: ^6.1.0
   test: ^1.16.0

--- a/packages/yet_another_json_isolate/pubspec.yaml
+++ b/packages/yet_another_json_isolate/pubspec.yaml
@@ -10,5 +10,5 @@ dependencies:
   async: ^2.8.0
 
 dev_dependencies:
-  lints: ^6.1.0
+  lints: ^4.0.0
   test: ^1.16.0


### PR DESCRIPTION
## Summary

- Upgrades `flutter_lints` to `^4.0.0` (supabase_flutter) and `lints` to `^4.0.0` (all other packages), compatible with the existing `sdk: >=3.3.0` constraint
- Adds `formatter: trailing_commas: preserve` to all `analysis_options.yaml` files
- Removes `avoid_print: false` overrides (rule is now enforced)
- Renames `_HttpMethod` to `HttpMethod` in postgrest, fixing `library_private_types_in_public_api`; hides it from the `supabase` re-export to avoid conflict with `functions_client`'s `HttpMethod`
- Fixes `invalid_runtime_check_with_js_interop_types` in `broadcast_web.dart` by typing the handler directly as `MessageEvent`
- Adds `library;` directives to export files that carry `@TestOn` or other library-level annotations
- Adds missing type annotations (`strict_top_level_inference`) in `local_storage_stub.dart` and `realtime_channel.dart`
- Removes stale `// ignore: non_constant_identifier_names` comments from `postgrest_filter_builder.dart`

`flutter analyze` reports no issues after these changes.