### PR TITLE
refactor(realtime)!: clean up connection naming on RealtimeClient

### DIFF
--- a/packages/realtime_client/lib/realtime_client.dart
+++ b/packages/realtime_client/lib/realtime_client.dart
@@ -6,7 +6,7 @@ export 'src/constants.dart'
         RealtimeConstants,
         RealtimeLogLevel,
         RealtimeProtocolVersion,
-        SocketStates;
+        SocketState;
 export 'src/realtime_channel.dart';
 export 'src/realtime_client.dart';
 export 'src/realtime_presence.dart';

--- a/packages/realtime_client/lib/src/constants.dart
+++ b/packages/realtime_client/lib/src/constants.dart
@@ -26,7 +26,7 @@ enum RealtimeProtocolVersion {
   final String vsn;
 }
 
-enum SocketStates {
+enum SocketState {
   /// Client attempting to establish a connection
   connecting,
 

--- a/packages/realtime_client/lib/src/realtime_client.dart
+++ b/packages/realtime_client/lib/src/realtime_client.dart
@@ -153,7 +153,9 @@ class RealtimeClient {
 
   @Deprecated("No longer used. Will be removed in the next major version.")
   int longpollerTimeout = 20000;
-  SocketStates? connectionStatus;
+
+  /// The current state of the socket, or `null` before the first [connect].
+  SocketState? connectionState;
   Future<String?> Function()? customAccessToken;
 
   /// Initializes the Socket
@@ -257,7 +259,7 @@ class RealtimeClient {
   @internal
   Future<void> connect() async {
     if (connection != null) {
-      if (connectionStatus != SocketStates.closed) {
+      if (connectionState != SocketState.closed) {
         return;
       }
       await disconnect();
@@ -266,7 +268,7 @@ class RealtimeClient {
     try {
       log('transport', 'connecting to $endPointURL', null);
       log('transport', 'connecting', null, Level.FINE);
-      connectionStatus = SocketStates.connecting;
+      connectionState = SocketState.connecting;
       final WebSocketChannel localConnection = transport(endPointURL, headers);
       connection = localConnection;
 
@@ -280,9 +282,9 @@ class RealtimeClient {
         // Don't schedule a reconnect and emit error if connection has been
         // closed by the user or [disconnect] waits for the connection to be
         // ready before closing it.
-        if (connectionStatus != SocketStates.disconnected &&
-            connectionStatus != SocketStates.disconnecting) {
-          connectionStatus = SocketStates.closed;
+        if (connectionState != SocketState.disconnected &&
+            connectionState != SocketState.disconnecting) {
+          connectionState = SocketState.closed;
           _onConnectionError(error);
           reconnectTimer.scheduleTimeout();
         }
@@ -291,11 +293,11 @@ class RealtimeClient {
 
       // Guard: bail out if disconnect() ran during the await
       if (connection != localConnection ||
-          connectionStatus != SocketStates.connecting) {
+          connectionState != SocketState.connecting) {
         return;
       }
 
-      connectionStatus = SocketStates.open;
+      connectionState = SocketState.open;
 
       _onConnectionOpen();
       _connectionSubscription = localConnection.stream.listen(
@@ -303,9 +305,9 @@ class RealtimeClient {
         onError: _onConnectionError,
         onDone: () {
           // communication has been closed
-          if (connectionStatus != SocketStates.disconnected &&
-              connectionStatus != SocketStates.disconnecting) {
-            connectionStatus = SocketStates.closed;
+          if (connectionState != SocketState.disconnected &&
+              connectionState != SocketState.disconnecting) {
+            connectionState = SocketState.closed;
           }
           _onConnectionClose();
         },
@@ -326,12 +328,12 @@ class RealtimeClient {
     _cancelPendingDisconnect();
     final connection = this.connection;
     if (connection != null) {
-      final oldState = connectionStatus;
+      final oldState = connectionState;
       final shouldCloseSink =
-          oldState == SocketStates.open || oldState == SocketStates.connecting;
+          oldState == SocketState.open || oldState == SocketState.connecting;
       if (shouldCloseSink) {
         // Don't set the state to `disconnecting` if the connection is already closed.
-        connectionStatus = SocketStates.disconnecting;
+        connectionState = SocketState.disconnecting;
         log('transport', 'disconnecting', {
           'code': code,
           'reason': reason,
@@ -350,7 +352,7 @@ class RealtimeClient {
           // avoid hanging the client. This is done by mimicking the onDone
           // callback of the connection stream. By canceling the subscription,
           // we avoid calling the onDone too.
-          connectionStatus = SocketStates.disconnected;
+          connectionState = SocketState.disconnected;
           _onConnectionClose();
         }
 
@@ -367,12 +369,12 @@ class RealtimeClient {
             onTimeout: onTimeout,
           );
         }
-        connectionStatus = SocketStates.disconnected;
+        connectionState = SocketState.disconnected;
         log('transport', 'disconnected', null, Level.FINE);
       }
 
       // Cancel any reconnect scheduled by `_onConnectionClose`. When the socket has
-      // already dropped (`connectionStatus == closed`) the block above is skipped, so
+      // already dropped (`connectionState == closed`) the block above is skipped, so
       // without this an armed backoff timer would fire after the user
       // explicitly disconnected and silently reopen the connection.
       reconnectTimer.cancel();
@@ -444,17 +446,8 @@ class RealtimeClient {
   Stream<RealtimeHeartbeatStatus> get onHeartbeat =>
       _heartbeatController.stream;
 
-  /// Returns the current state of the socket.
-  String get connectionState => switch (connectionStatus) {
-    SocketStates.connecting => 'connecting',
-    SocketStates.open => 'open',
-    SocketStates.disconnecting => 'disconnecting',
-    SocketStates.disconnected => 'disconnected',
-    SocketStates.closed || null => 'closed',
-  };
-
   /// Returns `true` is the connection is open.
-  bool get isConnected => connectionStatus == SocketStates.open;
+  bool get isConnected => connectionState == SocketState.open;
 
   /// Removes a subscription from the socket.
   @internal
@@ -684,9 +677,9 @@ class RealtimeClient {
     }
     log('transport', 'close', event, Level.FINE);
 
-    /// SocketStates.disconnected: by user with socket.disconnect()
-    /// SocketStates.closed: NOT by user, should try to reconnect
-    if (connectionStatus == SocketStates.closed) {
+    /// SocketState.disconnected: by user with socket.disconnect()
+    /// SocketState.closed: NOT by user, should try to reconnect
+    if (connectionState == SocketState.closed) {
       _triggerChanError(event);
       reconnectTimer.scheduleTimeout();
     }

--- a/packages/realtime_client/lib/src/realtime_client.dart
+++ b/packages/realtime_client/lib/src/realtime_client.dart
@@ -778,7 +778,7 @@ class RealtimeClient {
       pendingHeartbeatRef = null;
       log(
         'transport',
-        'heartbeat timeout. Attempting to re-establish conn',
+        'heartbeat timeout. Attempting to re-establish connection',
       );
       _heartbeatController.add(RealtimeHeartbeatStatus.timeout);
       unawaited(

--- a/packages/realtime_client/lib/src/realtime_client.dart
+++ b/packages/realtime_client/lib/src/realtime_client.dart
@@ -138,7 +138,7 @@ class RealtimeClient {
   final RealtimeEncode encode;
   final RealtimeDecode decode;
   late TimerCalculation reconnectAfterMs;
-  WebSocketChannel? conn;
+  WebSocketChannel? connection;
   StreamSubscription<dynamic>? _connectionSubscription;
   List<dynamic> sendBuffer = [];
   Map<String, List<Function>> stateChangeCallbacks = {
@@ -153,7 +153,7 @@ class RealtimeClient {
 
   @Deprecated("No longer used. Will be removed in the next major version.")
   int longpollerTimeout = 20000;
-  SocketStates? connState;
+  SocketStates? connectionStatus;
   Future<String?> Function()? customAccessToken;
 
   /// Initializes the Socket
@@ -256,8 +256,8 @@ class RealtimeClient {
   /// Connects the socket.
   @internal
   Future<void> connect() async {
-    if (conn != null) {
-      if (connState != SocketStates.closed) {
+    if (connection != null) {
+      if (connectionStatus != SocketStates.closed) {
         return;
       }
       await disconnect();
@@ -266,52 +266,53 @@ class RealtimeClient {
     try {
       log('transport', 'connecting to $endPointURL', null);
       log('transport', 'connecting', null, Level.FINE);
-      connState = SocketStates.connecting;
-      final WebSocketChannel localConn = transport(endPointURL, headers);
-      conn = localConn;
+      connectionStatus = SocketStates.connecting;
+      final WebSocketChannel localConnection = transport(endPointURL, headers);
+      connection = localConnection;
 
       try {
-        await localConn.ready;
+        await localConnection.ready;
       } catch (error) {
         // Bail out if disconnect() ran or a new connect() started during await
-        if (conn != localConn) {
+        if (connection != localConnection) {
           return;
         }
         // Don't schedule a reconnect and emit error if connection has been
         // closed by the user or [disconnect] waits for the connection to be
         // ready before closing it.
-        if (connState != SocketStates.disconnected &&
-            connState != SocketStates.disconnecting) {
-          connState = SocketStates.closed;
-          _onConnError(error);
+        if (connectionStatus != SocketStates.disconnected &&
+            connectionStatus != SocketStates.disconnecting) {
+          connectionStatus = SocketStates.closed;
+          _onConnectionError(error);
           reconnectTimer.scheduleTimeout();
         }
         return;
       }
 
       // Guard: bail out if disconnect() ran during the await
-      if (conn != localConn || connState != SocketStates.connecting) {
+      if (connection != localConnection ||
+          connectionStatus != SocketStates.connecting) {
         return;
       }
 
-      connState = SocketStates.open;
+      connectionStatus = SocketStates.open;
 
-      _onConnOpen();
-      _connectionSubscription = localConn.stream.listen(
-        (message) => onConnMessage(message),
-        onError: _onConnError,
+      _onConnectionOpen();
+      _connectionSubscription = localConnection.stream.listen(
+        (message) => onConnectionMessage(message),
+        onError: _onConnectionError,
         onDone: () {
           // communication has been closed
-          if (connState != SocketStates.disconnected &&
-              connState != SocketStates.disconnecting) {
-            connState = SocketStates.closed;
+          if (connectionStatus != SocketStates.disconnected &&
+              connectionStatus != SocketStates.disconnecting) {
+            connectionStatus = SocketStates.closed;
           }
-          _onConnClose();
+          _onConnectionClose();
         },
       );
     } catch (e) {
       /// General error handling
-      _onConnError(e);
+      _onConnectionError(e);
     }
   }
 
@@ -323,14 +324,14 @@ class RealtimeClient {
   /// Disconnects the socket with status [code] and [reason] for the disconnect
   Future<void> disconnect({int? code, String? reason}) async {
     _cancelPendingDisconnect();
-    final conn = this.conn;
-    if (conn != null) {
-      final oldState = connState;
+    final connection = this.connection;
+    if (connection != null) {
+      final oldState = connectionStatus;
       final shouldCloseSink =
           oldState == SocketStates.open || oldState == SocketStates.connecting;
       if (shouldCloseSink) {
         // Don't set the state to `disconnecting` if the connection is already closed.
-        connState = SocketStates.disconnecting;
+        connectionStatus = SocketStates.disconnecting;
         log('transport', 'disconnecting', {
           'code': code,
           'reason': reason,
@@ -349,34 +350,34 @@ class RealtimeClient {
           // avoid hanging the client. This is done by mimicking the onDone
           // callback of the connection stream. By canceling the subscription,
           // we avoid calling the onDone too.
-          connState = SocketStates.disconnected;
-          _onConnClose();
+          connectionStatus = SocketStates.disconnected;
+          _onConnectionClose();
         }
 
         if (code != null) {
           // Add a timeout to close the sink to avoid hanging in case something
           // is wrong with the connection.
           // The Dart SDK has a timeout of 5 seconds for closing the IO WebSocket connection, so we set a timeout of 6 seconds here to avoid hanging indefinitely.
-          await conn.sink
+          await connection.sink
               .close(code, reason ?? '')
               .timeout(connectionCloseTimeout, onTimeout: onTimeout);
         } else {
-          await conn.sink.close().timeout(
+          await connection.sink.close().timeout(
             connectionCloseTimeout,
             onTimeout: onTimeout,
           );
         }
-        connState = SocketStates.disconnected;
+        connectionStatus = SocketStates.disconnected;
         log('transport', 'disconnected', null, Level.FINE);
       }
 
-      // Cancel any reconnect scheduled by `_onConnClose`. When the socket has
-      // already dropped (`connState == closed`) the block above is skipped, so
+      // Cancel any reconnect scheduled by `_onConnectionClose`. When the socket has
+      // already dropped (`connectionStatus == closed`) the block above is skipped, so
       // without this an armed backoff timer would fire after the user
       // explicitly disconnected and silently reopen the connection.
       reconnectTimer.cancel();
 
-      this.conn = null;
+      this.connection = null;
       await _connectionSubscription?.cancel();
       _connectionSubscription = null;
 
@@ -444,7 +445,7 @@ class RealtimeClient {
       _heartbeatController.stream;
 
   /// Returns the current state of the socket.
-  String get connectionState => switch (connState) {
+  String get connectionState => switch (connectionStatus) {
     SocketStates.connecting => 'connecting',
     SocketStates.open => 'open',
     SocketStates.disconnecting => 'disconnecting',
@@ -453,7 +454,7 @@ class RealtimeClient {
   };
 
   /// Returns `true` is the connection is open.
-  bool get isConnected => connState == SocketStates.open;
+  bool get isConnected => connectionStatus == SocketStates.open;
 
   /// Removes a subscription from the socket.
   @internal
@@ -522,7 +523,7 @@ class RealtimeClient {
   // ignore: function-always-returns-null
   String? push(Message message) {
     void callback() {
-      conn?.sink.add(encode(message.toJson()));
+      connection?.sink.add(encode(message.toJson()));
     }
 
     log(
@@ -539,7 +540,7 @@ class RealtimeClient {
     return null;
   }
 
-  void onConnMessage(Object rawMessage) {
+  void onConnectionMessage(Object rawMessage) {
     final Map<String, dynamic> message;
     try {
       message = decode(rawMessage);
@@ -645,7 +646,7 @@ class RealtimeClient {
     }
   }
 
-  void _onConnOpen() {
+  void _onConnectionOpen() {
     log('transport', 'connected to $endPointURL');
     log('transport', 'connected', null, Level.FINE);
     unawaited(_resolveAccessTokenAndFlush());
@@ -672,17 +673,20 @@ class RealtimeClient {
   }
 
   /// communication has been closed
-  void _onConnClose() {
-    final statusCode = conn?.closeCode;
+  void _onConnectionClose() {
+    final statusCode = connection?.closeCode;
     RealtimeCloseEvent? event;
     if (statusCode != null) {
-      event = RealtimeCloseEvent(code: statusCode, reason: conn?.closeReason);
+      event = RealtimeCloseEvent(
+        code: statusCode,
+        reason: connection?.closeReason,
+      );
     }
     log('transport', 'close', event, Level.FINE);
 
     /// SocketStates.disconnected: by user with socket.disconnect()
     /// SocketStates.closed: NOT by user, should try to reconnect
-    if (connState == SocketStates.closed) {
+    if (connectionStatus == SocketStates.closed) {
       _triggerChanError(event);
       reconnectTimer.scheduleTimeout();
     }
@@ -692,7 +696,7 @@ class RealtimeClient {
     }
   }
 
-  void _onConnError(dynamic error) {
+  void _onConnectionError(dynamic error) {
     log('transport', error.toString());
     _triggerChanError(error);
     for (final callback in stateChangeCallbacks['error']!) {
@@ -777,7 +781,9 @@ class RealtimeClient {
         'heartbeat timeout. Attempting to re-establish conn',
       );
       _heartbeatController.add(RealtimeHeartbeatStatus.timeout);
-      unawaited(conn?.sink.close(Constants.wsCloseNormal, 'heartbeat timeout'));
+      unawaited(
+        connection?.sink.close(Constants.wsCloseNormal, 'heartbeat timeout'),
+      );
       return;
     }
     pendingHeartbeatRef = makeRef();

--- a/packages/realtime_client/test/channel_test.dart
+++ b/packages/realtime_client/test/channel_test.dart
@@ -719,7 +719,7 @@ void main() {
       expect(channel.subTopic, 'myTopic');
     });
 
-    test('send message via ws conn when subscribed to channel', () async {
+    test('send message via WebSocket when subscribed to channel', () async {
       final subscribed = Completer<void>();
       channel.subscribe((status, [error]) {
         if (status == RealtimeSubscribeStatus.subscribed) {

--- a/packages/realtime_client/test/heartbeat_test.dart
+++ b/packages/realtime_client/test/heartbeat_test.dart
@@ -40,7 +40,7 @@ void main() {
   });
 
   test('emits sent when a heartbeat is pushed', () async {
-    client.connState = SocketStates.open;
+    client.connectionStatus = SocketStates.open;
 
     await client.sendHeartbeat();
     await pumpEventQueue();
@@ -52,7 +52,7 @@ void main() {
   test(
     'emits timeout when the previous heartbeat was not acknowledged',
     () async {
-      client.connState = SocketStates.open;
+      client.connectionStatus = SocketStates.open;
       client.pendingHeartbeatRef = 'stale-ref';
 
       await client.sendHeartbeat();
@@ -66,7 +66,7 @@ void main() {
   test('emits ok when the heartbeat reply succeeds', () async {
     client.pendingHeartbeatRef = 'ref-1';
 
-    client.onConnMessage(heartbeatReply('ref-1', 'ok'));
+    client.onConnectionMessage(heartbeatReply('ref-1', 'ok'));
     await pumpEventQueue();
 
     expect(statuses, [RealtimeHeartbeatStatus.ok]);
@@ -76,7 +76,7 @@ void main() {
   test('emits error when the heartbeat reply fails', () async {
     client.pendingHeartbeatRef = 'ref-2';
 
-    client.onConnMessage(heartbeatReply('ref-2', 'error'));
+    client.onConnectionMessage(heartbeatReply('ref-2', 'error'));
     await pumpEventQueue();
 
     expect(statuses, [RealtimeHeartbeatStatus.error]);
@@ -87,7 +87,7 @@ void main() {
     () async {
       client.pendingHeartbeatRef = 'ref-3';
 
-      client.onConnMessage(heartbeatReply('other-ref', 'ok'));
+      client.onConnectionMessage(heartbeatReply('other-ref', 'ok'));
       await pumpEventQueue();
 
       expect(statuses, isEmpty);

--- a/packages/realtime_client/test/heartbeat_test.dart
+++ b/packages/realtime_client/test/heartbeat_test.dart
@@ -40,7 +40,7 @@ void main() {
   });
 
   test('emits sent when a heartbeat is pushed', () async {
-    client.connectionStatus = SocketStates.open;
+    client.connectionState = SocketState.open;
 
     await client.sendHeartbeat();
     await pumpEventQueue();
@@ -52,7 +52,7 @@ void main() {
   test(
     'emits timeout when the previous heartbeat was not acknowledged',
     () async {
-      client.connectionStatus = SocketStates.open;
+      client.connectionState = SocketState.open;
       client.pendingHeartbeatRef = 'stale-ref';
 
       await client.sendHeartbeat();

--- a/packages/realtime_client/test/socket_test.dart
+++ b/packages/realtime_client/test/socket_test.dart
@@ -200,12 +200,12 @@ void main() {
 
     test('establishes websocket connection with endpoint', () async {
       final connectFuture = socket.connect();
-      expect(socket.connState, SocketStates.connecting);
+      expect(socket.connectionStatus, SocketStates.connecting);
 
-      final connection = socket.conn;
+      final connection = socket.connection;
 
       await connectFuture;
-      expect(socket.connState, SocketStates.open);
+      expect(socket.connectionStatus, SocketStates.open);
 
       expect(connection, isA<IOWebSocketChannel>());
       //! Not verifying connection url
@@ -253,9 +253,9 @@ void main() {
 
     test('is idempotent', () {
       unawaited(socket.connect());
-      final connection = socket.conn;
+      final connection = socket.connection;
       unawaited(socket.connect());
-      expect(socket.conn, connection);
+      expect(socket.connection, connection);
     });
   });
 
@@ -272,10 +272,10 @@ void main() {
     test('removes existing connection', () async {
       await socket.connect();
 
-      expect(socket.conn, isNotNull);
+      expect(socket.connection, isNotNull);
       await socket.disconnect();
 
-      expect(socket.conn, isNull);
+      expect(socket.connection, isNull);
     });
 
     test('calls connection close callback', () async {
@@ -297,7 +297,7 @@ void main() {
       const tReason = 'reason';
 
       await mockedSocket.connect();
-      mockedSocket.connState = SocketStates.open;
+      mockedSocket.connectionStatus = SocketStates.open;
       await Future.delayed(const Duration(milliseconds: 200));
       await mockedSocket.disconnect(code: tCode, reason: tReason);
       await Future.delayed(const Duration(milliseconds: 200));
@@ -312,19 +312,19 @@ void main() {
 
     test('disconnecting a closed connections stays closed', () async {
       await socket.connect();
-      expect(socket.connState, SocketStates.open);
+      expect(socket.connectionStatus, SocketStates.open);
       await mockServer.close();
       await Future.delayed(const Duration(milliseconds: 200));
-      expect(socket.connState, SocketStates.closed);
-      expect(socket.conn, isNotNull);
+      expect(socket.connectionStatus, SocketStates.closed);
+      expect(socket.connection, isNotNull);
 
       final disconnectFuture = socket.disconnect();
 
-      // `connState` stays `closed` during disconnect
-      expect(socket.connState, SocketStates.closed);
+      // `connectionStatus` stays `closed` during disconnect
+      expect(socket.connectionStatus, SocketStates.closed);
       await disconnectFuture;
-      expect(socket.connState, SocketStates.closed);
-      expect(socket.conn, isNull);
+      expect(socket.connectionStatus, SocketStates.closed);
+      expect(socket.connection, isNull);
     });
 
     test('cancels a pending reconnect after an unexpected drop', () async {
@@ -361,7 +361,7 @@ void main() {
       // is marked closed and a reconnect is scheduled.
       await streamController.close();
       await Future.delayed(const Duration(milliseconds: 5));
-      expect(mockedSocket.connState, SocketStates.closed);
+      expect(mockedSocket.connectionStatus, SocketStates.closed);
 
       // The user disconnects explicitly while the socket is already closed.
       await mockedSocket.disconnect();
@@ -415,22 +415,22 @@ void main() {
 
       await mockedSocket.connect();
       expect(connectCount, 1);
-      expect(mockedSocket.connState, SocketStates.open);
+      expect(mockedSocket.connectionStatus, SocketStates.open);
 
       // Simulate the server dropping the connection.
       await firstController.close();
       await Future.delayed(const Duration(milliseconds: 5));
-      expect(mockedSocket.connState, SocketStates.closed);
+      expect(mockedSocket.connectionStatus, SocketStates.closed);
 
       // A manual reconnect must open a fresh connection instead of being a
-      // no-op because `conn` still references the dropped socket.
+      // no-op because `connection` still references the dropped socket.
       await mockedSocket.connect();
       expect(
         connectCount,
         2,
         reason: 'manual connect() must reconnect after a drop',
       );
-      expect(mockedSocket.connState, SocketStates.open);
+      expect(mockedSocket.connectionStatus, SocketStates.open);
 
       await mockedSocket.disconnect();
     });
@@ -486,22 +486,22 @@ void main() {
       // The retry counter must grow (1, 2, 3, ...) across reconnect attempts
       // instead of being reset to 1 on every `disconnect()` in `_reconnect`.
       expect(triesSeen.take(3), [1, 2, 3]);
-      expect(mockedSocket.connState, SocketStates.open);
+      expect(mockedSocket.connectionStatus, SocketStates.open);
 
       await mockedSocket.disconnect();
     });
 
     test('disconnecting an open connection', () async {
       await socket.connect();
-      expect(socket.connState, SocketStates.open);
+      expect(socket.connectionStatus, SocketStates.open);
 
       final disconnectFuture = socket.disconnect();
 
-      // `connState` stays `closed` during disconnect
-      expect(socket.connState, SocketStates.disconnecting);
+      // `connectionStatus` stays `closed` during disconnect
+      expect(socket.connectionStatus, SocketStates.disconnecting);
       await disconnectFuture;
-      expect(socket.connState, SocketStates.disconnected);
-      expect(socket.conn, isNull);
+      expect(socket.connectionStatus, SocketStates.disconnected);
+      expect(socket.connection, isNull);
     });
 
     test('does not throw when no connection', () {
@@ -528,11 +528,11 @@ void main() {
       when(() => mockedSink.close()).thenAnswer((_) => closeCompleter.future);
 
       await mockedSocket.connect();
-      expect(mockedSocket.connState, SocketStates.open);
+      expect(mockedSocket.connectionStatus, SocketStates.open);
 
       await mockedSocket.disconnect();
-      expect(mockedSocket.connState, SocketStates.disconnected);
-      expect(mockedSocket.conn, isNull);
+      expect(mockedSocket.connectionStatus, SocketStates.disconnected);
+      expect(mockedSocket.connection, isNull);
       expect(closeCallbacks, 1);
       verify(() => mockedSink.close()).called(1);
 
@@ -813,7 +813,7 @@ void main() {
 
     test('sends data to connection when connected', () {
       unawaited(mockedSocket.connect());
-      mockedSocket.connState = SocketStates.open;
+      mockedSocket.connectionStatus = SocketStates.open;
 
       final message = Message(
         topic: topic,
@@ -830,7 +830,7 @@ void main() {
 
     test('buffers data when not connected', () async {
       unawaited(mockedSocket.connect());
-      mockedSocket.connState = SocketStates.connecting;
+      mockedSocket.connectionStatus = SocketStates.connecting;
 
       expect(mockedSocket.sendBuffer, isEmpty);
 
@@ -854,7 +854,7 @@ void main() {
 
     test('sends a broadcast with a binary payload as a binary frame', () {
       unawaited(mockedSocket.connect());
-      mockedSocket.connState = SocketStates.open;
+      mockedSocket.connectionStatus = SocketStates.open;
 
       final binaryPayload = Uint8List.fromList([1, 2, 3]);
       final message = Message(
@@ -886,7 +886,7 @@ void main() {
         version: RealtimeProtocolVersion.v1,
       );
       unawaited(legacySocket.connect());
-      legacySocket.connState = SocketStates.open;
+      legacySocket.connectionStatus = SocketStates.open;
 
       final legacyData = json.encode({
         'topic': topic,
@@ -921,7 +921,7 @@ void main() {
         encode: (_) => 'custom-frame',
       );
       unawaited(customSocket.connect());
-      customSocket.connState = SocketStates.open;
+      customSocket.connectionStatus = SocketStates.open;
 
       customSocket.push(
         Message(topic: topic, payload: payload, event: event, ref: ref),
@@ -933,11 +933,11 @@ void main() {
     });
   });
 
-  group('onConnMessage', () {
+  group('onConnectionMessage', () {
     test('drops a malformed frame without throwing', () {
       final socket = RealtimeClient(socketEndpoint);
       expect(
-        () => socket.onConnMessage('{"not": "an array"}'),
+        () => socket.onConnectionMessage('{"not": "an array"}'),
         returnsNormally,
       );
     });
@@ -966,7 +966,7 @@ void main() {
         ...payload,
       ]);
 
-      socket.onConnMessage(frame);
+      socket.onConnectionMessage(frame);
 
       expect(received, {
         'type': 'broadcast',
@@ -990,7 +990,7 @@ void main() {
           callback: (payload) => received = payload,
         );
 
-        socket.onConnMessage(
+        socket.onConnectionMessage(
           json.encode({
             'topic': 'realtime:room',
             'event': 'broadcast',
@@ -1193,7 +1193,7 @@ void main() {
       verify(() => erroredChannel.rejoin()).called(1);
       verifyNever(() => healthyChannel.rejoin());
       expect(opens, 1);
-      expect(socket.connState, SocketStates.open);
+      expect(socket.connectionStatus, SocketStates.open);
 
       await socket.disconnect();
       await streamController.close();
@@ -1295,7 +1295,7 @@ void main() {
     //! Unimplemented Test: closes socket when heartbeat is not ack'd within heartbeat window
 
     test('pushes heartbeat data when connected', () async {
-      mockedSocket.connState = SocketStates.open;
+      mockedSocket.connectionStatus = SocketStates.open;
 
       await mockedSocket.sendHeartbeat();
 
@@ -1303,7 +1303,7 @@ void main() {
     });
 
     test('no ops when not connected', () async {
-      mockedSocket.connState = SocketStates.connecting;
+      mockedSocket.connectionStatus = SocketStates.connecting;
 
       await mockedSocket.sendHeartbeat();
       verifyNever(() => mockedSink.add(any()));
@@ -1344,13 +1344,13 @@ void main() {
         await connectFuture;
 
         // Should NOT have transitioned to open because disconnect nullified connection
-        expect(socket.connState, isNot(SocketStates.open));
-        expect(socket.conn, isNull);
+        expect(socket.connectionStatus, isNot(SocketStates.open));
+        expect(socket.connection, isNull);
       },
     );
 
     test(
-      'connect bails out when connState changes during await ready',
+      'connect bails out when connectionStatus changes during await ready',
       () async {
         final readyCompleter = Completer<void>();
         final mockedSocketChannel = MockIOWebSocketChannel();
@@ -1381,7 +1381,7 @@ void main() {
         await disconnectFuture;
         await connectFuture;
 
-        expect(socket.connState, isNot(SocketStates.open));
+        expect(socket.connectionStatus, isNot(SocketStates.open));
       },
     );
 
@@ -1441,8 +1441,8 @@ void main() {
       readyCompleter2.complete();
       await socket.connect();
 
-      expect(socket.connState, SocketStates.open);
-      expect(socket.conn, mockedSocketChannel2);
+      expect(socket.connectionStatus, SocketStates.open);
+      expect(socket.connection, mockedSocketChannel2);
 
       await socket.disconnect();
       await streamController2.close();

--- a/packages/realtime_client/test/socket_test.dart
+++ b/packages/realtime_client/test/socket_test.dart
@@ -200,12 +200,12 @@ void main() {
 
     test('establishes websocket connection with endpoint', () async {
       final connectFuture = socket.connect();
-      expect(socket.connectionStatus, SocketStates.connecting);
+      expect(socket.connectionState, SocketState.connecting);
 
       final connection = socket.connection;
 
       await connectFuture;
-      expect(socket.connectionStatus, SocketStates.open);
+      expect(socket.connectionState, SocketState.open);
 
       expect(connection, isA<IOWebSocketChannel>());
       //! Not verifying connection url
@@ -297,7 +297,7 @@ void main() {
       const tReason = 'reason';
 
       await mockedSocket.connect();
-      mockedSocket.connectionStatus = SocketStates.open;
+      mockedSocket.connectionState = SocketState.open;
       await Future.delayed(const Duration(milliseconds: 200));
       await mockedSocket.disconnect(code: tCode, reason: tReason);
       await Future.delayed(const Duration(milliseconds: 200));
@@ -312,18 +312,18 @@ void main() {
 
     test('disconnecting a closed connections stays closed', () async {
       await socket.connect();
-      expect(socket.connectionStatus, SocketStates.open);
+      expect(socket.connectionState, SocketState.open);
       await mockServer.close();
       await Future.delayed(const Duration(milliseconds: 200));
-      expect(socket.connectionStatus, SocketStates.closed);
+      expect(socket.connectionState, SocketState.closed);
       expect(socket.connection, isNotNull);
 
       final disconnectFuture = socket.disconnect();
 
-      // `connectionStatus` stays `closed` during disconnect
-      expect(socket.connectionStatus, SocketStates.closed);
+      // `connectionState` stays `closed` during disconnect
+      expect(socket.connectionState, SocketState.closed);
       await disconnectFuture;
-      expect(socket.connectionStatus, SocketStates.closed);
+      expect(socket.connectionState, SocketState.closed);
       expect(socket.connection, isNull);
     });
 
@@ -361,7 +361,7 @@ void main() {
       // is marked closed and a reconnect is scheduled.
       await streamController.close();
       await Future.delayed(const Duration(milliseconds: 5));
-      expect(mockedSocket.connectionStatus, SocketStates.closed);
+      expect(mockedSocket.connectionState, SocketState.closed);
 
       // The user disconnects explicitly while the socket is already closed.
       await mockedSocket.disconnect();
@@ -415,12 +415,12 @@ void main() {
 
       await mockedSocket.connect();
       expect(connectCount, 1);
-      expect(mockedSocket.connectionStatus, SocketStates.open);
+      expect(mockedSocket.connectionState, SocketState.open);
 
       // Simulate the server dropping the connection.
       await firstController.close();
       await Future.delayed(const Duration(milliseconds: 5));
-      expect(mockedSocket.connectionStatus, SocketStates.closed);
+      expect(mockedSocket.connectionState, SocketState.closed);
 
       // A manual reconnect must open a fresh connection instead of being a
       // no-op because `connection` still references the dropped socket.
@@ -430,7 +430,7 @@ void main() {
         2,
         reason: 'manual connect() must reconnect after a drop',
       );
-      expect(mockedSocket.connectionStatus, SocketStates.open);
+      expect(mockedSocket.connectionState, SocketState.open);
 
       await mockedSocket.disconnect();
     });
@@ -486,21 +486,21 @@ void main() {
       // The retry counter must grow (1, 2, 3, ...) across reconnect attempts
       // instead of being reset to 1 on every `disconnect()` in `_reconnect`.
       expect(triesSeen.take(3), [1, 2, 3]);
-      expect(mockedSocket.connectionStatus, SocketStates.open);
+      expect(mockedSocket.connectionState, SocketState.open);
 
       await mockedSocket.disconnect();
     });
 
     test('disconnecting an open connection', () async {
       await socket.connect();
-      expect(socket.connectionStatus, SocketStates.open);
+      expect(socket.connectionState, SocketState.open);
 
       final disconnectFuture = socket.disconnect();
 
-      // `connectionStatus` stays `closed` during disconnect
-      expect(socket.connectionStatus, SocketStates.disconnecting);
+      // `connectionState` stays `closed` during disconnect
+      expect(socket.connectionState, SocketState.disconnecting);
       await disconnectFuture;
-      expect(socket.connectionStatus, SocketStates.disconnected);
+      expect(socket.connectionState, SocketState.disconnected);
       expect(socket.connection, isNull);
     });
 
@@ -528,10 +528,10 @@ void main() {
       when(() => mockedSink.close()).thenAnswer((_) => closeCompleter.future);
 
       await mockedSocket.connect();
-      expect(mockedSocket.connectionStatus, SocketStates.open);
+      expect(mockedSocket.connectionState, SocketState.open);
 
       await mockedSocket.disconnect();
-      expect(mockedSocket.connectionStatus, SocketStates.disconnected);
+      expect(mockedSocket.connectionState, SocketState.disconnected);
       expect(mockedSocket.connection, isNull);
       expect(closeCallbacks, 1);
       verify(() => mockedSink.close()).called(1);
@@ -813,7 +813,7 @@ void main() {
 
     test('sends data to connection when connected', () {
       unawaited(mockedSocket.connect());
-      mockedSocket.connectionStatus = SocketStates.open;
+      mockedSocket.connectionState = SocketState.open;
 
       final message = Message(
         topic: topic,
@@ -830,7 +830,7 @@ void main() {
 
     test('buffers data when not connected', () async {
       unawaited(mockedSocket.connect());
-      mockedSocket.connectionStatus = SocketStates.connecting;
+      mockedSocket.connectionState = SocketState.connecting;
 
       expect(mockedSocket.sendBuffer, isEmpty);
 
@@ -854,7 +854,7 @@ void main() {
 
     test('sends a broadcast with a binary payload as a binary frame', () {
       unawaited(mockedSocket.connect());
-      mockedSocket.connectionStatus = SocketStates.open;
+      mockedSocket.connectionState = SocketState.open;
 
       final binaryPayload = Uint8List.fromList([1, 2, 3]);
       final message = Message(
@@ -886,7 +886,7 @@ void main() {
         version: RealtimeProtocolVersion.v1,
       );
       unawaited(legacySocket.connect());
-      legacySocket.connectionStatus = SocketStates.open;
+      legacySocket.connectionState = SocketState.open;
 
       final legacyData = json.encode({
         'topic': topic,
@@ -921,7 +921,7 @@ void main() {
         encode: (_) => 'custom-frame',
       );
       unawaited(customSocket.connect());
-      customSocket.connectionStatus = SocketStates.open;
+      customSocket.connectionState = SocketState.open;
 
       customSocket.push(
         Message(topic: topic, payload: payload, event: event, ref: ref),
@@ -1193,7 +1193,7 @@ void main() {
       verify(() => erroredChannel.rejoin()).called(1);
       verifyNever(() => healthyChannel.rejoin());
       expect(opens, 1);
-      expect(socket.connectionStatus, SocketStates.open);
+      expect(socket.connectionState, SocketState.open);
 
       await socket.disconnect();
       await streamController.close();
@@ -1295,7 +1295,7 @@ void main() {
     //! Unimplemented Test: closes socket when heartbeat is not ack'd within heartbeat window
 
     test('pushes heartbeat data when connected', () async {
-      mockedSocket.connectionStatus = SocketStates.open;
+      mockedSocket.connectionState = SocketState.open;
 
       await mockedSocket.sendHeartbeat();
 
@@ -1303,7 +1303,7 @@ void main() {
     });
 
     test('no ops when not connected', () async {
-      mockedSocket.connectionStatus = SocketStates.connecting;
+      mockedSocket.connectionState = SocketState.connecting;
 
       await mockedSocket.sendHeartbeat();
       verifyNever(() => mockedSink.add(any()));
@@ -1344,13 +1344,13 @@ void main() {
         await connectFuture;
 
         // Should NOT have transitioned to open because disconnect nullified connection
-        expect(socket.connectionStatus, isNot(SocketStates.open));
+        expect(socket.connectionState, isNot(SocketState.open));
         expect(socket.connection, isNull);
       },
     );
 
     test(
-      'connect bails out when connectionStatus changes during await ready',
+      'connect bails out when connectionState changes during await ready',
       () async {
         final readyCompleter = Completer<void>();
         final mockedSocketChannel = MockIOWebSocketChannel();
@@ -1381,7 +1381,7 @@ void main() {
         await disconnectFuture;
         await connectFuture;
 
-        expect(socket.connectionStatus, isNot(SocketStates.open));
+        expect(socket.connectionState, isNot(SocketState.open));
       },
     );
 
@@ -1441,7 +1441,7 @@ void main() {
       readyCompleter2.complete();
       await socket.connect();
 
-      expect(socket.connectionStatus, SocketStates.open);
+      expect(socket.connectionState, SocketState.open);
       expect(socket.connection, mockedSocketChannel2);
 
       await socket.disconnect();

--- a/packages/realtime_client/test/socket_test_stubs.dart
+++ b/packages/realtime_client/test/socket_test_stubs.dart
@@ -20,12 +20,12 @@ class SocketWithMockedChannel extends RealtimeClient {
   @override
   RealtimeChannel channel(
     String topic, [
-    RealtimeChannelConfig chanParams = const RealtimeChannelConfig(),
+    RealtimeChannelConfig config = const RealtimeChannelConfig(),
   ]) {
     if (mockedChannelLooker.containsKey(topic)) {
       channels.add(mockedChannelLooker[topic]!);
       return mockedChannelLooker[topic]!;
     }
-    return super.channel(topic, chanParams);
+    return super.channel(topic, config);
   }
 }

--- a/packages/supabase_flutter/lib/src/supabase.dart
+++ b/packages/supabase_flutter/lib/src/supabase.dart
@@ -312,7 +312,7 @@ class Supabase {
       // paused or detached — disconnect the WebSocket if it is active.
       // These states are not triggered on web
       if (realtime.isConnected ||
-          realtime.connState == SocketStates.connecting) {
+          realtime.connectionStatus == SocketStates.connecting) {
         await realtime.disconnect();
       }
     }

--- a/packages/supabase_flutter/lib/src/supabase.dart
+++ b/packages/supabase_flutter/lib/src/supabase.dart
@@ -312,7 +312,7 @@ class Supabase {
       // paused or detached — disconnect the WebSocket if it is active.
       // These states are not triggered on web
       if (realtime.isConnected ||
-          realtime.connectionStatus == SocketStates.connecting) {
+          realtime.connectionState == SocketState.connecting) {
         await realtime.disconnect();
       }
     }

--- a/packages/supabase_flutter/test/lifecycle_test.dart
+++ b/packages/supabase_flutter/test/lifecycle_test.dart
@@ -138,7 +138,7 @@ void main() {
 
       // Connect with ready completed immediately
       await connectAndReady(realtime);
-      expect(realtime.connState, SocketStates.open);
+      expect(realtime.connectionStatus, SocketStates.open);
 
       // paused → triggers disconnect
       binding.handleAppLifecycleStateChanged(AppLifecycleState.inactive);
@@ -152,8 +152,8 @@ void main() {
       // Complete any pending ready futures (reconnect)
       await settleLifecycle();
 
-      expect(realtime.connState, SocketStates.open);
-      expect(realtime.conn, isNotNull);
+      expect(realtime.connectionStatus, SocketStates.open);
+      expect(realtime.connection, isNotNull);
     });
 
     test('paused → resumed → inactive → resumed '
@@ -164,7 +164,7 @@ void main() {
       realtime.channel('test');
 
       await connectAndReady(realtime);
-      expect(realtime.connState, SocketStates.open);
+      expect(realtime.connectionStatus, SocketStates.open);
 
       // paused → starts disconnect
       binding.handleAppLifecycleStateChanged(AppLifecycleState.inactive);
@@ -185,8 +185,8 @@ void main() {
       await settleLifecycle();
 
       // Should have reconnected, not stuck disconnecting
-      expect(realtime.connState, SocketStates.open);
-      expect(realtime.conn, isNotNull);
+      expect(realtime.connectionStatus, SocketStates.open);
+      expect(realtime.connection, isNotNull);
     });
 
     test('rapid paused → resumed → paused → resumed '
@@ -197,7 +197,7 @@ void main() {
       realtime.channel('test');
 
       await connectAndReady(realtime);
-      expect(realtime.connState, SocketStates.open);
+      expect(realtime.connectionStatus, SocketStates.open);
 
       // Rapid lifecycle flapping
       binding.handleAppLifecycleStateChanged(AppLifecycleState.inactive);
@@ -217,8 +217,8 @@ void main() {
       // Complete all pending ready futures as they appear
       await settleLifecycle();
 
-      expect(realtime.connState, SocketStates.open);
-      expect(realtime.conn, isNotNull);
+      expect(realtime.connectionStatus, SocketStates.open);
+      expect(realtime.connection, isNotNull);
     });
 
     test('resumed then paused before connect completes '
@@ -229,7 +229,7 @@ void main() {
       realtime.channel('test');
 
       await connectAndReady(realtime);
-      expect(realtime.connState, SocketStates.open);
+      expect(realtime.connectionStatus, SocketStates.open);
 
       // paused → triggers disconnect
       binding.handleAppLifecycleStateChanged(AppLifecycleState.inactive);
@@ -250,8 +250,8 @@ void main() {
       await settleLifecycle();
 
       // Should be disconnected since the last event was paused
-      expect(realtime.connState, SocketStates.disconnected);
-      expect(realtime.conn, isNull);
+      expect(realtime.connectionStatus, SocketStates.disconnected);
+      expect(realtime.connection, isNull);
     });
   });
 }

--- a/packages/supabase_flutter/test/lifecycle_test.dart
+++ b/packages/supabase_flutter/test/lifecycle_test.dart
@@ -138,7 +138,7 @@ void main() {
 
       // Connect with ready completed immediately
       await connectAndReady(realtime);
-      expect(realtime.connectionStatus, SocketStates.open);
+      expect(realtime.connectionState, SocketState.open);
 
       // paused → triggers disconnect
       binding.handleAppLifecycleStateChanged(AppLifecycleState.inactive);
@@ -152,7 +152,7 @@ void main() {
       // Complete any pending ready futures (reconnect)
       await settleLifecycle();
 
-      expect(realtime.connectionStatus, SocketStates.open);
+      expect(realtime.connectionState, SocketState.open);
       expect(realtime.connection, isNotNull);
     });
 
@@ -164,7 +164,7 @@ void main() {
       realtime.channel('test');
 
       await connectAndReady(realtime);
-      expect(realtime.connectionStatus, SocketStates.open);
+      expect(realtime.connectionState, SocketState.open);
 
       // paused → starts disconnect
       binding.handleAppLifecycleStateChanged(AppLifecycleState.inactive);
@@ -185,7 +185,7 @@ void main() {
       await settleLifecycle();
 
       // Should have reconnected, not stuck disconnecting
-      expect(realtime.connectionStatus, SocketStates.open);
+      expect(realtime.connectionState, SocketState.open);
       expect(realtime.connection, isNotNull);
     });
 
@@ -197,7 +197,7 @@ void main() {
       realtime.channel('test');
 
       await connectAndReady(realtime);
-      expect(realtime.connectionStatus, SocketStates.open);
+      expect(realtime.connectionState, SocketState.open);
 
       // Rapid lifecycle flapping
       binding.handleAppLifecycleStateChanged(AppLifecycleState.inactive);
@@ -217,7 +217,7 @@ void main() {
       // Complete all pending ready futures as they appear
       await settleLifecycle();
 
-      expect(realtime.connectionStatus, SocketStates.open);
+      expect(realtime.connectionState, SocketState.open);
       expect(realtime.connection, isNotNull);
     });
 
@@ -229,7 +229,7 @@ void main() {
       realtime.channel('test');
 
       await connectAndReady(realtime);
-      expect(realtime.connectionStatus, SocketStates.open);
+      expect(realtime.connectionState, SocketState.open);
 
       // paused → triggers disconnect
       binding.handleAppLifecycleStateChanged(AppLifecycleState.inactive);
@@ -250,7 +250,7 @@ void main() {
       await settleLifecycle();
 
       // Should be disconnected since the last event was paused
-      expect(realtime.connectionStatus, SocketStates.disconnected);
+      expect(realtime.connectionState, SocketState.disconnected);
       expect(realtime.connection, isNull);
     });
   });

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -1393,6 +1393,8 @@ features:
     status: implemented
     symbols:
       - RealtimeChannel.subscribe
+      - RealtimeClient.connection
+      - RealtimeClient.onConnectionMessage
   realtime.client.disconnect:
     status: implemented
     symbols:
@@ -1403,6 +1405,7 @@ features:
     status: implemented
     symbols:
       - RealtimeClient.connectionState
+      - SocketState
   realtime.client.get_channels:
     status: implemented
     symbols:


### PR DESCRIPTION
## What

Cleans up the connection-related naming on `RealtimeClient`. Split out of #1397 so that PR could carry only the protocol 2.0.0 feature without breaking changes.

### Spell out the `conn` abbreviation

| Before | After |
| --- | --- |
| `RealtimeClient.conn` | `connection` |
| `RealtimeClient.connState` | `connectionState` (see below) |
| `RealtimeClient.onConnMessage` | `onConnectionMessage` |

Private and local: `_onConnOpen` / `_onConnClose` / `_onConnError` became `_onConnectionOpen` / `_onConnectionClose` / `_onConnectionError`, and the `localConn` local in `connect()` became `localConnection`.

Also the shortenings the rename itself did not reach: the heartbeat timeout log message now reads "Attempting to re-establish connection", a `channel_test` description that said "via ws conn", and `chanParams` on the test stub's `channel` override (renamed to `config`, matching the `RealtimeClient.channel` signature it overrides).

### Collapse the two socket-state accessors

Spelling out `connState` left it one word away from the existing `String get connectionState`, and both carried the same information. The stringly typed getter is gone and the typed field takes the name:

```dart
// before
SocketStates? connState;
String get connectionState => switch (connState) { ... };

// after
SocketState? connectionState;
```

For the string form use `connectionState?.name`; for the common case `isConnected` is unchanged.

### Singularize the enum

`SocketStates` is now `SocketState`, matching Dart convention and the large majority of the 51 enums in the repository.

Consumers updated: `supabase_flutter` (`supabase.dart`, `lifecycle_test.dart`).

## Breaking changes

- `RealtimeClient.conn` → `connection`
- `RealtimeClient.onConnMessage` → `onConnectionMessage`
- `RealtimeClient.connState` → `connectionState`
- `RealtimeClient.connectionState` changes type from `String` to `SocketState?`. This one is a silent change for anyone reading it as a string, so it is worth calling out in the release notes.
- `SocketStates` → `SocketState`

Renames and one removal. No behaviour change.

## Capability matrix

`RealtimeClient.connection`, `RealtimeClient.onConnectionMessage`, and `SocketState` are registered in `sdk-compliance.yaml`. `RealtimeClient.connectionState` keeps its name and its existing entry.

## Notes

- Rebased onto `main` now that #1397 has merged.
- The description previously said this would be retargeted to `v3` (tracked in #1278). It still targets `main`; happy to flip the base if that is still the plan.
- The remaining plural enums are tracked in #1652. Only `PostgresTypes` among them is actually exported, so three of the four can land before v3; left out here to keep this PR scoped.

## Tests

`realtime_client` 203 passing, `supabase` 135 passing, `supabase_flutter` 63 passing. `dart analyze` and `dart format` clean. The capability matrix symbol and schema checks were run locally against `main` and pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Breaking Changes**
  - Renamed realtime connection APIs for clearer terminology, including `SocketState`, `connection`, `connectionState`, and `onConnectionMessage`.
  - Removed the previous string-based connection-state getter.
  - Connection status is now represented directly through typed socket states.

- **Bug Fixes**
  - Disconnecting now reliably cancels pending reconnect attempts and clears the active connection.

- **Documentation**
  - Updated SDK capability information to reflect the renamed realtime APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
