### PR TITLE
fix(auth): update session on email change links in PKCE flow

### DIFF
--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -943,6 +943,10 @@ class GoTrueClient {
       _saveSession(session);
       if (redirectType == 'recovery') {
         notifyAllSubscribers(AuthChangeEvent.passwordRecovery);
+      } else if (redirectType == 'email_change') {
+        // The user was already signed in and only changed their email, so emit
+        // a userUpdated event rather than treating this as a fresh sign in.
+        notifyAllSubscribers(AuthChangeEvent.userUpdated);
       } else {
         notifyAllSubscribers(AuthChangeEvent.signedIn);
       }

--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -939,8 +939,6 @@ class GoTrueClient {
       _saveSession(session);
       if (redirectType == 'recovery') {
         notifyAllSubscribers(AuthChangeEvent.passwordRecovery);
-      } else if (redirectType == 'email_change') {
-        notifyAllSubscribers(AuthChangeEvent.userUpdated);
       } else {
         notifyAllSubscribers(AuthChangeEvent.signedIn);
       }

--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -886,14 +886,20 @@ class GoTrueClient {
       throw AuthException(errorDescription, statusCode: errorCode, code: error);
     }
 
-    if (_flowType == AuthFlowType.pkce) {
-      final authCode = originUrl.queryParameters['code'];
-      if (authCode == null) {
-        throw AuthPKCEGrantCodeExchangeError(
-          'No code detected in query parameters.',
-        );
-      }
+    // Detect the callback type from the URL contents rather than the
+    // configured flow type. Some redirects (e.g. email change confirmation)
+    // return implicit-style tokens in the URL fragment even when the client is
+    // configured for PKCE, so we must handle whichever form the URL contains.
+    final authCode = url.queryParameters['code'];
+    if (authCode != null) {
       return await exchangeCodeForSession(authCode);
+    }
+
+    if (_flowType == AuthFlowType.pkce &&
+        !url.queryParameters.containsKey('access_token')) {
+      throw AuthPKCEGrantCodeExchangeError(
+        'No code detected in query parameters.',
+      );
     }
 
     final accessToken = url.queryParameters['access_token'];

--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -886,10 +886,6 @@ class GoTrueClient {
       throw AuthException(errorDescription, statusCode: errorCode, code: error);
     }
 
-    // Detect the callback type from the URL contents rather than the
-    // configured flow type. Some redirects (e.g. email change confirmation)
-    // return implicit-style tokens in the URL fragment even when the client is
-    // configured for PKCE, so we must handle whichever form the URL contains.
     final authCode = url.queryParameters['code'];
     if (authCode != null) {
       return await exchangeCodeForSession(authCode);
@@ -944,8 +940,6 @@ class GoTrueClient {
       if (redirectType == 'recovery') {
         notifyAllSubscribers(AuthChangeEvent.passwordRecovery);
       } else if (redirectType == 'email_change') {
-        // The user was already signed in and only changed their email, so emit
-        // a userUpdated event rather than treating this as a fresh sign in.
         notifyAllSubscribers(AuthChangeEvent.userUpdated);
       } else {
         notifyAllSubscribers(AuthChangeEvent.signedIn);

--- a/packages/gotrue/test/client_test.dart
+++ b/packages/gotrue/test/client_test.dart
@@ -692,6 +692,47 @@ void main() {
         );
       }
     });
+
+    test(
+      'getSessionFromUrl handles implicit tokens in the fragment',
+      () async {
+        // Email change confirmation links return implicit-style tokens in the
+        // fragment even when the client is configured for the PKCE flow, so
+        // they must still be handled. See
+        // https://github.com/supabase/supabase-flutter/issues/986
+        final pkceClient = GoTrueClient(
+          url: gotrueUrl,
+          flowType: AuthFlowType.pkce,
+          asyncStorage: TestAsyncStorage(),
+          httpClient: MockedHttpClient({
+            'id': '18bc7a4e-c095-4573-93dc-e0be29bada97',
+            'aud': '',
+            'role': '',
+            'email': 'new@email.com',
+            'app_metadata': {
+              'provider': 'email',
+              'providers': ['email']
+            },
+            'user_metadata': {},
+            'created_at': '2023-04-01T09:38:59.784028Z',
+            'updated_at': '2023-04-01T09:38:59.908816Z',
+          }),
+        );
+
+        final url = Uri.parse(
+          'http://my-callback-url.com/#access_token=my-access-token'
+          '&expires_in=3600&refresh_token=my-refresh-token'
+          '&token_type=bearer&type=email_change',
+        );
+
+        final res = await pkceClient.getSessionFromUrl(url);
+        expect(res.session.accessToken, 'my-access-token');
+        expect(res.session.refreshToken, 'my-refresh-token');
+        expect(res.session.user.email, 'new@email.com');
+        expect(res.redirectType, 'email_change');
+        expect(pkceClient.currentUser?.email, 'new@email.com');
+      },
+    );
   });
 
   group('Recovering an already refreshed session', () {

--- a/packages/gotrue/test/client_test.dart
+++ b/packages/gotrue/test/client_test.dart
@@ -726,7 +726,8 @@ void main() {
         );
 
         final emittedEvent = pkceClient.onAuthStateChange
-            .firstWhere((state) => state.event != AuthChangeEvent.initialSession)
+            .firstWhere(
+                (state) => state.event != AuthChangeEvent.initialSession)
             .then((state) => state.event);
 
         final res = await pkceClient.getSessionFromUrl(url);

--- a/packages/gotrue/test/client_test.dart
+++ b/packages/gotrue/test/client_test.dart
@@ -696,10 +696,6 @@ void main() {
     test(
       'getSessionFromUrl handles implicit tokens in the fragment',
       () async {
-        // Email change confirmation links return implicit-style tokens in the
-        // fragment even when the client is configured for the PKCE flow, so
-        // they must still be handled. See
-        // https://github.com/supabase/supabase-flutter/issues/986
         final pkceClient = GoTrueClient(
           url: gotrueUrl,
           flowType: AuthFlowType.pkce,

--- a/packages/gotrue/test/client_test.dart
+++ b/packages/gotrue/test/client_test.dart
@@ -726,11 +726,11 @@ void main() {
                 (state) => state.event != AuthChangeEvent.initialSession)
             .then((state) => state.event);
 
-        final res = await pkceClient.getSessionFromUrl(url);
-        expect(res.session.accessToken, 'my-access-token');
-        expect(res.session.refreshToken, 'my-refresh-token');
-        expect(res.session.user.email, 'new@email.com');
-        expect(res.redirectType, 'email_change');
+        final response = await pkceClient.getSessionFromUrl(url);
+        expect(response.session.accessToken, 'my-access-token');
+        expect(response.session.refreshToken, 'my-refresh-token');
+        expect(response.session.user.email, 'new@email.com');
+        expect(response.redirectType, 'email_change');
         expect(pkceClient.currentUser?.email, 'new@email.com');
         expect(await emittedEvent, AuthChangeEvent.userUpdated);
       },

--- a/packages/gotrue/test/client_test.dart
+++ b/packages/gotrue/test/client_test.dart
@@ -732,7 +732,7 @@ void main() {
         expect(response.session.user.email, 'new@email.com');
         expect(response.redirectType, 'email_change');
         expect(pkceClient.currentUser?.email, 'new@email.com');
-        expect(await emittedEvent, AuthChangeEvent.userUpdated);
+        expect(await emittedEvent, AuthChangeEvent.signedIn);
       },
     );
   });

--- a/packages/gotrue/test/client_test.dart
+++ b/packages/gotrue/test/client_test.dart
@@ -725,12 +725,17 @@ void main() {
           '&token_type=bearer&type=email_change',
         );
 
+        final emittedEvent = pkceClient.onAuthStateChange
+            .firstWhere((state) => state.event != AuthChangeEvent.initialSession)
+            .then((state) => state.event);
+
         final res = await pkceClient.getSessionFromUrl(url);
         expect(res.session.accessToken, 'my-access-token');
         expect(res.session.refreshToken, 'my-refresh-token');
         expect(res.session.user.email, 'new@email.com');
         expect(res.redirectType, 'email_change');
         expect(pkceClient.currentUser?.email, 'new@email.com');
+        expect(await emittedEvent, AuthChangeEvent.userUpdated);
       },
     );
   });

--- a/packages/supabase_flutter/lib/src/supabase_auth.dart
+++ b/packages/supabase_flutter/lib/src/supabase_auth.dart
@@ -52,7 +52,6 @@ class SupabaseAuth with WidgetsBindingObserver {
   static WidgetsBinding? get _widgetsBindingInstance => WidgetsBinding.instance;
 
   late LocalStorage _localStorage;
-  late AuthFlowType _authFlowType;
 
   /// Whether to automatically refresh the token
   late bool _autoRefreshToken;
@@ -81,7 +80,6 @@ class SupabaseAuth with WidgetsBindingObserver {
     required FlutterAuthClientOptions options,
   }) async {
     _localStorage = options.localStorage!;
-    _authFlowType = options.authFlowType;
     _autoRefreshToken = options.autoRefreshToken;
 
     _authSubscription = Supabase.instance.client.auth.onAuthStateChange.listen(
@@ -181,11 +179,13 @@ class SupabaseAuth with WidgetsBindingObserver {
 
   /// If _authCallbackUrlHost not init, we treat all deep links as auth callback
   bool _isAuthCallbackDeeplink(Uri uri) {
-    return (uri.fragment.contains('access_token') &&
-            _authFlowType == AuthFlowType.implicit) ||
-        (uri.queryParameters.containsKey('code') &&
-            _authFlowType == AuthFlowType.pkce) ||
-        (uri.fragment.contains('error_description'));
+    // Detect the callback from the URL contents rather than the configured
+    // flow type. Some redirects (e.g. email change confirmation) return
+    // implicit-style tokens in the fragment even when the client is configured
+    // for PKCE, so both forms must be recognized regardless of the flow type.
+    return uri.fragment.contains('access_token') ||
+        uri.queryParameters.containsKey('code') ||
+        uri.fragment.contains('error_description');
   }
 
   /// Enable deep link observer to handle deep links

--- a/packages/supabase_flutter/lib/src/supabase_auth.dart
+++ b/packages/supabase_flutter/lib/src/supabase_auth.dart
@@ -179,16 +179,6 @@ class SupabaseAuth with WidgetsBindingObserver {
 
   /// If _authCallbackUrlHost not init, we treat all deep links as auth callback
   bool _isAuthCallbackDeeplink(Uri uri) {
-    // Detect the callback from the URL contents rather than the configured
-    // flow type. Some redirects (e.g. email change confirmation) return
-    // implicit-style tokens in the fragment even when the client is configured
-    // for PKCE, so both forms must be recognized regardless of the flow type.
-    //
-    // Auth parameters can be delivered either in the query (PKCE) or in the
-    // fragment (implicit), so both are inspected, mirroring how
-    // [GoTrueClient.getSessionFromUrl] parses the URL. Parameter keys are
-    // matched exactly to avoid false positives from unrelated deep links that
-    // merely contain one of these words.
     final fragmentParameters = Uri.splitQueryString(uri.fragment);
     bool hasParameter(String key) =>
         uri.queryParameters.containsKey(key) ||

--- a/packages/supabase_flutter/lib/src/supabase_auth.dart
+++ b/packages/supabase_flutter/lib/src/supabase_auth.dart
@@ -183,9 +183,20 @@ class SupabaseAuth with WidgetsBindingObserver {
     // flow type. Some redirects (e.g. email change confirmation) return
     // implicit-style tokens in the fragment even when the client is configured
     // for PKCE, so both forms must be recognized regardless of the flow type.
-    return uri.fragment.contains('access_token') ||
-        uri.queryParameters.containsKey('code') ||
-        uri.fragment.contains('error_description');
+    //
+    // Auth parameters can be delivered either in the query (PKCE) or in the
+    // fragment (implicit), so both are inspected, mirroring how
+    // [GoTrueClient.getSessionFromUrl] parses the URL. Parameter keys are
+    // matched exactly to avoid false positives from unrelated deep links that
+    // merely contain one of these words.
+    final fragmentParameters = Uri.splitQueryString(uri.fragment);
+    bool hasParameter(String key) =>
+        uri.queryParameters.containsKey(key) ||
+        fragmentParameters.containsKey(key);
+
+    return hasParameter('access_token') ||
+        hasParameter('code') ||
+        hasParameter('error_description');
   }
 
   /// Enable deep link observer to handle deep links

--- a/packages/supabase_flutter/test/deep_link_test.dart
+++ b/packages/supabase_flutter/test/deep_link_test.dart
@@ -52,7 +52,7 @@ void main() {
 
   group('Deep Link with implicit token while PKCE flow is configured', () {
     late final GetUserHttpClient getUserHttpClient;
-    late final Future<AuthState> userUpdatedState;
+    late final Future<AuthState> signedInState;
 
     setUp(() async {
       getUserHttpClient = GetUserHttpClient('new@email.com');
@@ -75,15 +75,15 @@ void main() {
         ),
       );
 
-      userUpdatedState = Supabase.instance.client.auth.onAuthStateChange
-          .firstWhere((state) => state.event == AuthChangeEvent.userUpdated)
+      signedInState = Supabase.instance.client.auth.onAuthStateChange
+          .firstWhere((state) => state.event == AuthChangeEvent.signedIn)
           .timeout(const Duration(seconds: 5));
     });
 
     test(
         'Implicit token in the fragment triggers `getSessionFromUrl` and '
         'updates the current user', () async {
-      final state = await userUpdatedState;
+      final state = await signedInState;
       expect(state.session?.user.email, 'new@email.com');
       expect(getUserHttpClient.requestCount, 1);
       expect(getUserHttpClient.lastRequestUrl?.path, endsWith('/user'));

--- a/packages/supabase_flutter/test/deep_link_test.dart
+++ b/packages/supabase_flutter/test/deep_link_test.dart
@@ -57,9 +57,6 @@ void main() {
     setUp(() async {
       getUserHttpClient = GetUserHttpClient('new@email.com');
 
-      // Email change confirmation links return implicit-style tokens in the
-      // fragment even when the client is configured for the (default) PKCE
-      // flow. See https://github.com/supabase/supabase-flutter/issues/986
       mockAppLink(
         mockMethodChannel: false,
         mockEventChannel: true,
@@ -78,8 +75,6 @@ void main() {
         ),
       );
 
-      // Subscribe before the (asynchronously delivered) deep link is handled so
-      // the event is not missed, avoiding a flaky fixed delay.
       userUpdatedState = Supabase.instance.client.auth.onAuthStateChange
           .firstWhere((state) => state.event == AuthChangeEvent.userUpdated)
           .timeout(const Duration(seconds: 5));

--- a/packages/supabase_flutter/test/deep_link_test.dart
+++ b/packages/supabase_flutter/test/deep_link_test.dart
@@ -9,6 +9,10 @@ void main() {
   const supabaseUrl = '';
   const supabaseKey = '';
 
+  tearDown(() async {
+    await Supabase.instance.dispose();
+  });
+
   group('Deep Link with PKCE code', () {
     late final PkceHttpClient pkceHttpClient;
 
@@ -43,6 +47,49 @@ void main() {
       await Future.delayed(const Duration(milliseconds: 500));
       expect(pkceHttpClient.requestCount, 1);
       expect(pkceHttpClient.lastRequestBody['auth_code'], 'my-code-verifier');
+    });
+  });
+
+  group('Deep Link with implicit token while PKCE flow is configured', () {
+    late final GetUserHttpClient getUserHttpClient;
+
+    setUp(() async {
+      getUserHttpClient = GetUserHttpClient('new@email.com');
+
+      // Email change confirmation links return implicit-style tokens in the
+      // fragment even when the client is configured for the (default) PKCE
+      // flow. See https://github.com/supabase/supabase-flutter/issues/986
+      mockAppLink(
+        mockMethodChannel: false,
+        mockEventChannel: true,
+        initialLink: 'com.supabase://callback/#access_token=my-access-token'
+            '&expires_in=3600&refresh_token=my-refresh-token'
+            '&token_type=bearer&type=email_change',
+      );
+      await Supabase.initialize(
+        url: supabaseUrl,
+        publishableKey: supabaseKey,
+        debug: false,
+        httpClient: getUserHttpClient,
+        authOptions: FlutterAuthClientOptions(
+          localStorage: MockEmptyLocalStorage(),
+          pkceAsyncStorage: MockAsyncStorage(),
+        ),
+      );
+    });
+
+    test(
+        'Implicit token in the fragment triggers `getSessionFromUrl` and '
+        'updates the current user', () async {
+      // Wait for the initial app link to be handled, as this is an async
+      // process when mocking the event channel.
+      await Future.delayed(const Duration(milliseconds: 500));
+      expect(getUserHttpClient.requestCount, 1);
+      expect(getUserHttpClient.lastRequestUrl?.path, endsWith('/user'));
+      expect(
+        Supabase.instance.client.auth.currentUser?.email,
+        'new@email.com',
+      );
     });
   });
 }

--- a/packages/supabase_flutter/test/deep_link_test.dart
+++ b/packages/supabase_flutter/test/deep_link_test.dart
@@ -52,6 +52,7 @@ void main() {
 
   group('Deep Link with implicit token while PKCE flow is configured', () {
     late final GetUserHttpClient getUserHttpClient;
+    late final Future<AuthState> userUpdatedState;
 
     setUp(() async {
       getUserHttpClient = GetUserHttpClient('new@email.com');
@@ -76,14 +77,19 @@ void main() {
           pkceAsyncStorage: MockAsyncStorage(),
         ),
       );
+
+      // Subscribe before the (asynchronously delivered) deep link is handled so
+      // the event is not missed, avoiding a flaky fixed delay.
+      userUpdatedState = Supabase.instance.client.auth.onAuthStateChange
+          .firstWhere((state) => state.event == AuthChangeEvent.userUpdated)
+          .timeout(const Duration(seconds: 5));
     });
 
     test(
         'Implicit token in the fragment triggers `getSessionFromUrl` and '
         'updates the current user', () async {
-      // Wait for the initial app link to be handled, as this is an async
-      // process when mocking the event channel.
-      await Future.delayed(const Duration(milliseconds: 500));
+      final state = await userUpdatedState;
+      expect(state.session?.user.email, 'new@email.com');
       expect(getUserHttpClient.requestCount, 1);
       expect(getUserHttpClient.lastRequestUrl?.path, endsWith('/user'));
       expect(

--- a/packages/supabase_flutter/test/widget_test_stubs.dart
+++ b/packages/supabase_flutter/test/widget_test_stubs.dart
@@ -133,10 +133,6 @@ void mockAppLink({
   }
 }
 
-/// HTTP client that mimics the `GET /user` endpoint returning the given email.
-///
-/// Used to verify that an implicit-style token callback (e.g. an email change
-/// confirmation link) is handled even when the client is configured for PKCE.
 class GetUserHttpClient extends BaseClient {
   GetUserHttpClient(this.email);
 

--- a/packages/supabase_flutter/test/widget_test_stubs.dart
+++ b/packages/supabase_flutter/test/widget_test_stubs.dart
@@ -133,6 +133,48 @@ void mockAppLink({
   }
 }
 
+/// HTTP client that mimics the `GET /user` endpoint returning the given email.
+///
+/// Used to verify that an implicit-style token callback (e.g. an email change
+/// confirmation link) is handled even when the client is configured for PKCE.
+class GetUserHttpClient extends BaseClient {
+  GetUserHttpClient(this.email);
+
+  final String email;
+  int requestCount = 0;
+  Uri? lastRequestUrl;
+
+  @override
+  Future<StreamedResponse> send(BaseRequest request) async {
+    requestCount++;
+    lastRequestUrl = request.url;
+
+    return StreamedResponse(
+      Stream.value(
+        utf8.encode(
+          jsonEncode(
+            {
+              'id': '18bc7a4e-c095-4573-93dc-e0be29bada97',
+              'aud': '',
+              'role': '',
+              'email': email,
+              'app_metadata': {
+                'provider': 'email',
+                'providers': ['email']
+              },
+              'user_metadata': {},
+              'created_at': '2023-04-01T09:38:59.784028Z',
+              'updated_at': '2023-04-01T09:38:59.908816Z',
+            },
+          ),
+        ),
+      ),
+      200,
+      request: request,
+    );
+  }
+}
+
 class MockAsyncStorage extends GotrueAsyncStorage {
   final Map<String, String> _map = {};
 


### PR DESCRIPTION
## Description

Fixes #986. `auth.currentUser?.email` still contained the old email after an email change was confirmed.

### Root cause

`supabase_flutter` defaults to the **PKCE** flow. However, `updateUser` does not send a `code_challenge` when initiating an email change (unlike `resetPasswordForEmail`), so GoTrue returns an **implicit-style** confirmation link with the tokens in the URL fragment (`#access_token=...&type=email_change`), not a PKCE `code`.

Both the deep-link detector and `getSessionFromUrl` gated their behavior on the *configured* flow type:

- `SupabaseAuth._isAuthCallbackDeeplink` only recognized an `access_token` fragment when the flow was `implicit`, so for a PKCE-configured client the email-change link was ignored entirely and `getSessionFromUrl` was never called.
- `GoTrueClient.getSessionFromUrl` threw `AuthPKCEGrantCodeExchangeError('No code detected...')` for any PKCE-flow URL without a `code`, so even if reached it would reject the token.

The result was that the session was never updated and the stale email remained.

### Fix

Detect the callback type from the **URL contents** rather than the configured flow type (matching how `supabase-js` behaves):

- `gotrue`: exchange the code when a `code` is present; otherwise fall through to implicit token handling. Only throw the PKCE error when there is neither a `code` nor an `access_token`.
- `supabase_flutter`: recognize the `access_token` / `code` / `error_description` parameters in both the query and the fragment, matching them as exact keys rather than substrings, regardless of the configured flow type. Removed the now-unused `_authFlowType` field.

### Edge-case behavior change to note

A client configured for the `implicit` flow that receives a URL containing a `code` will now route to `exchangeCodeForSession` (which requires `asyncStorage`), whereas previously it would fall through to "No access_token detected". In `supabase_flutter` this is safe because `pkceAsyncStorage` is always set by default. For direct `gotrue` usage with `flowType: implicit` and no `asyncStorage`, this would assert. This matches `supabase-js`, which also detects by URL contents.

### Tests

- `gotrue/test/client_test.dart`: server-free unit test confirming a PKCE-configured client handles implicit tokens in the fragment, updates `currentUser`, and emits `signedIn`.
- `supabase_flutter/test/deep_link_test.dart`: verifies an implicit-style token deep link triggers `getSessionFromUrl` and updates `currentUser.email` while configured for PKCE. Waits on the specific auth state event rather than a fixed delay.

All affected package tests pass and `dart analyze` is clean.

## What kind of change does this PR introduce?

Bug fix
