### PR TITLE
chore: bump supabase/actions reusable workflows to latest sha

### DIFF
--- a/.github/workflows/block-merge.yml
+++ b/.github/workflows/block-merge.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   block-merge:
-    uses: supabase/actions/.github/workflows/block-merge.yml@659b3cd74a64ee2f1ca0a527922f134707e54671
+    uses: supabase/actions/.github/workflows/block-merge.yml@2e898cb306c525525ad3f0b34c6f0ab1e3f8ba87
     with:
       block_labels: "do-not-merge,blocked"
       block_keywords: "wip,do not merge"

--- a/.github/workflows/block-merge.yml
+++ b/.github/workflows/block-merge.yml
@@ -11,6 +11,8 @@ on:
       - labeled
       - unlabeled
 
+permissions: {}
+
 jobs:
   block-merge:
     uses: supabase/actions/.github/workflows/block-merge.yml@2e898cb306c525525ad3f0b34c6f0ab1e3f8ba87

--- a/.github/workflows/label-issues.yml
+++ b/.github/workflows/label-issues.yml
@@ -10,6 +10,10 @@ on:
       - opened
       - edited
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   label:
     uses: supabase/actions/.github/workflows/label-issues.yml@2e898cb306c525525ad3f0b34c6f0ab1e3f8ba87

--- a/.github/workflows/label-issues.yml
+++ b/.github/workflows/label-issues.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   label:
-    uses: supabase/actions/.github/workflows/label-issues.yml@659b3cd74a64ee2f1ca0a527922f134707e54671
+    uses: supabase/actions/.github/workflows/label-issues.yml@2e898cb306c525525ad3f0b34c6f0ab1e3f8ba87
     with:
       label_mappings: |
         {

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -6,6 +6,10 @@ on:
     - cron: "0 0 * * 0"
   workflow_dispatch:
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   stale:
     uses: supabase/actions/.github/workflows/stale.yml@2e898cb306c525525ad3f0b34c6f0ab1e3f8ba87

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   stale:
-    uses: supabase/actions/.github/workflows/stale.yml@659b3cd74a64ee2f1ca0a527922f134707e54671
+    uses: supabase/actions/.github/workflows/stale.yml@2e898cb306c525525ad3f0b34c6f0ab1e3f8ba87
     with:
       days_before_issue_stale: 180
       days_before_issue_close: 30


### PR DESCRIPTION
Bumps the pinned `supabase/actions` ref from `659b3cd` to `2e898cb` for all three reusable workflow callers (block-merge, stale, label-issues).

This pulls in:
- **block-merge**: no longer fails on draft PRs ([supabase/actions#4](https://github.com/supabase/actions/pull/4)), since GitHub already prevents merging drafts. Label and title-keyword blocking are unchanged.
- **pinning hardening**: inner actions (e.g. `github-script`) are now pinned to SHAs and bumped to v8.

All three callers shared the same pinned SHA, so they're bumped together to stay consistent.