### PR TITLE
fix(realtime_client): cancel connection stream subscription on disconnect

### DIFF
--- a/packages/functions_client/lib/src/functions_client.dart
+++ b/packages/functions_client/lib/src/functions_client.dart
@@ -182,13 +182,12 @@ class FunctionsClient {
 
     if (200 <= response.statusCode && response.statusCode < 300) {
       return FunctionResponse(data: data, status: response.statusCode);
-    } else {
-      throw FunctionException(
-        status: response.statusCode,
-        details: data,
-        reasonPhrase: response.reasonPhrase,
-      );
     }
+    throw FunctionException(
+      status: response.statusCode,
+      details: data,
+      reasonPhrase: response.reasonPhrase,
+    );
   }
 
   /// Disposes the self created isolate for json encoding/decoding

--- a/packages/functions_client/lib/src/functions_client.dart
+++ b/packages/functions_client/lib/src/functions_client.dart
@@ -100,7 +100,7 @@ class FunctionsClient {
 
     // Merge query parameters with forceFunctionRegion if region is specified
     final effectiveQueryParams = <String, dynamic>{
-      if (queryParameters != null) ...queryParameters,
+      ...?queryParameters,
       if (effectiveRegion != null && effectiveRegion != 'any')
         'forceFunctionRegion': effectiveRegion,
     };
@@ -111,7 +111,7 @@ class FunctionsClient {
 
     final finalHeaders = <String, String>{
       ..._headers,
-      if (headers != null) ...headers,
+      ...?headers,
       if (effectiveRegion != null && effectiveRegion != 'any')
         'x-region': effectiveRegion,
     };

--- a/packages/functions_client/lib/src/types.dart
+++ b/packages/functions_client/lib/src/types.dart
@@ -20,7 +20,7 @@ class FunctionResponse {
   final dynamic data;
   final int status;
 
-  FunctionResponse({
+  const FunctionResponse({
     this.data,
     required this.status,
   });

--- a/packages/functions_client/test/custom_http_client.dart
+++ b/packages/functions_client/test/custom_http_client.dart
@@ -60,42 +60,40 @@ class CustomHttpClient extends BaseClient {
           "Content-Type": "application/json",
         },
       );
-    } else {
-      final Stream<List<int>> stream;
-      final Map<String, String> headers;
-
-      if (request is MultipartRequest) {
-        stream = Stream.value(
-          utf8.encode(jsonEncode([
-            for (final file in request.files)
-              {
-                "name": file.field,
-                "content": await file.finalize().bytesToString()
-              }
-          ])),
-        );
-        headers = {"Content-Type": "application/json"};
-      } else {
-        // Check if the request contains binary data (Uint8List)
-        final isOctetStream =
-            request.headers['Content-Type'] == 'application/octet-stream';
-        if (isOctetStream) {
-          // Return the original binary data
-          final bodyBytes = (request as Request).bodyBytes;
-          stream = Stream.value(bodyBytes);
-          headers = {"Content-Type": "application/octet-stream"};
-        } else {
-          stream =
-              Stream.value(utf8.encode(jsonEncode({"key": "Hello World"})));
-          headers = {"Content-Type": "application/json"};
-        }
-      }
-      return StreamedResponse(
-        stream,
-        200,
-        request: request,
-        headers: headers,
-      );
     }
+    final Stream<List<int>> stream;
+    final Map<String, String> headers;
+
+    if (request is MultipartRequest) {
+      stream = Stream.value(
+        utf8.encode(jsonEncode([
+          for (final file in request.files)
+            {
+              "name": file.field,
+              "content": await file.finalize().bytesToString()
+            }
+        ])),
+      );
+      headers = {"Content-Type": "application/json"};
+    } else {
+      // Check if the request contains binary data (Uint8List)
+      final isOctetStream =
+          request.headers['Content-Type'] == 'application/octet-stream';
+      if (isOctetStream) {
+        // Return the original binary data
+        final bodyBytes = (request as Request).bodyBytes;
+        stream = Stream.value(bodyBytes);
+        headers = {"Content-Type": "application/octet-stream"};
+      } else {
+        stream = Stream.value(utf8.encode(jsonEncode({"key": "Hello World"})));
+        headers = {"Content-Type": "application/json"};
+      }
+    }
+    return StreamedResponse(
+      stream,
+      200,
+      request: request,
+      headers: headers,
+    );
   }
 }

--- a/packages/gotrue/lib/src/gotrue_admin_mfa_api.dart
+++ b/packages/gotrue/lib/src/gotrue_admin_mfa_api.dart
@@ -8,7 +8,7 @@ class GoTrueAdminMFAApi {
   final Map<String, String> _headers;
   final GotrueFetch _fetch;
 
-  GoTrueAdminMFAApi({
+  const GoTrueAdminMFAApi({
     required String url,
     required Map<String, String> headers,
     required GotrueFetch fetch,

--- a/packages/gotrue/lib/src/gotrue_admin_oauth_api.dart
+++ b/packages/gotrue/lib/src/gotrue_admin_oauth_api.dart
@@ -8,7 +8,7 @@ import 'types/types.dart';
 class OAuthClientResponse {
   final OAuthClient? client;
 
-  OAuthClientResponse({this.client});
+  const OAuthClientResponse({this.client});
 
   factory OAuthClientResponse.fromJson(Map<String, dynamic> json) {
     return OAuthClientResponse(
@@ -26,7 +26,7 @@ class OAuthClientListResponse {
   final int? lastPage;
   final int total;
 
-  OAuthClientListResponse({
+  const OAuthClientListResponse({
     required this.clients,
     this.aud,
     this.nextPage,
@@ -54,7 +54,7 @@ class GoTrueAdminOAuthApi {
   final Map<String, String> _headers;
   final GotrueFetch _fetch;
 
-  GoTrueAdminOAuthApi({
+  const GoTrueAdminOAuthApi({
     required String url,
     required Map<String, String> headers,
     required GotrueFetch fetch,

--- a/packages/gotrue/lib/src/gotrue_admin_passkey_api.dart
+++ b/packages/gotrue/lib/src/gotrue_admin_passkey_api.dart
@@ -18,7 +18,7 @@ class GoTrueAdminPasskeyApi {
   final Map<String, String> _headers;
   final GotrueFetch _fetch;
 
-  GoTrueAdminPasskeyApi({
+  const GoTrueAdminPasskeyApi({
     required String url,
     required Map<String, String> headers,
     required GotrueFetch fetch,
@@ -44,9 +44,7 @@ class GoTrueAdminPasskeyApi {
         data.toString(),
       );
     }
-    return data
-        .map((e) => Passkey.fromJson(Map<String, dynamic>.from(e as Map)))
-        .toList();
+    return data.map((e) => Passkey.fromJson(Map.from(e as Map))).toList();
   }
 
   /// Deletes the passkey with [passkeyId] from the user with [userId].

--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -1401,7 +1401,7 @@ class GoTrueClient {
     _broadcastChannelSubscription?.cancel();
     for (final completer in _pendingRefreshes.values) {
       if (!completer.isCompleted) {
-        completer.completeError(AuthException('Disposed'));
+        completer.completeError(AuthException('Disposed'), StackTrace.current);
       }
     }
     _pendingRefreshes.clear();

--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -242,7 +242,7 @@ class GoTrueClient {
       'You must provide either an email or phone number',
     );
 
-    late final Map<String, dynamic> response;
+    final Map<String, dynamic> response;
 
     if (email != null) {
       String? codeChallenge;
@@ -314,7 +314,7 @@ class GoTrueClient {
     required String password,
     String? captchaToken,
   }) async {
-    late final Map<String, dynamic> response;
+    final Map<String, dynamic> response;
 
     if (email != null) {
       response = await _fetch.request(
@@ -365,7 +365,7 @@ class GoTrueClient {
     String? redirectTo,
     String? scopes,
     Map<String, String>? queryParams,
-  }) async {
+  }) {
     return _getUrlForProvider(
       provider,
       url: '$_url/authorize',
@@ -767,9 +767,8 @@ class GoTrueClient {
 
     if ((response as Map).containsKey(['message_id'])) {
       return ResendResponse(messageId: response['message_id']);
-    } else {
-      return ResendResponse();
     }
+    return ResendResponse();
   }
 
   /// Gets the current user details from current session or custom [jwt]
@@ -1162,21 +1161,19 @@ class GoTrueClient {
         final refreshToken = session.refreshToken;
         if (_autoRefreshToken && refreshToken != null) {
           return await _callRefreshToken(refreshToken);
-        } else {
-          await signOut();
-          throw notifyException(AuthException('Session expired.'));
         }
-      } else {
-        final shouldEmitEvent = _currentSession == null ||
-            _currentSession!.user.id != session.user.id;
-        _saveSession(session);
-
-        if (shouldEmitEvent) {
-          notifyAllSubscribers(AuthChangeEvent.tokenRefreshed);
-        }
-
-        return AuthResponse(session: session);
+        await signOut();
+        throw notifyException(AuthException('Session expired.'));
       }
+      final shouldEmitEvent = _currentSession == null ||
+          _currentSession!.user.id != session.user.id;
+      _saveSession(session);
+
+      if (shouldEmitEvent) {
+        notifyAllSubscribers(AuthChangeEvent.tokenRefreshed);
+      }
+
+      return AuthResponse(session: session);
     } catch (error, stackTrace) {
       notifyException(error, stackTrace);
       rethrow;

--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -1242,7 +1242,7 @@ class GoTrueClient {
   Future<AuthResponse> _refreshAccessToken(String refreshToken) async {
     final startedAt = DateTime.now();
     var attempt = 0;
-    return await retry<AuthResponse>(
+    return await retry(
       // Make a GET request
       () async {
         attempt++;

--- a/packages/gotrue/lib/src/gotrue_mfa_api.dart
+++ b/packages/gotrue/lib/src/gotrue_mfa_api.dart
@@ -4,7 +4,7 @@ class GoTrueMFAApi {
   final GoTrueClient _client;
   final GotrueFetch _fetch;
 
-  GoTrueMFAApi({required GoTrueClient client, required GotrueFetch fetch})
+  const GoTrueMFAApi({required GoTrueClient client, required GotrueFetch fetch})
       : _client = client,
         _fetch = fetch;
 

--- a/packages/gotrue/lib/src/gotrue_passkey_api.dart
+++ b/packages/gotrue/lib/src/gotrue_passkey_api.dart
@@ -42,7 +42,7 @@ class GoTruePasskeyApi {
   final GoTrueClient _client;
   final GotrueFetch _fetch;
 
-  GoTruePasskeyApi({
+  const GoTruePasskeyApi({
     required GoTrueClient client,
     required GotrueFetch fetch,
   })  : _client = client,
@@ -183,9 +183,7 @@ class GoTruePasskeyApi {
         data.toString(),
       );
     }
-    return data
-        .map((e) => Passkey.fromJson(Map<String, dynamic>.from(e as Map)))
-        .toList();
+    return data.map((e) => Passkey.fromJson(Map.from(e as Map))).toList();
   }
 
   /// Updates the friendly name of a passkey.

--- a/packages/gotrue/lib/src/types/auth_exception.dart
+++ b/packages/gotrue/lib/src/types/auth_exception.dart
@@ -38,7 +38,7 @@ class AuthException implements Exception {
 }
 
 class AuthPKCEGrantCodeExchangeError extends AuthException {
-  AuthPKCEGrantCodeExchangeError(super.message);
+  const AuthPKCEGrantCodeExchangeError(super.message);
 }
 
 class AuthSessionMissingException extends AuthException {
@@ -64,7 +64,7 @@ class AuthRetryableFetchException extends AuthException {
 }
 
 class AuthApiException extends AuthException {
-  AuthApiException(super.message, {super.statusCode, super.code});
+  const AuthApiException(super.message, {super.statusCode, super.code});
 
   @override
   String toString() =>

--- a/packages/gotrue/lib/src/types/jwt.dart
+++ b/packages/gotrue/lib/src/types/jwt.dart
@@ -14,7 +14,7 @@ class JwtHeader {
   /// Token type - typically 'JWT'
   final String? typ;
 
-  JwtHeader({
+  const JwtHeader({
     required this.alg,
     this.kid,
     this.typ,
@@ -88,7 +88,7 @@ class JwtPayload {
   }
 
   Map<String, dynamic> toJson() {
-    return Map<String, dynamic>.of(claims);
+    return Map.of(claims);
   }
 }
 
@@ -106,7 +106,7 @@ class DecodedJwt {
   /// Raw encoded parts of the JWT
   final JwtRawParts raw;
 
-  DecodedJwt({
+  const DecodedJwt({
     required this.header,
     required this.payload,
     required this.signature,
@@ -125,7 +125,7 @@ class JwtRawParts {
   /// Raw base64url encoded signature
   final String signature;
 
-  JwtRawParts({
+  const JwtRawParts({
     required this.header,
     required this.payload,
     required this.signature,
@@ -143,7 +143,7 @@ class GetClaimsResponse {
   /// JWT signature
   final List<int> signature;
 
-  GetClaimsResponse({
+  const GetClaimsResponse({
     required this.claims,
     required this.header,
     required this.signature,
@@ -164,7 +164,7 @@ class GetClaimsOptions {
 class JWKSet {
   final List<JWK> keys;
 
-  JWKSet({required this.keys});
+  const JWKSet({required this.keys});
 
   factory JWKSet.fromJson(Map<String, dynamic> json) {
     final keys = (json['keys'] as List<dynamic>?)

--- a/packages/gotrue/lib/src/types/jwt.dart
+++ b/packages/gotrue/lib/src/types/jwt.dart
@@ -83,12 +83,12 @@ class JwtPayload {
       nbf: json['nbf'] as int?,
       iat: json['iat'] as int?,
       jti: json['jti'] as String?,
-      claims: Map<String, dynamic>.from(json),
+      claims: Map<String, dynamic>.of(json),
     );
   }
 
   Map<String, dynamic> toJson() {
-    return Map<String, dynamic>.from(claims);
+    return Map<String, dynamic>.of(claims);
   }
 }
 
@@ -221,7 +221,7 @@ class JWK {
     final alg = json['alg'] as String?;
     final kid = json['kid'] as String?;
 
-    final Map<String, dynamic> additionalProperties = Map.from(json);
+    final Map<String, dynamic> additionalProperties = Map.of(json);
     additionalProperties.remove('kty');
     additionalProperties.remove('key_ops');
     additionalProperties.remove('alg');

--- a/packages/gotrue/lib/src/types/mfa.dart
+++ b/packages/gotrue/lib/src/types/mfa.dart
@@ -88,10 +88,9 @@ class PhoneEnrollment {
     } else if (value is Map<String, dynamic>) {
       // Server returns phone data as an object
       return PhoneEnrollment.fromJson(value);
-    } else {
-      throw ArgumentError(
-          'Invalid phone enrollment data type: ${value.runtimeType}');
     }
+    throw ArgumentError(
+        'Invalid phone enrollment data type: ${value.runtimeType}');
   }
 }
 

--- a/packages/gotrue/lib/src/types/mfa.dart
+++ b/packages/gotrue/lib/src/types/mfa.dart
@@ -193,7 +193,7 @@ class AuthMFAListFactorsResponse {
   final List<Factor> phone;
   final List<Factor> webauthn;
 
-  AuthMFAListFactorsResponse({
+  const AuthMFAListFactorsResponse({
     required this.all,
     required this.totp,
     required this.phone,

--- a/packages/gotrue/lib/src/types/passkey.dart
+++ b/packages/gotrue/lib/src/types/passkey.dart
@@ -100,7 +100,7 @@ class PasskeyRegistrationOptionsResponse {
       Map<String, dynamic> json) {
     return PasskeyRegistrationOptionsResponse(
       challengeId: json['challenge_id'] as String,
-      options: Map<String, dynamic>.from(json['options'] as Map),
+      options: Map.from(json['options'] as Map),
       expiresAt: _parseExpiresAt(json),
     );
   }
@@ -134,7 +134,7 @@ class PasskeyAuthenticationOptionsResponse {
       Map<String, dynamic> json) {
     return PasskeyAuthenticationOptionsResponse(
       challengeId: json['challenge_id'] as String,
-      options: Map<String, dynamic>.from(json['options'] as Map),
+      options: Map.from(json['options'] as Map),
       expiresAt: _parseExpiresAt(json),
     );
   }

--- a/packages/gotrue/lib/src/types/types.dart
+++ b/packages/gotrue/lib/src/types/types.dart
@@ -192,7 +192,7 @@ class OAuthClient {
   /// Timestamp when the client was last updated
   final String updatedAt;
 
-  OAuthClient({
+  const OAuthClient({
     required this.clientId,
     required this.clientName,
     this.clientSecret,
@@ -219,7 +219,7 @@ class OAuthClient {
         json['registration_type'] as String,
       ),
       clientUri: json['client_uri'] as String?,
-      redirectUris: (json['redirect_uris'] as List).cast<String>(),
+      redirectUris: (json['redirect_uris'] as List).cast(),
       grantTypes: (json['grant_types'] as List)
           .map(
             (e) => OAuthClientGrantType.values.firstWhere(
@@ -262,7 +262,7 @@ class CreateOAuthClientParams {
   /// Scope of the OAuth client
   final String? scope;
 
-  CreateOAuthClientParams({
+  const CreateOAuthClientParams({
     required this.clientName,
     this.clientUri,
     required this.redirectUris,
@@ -306,7 +306,7 @@ class UpdateOAuthClientParams {
   /// Scope of the OAuth client
   final String? scope;
 
-  UpdateOAuthClientParams({
+  const UpdateOAuthClientParams({
     this.clientName,
     this.clientUri,
     this.redirectUris,

--- a/packages/gotrue/lib/src/types/user.dart
+++ b/packages/gotrue/lib/src/types/user.dart
@@ -227,7 +227,7 @@ class UserIdentity {
     return UserIdentity(
       id: map['id'] as String,
       userId: map['user_id'] as String,
-      identityData: (map['identity_data'] as Map?)?.cast<String, dynamic>(),
+      identityData: (map['identity_data'] as Map?)?.cast(),
       identityId: (map['identity_id'] ?? '') as String,
       provider: map['provider'] as String,
       createdAt: map['created_at'] as String?,

--- a/packages/gotrue/test/src/constants_test.dart
+++ b/packages/gotrue/test/src/constants_test.dart
@@ -304,7 +304,7 @@ void main() {
       expect(authEvents.length, equals(2));
       expect(authEvents.contains(AuthChangeEvent.signedIn), isTrue);
 
-      final linkTypeMap = <GenerateLinkType, String>{
+      final linkTypeMap = {
         GenerateLinkType.signup: 'signup_link',
         GenerateLinkType.recovery: 'recovery_link',
       };

--- a/packages/gotrue/test/src/types/auth_exception_test.dart
+++ b/packages/gotrue/test/src/types/auth_exception_test.dart
@@ -463,7 +463,7 @@ void main() {
     });
 
     test('can catch all auth exceptions as AuthException', () {
-      final exceptions = <AuthException>[
+      final exceptions = [
         const AuthException('base error'),
         AuthPKCEGrantCodeExchangeError('pkce error'),
         AuthSessionMissingException(),

--- a/packages/gotrue/test/src/types/session_test.dart
+++ b/packages/gotrue/test/src/types/session_test.dart
@@ -12,7 +12,7 @@ void main() {
     setUp(() {
       mockUser = const User(
         id: '123',
-        appMetadata: <String, dynamic>{},
+        appMetadata: {},
         userMetadata: <String, dynamic>{},
         aud: 'authenticated',
         createdAt: '2023-01-01T00:00:00Z',
@@ -292,7 +292,7 @@ void main() {
 
         final newUser = const User(
           id: '456',
-          appMetadata: <String, dynamic>{},
+          appMetadata: {},
           userMetadata: <String, dynamic>{},
           aud: 'authenticated',
           createdAt: '2023-01-02T00:00:00Z',
@@ -317,7 +317,7 @@ void main() {
 
         final newUser = const User(
           id: '456',
-          appMetadata: <String, dynamic>{},
+          appMetadata: {},
           userMetadata: <String, dynamic>{},
           aud: 'authenticated',
           createdAt: '2023-01-02T00:00:00Z',

--- a/packages/gotrue/test/src/types/user_test.dart
+++ b/packages/gotrue/test/src/types/user_test.dart
@@ -259,7 +259,7 @@ void main() {
       test('serializes user correctly', () {
         const user = User(
           id: '123',
-          appMetadata: <String, dynamic>{'provider': 'email'},
+          appMetadata: {'provider': 'email'},
           userMetadata: <String, dynamic>{'name': 'John Doe'},
           aud: 'authenticated',
           confirmationSentAt: '2023-01-01T00:00:00Z',
@@ -318,7 +318,7 @@ void main() {
 
         const user = User(
           id: '123',
-          appMetadata: <String, dynamic>{},
+          appMetadata: {},
           userMetadata: <String, dynamic>{},
           aud: 'authenticated',
           createdAt: '2023-01-01T00:00:00Z',
@@ -335,7 +335,7 @@ void main() {
       test('handles null identities and factors', () {
         const user = User(
           id: '123',
-          appMetadata: <String, dynamic>{},
+          appMetadata: {},
           userMetadata: <String, dynamic>{},
           aud: 'authenticated',
           createdAt: '2023-01-01T00:00:00Z',
@@ -354,7 +354,7 @@ void main() {
       test('includes all user properties', () {
         const user = User(
           id: '123',
-          appMetadata: <String, dynamic>{'provider': 'email'},
+          appMetadata: {'provider': 'email'},
           userMetadata: <String, dynamic>{'name': 'John Doe'},
           aud: 'authenticated',
           email: 'test@example.com',
@@ -375,7 +375,7 @@ void main() {
       test('returns true for identical users', () {
         const user1 = User(
           id: '123',
-          appMetadata: <String, dynamic>{'provider': 'email'},
+          appMetadata: {'provider': 'email'},
           userMetadata: <String, dynamic>{'name': 'John Doe'},
           aud: 'authenticated',
           email: 'test@example.com',
@@ -385,7 +385,7 @@ void main() {
 
         const user2 = User(
           id: '123',
-          appMetadata: <String, dynamic>{'provider': 'email'},
+          appMetadata: {'provider': 'email'},
           userMetadata: <String, dynamic>{'name': 'John Doe'},
           aud: 'authenticated',
           email: 'test@example.com',
@@ -400,7 +400,7 @@ void main() {
       test('returns false for users with different ids', () {
         const user1 = User(
           id: '123',
-          appMetadata: <String, dynamic>{},
+          appMetadata: {},
           userMetadata: <String, dynamic>{},
           aud: 'authenticated',
           createdAt: '2023-01-01T00:00:00Z',
@@ -408,7 +408,7 @@ void main() {
 
         const user2 = User(
           id: '456',
-          appMetadata: <String, dynamic>{},
+          appMetadata: {},
           userMetadata: <String, dynamic>{},
           aud: 'authenticated',
           createdAt: '2023-01-01T00:00:00Z',
@@ -440,7 +440,7 @@ void main() {
       test('handles deep collection equality correctly', () {
         const user1 = User(
           id: '123',
-          appMetadata: <String, dynamic>{
+          appMetadata: {
             'nested': <String, dynamic>{'key': 'value'}
           },
           userMetadata: <String, dynamic>{
@@ -452,7 +452,7 @@ void main() {
 
         const user2 = User(
           id: '123',
-          appMetadata: <String, dynamic>{
+          appMetadata: {
             'nested': <String, dynamic>{'key': 'value'}
           },
           userMetadata: <String, dynamic>{
@@ -468,7 +468,7 @@ void main() {
       test('returns true for reference equality', () {
         const user = User(
           id: '123',
-          appMetadata: <String, dynamic>{},
+          appMetadata: {},
           userMetadata: <String, dynamic>{},
           aud: 'authenticated',
           createdAt: '2023-01-01T00:00:00Z',
@@ -482,7 +482,7 @@ void main() {
       test('preserves all data through JSON roundtrip', () {
         const original = User(
           id: '123',
-          appMetadata: <String, dynamic>{'provider': 'email'},
+          appMetadata: {'provider': 'email'},
           userMetadata: <String, dynamic>{'name': 'John Doe'},
           aud: 'authenticated',
           email: 'test@example.com',
@@ -500,7 +500,7 @@ void main() {
       test('preserves complex nested data', () {
         const original = User(
           id: '123',
-          appMetadata: <String, dynamic>{
+          appMetadata: {
             'provider': 'oauth',
             'providers': ['google', 'facebook'],
             'nested': <String, dynamic>{'deep': 'value'}

--- a/packages/postgrest/lib/src/postgrest.dart
+++ b/packages/postgrest/lib/src/postgrest.dart
@@ -41,7 +41,7 @@ class PostgrestClient {
     this.retryEnabled = true,
     @visibleForTesting Duration Function(int attempt)? retryDelay,
   })  : _schema = schema,
-        headers = {...defaultHeaders, if (headers != null) ...headers},
+        headers = {...defaultHeaders, ...?headers},
         _isolate = isolate ?? (YAJsonIsolate()..initialize()),
         _hasCustomIsolate = isolate != null,
         _retryDelay = retryDelay {

--- a/packages/postgrest/lib/src/postgrest.dart
+++ b/packages/postgrest/lib/src/postgrest.dart
@@ -69,7 +69,7 @@ class PostgrestClient {
   /// Perform a table operation.
   PostgrestQueryBuilder<void> from(String table) {
     final url = '${this.url}/$table';
-    return PostgrestQueryBuilder<void>(
+    return PostgrestQueryBuilder(
       url: Uri.parse(url),
       headers: {...headers},
       schema: _schema,

--- a/packages/postgrest/lib/src/postgrest_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_builder.dart
@@ -360,7 +360,7 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
     PostgrestException error,
   ) {
     if (error.details is String &&
-        error.details.toString().contains('Results contain 0 rows')) {
+        (error.details as String).contains('Results contain 0 rows')) {
       if (_count != null && response.request!.method != HttpMethod.head.value) {
         if (_converter != null) {
           return PostgrestResponse<S>(data: _converter(null as R), count: 0)

--- a/packages/postgrest/lib/src/postgrest_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_builder.dart
@@ -194,7 +194,7 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
       }
 
       final response = await _executeWithRetry(send, method, execHeaders);
-      return _parseResponse(response, method);
+      return await _parseResponse(response, method);
     } catch (error) {
       rethrow;
     }
@@ -318,45 +318,43 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
           data: converted,
           count: count!,
         ) as T;
-      } else {
-        return converted as T;
       }
-    } else {
-      late PostgrestException error;
-      if (response.request!.method != HttpMethod.head.value) {
-        try {
-          final errorJson = jsonDecode(response.body) as Map<String, dynamic>;
-          error = PostgrestException.fromJson(
-            errorJson,
-            message: response.body,
-            code: response.statusCode,
-            details: response.reasonPhrase,
-          );
-
-          if (_maybeSingle) {
-            return _handleMaybeSingleError(response, error);
-          }
-        } catch (_) {
-          error = PostgrestException(
-            message: response.body,
-            code: '${response.statusCode}',
-            details: response.reasonPhrase,
-          );
-        }
-      } else {
-        error = PostgrestException(
-          code: '${response.statusCode}',
+      return converted as T;
+    }
+    PostgrestException error;
+    if (response.request!.method != HttpMethod.head.value) {
+      try {
+        final errorJson = jsonDecode(response.body) as Map<String, dynamic>;
+        error = PostgrestException.fromJson(
+          errorJson,
           message: response.body,
-          details: 'Error in Postgrest response for method HEAD',
-          hint: response.reasonPhrase,
+          code: response.statusCode,
+          details: response.reasonPhrase,
+        );
+
+        if (_maybeSingle) {
+          return _handleMaybeSingleError(response, error);
+        }
+      } catch (_) {
+        error = PostgrestException(
+          message: response.body,
+          code: '${response.statusCode}',
+          details: response.reasonPhrase,
         );
       }
-
-      _log.finest('$error from request: $_url');
-      _log.fine('$error from request');
-
-      throw error;
+    } else {
+      error = PostgrestException(
+        code: '${response.statusCode}',
+        message: response.body,
+        details: 'Error in Postgrest response for method HEAD',
+        hint: response.reasonPhrase,
+      );
     }
+
+    _log.finest('$error from request: $_url');
+    _log.fine('$error from request');
+
+    throw error;
   }
 
   /// When [_maybeSingle] is true, check whether error details contain
@@ -372,19 +370,15 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
         if (_converter != null) {
           return PostgrestResponse<S>(data: _converter(null as R), count: 0)
               as T;
-        } else {
-          return null as T;
         }
-      } else {
-        if (_converter != null) {
-          return _converter(null as R) as T;
-        } else {
-          return null as T;
-        }
+        return null as T;
       }
-    } else {
-      throw error;
+      if (_converter != null) {
+        return _converter(null as R) as T;
+      }
+      return null as T;
     }
+    throw error;
   }
 
   /// Get new Uri with updated queryParams
@@ -393,7 +387,7 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
   /// [url] may be used to update based on a different url than the current one
   Uri appendSearchParams(String key, String value, [Uri? url]) {
     final searchParams =
-        Map<String, dynamic>.from((url ?? _url).queryParametersAll);
+        Map<String, dynamic>.of((url ?? _url).queryParametersAll);
     searchParams[key] = [...searchParams[key] ?? [], value];
     return (url ?? _url).replace(queryParameters: searchParams);
   }
@@ -402,7 +396,7 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
   ///
   /// [url] may be used to update based on a different url than the current one
   Uri overrideSearchParams(String key, String value) {
-    final searchParams = Map<String, dynamic>.from(_url.queryParametersAll);
+    final searchParams = Map<String, dynamic>.of(_url.queryParametersAll);
     searchParams[key] = value;
     return _url.replace(queryParameters: searchParams);
   }
@@ -411,9 +405,8 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
   String _cleanFilterArray(List filter) {
     if (filter.every((element) => element is num)) {
       return filter.map((s) => '$s').join(',');
-    } else {
-      return filter.map((s) => '"$s"').join(',');
     }
+    return filter.map((s) => '"$s"').join(',');
   }
 
   @override
@@ -466,7 +459,8 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
       });
     }
 
-    return _execute().then(onValue, onError: (Object error, StackTrace stack) {
+    return _execute().then(onValue,
+        onError: (Object error, StackTrace stack) async {
       final enrichedStack = enrichStack(stack);
       final FutureOr<U> result;
       if (onError is Function(Object, StackTrace)) {
@@ -489,7 +483,7 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
         );
       }
       try {
-        return result;
+        return await result;
       } on TypeError {
         throw ArgumentError(
           "The error handler of Future.then must return a value of the "

--- a/packages/postgrest/lib/src/postgrest_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_builder.dart
@@ -142,62 +142,57 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
       }
     }
 
-    try {
-      if (method == null) {
-        throw ArgumentError(
-          'Missing table operation: select, insert, update or delete',
-        );
-      }
-
-      if (_schema == null) {
-        // skip
-      } else if (method == HttpMethod.get || method == HttpMethod.head) {
-        execHeaders['Accept-Profile'] = _schema;
-      } else {
-        execHeaders['Content-Profile'] = _schema;
-      }
-      if (method != HttpMethod.get && method != HttpMethod.head) {
-        execHeaders['Content-Type'] = 'application/json';
-      }
-      final bodyStr = jsonEncode(_body);
-      _log.finest("Request: ${method.value} $_url");
-
-      final Future<http.Response> Function() send;
-      if (method == HttpMethod.get) {
-        send = () => (_httpClient?.get ?? http.get)(_url, headers: execHeaders);
-      } else if (method == HttpMethod.post) {
-        send = () => (_httpClient?.post ?? http.post)(
-              _url,
-              headers: execHeaders,
-              body: bodyStr,
-            );
-      } else if (method == HttpMethod.put) {
-        send = () => (_httpClient?.put ?? http.put)(
-              _url,
-              headers: execHeaders,
-              body: bodyStr,
-            );
-      } else if (method == HttpMethod.patch) {
-        send = () => (_httpClient?.patch ?? http.patch)(
-              _url,
-              headers: execHeaders,
-              body: bodyStr,
-            );
-      } else if (method == HttpMethod.delete) {
-        send = () =>
-            (_httpClient?.delete ?? http.delete)(_url, headers: execHeaders);
-      } else if (method == HttpMethod.head) {
-        send =
-            () => (_httpClient?.head ?? http.head)(_url, headers: execHeaders);
-      } else {
-        throw StateError('Unknown HTTP method: ${method.value}');
-      }
-
-      final response = await _executeWithRetry(send, method, execHeaders);
-      return await _parseResponse(response, method);
-    } catch (error) {
-      rethrow;
+    if (method == null) {
+      throw ArgumentError(
+        'Missing table operation: select, insert, update or delete',
+      );
     }
+
+    if (_schema == null) {
+      // skip
+    } else if (method == HttpMethod.get || method == HttpMethod.head) {
+      execHeaders['Accept-Profile'] = _schema;
+    } else {
+      execHeaders['Content-Profile'] = _schema;
+    }
+    if (method != HttpMethod.get && method != HttpMethod.head) {
+      execHeaders['Content-Type'] = 'application/json';
+    }
+    final bodyStr = jsonEncode(_body);
+    _log.finest("Request: ${method.value} $_url");
+
+    final Future<http.Response> Function() send;
+    if (method == HttpMethod.get) {
+      send = () => (_httpClient?.get ?? http.get)(_url, headers: execHeaders);
+    } else if (method == HttpMethod.post) {
+      send = () => (_httpClient?.post ?? http.post)(
+            _url,
+            headers: execHeaders,
+            body: bodyStr,
+          );
+    } else if (method == HttpMethod.put) {
+      send = () => (_httpClient?.put ?? http.put)(
+            _url,
+            headers: execHeaders,
+            body: bodyStr,
+          );
+    } else if (method == HttpMethod.patch) {
+      send = () => (_httpClient?.patch ?? http.patch)(
+            _url,
+            headers: execHeaders,
+            body: bodyStr,
+          );
+    } else if (method == HttpMethod.delete) {
+      send = () =>
+          (_httpClient?.delete ?? http.delete)(_url, headers: execHeaders);
+    } else if (method == HttpMethod.head) {
+      send = () => (_httpClient?.head ?? http.head)(_url, headers: execHeaders);
+    } else {
+      throw StateError('Unknown HTTP method: ${method.value}');
+    }
+
+    final response = await _executeWithRetry(send, method, execHeaders);
+    return await _parseResponse(response, method);
   }
 
   Future<http.Response> _executeWithRetry(
@@ -388,7 +383,7 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
   Uri appendSearchParams(String key, String value, [Uri? url]) {
     final searchParams =
         Map<String, dynamic>.of((url ?? _url).queryParametersAll);
-    searchParams[key] = [...searchParams[key] ?? [], value];
+    searchParams[key] = [...?searchParams[key], value];
     return (url ?? _url).replace(queryParameters: searchParams);
   }
 

--- a/packages/postgrest/lib/src/postgrest_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_builder.dart
@@ -95,7 +95,7 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
     bool? retryEnabled,
     Duration Function(int attempt)? retryDelay,
   }) {
-    return PostgrestBuilder<T, S, R>(
+    return PostgrestBuilder(
       url: url ?? _url,
       headers: headers ?? _headers,
       schema: schema ?? _schema,

--- a/packages/postgrest/lib/src/postgrest_query_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_query_builder.dart
@@ -173,7 +173,7 @@ class PostgrestQueryBuilder<T> extends RawPostgrestBuilder<T, T, T> {
       );
     }
 
-    return PostgrestFilterBuilder<T>(_copyWith(
+    return PostgrestFilterBuilder(_copyWith(
       method: HttpMethod.post,
       headers: newHeaders,
       body: values,
@@ -205,7 +205,7 @@ class PostgrestQueryBuilder<T> extends RawPostgrestBuilder<T, T, T> {
     final newHeaders = {..._headers};
     newHeaders['Prefer'] = '';
 
-    return PostgrestFilterBuilder<T>(_copyWith(
+    return PostgrestFilterBuilder(_copyWith(
       method: HttpMethod.patch,
       headers: newHeaders,
       body: values,
@@ -235,7 +235,7 @@ class PostgrestQueryBuilder<T> extends RawPostgrestBuilder<T, T, T> {
   PostgrestFilterBuilder<T> delete() {
     final newHeaders = {..._headers};
     newHeaders['Prefer'] = '';
-    return PostgrestFilterBuilder<T>(_copyWith(
+    return PostgrestFilterBuilder(_copyWith(
       method: HttpMethod.delete,
       headers: newHeaders,
     ));
@@ -257,7 +257,7 @@ class PostgrestQueryBuilder<T> extends RawPostgrestBuilder<T, T, T> {
   /// int count = await supabase.from('users').count();
   /// ```
   PostgrestFilterBuilder<int> count([CountOption option = CountOption.exact]) {
-    return PostgrestFilterBuilder<int>(_copyWithType(
+    return PostgrestFilterBuilder(_copyWithType(
       method: HttpMethod.head,
       count: option,
     ));

--- a/packages/postgrest/lib/src/postgrest_transform_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_transform_builder.dart
@@ -48,7 +48,7 @@ class PostgrestTransformBuilder<T> extends RawPostgrestBuilder<T, T, T> {
       newHeaders['Prefer'] = '${newHeaders['Prefer']},';
     }
     newHeaders['Prefer'] = '${newHeaders['Prefer']}return=representation';
-    return PostgrestTransformBuilder<PostgrestList>(
+    return PostgrestTransformBuilder(
       _copyWithType(
         url: url,
         headers: newHeaders,

--- a/packages/postgrest/lib/src/raw_postgrest_builder.dart
+++ b/packages/postgrest/lib/src/raw_postgrest_builder.dart
@@ -30,7 +30,7 @@ class RawPostgrestBuilder<T, S, R> extends PostgrestBuilder<T, S, R> {
     CountOption? count,
     bool? maybeSingle,
   }) {
-    return RawPostgrestBuilder<O, P, Q>(PostgrestBuilder(
+    return RawPostgrestBuilder(PostgrestBuilder(
       url: url ?? _url,
       headers: headers ?? _headers,
       schema: schema ?? _schema,

--- a/packages/postgrest/test/reset_helper.dart
+++ b/packages/postgrest/test/reset_helper.dart
@@ -34,7 +34,7 @@ class ResetHelper {
 
       // Somehow the order of the users is sometimes not correct. Adding the delay should solve this.
       if (!DeepCollectionEquality().equals(insertedUsers, _users)) {
-        return reset(delay + 500);
+        return await reset(delay + 500);
       }
     } on PostgrestException catch (exception) {
       throw 'users table was not properly reset. $exception';

--- a/packages/postgrest/test/retry_test.dart
+++ b/packages/postgrest/test/retry_test.dart
@@ -7,14 +7,14 @@ import 'package:test/test.dart';
 
 typedef _ResponseFactory = Future<StreamedResponse> Function(BaseRequest);
 
-_ResponseFactory _ok() => (req) async => StreamedResponse(
+_ResponseFactory _ok() => (req) => StreamedResponse(
       Stream.value(Uint8List.fromList('[]'.codeUnits)),
       200,
       request: req,
       headers: {'content-type': 'application/json'},
     );
 
-_ResponseFactory _status(int code) => (req) async => StreamedResponse(
+_ResponseFactory _status(int code) => (req) => StreamedResponse(
       Stream.value(
           Uint8List.fromList('{"message":"err","code":"$code"}'.codeUnits)),
       code,
@@ -23,7 +23,7 @@ _ResponseFactory _status(int code) => (req) async => StreamedResponse(
     );
 
 _ResponseFactory _networkError() =>
-    (_) async => throw const SocketException('Connection refused');
+    (_) => throw const SocketException('Connection refused');
 
 class _MockRetryClient extends BaseClient {
   final List<_ResponseFactory> _responses;
@@ -79,7 +79,7 @@ void main() {
     test('HEAD retries on 520 then succeeds', () async {
       final mock = _MockRetryClient([
         _status(520),
-        (req) async => StreamedResponse(
+        (req) => StreamedResponse(
               Stream.empty(),
               200,
               request: req,

--- a/packages/postgrest/test/retry_test.dart
+++ b/packages/postgrest/test/retry_test.dart
@@ -7,20 +7,20 @@ import 'package:test/test.dart';
 
 typedef _ResponseFactory = Future<StreamedResponse> Function(BaseRequest);
 
-_ResponseFactory _ok() => (req) => StreamedResponse(
+_ResponseFactory _ok() => (req) => Future.value(StreamedResponse(
       Stream.value(Uint8List.fromList('[]'.codeUnits)),
       200,
       request: req,
       headers: {'content-type': 'application/json'},
-    );
+    ));
 
-_ResponseFactory _status(int code) => (req) => StreamedResponse(
+_ResponseFactory _status(int code) => (req) => Future.value(StreamedResponse(
       Stream.value(
           Uint8List.fromList('{"message":"err","code":"$code"}'.codeUnits)),
       code,
       request: req,
       headers: {'content-type': 'application/json'},
-    );
+    ));
 
 _ResponseFactory _networkError() =>
     (_) => throw const SocketException('Connection refused');
@@ -79,12 +79,12 @@ void main() {
     test('HEAD retries on 520 then succeeds', () async {
       final mock = _MockRetryClient([
         _status(520),
-        (req) => StreamedResponse(
+        (req) => Future.value(StreamedResponse(
               Stream.empty(),
               200,
               request: req,
               headers: {'content-range': '*/4'},
-            ),
+            )),
       ]);
       final client = _buildClient(mock);
 

--- a/packages/postgrest/test/stack_trace_test.dart
+++ b/packages/postgrest/test/stack_trace_test.dart
@@ -49,7 +49,7 @@ void main() {
       );
 
       expect(
-        capturedTrace.toString(),
+        capturedTrace?.toString(),
         contains('theCallerFunction'),
         reason: 'Stack trace should include the caller frame',
       );
@@ -76,7 +76,7 @@ void main() {
       );
 
       expect(
-        capturedTrace.toString(),
+        capturedTrace?.toString(),
         contains('anotherCallerFunction'),
         reason: 'Stack trace passed to onError should include the caller frame',
       );
@@ -106,7 +106,7 @@ void main() {
       );
 
       expect(
-        capturedTrace.toString(),
+        capturedTrace?.toString(),
         contains('singleArgCallerFunction'),
         reason:
             'Outer catch should include the caller frame even with a single-arg onError',
@@ -138,7 +138,7 @@ void main() {
       );
 
       expect(
-        capturedTrace.toString(),
+        capturedTrace?.toString(),
         contains('networkErrorFunction'),
         reason:
             'Stack trace should include the caller frame for network errors',
@@ -171,7 +171,7 @@ void main() {
 
       expect(actionCalled, isTrue);
       expect(
-        capturedTrace.toString(),
+        capturedTrace?.toString(),
         contains('whenCompleteFunction'),
         reason:
             'Stack trace should include the caller frame after whenComplete',

--- a/packages/postgrest/test/stack_trace_test.dart
+++ b/packages/postgrest/test/stack_trace_test.dart
@@ -5,13 +5,14 @@ import 'package:http/http.dart';
 import 'package:postgrest/postgrest.dart';
 import 'package:test/test.dart';
 
-_ResponseFactory _errorStatus(int code) => (req) => StreamedResponse(
-      Stream.value(
-          Uint8List.fromList('{"message":"err","code":"$code"}'.codeUnits)),
-      code,
-      request: req,
-      headers: {'content-type': 'application/json'},
-    );
+_ResponseFactory _errorStatus(int code) =>
+    (req) => Future.value(StreamedResponse(
+          Stream.value(
+              Uint8List.fromList('{"message":"err","code":"$code"}'.codeUnits)),
+          code,
+          request: req,
+          headers: {'content-type': 'application/json'},
+        ));
 
 typedef _ResponseFactory = Future<StreamedResponse> Function(BaseRequest);
 

--- a/packages/postgrest/test/stack_trace_test.dart
+++ b/packages/postgrest/test/stack_trace_test.dart
@@ -5,7 +5,7 @@ import 'package:http/http.dart';
 import 'package:postgrest/postgrest.dart';
 import 'package:test/test.dart';
 
-_ResponseFactory _errorStatus(int code) => (req) async => StreamedResponse(
+_ResponseFactory _errorStatus(int code) => (req) => StreamedResponse(
       Stream.value(
           Uint8List.fromList('{"message":"err","code":"$code"}'.codeUnits)),
       code,

--- a/packages/realtime_client/example/main.dart
+++ b/packages/realtime_client/example/main.dart
@@ -2,12 +2,12 @@ import 'package:realtime_client/realtime_client.dart';
 
 /// Example to use with Supabase Realtime https://supabase.io/
 Future<void> main() async {
-  final socket = RealtimeClient(
-    'ws://SUPABASE_API_ENDPOINT/realtime/v1',
-    params: {'apikey': 'SUPABSE_API_KEY'},
-    // ignore: avoid_print
-    logger: (kind, msg, data) => {print('$kind $msg $data')},
-  );
+  final socket = RealtimeClient('ws://SUPABASE_API_ENDPOINT/realtime/v1',
+      params: {'apikey': 'SUPABSE_API_KEY'},
+      // ignore: avoid_print
+      logger: (kind, msg, data) {
+    print('$kind $msg $data');
+  });
 
   final channel = socket.channel('realtime:public');
   channel.onPostgresChanges(

--- a/packages/realtime_client/lib/src/message.dart
+++ b/packages/realtime_client/lib/src/message.dart
@@ -8,7 +8,7 @@ class Message {
   final String? ref;
   final String? joinRef;
 
-  Message({
+  const Message({
     required this.topic,
     required this.event,
     required this.payload,

--- a/packages/realtime_client/lib/src/message.dart
+++ b/packages/realtime_client/lib/src/message.dart
@@ -18,7 +18,7 @@ class Message {
 
   /// Converting to JSON while removing functions
   Map<String, dynamic> toJson() {
-    late final dynamic processedPayload;
+    final dynamic processedPayload;
     if (payload is Map) {
       processedPayload = <String, dynamic>{};
       for (final outerKey in payload.keys) {

--- a/packages/realtime_client/lib/src/push.dart
+++ b/packages/realtime_client/lib/src/push.dart
@@ -135,9 +135,7 @@ class Push {
   }
 
   bool _hasReceived(String status) {
-    return _receivedResp != null &&
-        _receivedResp is Map &&
-        _receivedResp?['status'] == status;
+    return _receivedResp is Map && _receivedResp?['status'] == status;
   }
 }
 

--- a/packages/realtime_client/lib/src/realtime_channel.dart
+++ b/packages/realtime_client/lib/src/realtime_channel.dart
@@ -236,7 +236,6 @@ class RealtimeChannel {
         if (callback != null) {
           callback(RealtimeSubscribeStatus.subscribed, null);
         }
-        return;
       },
     ).receive('error', (error) {
       if (callback != null) {
@@ -249,10 +248,8 @@ class RealtimeChannel {
           ),
         );
       }
-      return;
     }).receive('timeout', (_) {
       if (callback != null) callback(RealtimeSubscribeStatus.timedOut, null);
-      return;
     });
     return this;
   }
@@ -848,7 +845,7 @@ class RealtimeChannel {
       });
       for (final bind in bindings) {
         if (handledPayload is Map<String, dynamic> &&
-            handledPayload.keys.contains('ids')) {
+            handledPayload.containsKey('ids')) {
           handledPayload = getEnrichedPayload(handledPayload);
         }
 

--- a/packages/realtime_client/lib/src/realtime_channel.dart
+++ b/packages/realtime_client/lib/src/realtime_channel.dart
@@ -154,7 +154,7 @@ class RealtimeChannel {
     final presenceEnabled = _shouldEnablePresence();
 
     final accessTokenPayload = <String, String>{};
-    final config = <String, dynamic>{
+    final config = {
       'broadcast': broadcast,
       'presence': {...presence, 'enabled': presenceEnabled},
       'postgres_changes':
@@ -541,6 +541,7 @@ class RealtimeChannel {
     required Map<String, dynamic> payload,
     Duration? timeout,
   }) async {
+    // ignore: avoid-inferrable-type-arguments
     final headers = <String, String>{
       'Content-Type': 'application/json',
       if (socket.params['apikey'] != null) 'apikey': socket.params['apikey']!,
@@ -633,6 +634,7 @@ class RealtimeChannel {
             'Please use httpSend() explicitly for REST delivery.',
       );
 
+      // ignore: avoid-inferrable-type-arguments
       final headers = <String, String>{
         'Content-Type': 'application/json',
         if (socket.params['apikey'] != null) 'apikey': socket.params['apikey']!,

--- a/packages/realtime_client/lib/src/realtime_channel.dart
+++ b/packages/realtime_client/lib/src/realtime_channel.dart
@@ -139,123 +139,121 @@ class RealtimeChannel {
     }
     if (joinedOnce == true) {
       throw "tried to subscribe multiple times. 'subscribe' can only be called a single time per channel instance";
-    } else {
-      final broadcast = params['config']['broadcast'];
-      final presence = params['config']['presence'];
-      final isPrivate = params['config']['private'];
+    }
+    final broadcast = params['config']['broadcast'];
+    final presence = params['config']['presence'];
+    final isPrivate = params['config']['private'];
 
-      _onError((e) {
-        if (callback != null) callback(RealtimeSubscribeStatus.channelError, e);
-      });
-      _onClose(() {
-        if (callback != null) callback(RealtimeSubscribeStatus.closed, null);
-      });
+    _onError((e) {
+      if (callback != null) callback(RealtimeSubscribeStatus.channelError, e);
+    });
+    _onClose(() {
+      if (callback != null) callback(RealtimeSubscribeStatus.closed, null);
+    });
 
-      final presenceEnabled = _shouldEnablePresence();
+    final presenceEnabled = _shouldEnablePresence();
 
-      final accessTokenPayload = <String, String>{};
-      final config = <String, dynamic>{
-        'broadcast': broadcast,
-        'presence': {...presence, 'enabled': presenceEnabled},
-        'postgres_changes':
-            _bindings['postgres_changes']?.map((r) => r.filter).toList() ?? [],
-        'private': isPrivate == true,
-      };
+    final accessTokenPayload = <String, String>{};
+    final config = <String, dynamic>{
+      'broadcast': broadcast,
+      'presence': {...presence, 'enabled': presenceEnabled},
+      'postgres_changes':
+          _bindings['postgres_changes']?.map((r) => r.filter).toList() ?? [],
+      'private': isPrivate == true,
+    };
 
-      if (socket.accessToken != null) {
-        accessTokenPayload['access_token'] = socket.accessToken!;
-      }
+    if (socket.accessToken != null) {
+      accessTokenPayload['access_token'] = socket.accessToken!;
+    }
 
-      updateJoinPayload({'config': config, ...accessTokenPayload});
+    updateJoinPayload({'config': config, ...accessTokenPayload});
 
-      joinedOnce = true;
-      rejoin(timeout ?? _timeout);
+    joinedOnce = true;
+    rejoin(timeout ?? _timeout);
 
-      joinPush.receive(
-        'ok',
-        (response) async {
-          final serverPostgresFilters = response['postgres_changes'];
-          if (socket.accessToken != null) {
-            try {
-              await socket.setAuth(socket.accessToken);
-            } on FormatException catch (e) {
-              // The cached access token may have expired by the time the
-              // channel rejoins (e.g. after the device wakes from a long
-              // sleep). Auth state listeners will re-call setAuth with a
-              // fresh token shortly after, so swallow this specific error
-              // to avoid surfacing it as an uncaught exception. The same
-              // filter is applied in `SupabaseClient._handleTokenChanged`.
-              if (!e.message.contains('InvalidJWTToken')) {
-                rethrow;
-              }
+    joinPush.receive(
+      'ok',
+      (response) async {
+        final serverPostgresFilters = response['postgres_changes'];
+        if (socket.accessToken != null) {
+          try {
+            await socket.setAuth(socket.accessToken);
+          } on FormatException catch (e) {
+            // The cached access token may have expired by the time the
+            // channel rejoins (e.g. after the device wakes from a long
+            // sleep). Auth state listeners will re-call setAuth with a
+            // fresh token shortly after, so swallow this specific error
+            // to avoid surfacing it as an uncaught exception. The same
+            // filter is applied in `SupabaseClient._handleTokenChanged`.
+            if (!e.message.contains('InvalidJWTToken')) {
+              rethrow;
             }
           }
+        }
 
-          if (serverPostgresFilters == null) {
-            if (callback != null) {
-              callback(RealtimeSubscribeStatus.subscribed, null);
-            }
-            return;
+        if (serverPostgresFilters == null) {
+          if (callback != null) {
+            callback(RealtimeSubscribeStatus.subscribed, null);
+          }
+          return;
+        }
+        final clientPostgresBindings = _bindings['postgres_changes'];
+        final bindingsLen = clientPostgresBindings?.length ?? 0;
+        final newPostgresBindings = <Binding>[];
+
+        for (var i = 0; i < bindingsLen; i++) {
+          final clientPostgresBinding = clientPostgresBindings![i];
+
+          final event = clientPostgresBinding.filter['event'];
+          final schema = clientPostgresBinding.filter['schema'];
+          final table = clientPostgresBinding.filter['table'];
+          final filter = clientPostgresBinding.filter['filter'];
+          final serverPostgresFilter = serverPostgresFilters[i];
+
+          if (serverPostgresFilter != null &&
+              serverPostgresFilter['event'] == event &&
+              serverPostgresFilter['schema'] == schema &&
+              serverPostgresFilter['table'] == table &&
+              serverPostgresFilter['filter'] == filter) {
+            newPostgresBindings.add(clientPostgresBinding.copyWith(
+              id: serverPostgresFilter['id']?.toString(),
+            ));
           } else {
-            final clientPostgresBindings = _bindings['postgres_changes'];
-            final bindingsLen = clientPostgresBindings?.length ?? 0;
-            final newPostgresBindings = <Binding>[];
-
-            for (var i = 0; i < bindingsLen; i++) {
-              final clientPostgresBinding = clientPostgresBindings![i];
-
-              final event = clientPostgresBinding.filter['event'];
-              final schema = clientPostgresBinding.filter['schema'];
-              final table = clientPostgresBinding.filter['table'];
-              final filter = clientPostgresBinding.filter['filter'];
-              final serverPostgresFilter = serverPostgresFilters[i];
-
-              if (serverPostgresFilter != null &&
-                  serverPostgresFilter['event'] == event &&
-                  serverPostgresFilter['schema'] == schema &&
-                  serverPostgresFilter['table'] == table &&
-                  serverPostgresFilter['filter'] == filter) {
-                newPostgresBindings.add(clientPostgresBinding.copyWith(
-                  id: serverPostgresFilter['id']?.toString(),
-                ));
-              } else {
-                unsubscribe();
-                if (callback != null) {
-                  callback(
-                    RealtimeSubscribeStatus.channelError,
-                    Exception(
-                        'mismatch between server and client bindings for postgres changes'),
-                  );
-                }
-                return;
-              }
-            }
-
-            _bindings['postgres_changes'] = newPostgresBindings;
-
+            unsubscribe();
             if (callback != null) {
-              callback(RealtimeSubscribeStatus.subscribed, null);
+              callback(
+                RealtimeSubscribeStatus.channelError,
+                Exception(
+                    'mismatch between server and client bindings for postgres changes'),
+              );
             }
             return;
           }
-        },
-      ).receive('error', (error) {
+        }
+
+        _bindings['postgres_changes'] = newPostgresBindings;
+
         if (callback != null) {
-          callback(
-            RealtimeSubscribeStatus.channelError,
-            Exception(
-              jsonEncode((error as Map<String, dynamic>).isNotEmpty
-                  ? (error).values.join(', ')
-                  : 'error'),
-            ),
-          );
+          callback(RealtimeSubscribeStatus.subscribed, null);
         }
         return;
-      }).receive('timeout', (_) {
-        if (callback != null) callback(RealtimeSubscribeStatus.timedOut, null);
-        return;
-      });
-    }
+      },
+    ).receive('error', (error) {
+      if (callback != null) {
+        callback(
+          RealtimeSubscribeStatus.channelError,
+          Exception(
+            jsonEncode((error as Map<String, dynamic>).isNotEmpty
+                ? (error).values.join(', ')
+                : 'error'),
+          ),
+        );
+      }
+      return;
+    }).receive('timeout', (_) {
+      if (callback != null) callback(RealtimeSubscribeStatus.timedOut, null);
+      return;
+    });
     return this;
   }
 
@@ -484,13 +482,10 @@ class RealtimeChannel {
   RealtimeChannel off(String type, Map<String, String> filter) {
     final typeLower = type.toLowerCase();
 
-    _bindings[typeLower] = _bindings[typeLower]!
-        .where((bind) {
-          return !(bind.type.toLowerCase() == typeLower &&
-              RealtimeChannel._isEqual(bind.filter, filter));
-        })
-        .toList()
-        .cast<Binding>();
+    _bindings[typeLower] = _bindings[typeLower]!.where((bind) {
+      return !(bind.type.toLowerCase() == typeLower &&
+          RealtimeChannel._isEqual(bind.filter, filter));
+    }).toList();
     return this;
   }
 
@@ -842,14 +837,12 @@ class RealtimeChannel {
                 (bindEvent == '*' ||
                     bindEvent?.toLowerCase() ==
                         (payload['data']?['type'] as String?)?.toLowerCase()));
-          } else {
-            final bindEvent = bind.filter['event']?.toLowerCase();
-            return (bindEvent == '*' ||
-                bindEvent == (payload?['event'] as String?)?.toLowerCase());
           }
-        } else {
-          return bind.type.toLowerCase() == typeLower;
+          final bindEvent = bind.filter['event']?.toLowerCase();
+          return (bindEvent == '*' ||
+              bindEvent == (payload?['event'] as String?)?.toLowerCase());
         }
+        return bind.type.toLowerCase() == typeLower;
       });
       for (final bind in bindings) {
         if (handledPayload is Map<String, dynamic> &&

--- a/packages/realtime_client/lib/src/realtime_client.dart
+++ b/packages/realtime_client/lib/src/realtime_client.dart
@@ -456,7 +456,7 @@ class RealtimeClient {
       jsonEncode(message);
 
   static Map<String, dynamic> _decodeLegacy(Object rawMessage) =>
-      Map<String, dynamic>.from(jsonDecode(rawMessage as String) as Map);
+      Map.from(jsonDecode(rawMessage as String) as Map);
 
   /// Returns the URL of the websocket.
   String get endPointURL {

--- a/packages/realtime_client/lib/src/realtime_client.dart
+++ b/packages/realtime_client/lib/src/realtime_client.dart
@@ -117,6 +117,7 @@ class RealtimeClient {
   final RealtimeDecode decode;
   late TimerCalculation reconnectAfterMs;
   WebSocketChannel? conn;
+  StreamSubscription? _connSubscription;
   List sendBuffer = [];
   Map<String, List<Function>> stateChangeCallbacks = {
     'open': [],
@@ -252,7 +253,7 @@ class RealtimeClient {
       connState = SocketStates.open;
 
       _onConnOpen();
-      localConn.stream.listen(
+      _connSubscription = localConn.stream.listen(
         (message) => onConnMessage(message),
         onError: _onConnError,
         onDone: () {
@@ -301,6 +302,8 @@ class RealtimeClient {
         log('transport', 'disconnected', null, Level.FINE);
       }
       this.conn = null;
+      await _connSubscription?.cancel();
+      _connSubscription = null;
 
       // remove open handles
       if (heartbeatTimer != null) heartbeatTimer?.cancel();

--- a/packages/realtime_client/lib/src/realtime_client.dart
+++ b/packages/realtime_client/lib/src/realtime_client.dart
@@ -385,10 +385,7 @@ class RealtimeClient {
   /// Removes a subscription from the socket.
   @internal
   void remove(RealtimeChannel channel) {
-    channels = channels
-        .where((c) => c.joinRef != channel.joinRef)
-        .toList()
-        .cast<RealtimeChannel>();
+    channels = channels.where((c) => c.joinRef != channel.joinRef).toList();
   }
 
   RealtimeChannel channel(

--- a/packages/realtime_client/lib/src/realtime_client.dart
+++ b/packages/realtime_client/lib/src/realtime_client.dart
@@ -183,7 +183,7 @@ class RealtimeClient {
             .toString(),
         headers = {
           ...Constants.defaultHeaders,
-          if (headers != null) ...headers,
+          ...?headers,
         },
         transport = transport ?? createWebSocketClient,
         encode = encode ??

--- a/packages/realtime_client/lib/src/realtime_client.dart
+++ b/packages/realtime_client/lib/src/realtime_client.dart
@@ -117,7 +117,7 @@ class RealtimeClient {
   final RealtimeDecode decode;
   late TimerCalculation reconnectAfterMs;
   WebSocketChannel? conn;
-  StreamSubscription? _connSubscription;
+  StreamSubscription? _connectionSubscription;
   List sendBuffer = [];
   Map<String, List<Function>> stateChangeCallbacks = {
     'open': [],
@@ -253,7 +253,7 @@ class RealtimeClient {
       connState = SocketStates.open;
 
       _onConnOpen();
-      _connSubscription = localConn.stream.listen(
+      _connectionSubscription = localConn.stream.listen(
         (message) => onConnMessage(message),
         onError: _onConnError,
         onDone: () {
@@ -302,8 +302,8 @@ class RealtimeClient {
         log('transport', 'disconnected', null, Level.FINE);
       }
       this.conn = null;
-      await _connSubscription?.cancel();
-      _connSubscription = null;
+      await _connectionSubscription?.cancel();
+      _connectionSubscription = null;
 
       // remove open handles
       if (heartbeatTimer != null) heartbeatTimer?.cancel();

--- a/packages/realtime_client/lib/src/realtime_presence.dart
+++ b/packages/realtime_client/lib/src/realtime_presence.dart
@@ -329,9 +329,8 @@ class RealtimePresence {
 
   static Map<String, List<Presence>> _cloneDeep(
       Map<String, List<Presence>> obj) {
-    return Map<String, List<Presence>>.fromEntries(obj.entries.map((entry) =>
-        MapEntry(entry.key,
-            entry.value.map((presence) => presence.deepClone()).toList())));
+    return Map.fromEntries(obj.entries.map((entry) => MapEntry(entry.key,
+        entry.value.map((presence) => presence.deepClone()).toList())));
   }
 
   void onJoin(PresenceOnJoinCallback callback) {
@@ -347,7 +346,7 @@ class RealtimePresence {
   }
 
   List<T> list<T>([PresenceChooser<T>? by]) {
-    return RealtimePresence._list<T>(state, by);
+    return RealtimePresence._list(state, by);
   }
 
   bool inPendingSyncState() {

--- a/packages/realtime_client/lib/src/realtime_presence.dart
+++ b/packages/realtime_client/lib/src/realtime_presence.dart
@@ -18,7 +18,7 @@ class Presence {
   factory Presence.fromJson(Map<String, dynamic> map) {
     final ref = map['presence_ref'];
     // Create a new map without presence_ref to avoid mutating the input
-    final payload = Map<String, dynamic>.from(map)..remove('presence_ref');
+    final payload = Map<String, dynamic>.of(map)..remove('presence_ref');
     return Presence(
       presenceRef: ref as String? ?? '',
       payload: payload,

--- a/packages/realtime_client/lib/src/serializer.dart
+++ b/packages/realtime_client/lib/src/serializer.dart
@@ -34,7 +34,7 @@ class Serializer {
   /// sending a binary broadcast push.
   final List<String> allowedMetadataKeys;
 
-  Serializer({List<String>? allowedMetadataKeys})
+  const Serializer({List<String>? allowedMetadataKeys})
       : allowedMetadataKeys = allowedMetadataKeys ?? const [];
 
   /// Encodes a message map into the string or binary representation that is
@@ -68,7 +68,7 @@ class Serializer {
       if (decoded is! List || decoded.length < 5) {
         throw FormatException('Invalid 2.0.0 text frame', rawPayload);
       }
-      return <String, dynamic>{
+      return {
         'join_ref': decoded[0],
         'ref': decoded[1],
         'topic': decoded[2],
@@ -82,7 +82,7 @@ class Serializer {
       return _binaryDecode(bytes);
     }
 
-    return <String, dynamic>{};
+    return {};
   }
 
   Uint8List _encodeBinaryUserBroadcastPush(
@@ -139,7 +139,7 @@ class Serializer {
       case kindUserBroadcast:
         return _decodeUserBroadcast(buffer, view);
       default:
-        return <String, dynamic>{};
+        return {};
     }
   }
 
@@ -167,7 +167,7 @@ class Serializer {
         ? jsonDecode(utf8.decode(payloadBytes))
         : payloadBytes;
 
-    final data = <String, dynamic>{
+    final data = {
       'type': broadcastEvent,
       'event': userEvent,
       'payload': parsedPayload,
@@ -176,7 +176,7 @@ class Serializer {
       data['meta'] = jsonDecode(metadata);
     }
 
-    return <String, dynamic>{
+    return {
       'join_ref': null,
       'ref': null,
       'topic': topic,
@@ -223,7 +223,7 @@ class Serializer {
   }
 
   Map<String, dynamic> _pick(Map<dynamic, dynamic> source, List<String> keys) {
-    return <String, dynamic>{
+    return {
       for (final key in keys)
         if (source.containsKey(key)) key: source[key],
     };

--- a/packages/realtime_client/lib/src/transformers.dart
+++ b/packages/realtime_client/lib/src/transformers.dart
@@ -308,6 +308,7 @@ Map<String, dynamic> getEnrichedPayload(Map<String, dynamic> payload) {
 
 Map<String, Map<String, dynamic>> getPayloadRecords(
     Map<String, dynamic> payload) {
+  // ignore: avoid-inferrable-type-arguments
   final records = <String, Map<String, dynamic>>{
     'new': {},
     'old': {},

--- a/packages/realtime_client/lib/src/transformers.dart
+++ b/packages/realtime_client/lib/src/transformers.dart
@@ -199,26 +199,24 @@ bool? toBoolean(dynamic value) {
 double? toDouble(dynamic value) {
   if (value is double) {
     return value;
-  } else {
-    try {
-      final temp = value.toString();
-      return double.parse(temp);
-    } catch (_) {
-      return null;
-    }
+  }
+  try {
+    final temp = value.toString();
+    return double.parse(temp);
+  } catch (_) {
+    return null;
   }
 }
 
 int? toInt(dynamic value) {
   if (value is int) {
     return value;
-  } else {
-    try {
-      final temp = value.toString();
-      return int.parse(temp);
-    } catch (_) {
-      return null;
-    }
+  }
+  try {
+    final temp = value.toString();
+    return int.parse(temp);
+  } catch (_) {
+    return null;
   }
 }
 

--- a/packages/realtime_client/lib/src/types.dart
+++ b/packages/realtime_client/lib/src/types.dart
@@ -50,9 +50,8 @@ extension PostgresChangeEventMethods on PostgresChangeEvent {
   String toRealtimeEvent() {
     if (this == PostgresChangeEvent.all) {
       return '*';
-    } else {
-      return name.toUpperCase();
     }
+    return name.toUpperCase();
   }
 
   static PostgresChangeEvent fromString(String event) {
@@ -132,9 +131,8 @@ extension ToType on RealtimeListenTypes {
   String toType() {
     if (this == RealtimeListenTypes.postgresChanges) {
       return 'postgres_changes';
-    } else {
-      return name;
     }
+    return name;
   }
 }
 
@@ -339,11 +337,7 @@ class PostgresChangeFilter {
   @override
   String toString() {
     if (type == PostgresChangeFilterType.inFilter) {
-      if (value is List<String>) {
-        return '$column=in.(${value.map((s) => '"$s"').join(',')})';
-      } else {
-        return '$column=in.(${value.map((s) => '"$s"').join(',')})';
-      }
+      return '$column=in.(${value.map((s) => '"$s"').join(',')})';
     }
     return '$column=${type.name}.$value';
   }

--- a/packages/realtime_client/lib/src/types.dart
+++ b/packages/realtime_client/lib/src/types.dart
@@ -83,7 +83,7 @@ class ChannelFilter {
   /// Only one filter can be applied
   final String? filter;
 
-  ChannelFilter({
+  const ChannelFilter({
     this.event,
     this.schema,
     this.table,
@@ -218,7 +218,7 @@ class PostgresChangePayload {
   final Map<String, dynamic> newRecord;
   final Map<String, dynamic> oldRecord;
   final dynamic errors;
-  PostgresChangePayload({
+  const PostgresChangePayload({
     required this.schema,
     required this.table,
     required this.commitTimestamp,
@@ -249,12 +249,8 @@ class PostgresChangePayload {
       commitTimestamp: commitTimestamp,
       eventType:
           PostgresChangeEventMethods.fromString(payload['eventType'] as String),
-      newRecord: newData is Map
-          ? Map<String, dynamic>.from(newData)
-          : <String, dynamic>{},
-      oldRecord: oldData is Map
-          ? Map<String, dynamic>.from(oldData)
-          : <String, dynamic>{},
+      newRecord: newData is Map ? Map.from(newData) : {},
+      oldRecord: oldData is Map ? Map.from(oldData) : {},
       errors: payload['errors'],
     );
   }
@@ -328,7 +324,7 @@ class PostgresChangeFilter {
   final dynamic value;
 
   /// {@macro postgres_change_filter}
-  PostgresChangeFilter({
+  const PostgresChangeFilter({
     required this.type,
     required this.column,
     required this.value,
@@ -348,7 +344,7 @@ abstract class RealtimePresencePayload {
   /// Name of the presence event.
   final PresenceEvent event;
 
-  RealtimePresencePayload({
+  const RealtimePresencePayload({
     required this.event,
   });
 
@@ -361,7 +357,7 @@ abstract class RealtimePresencePayload {
 
 /// Payload for [PresenceEvent.sync] callback.
 class RealtimePresenceSyncPayload extends RealtimePresencePayload {
-  RealtimePresenceSyncPayload({
+  const RealtimePresenceSyncPayload({
     required super.event,
   });
 
@@ -388,7 +384,7 @@ class RealtimePresenceJoinPayload extends RealtimePresencePayload {
   /// List of currently present presences.
   final List<Presence> currentPresences;
 
-  RealtimePresenceJoinPayload({
+  const RealtimePresenceJoinPayload({
     required super.event,
     required this.key,
     required this.currentPresences,
@@ -422,7 +418,7 @@ class RealtimePresenceLeavePayload extends RealtimePresencePayload {
   /// List of currently present presences.
   final List<Presence> currentPresences;
 
-  RealtimePresenceLeavePayload({
+  const RealtimePresenceLeavePayload({
     required super.event,
     required this.key,
     required this.currentPresences,
@@ -451,7 +447,7 @@ class SinglePresenceState {
   /// List of shared payloads of the client.
   final List<Presence> presences;
 
-  SinglePresenceState({
+  const SinglePresenceState({
     required this.key,
     required this.presences,
   });

--- a/packages/realtime_client/test/channel_test.dart
+++ b/packages/realtime_client/test/channel_test.dart
@@ -404,8 +404,8 @@ void main() {
             },
           ).then(
             (value) => completer.complete(value),
-            onError: (Object e, StackTrace st) =>
-                completer.completeError(e, st),
+            onError: (Object error, StackTrace stackTrace) =>
+                completer.completeError(error, stackTrace),
           );
 
           await for (final HttpRequest req in mockServer) {
@@ -429,7 +429,8 @@ void main() {
         },
       ).then(
         (value) => completer.complete(value),
-        onError: (Object e, StackTrace st) => completer.completeError(e, st),
+        onError: (Object error, StackTrace stackTrace) =>
+            completer.completeError(error, stackTrace),
       );
 
       await for (final HttpRequest req in mockServer) {

--- a/packages/realtime_client/test/channel_test.dart
+++ b/packages/realtime_client/test/channel_test.dart
@@ -404,8 +404,8 @@ void main() {
             },
           ).then(
             (value) => completer.complete(value),
-            onError: (Object error, StackTrace stackTrace) =>
-                completer.completeError(error, stackTrace),
+            onError: (Object e, StackTrace stackTrace) =>
+                completer.completeError(e, stackTrace),
           );
 
           await for (final HttpRequest req in mockServer) {
@@ -429,8 +429,8 @@ void main() {
         },
       ).then(
         (value) => completer.complete(value),
-        onError: (Object error, StackTrace stackTrace) =>
-            completer.completeError(error, stackTrace),
+        onError: (Object e, StackTrace stackTrace) =>
+            completer.completeError(e, stackTrace),
       );
 
       await for (final HttpRequest req in mockServer) {

--- a/packages/realtime_client/test/channel_test.dart
+++ b/packages/realtime_client/test/channel_test.dart
@@ -404,7 +404,8 @@ void main() {
             },
           ).then(
             (value) => completer.complete(value),
-            onError: (e) => completer.completeError(e),
+            onError: (Object e, StackTrace st) =>
+                completer.completeError(e, st),
           );
 
           await for (final HttpRequest req in mockServer) {
@@ -428,7 +429,7 @@ void main() {
         },
       ).then(
         (value) => completer.complete(value),
-        onError: (e) => completer.completeError(e),
+        onError: (Object e, StackTrace st) => completer.completeError(e, st),
       );
 
       await for (final HttpRequest req in mockServer) {
@@ -806,7 +807,7 @@ void main() {
 
       await expectLater(
         sendFuture,
-        throwsA(predicate((e) => e.toString().contains('Server error'))),
+        throwsA(predicate((Object e) => e.toString().contains('Server error'))),
       );
     });
 

--- a/packages/realtime_client/test/realtime_integration_test.dart
+++ b/packages/realtime_client/test/realtime_integration_test.dart
@@ -301,6 +301,7 @@ Future<RealtimeSubscribeStatus> _subscribe(RealtimeChannel channel) {
         status == RealtimeSubscribeStatus.timedOut) {
       completer.completeError(
         StateError('Failed to subscribe: $status ($error)'),
+        StackTrace.current,
       );
     }
   });

--- a/packages/realtime_client/test/serializer_test.dart
+++ b/packages/realtime_client/test/serializer_test.dart
@@ -17,7 +17,7 @@ Uint8List buildUserBroadcastFrame({
   final eventBytes = utf8.encode(event);
   final metadataBytes = utf8.encode(metadata);
 
-  final header = <int>[
+  final header = [
     Serializer.kindUserBroadcast,
     topicBytes.length,
     eventBytes.length,

--- a/packages/realtime_client/test/socket_test.dart
+++ b/packages/realtime_client/test/socket_test.dart
@@ -400,7 +400,7 @@ void main() {
       const tTopic2 = 'topic-2';
 
       final mockedSocket = SocketWithMockedChannel(socketEndpoint);
-      mockedSocket.mockedChannelLooker.addAll(<String, RealtimeChannel>{
+      mockedSocket.mockedChannelLooker.addAll({
         tTopic1: mockedChannel1,
         tTopic2: mockedChannel2,
       });
@@ -677,7 +677,7 @@ void main() {
       const tTopic2 = 'topic-2';
 
       final mockedSocket = SocketWithMockedChannel(socketEndpoint);
-      mockedSocket.mockedChannelLooker.addAll(<String, RealtimeChannel>{
+      mockedSocket.mockedChannelLooker.addAll({
         tTopic1: mockedChannel1,
         tTopic2: mockedChannel2,
       });
@@ -724,7 +724,7 @@ void main() {
       const tTopic3 = 'test-topic3';
 
       final mockedSocket = SocketWithMockedChannel(socketEndpoint);
-      mockedSocket.mockedChannelLooker.addAll(<String, RealtimeChannel>{
+      mockedSocket.mockedChannelLooker.addAll({
         tTopic1: mockedChannel1,
         tTopic2: mockedChannel2,
         tTopic3: mockedChannel3,

--- a/packages/realtime_client/test/socket_test.dart
+++ b/packages/realtime_client/test/socket_test.dart
@@ -45,8 +45,6 @@ String generateJwt([int? exp]) {
 }
 
 void main() {
-  const int int64MaxValue = 9223372036854775807;
-
   const socketEndpoint = 'wss://localhost:0/';
 
   late HttpServer mockServer;
@@ -644,7 +642,7 @@ void main() {
     });
 
     test('restarts for overflow', () {
-      socket.ref = int64MaxValue;
+      socket.ref = 9223372036854775807;
       expect(socket.makeRef(), '0');
       expect(socket.ref, 0);
     });

--- a/packages/realtime_client/test/socket_test_stubs.dart
+++ b/packages/realtime_client/test/socket_test_stubs.dart
@@ -25,8 +25,7 @@ class SocketWithMockedChannel extends RealtimeClient {
     if (mockedChannelLooker.keys.contains(topic)) {
       channels.add(mockedChannelLooker[topic]!);
       return mockedChannelLooker[topic]!;
-    } else {
-      return super.channel(topic, chanParams);
     }
+    return super.channel(topic, chanParams);
   }
 }

--- a/packages/realtime_client/test/socket_test_stubs.dart
+++ b/packages/realtime_client/test/socket_test_stubs.dart
@@ -22,7 +22,7 @@ class SocketWithMockedChannel extends RealtimeClient {
     String topic, [
     RealtimeChannelConfig chanParams = const RealtimeChannelConfig(),
   ]) {
-    if (mockedChannelLooker.keys.contains(topic)) {
+    if (mockedChannelLooker.containsKey(topic)) {
       channels.add(mockedChannelLooker[topic]!);
       return mockedChannelLooker[topic]!;
     }

--- a/packages/realtime_client/test/utils/realtime_test_utils.dart
+++ b/packages/realtime_client/test/utils/realtime_test_utils.dart
@@ -130,7 +130,8 @@ Future<void> primePostgresChanges({
       subscribed.complete();
     } else if (status == RealtimeSubscribeStatus.channelError ||
         status == RealtimeSubscribeStatus.timedOut) {
-      subscribed.completeError(StateError('warmup subscribe failed: $status'));
+      subscribed.completeError(
+          StateError('warmup subscribe failed: $status'), StackTrace.current);
     }
   });
 

--- a/packages/storage_client/lib/src/fetch.dart
+++ b/packages/storage_client/lib/src/fetch.dart
@@ -103,7 +103,7 @@ class Fetch {
     FetchOptions? options,
     int retryAttempts,
     StorageRetryController? retryController,
-  ) async {
+  ) {
     final contentType = fileOptions.contentType != null
         ? MediaType.parse(fileOptions.contentType!)
         : _parseMediaType(file.path);
@@ -132,7 +132,7 @@ class Fetch {
     FetchOptions? options,
     int retryAttempts,
     StorageRetryController? retryController,
-  ) async {
+  ) {
     final contentType = fileOptions.contentType != null
         ? MediaType.parse(fileOptions.contentType!)
         : _parseMediaType(url);
@@ -194,9 +194,8 @@ class Fetch {
 
         if (httpClient != null) {
           return httpClient!.send(request);
-        } else {
-          return request.send();
         }
+        return request.send();
       },
       retryIf: (error) =>
           retryController?.cancelled != true &&
@@ -214,21 +213,19 @@ class Fetch {
     if (_isSuccessStatusCode(response.statusCode)) {
       if (options?.noResolveJson == true) {
         return response.bodyBytes;
-      } else {
-        final jsonBody = json.decode(response.body);
-        return jsonBody;
       }
-    } else {
-      throw _handleError(
-        response,
-        StackTrace.current,
-        response.request?.url,
-        options,
-      );
+      final jsonBody = json.decode(response.body);
+      return jsonBody;
     }
+    throw _handleError(
+      response,
+      StackTrace.current,
+      response.request?.url,
+      options,
+    );
   }
 
-  Future<dynamic> head(String url, {FetchOptions? options}) async {
+  Future<dynamic> head(String url, {FetchOptions? options}) {
     return _handleRequest(
       'HEAD',
       url,
@@ -237,7 +234,7 @@ class Fetch {
     );
   }
 
-  Future<dynamic> get(String url, {FetchOptions? options}) async {
+  Future<dynamic> get(String url, {FetchOptions? options}) {
     return _handleRequest('GET', url, null, options);
   }
 
@@ -245,7 +242,7 @@ class Fetch {
     String url,
     Map<String, dynamic>? body, {
     FetchOptions? options,
-  }) async {
+  }) {
     return _handleRequest('POST', url, body, options);
   }
 
@@ -253,7 +250,7 @@ class Fetch {
     String url,
     Map<String, dynamic>? body, {
     FetchOptions? options,
-  }) async {
+  }) {
     return _handleRequest('PUT', url, body, options);
   }
 
@@ -261,7 +258,7 @@ class Fetch {
     String url,
     Map<String, dynamic>? body, {
     FetchOptions? options,
-  }) async {
+  }) {
     return _handleRequest('DELETE', url, body, options);
   }
 
@@ -272,7 +269,7 @@ class Fetch {
     FetchOptions? options,
     required int retryAttempts,
     required StorageRetryController? retryController,
-  }) async {
+  }) {
     return _handleFileRequest(
       'POST',
       url,
@@ -291,7 +288,7 @@ class Fetch {
     FetchOptions? options,
     required int retryAttempts,
     required StorageRetryController? retryController,
-  }) async {
+  }) {
     return _handleFileRequest(
       'PUT',
       url,
@@ -310,7 +307,7 @@ class Fetch {
     FetchOptions? options,
     required int retryAttempts,
     required StorageRetryController? retryController,
-  }) async {
+  }) {
     return _handleBinaryFileRequest(
       'POST',
       url,
@@ -329,7 +326,7 @@ class Fetch {
     FetchOptions? options,
     required int retryAttempts,
     required StorageRetryController? retryController,
-  }) async {
+  }) {
     return _handleBinaryFileRequest(
       'PUT',
       url,

--- a/packages/storage_client/lib/src/fetch.dart
+++ b/packages/storage_client/lib/src/fetch.dart
@@ -37,7 +37,7 @@ class Fetch {
     if (error is http.Response) {
       if (options?.noResolveJson == true) {
         return StorageException(
-          error.body.isEmpty ? error.reasonPhrase ?? '' : error.body,
+          error.body.isEmpty ? (error.reasonPhrase ?? '') : error.body,
           statusCode: '${error.statusCode}',
         );
       }

--- a/packages/storage_client/lib/src/storage_file_api.dart
+++ b/packages/storage_client/lib/src/storage_file_api.dart
@@ -430,12 +430,11 @@ class StorageFileApi {
       final path = e['path'] as String? ?? '';
       if (signedUrlPath != null) {
         return SignedUrlSuccess(path: path, signedUrl: '$url$signedUrlPath');
-      } else {
-        return SignedUrlFailure(
-          path: path,
-          error: e['error'] as String? ?? 'Unknown error',
-        );
       }
+      return SignedUrlFailure(
+        path: path,
+        error: e['error'] as String? ?? 'Unknown error',
+      );
     }).toList();
   }
 

--- a/packages/storage_client/lib/src/types.dart
+++ b/packages/storage_client/lib/src/types.dart
@@ -339,7 +339,7 @@ class StorageException implements Exception {
   final String? error;
   final String? statusCode;
 
-  const StorageException(this.message, {this.error, this.statusCode}) : super();
+  const StorageException(this.message, {this.error, this.statusCode});
 
   factory StorageException.fromJson(
     Map<String, dynamic> json, [

--- a/packages/storage_client/lib/src/types.dart
+++ b/packages/storage_client/lib/src/types.dart
@@ -39,7 +39,7 @@ class Bucket {
       public: json['public'] as bool,
       fileSizeLimit: json['file_size_limit'] as int?,
       allowedMimeTypes:
-          allowedMimeTypes is List ? allowedMimeTypes.cast<String>() : null,
+          allowedMimeTypes is List ? allowedMimeTypes.cast() : null,
     );
   }
 }

--- a/packages/storage_client/test/client_test.dart
+++ b/packages/storage_client/test/client_test.dart
@@ -663,7 +663,7 @@ void main() {
       customHttpClient.statusCode = 200;
 
       final fileApi = client.from('test-bucket');
-      final headersBefore = Map<String, String>.from(fileApi.headers);
+      final headersBefore = Map<String, String>.of(fileApi.headers);
 
       await fileApi.list();
 

--- a/packages/supabase/lib/src/auth_http_client.dart
+++ b/packages/supabase/lib/src/auth_http_client.dart
@@ -16,4 +16,7 @@ class AuthHttpClient extends BaseClient {
     request.headers.putIfAbsent("apikey", () => _supabaseKey);
     return _inner.send(request);
   }
+
+  @override
+  void close() => _inner.close();
 }

--- a/packages/supabase/lib/src/auth_user.dart
+++ b/packages/supabase/lib/src/auth_user.dart
@@ -2,7 +2,7 @@ import 'package:gotrue/gotrue.dart' show User;
 
 @Deprecated('No longer used. May be removed in the future.')
 class AuthUser extends User {
-  AuthUser({
+  const AuthUser({
     required super.id,
     required super.appMetadata,
     required super.userMetadata,

--- a/packages/supabase/lib/src/supabase_client.dart
+++ b/packages/supabase/lib/src/supabase_client.dart
@@ -65,8 +65,8 @@ class SupabaseClient {
   late final RealtimeClient realtime;
   late final PostgrestClient rest;
   StreamSubscription<AuthState>? _authStateSubscription;
-  late final YAJsonIsolate _isolate;
-  late final bool _hasCustomIsolate;
+  final YAJsonIsolate _isolate;
+  final bool _hasCustomIsolate;
   final Future<String?> Function()? accessToken;
 
   /// Increment ID of the stream to create different realtime topic for each stream

--- a/packages/supabase/lib/src/supabase_client.dart
+++ b/packages/supabase/lib/src/supabase_client.dart
@@ -277,8 +277,13 @@ class SupabaseClient {
     _log.fine('Dispose SupabaseClient');
     await realtime.disconnect();
     await _authStateSubscription?.cancel();
+    await functions.dispose();
+    await rest.dispose();
     if (!_hasCustomIsolate) {
       await _isolate.dispose();
+    }
+    if (_httpClient == null) {
+      _authHttpClient.close();
     }
     _authInstance?.dispose();
   }

--- a/packages/supabase/lib/src/supabase_client.dart
+++ b/packages/supabase/lib/src/supabase_client.dart
@@ -139,7 +139,7 @@ class SupabaseClient {
         _postgrestOptions = postgrestOptions,
         _headers = {
           ...Constants.defaultHeaders,
-          if (headers != null) ...headers
+          ...?headers,
         },
         _httpClient = httpClient,
         _isolate = isolate ?? (YAJsonIsolate()..initialize()),

--- a/packages/supabase/lib/src/supabase_client.dart
+++ b/packages/supabase/lib/src/supabase_client.dart
@@ -169,11 +169,10 @@ class SupabaseClient {
   GoTrueClient get auth {
     if (accessToken == null) {
       return _authInstance!;
-    } else {
-      throw AuthException(
-        'Supabase Client is configured with the accessToken option, accessing supabase.auth is not possible.',
-      );
     }
+    throw AuthException(
+      'Supabase Client is configured with the accessToken option, accessing supabase.auth is not possible.',
+    );
   }
 
   /// Perform a table operation.

--- a/packages/supabase/lib/src/supabase_event_types.dart
+++ b/packages/supabase/lib/src/supabase_event_types.dart
@@ -7,8 +7,7 @@ extension SupabaseEventTypesName on SupabaseEventTypes {
     final name = toString().split('.').last;
     if (name == 'all') {
       return '*';
-    } else {
-      return name.toUpperCase();
     }
+    return name.toUpperCase();
   }
 }

--- a/packages/supabase/lib/src/supabase_query_schema.dart
+++ b/packages/supabase/lib/src/supabase_query_schema.dart
@@ -15,7 +15,7 @@ class SupabaseQuerySchema {
   final RealtimeClient _realtime;
   final PostgrestClient _rest;
 
-  SupabaseQuerySchema({
+  const SupabaseQuerySchema({
     required Counter counter,
     required String restUrl,
     required Map<String, String> headers,

--- a/packages/supabase/lib/src/supabase_stream_builder.dart
+++ b/packages/supabase/lib/src/supabase_stream_builder.dart
@@ -7,7 +7,7 @@ import 'package:supabase/supabase.dart';
 part 'supabase_stream_filter_builder.dart';
 
 class _StreamPostgrestFilter {
-  _StreamPostgrestFilter({
+  const _StreamPostgrestFilter({
     required this.column,
     required this.value,
     required this.type,
@@ -24,7 +24,7 @@ class _StreamPostgrestFilter {
 }
 
 class _Order {
-  _Order({
+  const _Order({
     required this.column,
     required this.ascending,
   });
@@ -33,7 +33,7 @@ class _Order {
 }
 
 class RealtimeSubscribeException implements Exception {
-  RealtimeSubscribeException(this.status, [this.details]);
+  const RealtimeSubscribeException(this.status, [this.details]);
 
   final RealtimeSubscribeStatus status;
   final Object? details;

--- a/packages/supabase/lib/src/supabase_stream_builder.dart
+++ b/packages/supabase/lib/src/supabase_stream_builder.dart
@@ -161,7 +161,7 @@ class SupabaseStreamBuilder extends Stream<SupabaseStreamEvent> {
     );
   }
 
-  Future<void> _getStreamData() async {
+  void _getStreamData() {
     final currentStreamFilter = _streamFilter;
     _streamData = [];
     PostgresChangeFilter? realtimeFilter;
@@ -284,7 +284,7 @@ class SupabaseStreamBuilder extends Stream<SupabaseStreamEvent> {
 
     try {
       final data = await (transformQuery ?? query);
-      final rows = SupabaseStreamEvent.from(data);
+      final rows = SupabaseStreamEvent.of(data);
       _streamData = rows;
       _addStream();
     } catch (error, stackTrace) {
@@ -320,9 +320,8 @@ class SupabaseStreamBuilder extends Stream<SupabaseStreamEvent> {
         return orderModifier * columnA.compareTo(columnB);
       } else if (columnA is String && columnB is String) {
         return orderModifier * columnA.compareTo(columnB);
-      } else {
-        return 0;
       }
+      return 0;
     });
   }
 
@@ -377,7 +376,7 @@ class SupabaseStreamBuilder extends Stream<SupabaseStreamEvent> {
           subscription.pause();
           newValue.then(add, onError: addError).whenComplete(resume);
         } else {
-          controller.add(newValue as dynamic);
+          controller.add(newValue);
         }
       });
       controller.onCancel = subscription.cancel;

--- a/packages/supabase/test/client_test.dart
+++ b/packages/supabase/test/client_test.dart
@@ -290,8 +290,7 @@ void main() {
 
     group('Headers Management', () {
       test('should update headers and propagate to all clients', () {
-        final newHeaders = {'Custom-Header': 'custom-value'};
-        supabase.headers = newHeaders;
+        supabase.headers = {'Custom-Header': 'custom-value'};
 
         expect(supabase.headers['Custom-Header'], 'custom-value');
         expect(supabase.rest.headers['Custom-Header'], 'custom-value');
@@ -301,8 +300,7 @@ void main() {
       });
 
       test('should preserve default headers when setting custom headers', () {
-        final newHeaders = {'Custom-Header': 'custom-value'};
-        supabase.headers = newHeaders;
+        supabase.headers = {'Custom-Header': 'custom-value'};
 
         expect(supabase.headers['X-Client-Info'], startsWith('supabase-dart/'));
       });
@@ -314,8 +312,7 @@ void main() {
           accessToken: () async => 'custom-token',
         );
 
-        final newHeaders = {'Custom-Header': 'custom-value'};
-        customTokenClient.headers = newHeaders;
+        customTokenClient.headers = {'Custom-Header': 'custom-value'};
 
         expect(customTokenClient.headers['Custom-Header'], 'custom-value');
       });

--- a/packages/supabase/test/client_test.dart
+++ b/packages/supabase/test/client_test.dart
@@ -11,7 +11,7 @@ void main() {
   Future<HttpRequest> getRealtimeRequest({
     required HttpServer server,
     required SupabaseClient supabaseClient,
-  }) async {
+  }) {
     supabaseClient.channel('name').subscribe();
 
     return server.first;

--- a/packages/supabase/test/mock_test.dart
+++ b/packages/supabase/test/mock_test.dart
@@ -630,7 +630,7 @@ void main() {
                 event: PostgresChangeEvent.all,
                 schema: 'public',
                 table: 'todos',
-                callback: (payload) async {
+                callback: (payload) {
                   supabase.from('todos');
                 })
             .subscribe();

--- a/packages/supabase_flutter/example/lib/main.dart
+++ b/packages/supabase_flutter/example/lib/main.dart
@@ -34,7 +34,7 @@ class _MyWidgetState extends State<MyWidget> {
     super.initState();
   }
 
-  Future<void> _getAuth() async {
+  void _getAuth() {
     setState(() {
       _user = Supabase.instance.client.auth.currentUser;
     });

--- a/packages/supabase_flutter/lib/src/local_storage.dart
+++ b/packages/supabase_flutter/lib/src/local_storage.dart
@@ -106,11 +106,12 @@ class SharedPreferencesLocalStorage extends LocalStorage {
   }
 
   @override
-  Future<void> persistSession(String persistSessionString) {
+  Future<void> persistSession(String persistSessionString) async {
     if (_useWebLocalStorage) {
-      return web.persistSession(persistSessionKey, persistSessionString);
+      web.persistSession(persistSessionKey, persistSessionString);
+      return;
     }
-    return _prefs.setString(persistSessionKey, persistSessionString);
+    await _prefs.setString(persistSessionKey, persistSessionString);
   }
 }
 

--- a/packages/supabase_flutter/lib/src/local_storage_stub.dart
+++ b/packages/supabase_flutter/lib/src/local_storage_stub.dart
@@ -1,10 +1,9 @@
 // coverage:ignore-file
 Future<bool> hasAccessToken(String _) => throw UnimplementedError();
 
-Future<String?> accessToken(String _) async => throw UnimplementedError();
+String? accessToken(String _) => throw UnimplementedError();
 
-Future<void> removePersistedSession(String _) async =>
-    throw UnimplementedError();
+void removePersistedSession(String _) => throw UnimplementedError();
 
-Future<void> persistSession(String _, String persistSessionString) async =>
+void persistSession(String _, String persistSessionString) =>
     throw UnimplementedError();

--- a/packages/supabase_flutter/lib/src/local_storage_stub.dart
+++ b/packages/supabase_flutter/lib/src/local_storage_stub.dart
@@ -1,5 +1,5 @@
 // coverage:ignore-file
-Future<bool> hasAccessToken(String _) => throw UnimplementedError();
+bool hasAccessToken(String _) => throw UnimplementedError();
 
 String? accessToken(String _) => throw UnimplementedError();
 

--- a/packages/supabase_flutter/lib/src/local_storage_web.dart
+++ b/packages/supabase_flutter/lib/src/local_storage_web.dart
@@ -2,15 +2,14 @@ import 'package:web/web.dart';
 
 final _localStorage = window.localStorage;
 
-Future<bool> hasAccessToken(String persistSessionKey) async =>
+bool hasAccessToken(String persistSessionKey) =>
     _localStorage.getItem(persistSessionKey) != null;
 
-Future<String?> accessToken(String persistSessionKey) async =>
+String? accessToken(String persistSessionKey) =>
     _localStorage.getItem(persistSessionKey);
 
-Future<void> removePersistedSession(String persistSessionKey) async =>
+void removePersistedSession(String persistSessionKey) =>
     _localStorage.removeItem(persistSessionKey);
 
-Future<void> persistSession(
-        String persistSessionKey, persistSessionString) async =>
+void persistSession(String persistSessionKey, persistSessionString) =>
     _localStorage.setItem(persistSessionKey, persistSessionString);

--- a/packages/supabase_flutter/lib/src/passkey/passkey_options_mapper.dart
+++ b/packages/supabase_flutter/lib/src/passkey/passkey_options_mapper.dart
@@ -12,7 +12,7 @@ import 'package:passkeys/types.dart';
 RegisterRequestType passkeyRegisterRequestFromOptions(
   Map<String, dynamic> options,
 ) {
-  final json = Map<String, dynamic>.from(options);
+  final json = Map<String, dynamic>.of(options);
 
   final challenge = json['challenge'];
   if (challenge is String) {
@@ -38,7 +38,7 @@ RegisterRequestType passkeyRegisterRequestFromOptions(
 AuthenticateRequestType passkeyAuthenticateRequestFromOptions(
   Map<String, dynamic> options,
 ) {
-  final json = Map<String, dynamic>.from(options);
+  final json = Map<String, dynamic>.of(options);
 
   final challenge = json['challenge'];
   if (challenge is String) {

--- a/packages/supabase_flutter/lib/src/supabase.dart
+++ b/packages/supabase_flutter/lib/src/supabase.dart
@@ -216,7 +216,7 @@ class Supabase {
   }) {
     final headers = {
       ...Constants.defaultHeaders,
-      if (customHeaders != null) ...customHeaders,
+      ...?customHeaders,
     };
     client = SupabaseClient(
       supabaseUrl,

--- a/packages/supabase_flutter/lib/src/supabase_auth.dart
+++ b/packages/supabase_flutter/lib/src/supabase_auth.dart
@@ -372,7 +372,7 @@ extension GoTrueClientSignInProvider on GoTrueClient {
 
   String generateRawNonce() {
     final random = Random.secure();
-    return base64Url.encode(List<int>.generate(16, (_) => random.nextInt(256)));
+    return base64Url.encode(List.generate(16, (_) => random.nextInt(256)));
   }
 
   /// Links an oauth identity to an existing user.

--- a/packages/supabase_flutter/test/auth_test.dart
+++ b/packages/supabase_flutter/test/auth_test.dart
@@ -70,7 +70,7 @@ void main() {
           publishableKey: supabaseKey,
           debug: false,
           authOptions: FlutterAuthClientOptions(
-            localStorage: MockEmptyLocalStorage(),
+            localStorage: const MockEmptyLocalStorage(),
             pkceAsyncStorage: MockAsyncStorage(),
           ),
         );
@@ -90,7 +90,7 @@ void main() {
 
     group('Session recovery', () {
       test('handles corrupted session data gracefully', () async {
-        final corruptedStorage = MockExpiredStorage();
+        const corruptedStorage = MockExpiredStorage();
 
         await Supabase.initialize(
           url: supabaseUrl,
@@ -108,7 +108,7 @@ void main() {
       });
 
       test('handles null session during initialization', () async {
-        final emptyStorage = MockEmptyLocalStorage();
+        const emptyStorage = MockEmptyLocalStorage();
 
         await Supabase.initialize(
           url: supabaseUrl,

--- a/packages/supabase_flutter/test/auth_test.dart
+++ b/packages/supabase_flutter/test/auth_test.dart
@@ -9,7 +9,7 @@ class _MockLocalStorage extends MockLocalStorage {
   bool get initializeCalled => _initializeCalled;
 
   @override
-  Future<void> initialize() async {
+  Future<void> initialize() {
     _initializeCalled = true;
     return super.initialize();
   }

--- a/packages/supabase_flutter/test/deep_link_test.dart
+++ b/packages/supabase_flutter/test/deep_link_test.dart
@@ -33,7 +33,7 @@ void main() {
         debug: false,
         httpClient: pkceHttpClient,
         authOptions: FlutterAuthClientOptions(
-          localStorage: MockEmptyLocalStorage(),
+          localStorage: const MockEmptyLocalStorage(),
           pkceAsyncStorage: MockAsyncStorage()
             ..setItem(
                 key: 'supabase.auth.token-code-verifier',
@@ -73,7 +73,7 @@ void main() {
         debug: false,
         httpClient: getUserHttpClient,
         authOptions: FlutterAuthClientOptions(
-          localStorage: MockEmptyLocalStorage(),
+          localStorage: const MockEmptyLocalStorage(),
           pkceAsyncStorage: MockAsyncStorage(),
         ),
       );

--- a/packages/supabase_flutter/test/initialization_test.dart
+++ b/packages/supabase_flutter/test/initialization_test.dart
@@ -38,11 +38,11 @@ void main() {
 
     group('Custom storage initialization', () {
       test('initialize successfully with custom localStorage', () async {
-        final localStorage = MockLocalStorage();
+        const localStorage = MockLocalStorage();
         await Supabase.initialize(
           url: supabaseUrl,
           publishableKey: supabaseKey,
-          authOptions: FlutterAuthClientOptions(
+          authOptions: const FlutterAuthClientOptions(
             localStorage: localStorage,
           ),
         );
@@ -57,7 +57,7 @@ void main() {
           publishableKey: supabaseKey,
           debug: true,
           authOptions: FlutterAuthClientOptions(
-            localStorage: MockExpiredStorage(),
+            localStorage: const MockExpiredStorage(),
             pkceAsyncStorage: MockAsyncStorage(),
           ),
         );
@@ -144,7 +144,7 @@ void main() {
           publishableKey: supabaseKey,
           debug: false,
           authOptions: FlutterAuthClientOptions(
-            localStorage: MockLocalStorage(),
+            localStorage: const MockLocalStorage(),
             pkceAsyncStorage: MockAsyncStorage(),
           ),
         );
@@ -160,7 +160,7 @@ void main() {
           publishableKey: supabaseKey,
           debug: true,
           authOptions: FlutterAuthClientOptions(
-            localStorage: MockEmptyLocalStorage(),
+            localStorage: const MockEmptyLocalStorage(),
             pkceAsyncStorage: MockAsyncStorage(),
           ),
         );

--- a/packages/supabase_flutter/test/lifecycle_test.dart
+++ b/packages/supabase_flutter/test/lifecycle_test.dart
@@ -84,7 +84,7 @@ void main() {
         publishableKey: supabaseKey,
         debug: false,
         authOptions: FlutterAuthClientOptions(
-          localStorage: MockEmptyLocalStorage(),
+          localStorage: const MockEmptyLocalStorage(),
           pkceAsyncStorage: MockAsyncStorage(),
         ),
         realtimeClientOptions: RealtimeClientOptions(

--- a/packages/supabase_flutter/test/supabase_flutter_test.dart
+++ b/packages/supabase_flutter/test/supabase_flutter_test.dart
@@ -23,7 +23,7 @@ void main() {
       );
     });
 
-    test('can access Supabase singleton', () async {
+    test('can access Supabase singleton', () {
       final supabase = Supabase.instance.client;
 
       expect(supabase, isNotNull);

--- a/packages/supabase_flutter/test/supabase_flutter_test.dart
+++ b/packages/supabase_flutter/test/supabase_flutter_test.dart
@@ -17,7 +17,7 @@ void main() {
         publishableKey: supabaseKey,
         debug: false,
         authOptions: FlutterAuthClientOptions(
-          localStorage: MockLocalStorage(),
+          localStorage: const MockLocalStorage(),
           pkceAsyncStorage: MockAsyncStorage(),
         ),
       );
@@ -37,7 +37,7 @@ void main() {
         publishableKey: supabaseKey,
         debug: false,
         authOptions: FlutterAuthClientOptions(
-          localStorage: MockLocalStorage(),
+          localStorage: const MockLocalStorage(),
           pkceAsyncStorage: MockAsyncStorage(),
         ),
       );
@@ -53,7 +53,7 @@ void main() {
       publishableKey: supabaseUrl,
       debug: false,
       authOptions: FlutterAuthClientOptions(
-        localStorage: MockLocalStorage(),
+        localStorage: const MockLocalStorage(),
         pkceAsyncStorage: MockAsyncStorage(),
       ),
       accessToken: () async => 'my-access-token',
@@ -76,7 +76,7 @@ void main() {
         publishableKey: supabaseKey,
         debug: false,
         authOptions: FlutterAuthClientOptions(
-          localStorage: MockExpiredStorage(),
+          localStorage: const MockExpiredStorage(),
           pkceAsyncStorage: MockAsyncStorage(),
           autoRefreshToken: false,
         ),
@@ -100,7 +100,7 @@ void main() {
         publishableKey: supabaseKey,
         debug: false,
         authOptions: FlutterAuthClientOptions(
-          localStorage: MockEmptyLocalStorage(),
+          localStorage: const MockEmptyLocalStorage(),
           pkceAsyncStorage: MockAsyncStorage(),
         ),
       );

--- a/packages/supabase_flutter/test/widget_test.dart
+++ b/packages/supabase_flutter/test/widget_test.dart
@@ -8,7 +8,7 @@ void main() {
   const supabaseUrl = '';
   const supabaseKey = '';
 
-  setUpAll(() async {
+  setUpAll(() {
     mockAppLink();
   });
 

--- a/packages/supabase_flutter/test/widget_test.dart
+++ b/packages/supabase_flutter/test/widget_test.dart
@@ -19,7 +19,7 @@ void main() {
       url: supabaseUrl,
       publishableKey: supabaseKey,
       authOptions: FlutterAuthClientOptions(
-        localStorage: MockLocalStorage(),
+        localStorage: const MockLocalStorage(),
         pkceAsyncStorage: MockAsyncStorage(),
       ),
     );

--- a/packages/supabase_flutter/test/widget_test_stubs.dart
+++ b/packages/supabase_flutter/test/widget_test_stubs.dart
@@ -48,6 +48,7 @@ class _MockWidgetState extends State<MockWidget> {
 
 /// Local storage that returns an expired session
 class MockExpiredStorage extends LocalStorage {
+  const MockExpiredStorage();
   @override
   Future<void> initialize() async {}
   @override
@@ -65,6 +66,7 @@ class MockExpiredStorage extends LocalStorage {
 }
 
 class MockLocalStorage extends LocalStorage {
+  const MockLocalStorage();
   @override
   Future<void> initialize() async {}
   @override
@@ -82,6 +84,7 @@ class MockLocalStorage extends LocalStorage {
 }
 
 class MockEmptyLocalStorage extends LocalStorage {
+  const MockEmptyLocalStorage();
   @override
   Future<void> initialize() async {}
   @override

--- a/packages/supabase_lints/lib/analysis_options.yaml
+++ b/packages/supabase_lints/lib/analysis_options.yaml
@@ -22,7 +22,6 @@ dcm:
     avoid-duplicate-initializers: false
     avoid-duplicate-test-assertions: false
     avoid-dynamic: false
-    avoid-excessive-expressions: false
     avoid-map-keys-contains: false
     avoid-missing-completer-stack-trace: false
     avoid-missing-enum-constant-in-map: false
@@ -30,7 +29,6 @@ dcm:
     avoid-never-passed-parameters: false
     avoid-nullable-interpolation: false
     avoid-nullable-tostring: false
-    avoid-only-rethrow: false
     avoid-passing-async-when-sync-expected: false
     avoid-passing-self-as-argument: false
     avoid-self-compare: false
@@ -40,12 +38,10 @@ dcm:
     avoid-unassigned-stream-subscriptions: false
     avoid-unconditional-break: false
     avoid-unnecessary-late-fields: false
-    avoid-unnecessary-local-variable: false
     avoid-unnecessary-nullable-parameters: false
     avoid-unnecessary-nullable-return-type: false
     avoid-unnecessary-reassignment: false
     avoid-unnecessary-return: false
-    avoid-unnecessary-super: false
     avoid-unnecessary-type-assertions: false
     avoid-unsafe-collection-methods: false
     avoid-unused-parameters: false
@@ -60,13 +56,15 @@ dcm:
     prefer-correct-json-casts: false
     prefer-explicit-function-type: false
     prefer-match-file-name: false
-    prefer-null-aware-elements: false
-    prefer-null-aware-spread: false
     prefer-overriding-parent-equality: false
-    prefer-parentheses-with-if-null: false
     prefer-prefixed-global-constants: false
-    prefer-returning-shorthands: false
-    prefer-shorthands-with-enums: false
-    prefer-shorthands-with-static-fields: false
     prefer-switch-with-enums: false
     proper-super-calls: false
+
+    # Blocked until the minimum Dart SDK is raised. The fixes these rules
+    # suggest rely on language features newer than our current floor of 3.4.0,
+    # so they cannot be enabled yet.
+    prefer-null-aware-elements: false # needs null-aware elements (Dart 3.8)
+    prefer-returning-shorthands: false # needs dot shorthands (Dart 3.9)
+    prefer-shorthands-with-enums: false # needs dot shorthands (Dart 3.9)
+    prefer-shorthands-with-static-fields: false # needs dot shorthands (Dart 3.9)

--- a/packages/supabase_lints/lib/analysis_options.yaml
+++ b/packages/supabase_lints/lib/analysis_options.yaml
@@ -23,7 +23,6 @@ dcm:
     avoid-duplicate-test-assertions: false
     avoid-dynamic: false
     avoid-excessive-expressions: false
-    avoid-inferrable-type-arguments: false
     avoid-map-keys-contains: false
     avoid-missing-completer-stack-trace: false
     avoid-missing-enum-constant-in-map: false
@@ -59,7 +58,6 @@ dcm:
     no-equal-switch-case: false
     prefer-correct-callback-field-name: false
     prefer-correct-json-casts: false
-    prefer-declaring-const-constructor: false
     prefer-explicit-function-type: false
     prefer-match-file-name: false
     prefer-null-aware-elements: false

--- a/packages/supabase_lints/lib/analysis_options.yaml
+++ b/packages/supabase_lints/lib/analysis_options.yaml
@@ -22,13 +22,10 @@ dcm:
     avoid-duplicate-initializers: false
     avoid-duplicate-test-assertions: false
     avoid-dynamic: false
-    avoid-map-keys-contains: false
-    avoid-missing-completer-stack-trace: false
     avoid-missing-enum-constant-in-map: false
     avoid-misused-test-matchers: false
     avoid-never-passed-parameters: false
     avoid-nullable-interpolation: false
-    avoid-nullable-tostring: false
     avoid-passing-async-when-sync-expected: false
     avoid-passing-self-as-argument: false
     avoid-self-compare: false
@@ -37,11 +34,9 @@ dcm:
     avoid-unassigned-fields: false
     avoid-unassigned-stream-subscriptions: false
     avoid-unconditional-break: false
-    avoid-unnecessary-late-fields: false
     avoid-unnecessary-nullable-parameters: false
     avoid-unnecessary-nullable-return-type: false
     avoid-unnecessary-reassignment: false
-    avoid-unnecessary-return: false
     avoid-unnecessary-type-assertions: false
     avoid-unsafe-collection-methods: false
     avoid-unused-parameters: false

--- a/packages/supabase_lints/lib/analysis_options.yaml
+++ b/packages/supabase_lints/lib/analysis_options.yaml
@@ -27,7 +27,6 @@ dcm:
     avoid-map-keys-contains: false
     avoid-missing-completer-stack-trace: false
     avoid-missing-enum-constant-in-map: false
-    avoid-misused-set-literals: false
     avoid-misused-test-matchers: false
     avoid-never-passed-parameters: false
     avoid-nullable-interpolation: false
@@ -35,17 +34,13 @@ dcm:
     avoid-only-rethrow: false
     avoid-passing-async-when-sync-expected: false
     avoid-passing-self-as-argument: false
-    avoid-redundant-async: false
-    avoid-redundant-else: false
     avoid-self-compare: false
     avoid-shadowing: false
     avoid-throw-in-catch-block: false
     avoid-unassigned-fields: false
     avoid-unassigned-stream-subscriptions: false
     avoid-unconditional-break: false
-    avoid-unnecessary-futures: false
     avoid-unnecessary-late-fields: false
-    avoid-unnecessary-local-late: false
     avoid-unnecessary-local-variable: false
     avoid-unnecessary-nullable-parameters: false
     avoid-unnecessary-nullable-return-type: false
@@ -53,7 +48,6 @@ dcm:
     avoid-unnecessary-return: false
     avoid-unnecessary-super: false
     avoid-unnecessary-type-assertions: false
-    avoid-unnecessary-type-casts: false
     avoid-unsafe-collection-methods: false
     avoid-unused-parameters: false
     avoid-wildcard-cases-with-enums: false
@@ -63,19 +57,16 @@ dcm:
     move-variable-closer-to-its-usage: false
     no-empty-block: false
     no-equal-switch-case: false
-    no-equal-then-else: false
     prefer-correct-callback-field-name: false
     prefer-correct-json-casts: false
     prefer-declaring-const-constructor: false
     prefer-explicit-function-type: false
-    prefer-iterable-of: false
     prefer-match-file-name: false
     prefer-null-aware-elements: false
     prefer-null-aware-spread: false
     prefer-overriding-parent-equality: false
     prefer-parentheses-with-if-null: false
     prefer-prefixed-global-constants: false
-    prefer-return-await: false
     prefer-returning-shorthands: false
     prefer-shorthands-with-enums: false
     prefer-shorthands-with-static-fields: false

--- a/packages/supabase_lints/lib/analysis_options.yaml
+++ b/packages/supabase_lints/lib/analysis_options.yaml
@@ -46,7 +46,6 @@ dcm:
     avoid-unsafe-collection-methods: false
     avoid-unused-parameters: false
     avoid-wildcard-cases-with-enums: false
-    dispose-class-fields: false
     function-always-returns-null: false
     match-getter-setter-field-names: false
     move-variable-closer-to-its-usage: false

--- a/packages/yet_another_json_isolate/lib/src/_isolates_io.dart
+++ b/packages/yet_another_json_isolate/lib/src/_isolates_io.dart
@@ -107,7 +107,6 @@ void _compute(SendPort p) async {
 
       /// `true` for encoding and `false` for decoding
       final bool method = event.last;
-      // Assigned in both the try and catch branches below, so it must be late.
       // ignore: avoid-unnecessary-local-late
       late final List<dynamic> computationResult;
 
@@ -137,7 +136,7 @@ void _compute(SendPort p) async {
 /// [R] could also be a [List]. Meaning, a check `result is R` could return true
 /// for what was an error event.
 List<R> _buildSuccessResponse<R>(R result) {
-  return List<R>.filled(1, result);
+  return List.filled(1, result);
 }
 
 /// Wrap in [List] to ensure our expectations in the main isolate are met.

--- a/packages/yet_another_json_isolate/lib/src/_isolates_io.dart
+++ b/packages/yet_another_json_isolate/lib/src/_isolates_io.dart
@@ -107,6 +107,8 @@ void _compute(SendPort p) async {
 
       /// `true` for encoding and `false` for decoding
       final bool method = event.last;
+      // Assigned in both the try and catch branches below, so it must be late.
+      // ignore: avoid-unnecessary-local-late
       late final List<dynamic> computationResult;
 
       try {

--- a/packages/yet_another_json_isolate/lib/src/_isolates_web.dart
+++ b/packages/yet_another_json_isolate/lib/src/_isolates_web.dart
@@ -1,11 +1,10 @@
 import 'dart:convert';
 
 class YAJsonIsolate {
-  YAJsonIsolate({
+  const YAJsonIsolate({
     String? debugName,
   });
 
-  // Kept returning a Future to match the IO implementation's signature.
   Future<void> initialize() => Future.value();
 
   Future<void> dispose() => Future.value();

--- a/packages/yet_another_json_isolate/lib/src/_isolates_web.dart
+++ b/packages/yet_another_json_isolate/lib/src/_isolates_web.dart
@@ -5,9 +5,10 @@ class YAJsonIsolate {
     String? debugName,
   });
 
-  Future<void> initialize() async {}
+  // Kept returning a Future to match the IO implementation's signature.
+  Future<void> initialize() => Future.value();
 
-  Future<void> dispose() async {}
+  Future<void> dispose() => Future.value();
 
   Future<dynamic> decode(String json) async {
     await null;


### PR DESCRIPTION
Stacked on #1422.

## What

The websocket connection's `stream.listen` subscription in `RealtimeClient` was never stored, so it couldn't be cancelled explicitly when the connection is torn down. Store it in a field and cancel it in `disconnect()`.

## Context

This came out of investigating the `avoid-unassigned-stream-subscriptions` DCM rule. That rule could not be enabled cleanly: most of its other sites are test subscriptions of the form `stream.listen(expectAsync1(..., count: N))`, where the subscription must stay alive to receive the asserted events, cancelling them would break the assertions. So the rule stays disabled; this PR just takes the one genuine lib improvement it surfaced.

## Verification

- `dart analyze` clean.
- `dcm analyze packages` -> no issues found.
- realtime_client tests pass (socket_test 36, mock_test + channel_test 46).