### PR TITLE
docs: restyle README header to match supabase-js

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,33 @@
-![Supabase](https://raw.githubusercontent.com/supabase/supabase-flutter/main/.github/images/supabase-banner.jpg)
+<br />
+<p align="center">
+  <a href="https://supabase.com">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/supabase/supabase/master/packages/common/assets/images/supabase-logo-wordmark--dark.svg">
+      <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/supabase/supabase/master/packages/common/assets/images/supabase-logo-wordmark--light.svg">
+      <img alt="Supabase Logo" width="300" src="https://raw.githubusercontent.com/supabase/supabase/master/packages/common/assets/images/logo-preview.jpg">
+    </picture>
+  </a>
 
-# `Supabase Flutter`
+  <h1 align="center">Supabase Flutter</h1>
 
-Flutter Client library for [Supabase](https://supabase.com/).
+  <p align="center">
+    Flutter client library for <a href="https://supabase.com">Supabase</a>.
+  </p>
 
-- Documentation: https://supabase.com/docs/reference/dart/introduction
+  <p align="center">
+    <a href="https://supabase.com/docs/guides/with-flutter">Guides</a>
+    ·
+    <a href="https://supabase.com/docs/reference/dart/introduction">Reference Docs</a>
+  </p>
+</p>
+
+<div align="center">
+
+[![Build](https://github.com/supabase/supabase-flutter/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/supabase/supabase-flutter/actions/workflows/test.yml?query=branch%3Amain)
+[![Package](https://img.shields.io/pub/v/supabase_flutter.svg)](https://pub.dev/packages/supabase_flutter)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](#license)
+
+</div>
 
 ## Run locally
 


### PR DESCRIPTION
## What

Restyles the top of the root `README.md` to match the [supabase-js](https://github.com/supabase/supabase-js) layout:

- Centered Supabase wordmark logo with dark/light mode `<picture>` variants
- Centered `<h1>` title and tagline
- Centered nav links (Guides · Reference Docs) pointing at the Flutter/Dart docs
- Centered badge row: Build (`test.yml` on `main`), pub.dev version for `supabase_flutter`, and MIT license

The rest of the README is unchanged.