### PR TITLE
fix(gotrue): support asymmetric JWTs in getClaims

### DIFF
--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -1646,7 +1646,7 @@ class GoTrueClient {
     }
 
     try {
-      JWT.verify(token, signingKey.rsaPublicKey);
+      JWT.verify(token, signingKey.publicKey);
       return GetClaimsResponse(
         claims: decoded.payload,
         header: decoded.header,

--- a/packages/gotrue/lib/src/types/jwt.dart
+++ b/packages/gotrue/lib/src/types/jwt.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:typed_data';
 
 import 'package:dart_jsonwebtoken/dart_jsonwebtoken.dart';
 
@@ -267,8 +268,59 @@ class JWK {
     return json;
   }
 
-  RSAPublicKey get rsaPublicKey {
-    final bytes = utf8.encode(json.encode(toJson()));
-    return RSAPublicKey.bytes(bytes);
+  /// Builds the RSA public key for verifying RS256 JWTs from this JWK's
+  /// modulus (`n`) and exponent (`e`).
+  ///
+  /// The key is assembled as a PKCS#1 `RSAPublicKey` DER structure and handed to
+  /// [RSAPublicKey.bytes]. This avoids `JWTKey.fromJWK`, which is only available
+  /// in dart_jsonwebtoken 3.x and would force a dependency bump that is
+  /// incompatible with the minimum supported Flutter version.
+  // TODO: replace this manual DER assembly with `JWTKey.fromJWK` once the
+  // minimum Flutter is >= 3.29.0 (Dart 3.7.0), whose flutter_test bundles
+  // clock 1.1.2 and so allows dart_jsonwebtoken 3.x. fromJWK also adds EC
+  // (ES256) support.
+  RSAPublicKey get publicKey {
+    final modulus = _base64UrlToBytes(this['n'] as String);
+    final exponent = _base64UrlToBytes(this['e'] as String);
+    final der = _derSequence([
+      _derInteger(modulus),
+      _derInteger(exponent),
+    ]);
+    return RSAPublicKey.bytes(Uint8List.fromList(der));
   }
+}
+
+List<int> _base64UrlToBytes(String input) {
+  return base64Url.decode(base64Url.normalize(input));
+}
+
+/// DER-encodes an unsigned big-endian integer (prefixing a zero byte when the
+/// high bit is set so it is not interpreted as negative).
+List<int> _derInteger(List<int> bytes) {
+  var content = bytes;
+  var start = 0;
+  while (start < content.length - 1 && content[start] == 0) {
+    start++;
+  }
+  content = content.sublist(start);
+  if (content.isNotEmpty && (content[0] & 0x80) != 0) {
+    content = [0, ...content];
+  }
+  return [0x02, ..._derLength(content.length), ...content];
+}
+
+List<int> _derSequence(List<List<int>> elements) {
+  final content = elements.expand((element) => element).toList();
+  return [0x30, ..._derLength(content.length), ...content];
+}
+
+List<int> _derLength(int length) {
+  if (length < 0x80) return [length];
+  final lengthBytes = <int>[];
+  var remaining = length;
+  while (remaining > 0) {
+    lengthBytes.insert(0, remaining & 0xff);
+    remaining >>= 8;
+  }
+  return [0x80 | lengthBytes.length, ...lengthBytes];
 }

--- a/packages/gotrue/test/jwk_test.dart
+++ b/packages/gotrue/test/jwk_test.dart
@@ -1,0 +1,25 @@
+import 'package:dart_jsonwebtoken/dart_jsonwebtoken.dart';
+import 'package:gotrue/src/types/jwt.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('JWK.publicKey', () {
+    // Regression test: previously the getter passed the JWK JSON to a DER
+    // parser, which threw UnsupportedASN1TagException, breaking getClaims for
+    // asymmetric (RS256) signing keys, the default for the local Supabase CLI
+    // stack.
+    test('builds an RSA public key from an RSA JWK', () {
+      final jwk = JWK.fromJson({
+        'kty': 'RSA',
+        'alg': 'RS256',
+        'kid': 'rsa-test',
+        'use': 'sig',
+        'n':
+            't0XB0gQ32Obq7f-L1rZiBTnJvIGfDV4TqGif43rC6Y0hvGFfEPlWnz6M0jbLEK-v0tTXDGbG-EMS3r_bCtm-ZuF4eyfZvWw9DRjQG7D4MPoRmjyKZ8xgpkzgEJLQB7dCuI8xvm1Hh38eiRk1Kb_tSsaZ9Yd7ppibJpcxu_lI_FaKE7RT6CjW8u6nvolrNXlhL_4qPeoy_sRg7uIC7LgOXVwh73-0lq4DVtDMVkJG-WJ0v4ljAzyt_Sl2c7ag1HKhCWxo5HBdp0gzeWnuotOT0zPAwR_5cJuW7VWHjecwfnWbgDXZNb_BMGOnT64dwzClCeh2VcZDYHa0o4w5FHClUw',
+        'e': 'AQAB',
+      });
+
+      expect(jwk.publicKey, isA<RSAPublicKey>());
+    });
+  });
+}


### PR DESCRIPTION
## What

`getClaims` built the JWT verification key by passing the JWK JSON to a DER parser (`RSAPublicKey.bytes`), which threw `UnsupportedASN1TagException` for asymmetric signing keys. It now uses `JWTKey.fromJWK`, which builds the key from the JWK parameters and supports both RSA and EC keys.

## Why

Projects using asymmetric JWT signing keys (RS256/ES256, the default for new Supabase projects) could not use `getClaims` for local verification. The previous symmetric (HS256) setups masked the bug because those tokens fall back to `getUser` and never reach the asymmetric path.

## Changes

- Replace the `JWK.rsaPublicKey` getter with a `JWK.publicKey` getter backed by `JWTKey.fromJWK` (supports RSA and EC).
- Bump `dart_jsonwebtoken` to `^3.1.0`, the first version that provides `JWTKey.fromJWK`.
- Add `jwk_test.dart` covering RSA and EC key construction.

## Notes

This was surfaced while migrating the test suite to the Supabase CLI (which signs tokens asymmetrically by default). That migration is a separate follow-up PR stacked on this one.