### PR TITLE
ci: grant Actions write to release tagger token

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -27,6 +27,7 @@ jobs:
           private-key: ${{ secrets.PRIVATE_KEY }}
           permission-contents: write
           permission-pull-requests: write
+          permission-actions: write
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:


### PR DESCRIPTION
## Problem

The `Create Release Tags` workflow's `Trigger publish workflows` step runs:

```
gh workflow run release-publish.yml --ref $MELOS_PACKAGE_NAME-v$MELOS_PACKAGE_VERSION
```

This calls the [workflow dispatches REST endpoint](https://docs.github.com/en/rest/actions/workflows#create-a-workflow-dispatch-event) (`POST /repos/{owner}/{repo}/actions/workflows/{id}/dispatches`), which requires `actions: write` on the token. The generated app token only requested `contents` and `pull-requests`, so the dispatch failed with:

```
HTTP 403: Resource not accessible by integration
```

(See the failed run: https://github.com/supabase/supabase-flutter/actions/runs/27629921207/job/81701801564)

## Fix

Request `permission-actions: write` when generating the app token so it can create the workflow dispatch event.

## Prerequisite (already done)

`create-github-app-token` can only mint scopes the App actually holds, so the `LibsReleaseTagger` GitHub App also needed **Actions: Read and write** added to its repository permissions and the installation re-approved. This has been completed.

## Note on alternatives

A tag-triggered `on: push: tags:` approach was considered but rejected: GitHub does not create workflow runs when more than three tags are pushed at once, and a release pushes up to 9 package tags simultaneously, so most packages would be silently skipped. The per-package dispatch design avoids this.