### PR TITLE
feat(supabase_flutter)!: use a system web auth session for OAuth, SSO and identity linking

### DIFF
--- a/packages/supabase_flutter/README.md
+++ b/packages/supabase_flutter/README.md
@@ -269,9 +269,9 @@ Future<void> _facebookSignInWeb() async {
 
 ### <a id="oauth-login"></a>OAuth login
 
-The `signInWithIdToken()` method supports providers like Apple, Google, Facebook, Kakao, and Keycloak. For other providers, you need to use the `signInWithOAuth()` method to perform OAuth login. This will open the web browser to perform the OAuth login.
+The `signInWithIdToken()` method supports providers like Apple, Google, Facebook, Kakao, and Keycloak. For other providers, you need to use the `signInWithOAuth()` method to perform OAuth login. On native platforms this opens a system web authentication session (`ASWebAuthenticationSession` on iOS and macOS, Custom Tabs on Android) that closes itself once the login completes. On web the current tab is redirected to the provider.
 
-Use the `redirectTo` parameter to redirect the user to a deep link to bring the user back to the app. Learn more about setting up deep links in [Deep link config](#deep-link-config).
+Use the `redirectTo` parameter to send the user back to the app after login. Its scheme is also the callback scheme the web authentication session listens for, so on native platforms you need to register it. See [OAuth native config](#oauth-native-config).
 
 ```dart
 // Perform web based OAuth login
@@ -288,6 +288,37 @@ supabase.auth.onAuthStateChange.listen((data) {
   }
 });
 ```
+
+#### <a id="oauth-native-config"></a>OAuth native config
+
+On native platforms `signInWithOAuth()`, `signInWithSSO()` and `linkIdentity()` run inside a system web authentication session that captures the redirect back to your app. The session listens for the scheme of your `redirectTo` URL, so that scheme has to be registered with the platform.
+
+**Android**
+
+Register the callback activity in `android/app/src/main/AndroidManifest.xml`, inside the `<application>` tag, using the scheme of your `redirectTo` (here `io.supabase.flutter`):
+
+```xml
+<activity
+    android:name="com.linusu.flutter_web_auth_2.CallbackActivity"
+    android:exported="true">
+    <intent-filter android:label="flutter_web_auth_2">
+        <action android:name="android.intent.action.VIEW" />
+        <category android:name="android.intent.category.DEFAULT" />
+        <category android:name="android.intent.category.BROWSABLE" />
+        <data android:scheme="io.supabase.flutter" />
+    </intent-filter>
+</activity>
+```
+
+**iOS and macOS**
+
+No configuration is required for custom URL schemes. If you use an `https` `redirectTo` (universal link), it is passed through automatically; on iOS 17.4+ and macOS 14.4+ the host and path are taken from `redirectTo` to satisfy the universal link requirements.
+
+**Web**
+
+No configuration is required. The current tab is redirected to the provider and the session is restored when the browser returns to your app.
+
+If you only need OAuth, SSO and identity linking, this replaces the app links deep link setup below. You still need to set up deep links for magic links, email confirmation and password recovery, which arrive as real deep links from outside the app.
 
 ### <a id="passkeys"></a>Passkeys
 
@@ -475,7 +506,8 @@ You need to setup deep links if you want your native app to open when a user cli
 - Magic link login
 - Have `confirm email` enabled and are using email login
 - Resetting password for email login
-- Calling `.signInWithOAuth()` method
+
+`.signInWithOAuth()`, `.signInWithSSO()` and `.linkIdentity()` no longer rely on these deep links. They run inside a system web authentication session that captures the redirect itself, see [OAuth native config](#oauth-native-config).
 
 \*Currently supabase_flutter supports deep links on Android, iOS, Web, MacOS and Windows.
 

--- a/packages/supabase_flutter/example/linux/flutter/generated_plugin_registrant.cc
+++ b/packages/supabase_flutter/example/linux/flutter/generated_plugin_registrant.cc
@@ -6,14 +6,22 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <desktop_webview_window/desktop_webview_window_plugin.h>
 #include <gtk/gtk_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
+#include <window_to_front/window_to_front_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
+  g_autoptr(FlPluginRegistrar) desktop_webview_window_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "DesktopWebviewWindowPlugin");
+  desktop_webview_window_plugin_register_with_registrar(desktop_webview_window_registrar);
   g_autoptr(FlPluginRegistrar) gtk_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "GtkPlugin");
   gtk_plugin_register_with_registrar(gtk_registrar);
   g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
   url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);
+  g_autoptr(FlPluginRegistrar) window_to_front_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "WindowToFrontPlugin");
+  window_to_front_plugin_register_with_registrar(window_to_front_registrar);
 }

--- a/packages/supabase_flutter/example/linux/flutter/generated_plugins.cmake
+++ b/packages/supabase_flutter/example/linux/flutter/generated_plugins.cmake
@@ -3,11 +3,14 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  desktop_webview_window
   gtk
   url_launcher_linux
+  window_to_front
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST
+  jni
 )
 
 set(PLUGIN_BUNDLED_LIBRARIES)

--- a/packages/supabase_flutter/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/packages/supabase_flutter/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -6,11 +6,17 @@ import FlutterMacOS
 import Foundation
 
 import app_links
+import desktop_webview_window
+import flutter_web_auth_2
 import shared_preferences_foundation
 import url_launcher_macos
+import window_to_front
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AppLinksMacosPlugin.register(with: registry.registrar(forPlugin: "AppLinksMacosPlugin"))
+  DesktopWebviewWindowPlugin.register(with: registry.registrar(forPlugin: "DesktopWebviewWindowPlugin"))
+  FlutterWebAuth2Plugin.register(with: registry.registrar(forPlugin: "FlutterWebAuth2Plugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
+  WindowToFrontPlugin.register(with: registry.registrar(forPlugin: "WindowToFrontPlugin"))
 }

--- a/packages/supabase_flutter/example/windows/flutter/generated_plugin_registrant.cc
+++ b/packages/supabase_flutter/example/windows/flutter/generated_plugin_registrant.cc
@@ -7,11 +7,17 @@
 #include "generated_plugin_registrant.h"
 
 #include <app_links/app_links_plugin_c_api.h>
+#include <desktop_webview_window/desktop_webview_window_plugin.h>
 #include <url_launcher_windows/url_launcher_windows.h>
+#include <window_to_front/window_to_front_plugin.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   AppLinksPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("AppLinksPluginCApi"));
+  DesktopWebviewWindowPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("DesktopWebviewWindowPlugin"));
   UrlLauncherWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("UrlLauncherWindows"));
+  WindowToFrontPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("WindowToFrontPlugin"));
 }

--- a/packages/supabase_flutter/example/windows/flutter/generated_plugins.cmake
+++ b/packages/supabase_flutter/example/windows/flutter/generated_plugins.cmake
@@ -4,10 +4,13 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   app_links
+  desktop_webview_window
   url_launcher_windows
+  window_to_front
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST
+  jni
 )
 
 set(PLUGIN_BUNDLED_LIBRARIES)

--- a/packages/supabase_flutter/lib/src/oauth_redirect_stub.dart
+++ b/packages/supabase_flutter/lib/src/oauth_redirect_stub.dart
@@ -1,0 +1,7 @@
+// coverage:ignore-file
+
+/// Navigates the current browser tab to [url].
+///
+/// Only meaningful on web. The stub throws because native and desktop platforms
+/// go through the web auth session instead of a full-page redirect.
+void redirectToUrl(String url) => throw UnimplementedError();

--- a/packages/supabase_flutter/lib/src/oauth_redirect_web.dart
+++ b/packages/supabase_flutter/lib/src/oauth_redirect_web.dart
@@ -1,0 +1,5 @@
+import 'package:web/web.dart';
+
+/// Navigates the current browser tab to [url], preserving the full-page
+/// redirect behavior the OAuth flow relies on for web.
+void redirectToUrl(String url) => window.location.assign(url);

--- a/packages/supabase_flutter/lib/src/supabase_auth.dart
+++ b/packages/supabase_flutter/lib/src/supabase_auth.dart
@@ -7,10 +7,13 @@ import 'package:flutter/foundation.dart'
     show defaultTargetPlatform, kIsWeb, TargetPlatform;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_web_auth_2/flutter_web_auth_2.dart';
 import 'package:logging/logging.dart';
 import 'package:supabase_common/supabase_common.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
-import 'package:url_launcher/url_launcher.dart';
+
+import './oauth_redirect_stub.dart'
+    if (dart.library.js_interop) './oauth_redirect_web.dart';
 
 import 'clear_auth_url_parameters_stub.dart'
     if (dart.library.js_interop) 'clear_auth_url_parameters_web.dart';
@@ -349,8 +352,8 @@ extension GoTrueClientSignInProvider on GoTrueClient {
     OAuthProvider provider, {
     String? redirectTo,
     String? scopes,
-    LaunchMode authScreenLaunchMode = LaunchMode.platformDefault,
     Map<String, String>? queryParams,
+    bool preferEphemeral = false,
   }) async {
     final res = await getOAuthSignInUrl(
       provider: provider,
@@ -358,34 +361,10 @@ extension GoTrueClientSignInProvider on GoTrueClient {
       scopes: scopes,
       queryParams: queryParams,
     );
-    return _launchAuthUrl(res.url, provider, authScreenLaunchMode);
-  }
-
-  /// Launches the [url] for an OAuth or identity-linking flow, forcing an
-  /// external browser for Google on Android.
-  Future<bool> _launchAuthUrl(
-    String url,
-    OAuthProvider provider,
-    LaunchMode authScreenLaunchMode,
-  ) {
-    final uri = Uri.parse(url);
-
-    LaunchMode launchMode = authScreenLaunchMode;
-
-    // `defaultTargetPlatform` reports the host OS even on web, so guard with
-    // `kIsWeb` to keep the external-browser workaround native-only.
-    final isAndroid =
-        !kIsWeb && defaultTargetPlatform == TargetPlatform.android;
-
-    // Google login has to be performed on external browser window on Android
-    if (provider == OAuthProvider.google && isAndroid) {
-      launchMode = LaunchMode.externalApplication;
-    }
-
-    return launchUrl(
-      uri,
-      mode: launchMode,
-      webOnlyWindowName: '_self',
+    return _authenticateWithRedirect(
+      Uri.parse(res.url),
+      redirectTo: redirectTo,
+      preferEphemeral: preferEphemeral,
     );
   }
 
@@ -402,8 +381,9 @@ extension GoTrueClientSignInProvider on GoTrueClient {
   /// If you have built an organization-specific login page, you can use the
   /// organization's SSO Identity Provider UUID directly instead.
   ///
-  /// Returns true if the URL was launched successfully, otherwise either returns
-  /// false or throws a [PlatformException] depending on the launchUrl failure.
+  /// On web the current tab is redirected to the identity provider. On every
+  /// other platform the flow runs inside a system web authentication session
+  /// and resolves once the session has been established.
   ///
   /// ```dart
   /// await supabase.auth.signInWithSSO(
@@ -415,7 +395,7 @@ extension GoTrueClientSignInProvider on GoTrueClient {
     String? domain,
     String? redirectTo,
     String? captchaToken,
-    LaunchMode launchMode = LaunchMode.platformDefault,
+    bool preferEphemeral = false,
   }) async {
     final ssoUrl = await getSSOSignInUrl(
       providerId: providerId,
@@ -423,10 +403,10 @@ extension GoTrueClientSignInProvider on GoTrueClient {
       redirectTo: redirectTo,
       captchaToken: captchaToken,
     );
-    return await launchUrl(
+    return _authenticateWithRedirect(
       Uri.parse(ssoUrl),
-      mode: launchMode,
-      webOnlyWindowName: '_self',
+      redirectTo: redirectTo,
+      preferEphemeral: preferEphemeral,
     );
   }
 
@@ -441,8 +421,8 @@ extension GoTrueClientSignInProvider on GoTrueClient {
     OAuthProvider provider, {
     String? redirectTo,
     String? scopes,
-    LaunchMode authScreenLaunchMode = LaunchMode.platformDefault,
     Map<String, String>? queryParams,
+    bool preferEphemeral = false,
   }) async {
     final res = await getLinkIdentityUrl(
       provider,
@@ -450,6 +430,52 @@ extension GoTrueClientSignInProvider on GoTrueClient {
       scopes: scopes,
       queryParams: queryParams,
     );
-    return _launchAuthUrl(res.url, provider, authScreenLaunchMode);
+    return _authenticateWithRedirect(
+      Uri.parse(res.url),
+      redirectTo: redirectTo,
+      preferEphemeral: preferEphemeral,
+    );
+  }
+
+  /// Runs an OAuth-style redirect flow for [url].
+  ///
+  /// On web the current tab is redirected to [url] and the session is picked up
+  /// when the browser returns to the app. On every other platform the flow runs
+  /// inside a system web authentication session (`ASWebAuthenticationSession` on
+  /// Apple platforms, Custom Tabs on Android) which captures the redirect to
+  /// [redirectTo] and hands it back, so the session is established before this
+  /// returns. [preferEphemeral] requests an ephemeral session that does not
+  /// share cookies with the system browser (Apple platforms and Android only).
+  Future<bool> _authenticateWithRedirect(
+    Uri url, {
+    required String? redirectTo,
+    required bool preferEphemeral,
+  }) async {
+    if (kIsWeb) {
+      redirectToUrl(url.toString());
+      return true;
+    }
+
+    if (redirectTo == null) {
+      throw const AuthException(
+        'redirectTo is required to capture the authentication callback on this '
+        'platform.',
+      );
+    }
+
+    final redirectUri = Uri.parse(redirectTo);
+    final isHttps = redirectUri.scheme == 'https';
+    final result = await FlutterWebAuth2.authenticate(
+      url: url.toString(),
+      callbackUrlScheme: redirectUri.scheme,
+      options: FlutterWebAuth2Options(
+        preferEphemeral: preferEphemeral,
+        httpsHost: isHttps ? redirectUri.host : null,
+        httpsPath: isHttps ? redirectUri.path : null,
+      ),
+    );
+
+    await getSessionFromUrl(Uri.parse(result));
+    return true;
   }
 }

--- a/packages/supabase_flutter/lib/supabase_flutter.dart
+++ b/packages/supabase_flutter/lib/supabase_flutter.dart
@@ -2,7 +2,6 @@
 library;
 
 export 'package:supabase/supabase.dart';
-export 'package:url_launcher/url_launcher.dart' show LaunchMode;
 
 export 'src/flutter_go_true_client_options.dart';
 export 'src/local_storage.dart';

--- a/packages/supabase_flutter/pubspec.yaml
+++ b/packages/supabase_flutter/pubspec.yaml
@@ -28,7 +28,7 @@ dependencies:
   passkeys_platform_interface: ^2.8.0
   supabase: 2.16.0
   supabase_common: 0.1.2
-  url_launcher: ^6.3.2
+  flutter_web_auth_2: ^5.0.0
   shared_preferences: ^2.5.5
   logging: ^1.3.0
   web: '>=1.0.0 <2.0.0'
@@ -38,6 +38,8 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   supabase_lints: ^0.1.1
+  flutter_web_auth_2_platform_interface: ^5.0.0
+  plugin_platform_interface: ^2.0.0
   web_socket_channel: '>=3.0.0 <4.0.0'
 
 platforms:

--- a/packages/supabase_flutter/test/oauth_test.dart
+++ b/packages/supabase_flutter/test/oauth_test.dart
@@ -1,0 +1,98 @@
+@TestOn('!browser')
+/// Tests for the native OAuth flow that runs through the system web
+/// authentication session.
+library;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_web_auth_2_platform_interface/flutter_web_auth_2_platform_interface.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import 'widget_test_stubs.dart';
+
+void main() {
+  late FakeFlutterWebAuth2 fakeWebAuth;
+  late PkceHttpClient pkceHttpClient;
+
+  setUp(() async {
+    TestWidgetsFlutterBinding.ensureInitialized();
+
+    fakeWebAuth = FakeFlutterWebAuth2(
+      'io.supabase.flutter://callback/?code=my-code-verifier',
+    );
+    FlutterWebAuth2Platform.instance = fakeWebAuth;
+
+    pkceHttpClient = PkceHttpClient();
+
+    await Supabase.initialize(
+      url: 'https://test.supabase.co',
+      publishableKey: '',
+      debug: false,
+      httpClient: pkceHttpClient,
+      authOptions: FlutterAuthClientOptions(
+        localStorage: MockEmptyLocalStorage(),
+        pkceAsyncStorage: MockAsyncStorage(),
+      ),
+    );
+  });
+
+  tearDown(() async {
+    await Supabase.instance.dispose();
+  });
+
+  test(
+    'signInWithOAuth runs the web auth session and exchanges the returned code',
+    () async {
+      await Supabase.instance.client.auth.signInWithOAuth(
+        OAuthProvider.github,
+        redirectTo: 'io.supabase.flutter://callback',
+      );
+
+      // The authorize URL is opened in the web auth session, and the callback
+      // scheme is derived from redirectTo.
+      expect(fakeWebAuth.authenticatedUrl, contains('/auth/v1/authorize'));
+      expect(fakeWebAuth.authenticatedUrl, contains('provider=github'));
+      expect(fakeWebAuth.callbackUrlScheme, 'io.supabase.flutter');
+
+      // The code from the callback URL is exchanged for a session.
+      expect(pkceHttpClient.lastRequestBody['auth_code'], 'my-code-verifier');
+      expect(
+        Supabase.instance.client.auth.currentUser?.email,
+        'fake1@email.com',
+      );
+    },
+  );
+
+  test(
+    'preferEphemeral is forwarded to the web auth session options',
+    () async {
+      await Supabase.instance.client.auth.signInWithOAuth(
+        OAuthProvider.github,
+        redirectTo: 'io.supabase.flutter://callback',
+        preferEphemeral: true,
+      );
+
+      expect(fakeWebAuth.options?['preferEphemeral'], true);
+    },
+  );
+
+  test('https redirectTo forwards host and path for universal links', () async {
+    await Supabase.instance.client.auth.signInWithOAuth(
+      OAuthProvider.github,
+      redirectTo: 'https://myapp.com/auth/callback',
+    );
+
+    expect(fakeWebAuth.callbackUrlScheme, 'https');
+    expect(fakeWebAuth.options?['httpsHost'], 'myapp.com');
+    expect(fakeWebAuth.options?['httpsPath'], '/auth/callback');
+  });
+
+  test(
+    'signInWithOAuth without redirectTo throws on native platforms',
+    () async {
+      await expectLater(
+        Supabase.instance.client.auth.signInWithOAuth(OAuthProvider.github),
+        throwsA(isA<AuthException>()),
+      );
+    },
+  );
+}

--- a/packages/supabase_flutter/test/widget_test_stubs.dart
+++ b/packages/supabase_flutter/test/widget_test_stubs.dart
@@ -5,10 +5,42 @@ import 'package:dart_jsonwebtoken/dart_jsonwebtoken.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_web_auth_2_platform_interface/flutter_web_auth_2_platform_interface.dart';
 import 'package:http/http.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 import 'utils.dart';
+
+/// Fake [FlutterWebAuth2Platform] that records the authentication request and
+/// returns a preconfigured callback URL, standing in for the system web auth
+/// session in tests.
+class FakeFlutterWebAuth2 extends FlutterWebAuth2Platform
+    with MockPlatformInterfaceMixin {
+  FakeFlutterWebAuth2(this.callbackUrl);
+
+  /// The callback URL the fake session resolves with.
+  final String callbackUrl;
+
+  String? authenticatedUrl;
+  String? callbackUrlScheme;
+  Map<String, dynamic>? options;
+
+  @override
+  Future<String> authenticate({
+    required String url,
+    required String callbackUrlScheme,
+    required Map<String, dynamic> options,
+  }) async {
+    authenticatedUrl = url;
+    this.callbackUrlScheme = callbackUrlScheme;
+    this.options = options;
+    return callbackUrl;
+  }
+
+  @override
+  Future<void> clearAllDanglingCalls() async {}
+}
 
 class MockWidget extends StatefulWidget {
   const MockWidget({super.key});

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -225,6 +225,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.2"
+  code_assets:
+    dependency: transitive
+    description:
+      name: code_assets
+      sha256: bf394f466ba9205f1812a0433b392d6af280f155f56651eda7c18cc32ed493b8
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.1"
   collection:
     dependency: transitive
     description:
@@ -289,6 +297,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.8"
+  desktop_webview_window:
+    dependency: transitive
+    description:
+      name: desktop_webview_window
+      sha256: b6fdae2cbf9571879b1761c12f27facaf82e22d0bdc74d049907c2a09a432957
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.0"
   device_info_plus:
     dependency: transitive
     description:
@@ -368,6 +384,22 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_web_auth_2:
+    dependency: transitive
+    description:
+      name: flutter_web_auth_2
+      sha256: "8f9303471dcd96670878c9b7c0c4e14c37595b2add67465f6a868f17a5872dfc"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.3"
+  flutter_web_auth_2_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_web_auth_2_platform_interface
+      sha256: ba0fbba55bffb47242025f96852ad1ffba34bc451568f56ef36e613612baffab
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.0"
   flutter_web_plugins:
     dependency: transitive
     description: flutter
@@ -410,6 +442,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  hooks:
+    dependency: transitive
+    description:
+      name: hooks
+      sha256: "9a62a50b50b769a737bc0a8ff381f333529df3ab746b2f6b02e83760231455ba"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.2"
   http:
     dependency: transitive
     description:
@@ -447,6 +487,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
+  jni:
+    dependency: transitive
+    description:
+      name: jni
+      sha256: c2230682d5bc2362c1c9e8d3c7f406d9cbba23ab3f2e203a025dd47e0fb2e68f
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
+  jni_flutter:
+    dependency: transitive
+    description:
+      name: jni_flutter
+      sha256: "8b59e590786050b1cd866677dddaf76b1ade5e7bc751abe04b86e84d379d3ba6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1"
   json_annotation:
     dependency: transitive
     description:
@@ -567,6 +623,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.2"
+  objective_c:
+    dependency: transitive
+    description:
+      name: objective_c
+      sha256: "6cb691c686fa2838c6deb34980d426145c2a5d537491cb83d463c33cdbc726ed"
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.4.1"
   otp:
     dependency: transitive
     description:
@@ -663,6 +727,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  path_provider:
+    dependency: transitive
+    description:
+      name: path_provider
+      sha256: a7f4874f987173da295a61c181b8ee71dab59b332a486b391babf26a1b884825
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.6"
+  path_provider_android:
+    dependency: transitive
+    description:
+      name: path_provider_android
+      sha256: "69cbd515a62b94d32a7944f086b2f82b4ac40a1d45bebfc00813a430ab2dabcd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.1"
+  path_provider_foundation:
+    dependency: transitive
+    description:
+      name: path_provider_foundation
+      sha256: "2a376b7d6392d80cd3705782d2caa734ca4727776db0b6ec36ef3f1855197699"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.6.0"
   path_provider_linux:
     dependency: transitive
     description:
@@ -791,6 +879,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.0"
+  record_use:
+    dependency: transitive
+    description:
+      name: record_use
+      sha256: "2551bd8eecfe95d14ae75f6021ad0248be5c27f138c2ec12fcb52b500b3ba1ed"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.0"
   scratch_space:
     dependency: transitive
     description:
@@ -1164,6 +1260,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
+  window_to_front:
+    dependency: transitive
+    description:
+      name: window_to_front
+      sha256: "14fad8984db4415e2eeb30b04bb77140b180e260d6cb66b26de126a8657a9241"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.4"
   xdg_directories:
     dependency: transitive
     description:


### PR DESCRIPTION
## What

Move `signInWithOAuth`, `signInWithSSO` and `linkIdentity` off `url_launcher` and onto a native system web authentication session via `flutter_web_auth_2`:

- iOS and macOS: `ASWebAuthenticationSession`
- Android: Custom Tabs
- Web: full page redirect of the current tab (unchanged behavior, now done via the `web` package)

The session captures the redirect to the `redirectTo` scheme, closes itself, and returns the callback URL, which is exchanged with `getSessionFromUrl`.

Addresses #1402. Fixes #1174.

## Why

`url_launcher`'s in-app browser does not dismiss itself when the OAuth redirect returns to the app, leaving the user on a blank page after a successful sign in (#1174). A system web auth session is OS owned, auto-dismisses, and hands the callback back to the caller, so it fixes the dismissal on every platform and lets the call resolve on completion.

## Changes

- Add `flutter_web_auth_2`; remove `url_launcher` as a direct dependency and the `LaunchMode` export.
- Replace `authScreenLaunchMode` / `launchMode` with a `preferEphemeral` option.
- Derive the callback scheme from `redirectTo`; forward host and path for `https` universal links.
- Web redirect via a small conditional-import shim over `package:web`.
- README updated with the required native config; new `oauth_test.dart` covering the native flow, `preferEphemeral`, `https` universal links, and the missing-`redirectTo` error.

## Breaking changes

- `authScreenLaunchMode` / `launchMode` removed; `LaunchMode` no longer exported.
- Android apps must register the `flutter_web_auth_2` `CallbackActivity` for their redirect scheme.
- The OAuth callback no longer arrives through the `app_links` deep link handler (magic links, email confirmation and password recovery still do).

## Status

Draft. `flutter analyze` and `flutter test` pass, but the native and desktop flows have not been verified on device yet. See the open questions in #1402 (forcing the external browser, the web popup vs redirect choice, dropping the Google on Android workaround, desktop callback model).
