### PR TITLE
ci: extract example app builds into a separate workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,151 @@
+name: Build
+
+on:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  changes:
+    name: Detect affected packages
+    runs-on: ubuntu-latest
+    outputs:
+      flutter: ${{ steps.detect.outputs.flutter }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Setup Dart
+        uses: dart-lang/setup-dart@e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c # v1.7.1
+        with:
+          sdk: stable
+
+      - name: Detect affected packages
+        id: detect
+        run: |
+          set -euo pipefail
+
+          dart pub global activate melos
+
+          BASE="${{ github.event.pull_request.base.sha }}"
+
+          FORCE_ALL=false
+          if [ -z "$BASE" ]; then
+            FORCE_ALL=true
+          elif git diff --name-only "$BASE...HEAD" \
+              | grep -qE '^(\.github/workflows/build\.yml|melos\.yaml|pubspec\.lock|supabase/)'; then
+            FORCE_ALL=true
+          fi
+
+          if [ "$FORCE_ALL" = "true" ]; then
+            echo "Running all packages."
+            CHANGED=$(melos list --json | jq -r '.[].name')
+          else
+            CHANGED=$(melos list --json --diff="$BASE...HEAD" --include-dependents | jq -r '.[].name')
+          fi
+
+          echo "Affected packages:"
+          echo "$CHANGED"
+
+          if echo "$CHANGED" | grep -qx "supabase_flutter"; then
+            echo "flutter=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "flutter=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  build-flutter:
+    name: Build on ${{ matrix.os }}
+    needs: changes
+    if: ${{ needs.changes.outputs.flutter == 'true' }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    defaults:
+      run:
+        working-directory: packages/supabase_flutter
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
+        with:
+          channel: 'stable'
+          # Caching the latest stable is flaky: the cached SDK contains
+          # runner-image-specific binaries that break silently when the runner
+          # image is updated.
+          cache: false
+
+      - name: Show Flutter version
+        run: flutter --version
+
+      - name: Bootstrap workspace
+        run: |
+          cd ../../
+          dart pub global activate melos
+          melos bootstrap
+
+      - name: Build web app
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        run: |
+          cd example
+          flutter build web
+
+      - name: Build Linux app
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgtk-3-dev libblkid-dev liblzma-dev
+          cd example
+          flutter build linux
+
+      - name: Build Android app
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        run: |
+          cd example
+          flutter build apk
+
+      - name: Build macOS app
+        if: ${{ matrix.os == 'macos-latest' }}
+        run: |
+          cd example
+          flutter build macos
+
+      - name: Build iOS app
+        if: ${{ matrix.os == 'macos-latest' }}
+        run: |
+          cd example
+          flutter build ios --no-codesign
+
+      - name: Build Windows app
+        if: ${{ matrix.os == 'windows-latest' }}
+        run: |
+          cd example
+          flutter build windows
+
+  build-result:
+    name: Build result
+    needs: [changes, build-flutter]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify all jobs succeeded
+        run: |
+          if ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}; then
+            echo "One or more jobs failed or were cancelled."
+            exit 1
+          fi
+          echo "All required jobs passed or were skipped."

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -292,43 +292,9 @@ jobs:
           path-to-lcov: packages/supabase_flutter/coverage/lcov.info
           fail-on-error: false
 
-      - name: Build and test web (JS)
+      - name: Test web (JS)
         if: ${{ matrix.os == 'ubuntu-latest' && matrix.flutter-version == 'latest'}}
-        run: |
-          flutter test --platform chrome
-          cd example && flutter build web
-
-      - name: Build macOS app
-        if: ${{ matrix.os == 'macos-latest' && matrix.flutter-version == 'latest'}}
-        run: |
-          cd example
-          flutter build macos
-
-      - name: Build Windows app
-        if: ${{ matrix.os == 'windows-latest' && matrix.flutter-version == 'latest'}}
-        run: |
-          cd example
-          flutter build windows
-
-      - name: Build Linux app
-        if: ${{ matrix.os == 'ubuntu-latest' && matrix.flutter-version == 'latest'}}
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libgtk-3-dev libblkid-dev liblzma-dev
-          cd example
-          flutter build linux
-
-      - name: Build iOS app
-        if: ${{ matrix.os == 'macos-latest' && matrix.flutter-version == 'latest'}}
-        run: |
-          cd example
-          flutter build ios --no-codesign
-
-      - name: Build Android app
-        if: ${{ matrix.os == 'ubuntu-latest' && matrix.flutter-version == 'latest'}}
-        run: |
-          cd example
-          flutter build apk
+        run: flutter test --platform chrome
 
   coverage-finished:
     name: Finish coverage


### PR DESCRIPTION
## What

Moves the example app platform builds out of the `Test` workflow into a dedicated `Build` workflow.

Previously the `test-flutter` job in `test.yml` ran the unit tests and then built the example app for web, macOS, Windows, iOS, Android, and Linux ([example run](https://github.com/supabase/supabase-flutter/actions/runs/27605971605/job/81618020411?pr=1411)). These builds are now in their own workflow.

## Changes

- **New `.github/workflows/build.yml`** (runs on `pull_request`):
  - `changes` job: detects whether `supabase_flutter` is affected, simplified for PR-only triggers.
  - `build-flutter` job: matrix over `ubuntu-latest`, `macos-latest`, `windows-latest` on Flutter `3.x`, building the example app per platform (ubuntu: web/Linux/Android, macos: macOS/iOS, windows: Windows).
  - `build-result` job: aggregate pass/fail gate.
- **`.github/workflows/test.yml`**:
  - Removed all six app build steps from `test-flutter`.
  - Kept the web test, renamed `Build and test web (JS)` -> `Test web (JS)` (now only runs `flutter test --platform chrome`).

## Notes

- The web step previously did both a test and a build. The test stays in `test.yml`; only `flutter build web` moved to `build.yml`.
- The build matrix only uses Flutter `3.x` since builds previously only ran on `3.x`.
- If branch protection has required status checks, the old build check names no longer exist. Consider adding `Build result` as a required check.