### PR TITLE
fix: raise min Dart SDK to 3.4.0 across all packages

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -202,7 +202,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        flutter-version: ['3.19.x', '3.x']
+        flutter-version: ['3.22.x', '3.x']
 
     defaults:
       run:
@@ -221,7 +221,7 @@ jobs:
           channel: 'stable'
           # Caching 3.x (latest stable) is flaky: the cached SDK contains
           # runner-image-specific binaries that break silently when the runner
-          # image is updated. Pinned versions like 3.19.x are stable to cache.
+          # image is updated. Pinned versions like 3.22.x are stable to cache.
           cache: ${{ matrix.flutter-version != '3.x' }}
 
       - name: Show Flutter version

--- a/packages/functions_client/pubspec.yaml
+++ b/packages/functions_client/pubspec.yaml
@@ -6,7 +6,7 @@ repository: 'https://github.com/supabase/supabase-flutter/tree/main/packages/fun
 documentation: 'https://supabase.com/docs/reference/dart/functions-invoke'
 
 environment:
-  sdk: '>=3.3.0 <4.0.0'
+  sdk: '>=3.4.0 <4.0.0'
 
 dependencies:
   http: ^1.2.2

--- a/packages/gotrue/pubspec.yaml
+++ b/packages/gotrue/pubspec.yaml
@@ -6,7 +6,7 @@ repository: "https://github.com/supabase/supabase-flutter/tree/main/packages/got
 documentation: "https://supabase.com/docs/reference/dart/auth-signup"
 
 environment:
-  sdk: ">=3.3.0 <4.0.0"
+  sdk: ">=3.4.0 <4.0.0"
 
 dependencies:
   collection: ^1.15.0

--- a/packages/postgrest/pubspec.yaml
+++ b/packages/postgrest/pubspec.yaml
@@ -6,7 +6,7 @@ repository: 'https://github.com/supabase/supabase-flutter/tree/main/packages/pos
 documentation: 'https://supabase.com/docs/reference/dart/select'
 
 environment:
-  sdk: '>=3.3.0 <4.0.0'
+  sdk: '>=3.4.0 <4.0.0'
 
 dependencies:
   http: ^1.2.2

--- a/packages/realtime_client/pubspec.yaml
+++ b/packages/realtime_client/pubspec.yaml
@@ -6,7 +6,7 @@ repository: 'https://github.com/supabase/supabase-flutter/tree/main/packages/rea
 documentation: 'https://supabase.com/docs/reference/dart/subscribe'
 
 environment:
-  sdk: '>=3.3.0 <4.0.0'
+  sdk: '>=3.4.0 <4.0.0'
 
 dependencies:
   collection: ^1.15.0

--- a/packages/storage_client/pubspec.yaml
+++ b/packages/storage_client/pubspec.yaml
@@ -6,7 +6,7 @@ repository: 'https://github.com/supabase/supabase-flutter/tree/main/packages/sto
 documentation: 'https://supabase.com/docs/reference/dart/storage-createbucket'
 
 environment:
-  sdk: '>=3.3.0 <4.0.0'
+  sdk: '>=3.4.0 <4.0.0'
 
 dependencies:
   http: ^1.2.2

--- a/packages/supabase/pubspec.yaml
+++ b/packages/supabase/pubspec.yaml
@@ -6,7 +6,7 @@ repository: 'https://github.com/supabase/supabase-flutter/tree/main/packages/sup
 documentation: 'https://supabase.com/docs/reference/dart/introduction'
 
 environment:
-  sdk: '>=3.3.0 <4.0.0'
+  sdk: '>=3.4.0 <4.0.0'
 
 dependencies:
   functions_client: 2.6.0

--- a/packages/supabase_flutter/example/lib/main.dart
+++ b/packages/supabase_flutter/example/lib/main.dart
@@ -8,7 +8,7 @@ Future<void> main() async {
 }
 
 class MyApp extends StatelessWidget {
-  const MyApp({Key? key}) : super(key: key);
+  const MyApp({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -20,7 +20,7 @@ class MyApp extends StatelessWidget {
 }
 
 class MyWidget extends StatefulWidget {
-  const MyWidget({Key? key}) : super(key: key);
+  const MyWidget({super.key});
 
   @override
   State<MyWidget> createState() => _MyWidgetState();
@@ -64,7 +64,7 @@ class _MyWidgetState extends State<MyWidget> {
 }
 
 class _LoginForm extends StatefulWidget {
-  const _LoginForm({Key? key}) : super(key: key);
+  const _LoginForm();
 
   @override
   State<_LoginForm> createState() => _LoginFormState();
@@ -160,7 +160,7 @@ class _LoginFormState extends State<_LoginForm> {
 }
 
 class _ProfileForm extends StatefulWidget {
-  const _ProfileForm({Key? key}) : super(key: key);
+  const _ProfileForm();
 
   @override
   State<_ProfileForm> createState() => _ProfileFormState();

--- a/packages/supabase_flutter/example/pubspec.yaml
+++ b/packages/supabase_flutter/example/pubspec.yaml
@@ -6,7 +6,7 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.15.0 <3.0.0'
+  sdk: '>=3.4.0 <4.0.0'
 
 dependencies:
   flutter:

--- a/packages/supabase_flutter/pubspec.yaml
+++ b/packages/supabase_flutter/pubspec.yaml
@@ -6,8 +6,8 @@ repository: 'https://github.com/supabase/supabase-flutter/tree/main/packages/sup
 documentation: 'https://supabase.com/docs/reference/dart/introduction'
 
 environment:
-  sdk: '>=3.3.0 <4.0.0'
-  flutter: '>=3.19.0'
+  sdk: '>=3.4.0 <4.0.0'
+  flutter: '>=3.22.0'
 
 dependencies:
   app_links: '>=6.2.0 <8.0.0'

--- a/packages/yet_another_json_isolate/pubspec.yaml
+++ b/packages/yet_another_json_isolate/pubspec.yaml
@@ -4,7 +4,7 @@ version: 2.1.0
 homepage: https://github.com/supabase-community/json-isolate-dart
 
 environment:
-  sdk: '>=3.0.0 <4.0.0'
+  sdk: '>=3.4.0 <4.0.0'
 
 dependencies:
   async: ^2.8.0


### PR DESCRIPTION
## What

Raises the minimum Dart SDK to `>=3.4.0` for **every package** in the workspace (functions_client, gotrue, postgrest, realtime_client, storage_client, supabase, supabase_flutter, yet_another_json_isolate) so the floor is consistent across the repo. Also:

- `supabase_flutter`: `environment.flutter` `>=3.19.0` → `>=3.22.0` (the release that bundled Dart 3.4.0)
- CI: the `test-flutter` matrix floor `3.19.x` → `3.22.x`
- Example app: corrects its stale `>=2.15.0 <3.0.0` constraint to `>=3.4.0 <4.0.0`

## Why

`supabase_flutter` needs Dart 3.4.0 to add the [`passkeys`](https://pub.dev/packages/passkeys) plugin (see the stacked passkey PR #1408): `passkeys` → `passkeys_web ^2.8.1` → `web ^1.1.1`, and `web >=1.0.0` requires Dart `>=3.4.0`.

```
Because passkeys >=2.17.4 depends on passkeys_web ^2.8.1 which depends on web ^1.1.1,
passkeys >=2.17.4 requires web ^1.1.1.
So, because web >=1.0.0 requires SDK version >=3.4.0 <4.0.0 ...
```

Bumping every package keeps the supported-SDK floor uniform rather than having `supabase_flutter` diverge from the rest.

> Note: `passkeys`/`passkeys_web` themselves declare `sdk: ">=3.0.0"` even though they really require 3.4.0. Submitted an upstream fix for that so the constraint is honest: corbado/flutter-passkeys#243.

## Note

Raising the minimum SDK is a breaking change for consumers still on Dart 3.3.x, so this should land in a minor/major release rather than a patch.

## Test plan

- [x] `melos bootstrap` resolves all 9 packages on Dart 3.4.0+
- [x] CI matrix updated so the min-version job uses an SDK that satisfies the new floor