### PR TITLE
ci: replace CodeQL default setup with an advanced workflow scanning Actions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,49 @@
+name: CodeQL
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: "30 4 * * 1"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze ${{ matrix.language }}
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        # CodeQL does not support Dart, so the package source cannot be
+        # analyzed. The only meaningful supported language in this monorepo
+        # is the GitHub Actions workflows themselves.
+        language:
+          - actions
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@8272c299f21ca24af15dfe9ac0971ba969e5e0d5 # v3.36.2
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: none
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@8272c299f21ca24af15dfe9ac0971ba969e5e0d5 # v3.36.2
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## What kind of change does this PR introduce?

CI fix.

## What is the current behavior?

The repository used CodeQL's Default setup, which auto-detected languages from the Flutter example app's platform scaffold. This produced four broken configurations:

- `java-kotlin` from `packages/supabase_flutter/example/android/`
- `swift` from `example/ios/` and `example/macos/`
- `c-cpp` from `example/linux/` and `example/windows/`
- `ruby` from the CocoaPods `Podfile`s

None of that is real source worth scanning, and CodeQL has no build system for it, so the scans failed with "No build command found" and "CodeQL exited with errors". CodeQL has no Dart support, so the actual SDK source (the Dart packages) cannot be analyzed at all. Only the `actions` configuration was meaningful and passing.

## What is the new behavior?

Adds `.github/workflows/codeql.yml`, an advanced CodeQL setup that scans only `actions` (the GitHub Actions workflows), which is the one supported language with real value in this monorepo. It uses `build-mode: none`, so there is nothing to build and nothing to fail.

- Runs on push and pull requests targeting `main`, plus a weekly schedule
- `actions/checkout` pinned by SHA to match the existing workflows
- `github/codeql-action` pinned by SHA to v3.36.2

Note: advanced setup and Default setup cannot coexist. Default setup must be disabled in the repository settings (Settings > Code security > Code scanning) for this workflow to take effect and to clear the failing java-kotlin, swift, ruby, and c-cpp configurations.

## Additional context

CodeQL's supported languages are C/C++, C#, Go, Java/Kotlin, JavaScript/TypeScript, Python, Ruby, Swift, and GitHub Actions. Dart and Flutter are not supported, which is why the SDK source itself is out of scope for CodeQL.