### PR TITLE
chore: update sdk-compliance.yaml for realtime capability renames

### DIFF
--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -261,7 +261,6 @@ features:
   storage.analytics.iceberg_table: not_implemented
 
   # realtime — channel
-  realtime.channel.channel: implemented
   realtime.channel.subscribe: implemented
   realtime.channel.unsubscribe: implemented
   realtime.channel.send: implemented
@@ -270,16 +269,13 @@ features:
     note: "httpSend posts to the legacy /api/broadcast endpoint with a messages array and returns Future<void>, not the newer per-channel endpoint returning {success}."
 
   # realtime — client
+  realtime.client.channel: implemented
   realtime.client.connect: implemented
   realtime.client.disconnect: implemented
   realtime.client.connection_state: implemented
-  realtime.client.endpoint_url: implemented
   realtime.client.get_channels: implemented
   realtime.client.remove_channel: implemented
   realtime.client.remove_all_channels: implemented
-  realtime.client.is_connected: implemented
-  realtime.client.is_connecting: not_implemented
-  realtime.client.is_disconnecting: not_implemented
   realtime.client.listen_heartbeats: not_implemented
   realtime.client.set_auth_token: implemented
 


### PR DESCRIPTION
## Summary

Keeps `sdk-compliance.yaml` in sync with the canonical capability registry changes landed in [supabase/sdk#27](https://github.com/supabase/sdk/pull/27).

**Four capabilities removed from the registry** (no longer tracked across SDKs):
- `realtime.client.endpoint_url`
- `realtime.client.is_connected`
- `realtime.client.is_connecting`
- `realtime.client.is_disconnecting`

**One capability renamed and moved:**
- `realtime.channel.channel` → `realtime.client.channel` (moved from the `# realtime — channel` section to `# realtime — client`)

## Depends on

- https://github.com/supabase/sdk/pull/27