### PR TITLE
chore: add All as top option in Platform dropdown of bug report form

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -73,6 +73,7 @@ body:
       description: Select the platform(s) on which you can reproduce the bug
       multiple: true
       options:
+        - All
         - Android
         - iOS
         - Web


### PR DESCRIPTION
## What kind of change does this PR introduce?

Adds "All" as the top option in the Platform dropdown of the bug report issue form, so reporters can indicate a bug reproduces across all platforms without selecting each one individually.