### PR TITLE
test: use proper matchers in tests

### DIFF
--- a/packages/functions_client/test/functions_dart_test.dart
+++ b/packages/functions_client/test/functions_dart_test.dart
@@ -20,12 +20,11 @@ void main() {
           FunctionsClient("", {}, httpClient: customHttpClient);
     });
     test('function throws', () async {
-      try {
-        await functionsCustomHttpClient.invoke('error-function');
-        fail('should throw');
-      } on FunctionException catch (e) {
-        expect(e.status, 420);
-      }
+      await expectLater(
+        () => functionsCustomHttpClient.invoke('error-function'),
+        throwsA(
+            isA<FunctionException>().having((e) => e.status, 'status', 420)),
+      );
     });
 
     test('function call', () async {
@@ -411,15 +410,14 @@ void main() {
 
     group('Error handling', () {
       test('FunctionException contains all error details', () async {
-        try {
-          await functionsCustomHttpClient.invoke('error-function');
-          fail('should throw');
-        } on FunctionException catch (e) {
-          expect(e.status, 420);
-          expect(e.details, isNotNull);
-          expect(e.reasonPhrase, isNotNull);
-          expect(e.toString(), contains('420'));
-        }
+        await expectLater(
+          () => functionsCustomHttpClient.invoke('error-function'),
+          throwsA(isA<FunctionException>()
+              .having((e) => e.status, 'status', 420)
+              .having((e) => e.details, 'details', isNotNull)
+              .having((e) => e.reasonPhrase, 'reasonPhrase', isNotNull)
+              .having((e) => e.toString(), 'toString()', contains('420'))),
+        );
       });
     });
 

--- a/packages/gotrue/test/client_test.dart
+++ b/packages/gotrue/test/client_test.dart
@@ -104,15 +104,11 @@ void main() {
     test(
       'signUp() with weak password throws AuthWeakPasswordException',
       () async {
-        try {
-          await client.signUp(email: newEmail, password: '123');
-          fail('signUp with weak password should throw exception');
-        } on AuthException catch (error) {
-          expect(error, isA<AuthWeakPasswordException>());
-          expect(error.code, ErrorCode.weakPassword.code);
-        } catch (error) {
-          fail('signUp threw ${error.runtimeType} instead of AuthException');
-        }
+        await expectLater(
+          () => client.signUp(email: newEmail, password: '123'),
+          throwsA(isA<AuthWeakPasswordException>()
+              .having((e) => e.code, 'code', ErrorCode.weakPassword.code)),
+        );
       },
     );
 
@@ -125,10 +121,10 @@ void main() {
       final urlWithoutAccessToken = Uri.parse(
         'http://my-callback-url.com/welcome#expires_in=$expiresIn&refresh_token=$refreshToken&token_type=$tokenType&provider_token=$providerToken',
       );
-      try {
-        await client.getSessionFromUrl(urlWithoutAccessToken);
-        fail('getSessionFromUrl did not throw exception');
-      } catch (_) {}
+      await expectLater(
+        () => client.getSessionFromUrl(urlWithoutAccessToken),
+        throwsA(anything),
+      );
     });
 
     test('Parsing an error URL should throw', () async {
@@ -138,18 +134,13 @@ void main() {
       final urlWithoutAccessToken = Uri.parse(
         'http://my-callback-url.com/#error=unauthorized_client&error_code=401&error_description=${Uri.encodeComponent(errorMessage)}',
       );
-      try {
-        await client.getSessionFromUrl(urlWithoutAccessToken);
-        fail('getSessionFromUrl did not throw exception');
-      } on AuthException catch (error) {
-        expect(error.message, errorMessage);
-        expect(error.statusCode, '401');
-        expect(error.code, 'unauthorized_client');
-      } catch (error) {
-        fail(
-          'getSessionFromUrl threw ${error.runtimeType} instead of AuthException',
-        );
-      }
+      await expectLater(
+        () => client.getSessionFromUrl(urlWithoutAccessToken),
+        throwsA(isA<AuthException>()
+            .having((e) => e.message, 'message', errorMessage)
+            .having((e) => e.statusCode, 'statusCode', '401')
+            .having((e) => e.code, 'code', 'unauthorized_client')),
+      );
     });
 
     test('Subscribe a listener', () async {
@@ -442,12 +433,11 @@ void main() {
 
     test('Update user with the same password throws AuthException', () async {
       await client.signInWithPassword(email: email1, password: password);
-      try {
-        await client.updateUser(UserAttributes(password: password));
-        fail('updateUser did not throw');
-      } on AuthException catch (error) {
-        expect(error.code, ErrorCode.samePassword.code);
-      }
+      await expectLater(
+        () => client.updateUser(UserAttributes(password: password)),
+        throwsA(isA<AuthException>()
+            .having((e) => e.code, 'code', ErrorCode.samePassword.code)),
+      );
     });
 
     test('signOut', () async {
@@ -473,15 +463,14 @@ void main() {
     });
 
     test('signIn() with the wrong password', () async {
-      try {
-        await client.signInWithPassword(
+      await expectLater(
+        () => client.signInWithPassword(
           email: email1,
           password: 'wrong_$password',
-        );
-        fail('signInWithPassword did not throw');
-      } on AuthException catch (error) {
-        expect(error.message, isNotNull);
-      }
+        ),
+        throwsA(isA<AuthException>()
+            .having((e) => e.message, 'message', isNotNull)),
+      );
     });
 
     group('The auth client can signin with third-party oAuth providers', () {
@@ -686,16 +675,11 @@ void main() {
       final urlWithoutAccessToken = Uri.parse(
         'http://my-callback-url.com/#error=unauthorized_client&error_code=401&error_description=${Uri.encodeComponent(errorMessage)}',
       );
-      try {
-        await client.getSessionFromUrl(urlWithoutAccessToken);
-        fail('getSessionFromUrl did not throw exception');
-      } on AuthException catch (error) {
-        expect(error.message, errorMessage);
-      } catch (error) {
-        fail(
-          'getSessionFromUrl threw ${error.runtimeType} instead of AuthException',
-        );
-      }
+      await expectLater(
+        () => client.getSessionFromUrl(urlWithoutAccessToken),
+        throwsA(isA<AuthException>()
+            .having((e) => e.message, 'message', errorMessage)),
+      );
     });
 
     test(

--- a/packages/gotrue/test/fetch_test.dart
+++ b/packages/gotrue/test/fetch_test.dart
@@ -72,12 +72,10 @@ void main() {
 
 Future<void> _testFetchRequest(Client client) async {
   final GotrueFetch fetch = GotrueFetch(client);
-  try {
-    await fetch.request(_mockUrl, RequestMethodType.get);
-  } on AuthException catch (error) {
-    expect(error.code, 'weak_password');
-    expect(error.message, 'error_message');
-  } catch (error) {
-    fail('Should have thrown AuthException');
-  }
+  await expectLater(
+    () => fetch.request(_mockUrl, RequestMethodType.get),
+    throwsA(isA<AuthException>()
+        .having((e) => e.code, 'code', 'weak_password')
+        .having((e) => e.message, 'message', 'error_message')),
+  );
 }

--- a/packages/gotrue/test/otp_mock_test.dart
+++ b/packages/gotrue/test/otp_mock_test.dart
@@ -57,13 +57,11 @@ void main() {
     });
 
     test('signInWithOtp() without email or phone should throw', () async {
-      try {
-        await client.signInWithOtp();
-        fail('Should have thrown an exception');
-      } on AuthException catch (e) {
-        expect(e.message,
-            contains('You must provide either an email, phone number'));
-      }
+      await expectLater(
+        () => client.signInWithOtp(),
+        throwsA(isA<AuthException>().having((e) => e.message, 'message',
+            contains('You must provide either an email, phone number'))),
+      );
     });
 
     test('verifyOTP() with phone number', () async {
@@ -149,32 +147,28 @@ void main() {
         'verifyOTP() with recovery type and tokenHash should reject email/phone',
         () async {
       // Recovery type with tokenHash should not accept email/phone
-      try {
-        await client.verifyOTP(
+      await expectLater(
+        () => client.verifyOTP(
           email: testEmail,
           tokenHash: 'mock-token-hash',
           type: OtpType.recovery,
-        );
-        fail('Should have thrown an assertion error');
-      } catch (e) {
-        expect(e, isA<AssertionError>());
-        expect(
-            e.toString(),
+        ),
+        throwsA(isA<AssertionError>().having(
+            (e) => e.toString(),
+            'toString()',
             contains(
-                'For recovery type with tokenHash, only tokenHash and type should be provided'));
-      }
+                'For recovery type with tokenHash, only tokenHash and type should be provided'))),
+      );
     });
 
     test('verifyOTP() without token should throw', () async {
-      try {
-        await client.verifyOTP(
+      await expectLater(
+        () => client.verifyOTP(
           email: testEmail,
           type: OtpType.email,
-        );
-        fail('Should have thrown an exception');
-      } catch (e) {
-        expect(e, isA<AssertionError>());
-      }
+        ),
+        throwsA(isA<AssertionError>()),
+      );
     });
 
     test('signUp() with phone number', () async {
@@ -235,12 +229,10 @@ void main() {
     });
 
     test('reauthenticate() throws when no session', () async {
-      try {
-        await client.reauthenticate();
-        fail('Should have thrown an exception');
-      } on AuthSessionMissingException catch (_) {
-        // Expected exception
-      }
+      await expectLater(
+        () => client.reauthenticate(),
+        throwsA(isA<AuthSessionMissingException>()),
+      );
     });
 
     test('resend() with phone type', () async {
@@ -280,27 +272,23 @@ void main() {
     });
 
     test('resend() with wrong type for phone throws', () async {
-      try {
-        await client.resend(
+      await expectLater(
+        () => client.resend(
           phone: testPhone,
           type: OtpType.signup, // This should be sms or phoneChange for phone
-        );
-        fail('Should have thrown an exception');
-      } catch (e) {
-        expect(e, isA<AssertionError>());
-      }
+        ),
+        throwsA(isA<AssertionError>()),
+      );
     });
 
     test('resend() with wrong type for email throws', () async {
-      try {
-        await client.resend(
+      await expectLater(
+        () => client.resend(
           email: testEmail,
           type: OtpType.sms, // This should be signup or emailChange for email
-        );
-        fail('Should have thrown an exception');
-      } catch (e) {
-        expect(e, isA<AssertionError>());
-      }
+        ),
+        throwsA(isA<AssertionError>()),
+      );
     });
 
     test('signInWithOtp() with different channel types', () async {
@@ -326,16 +314,15 @@ void main() {
         asyncStorage: TestAsyncStorage(),
       );
 
-      try {
-        await client.verifyOTP(
+      await expectLater(
+        () => client.verifyOTP(
           phone: testPhone,
           token: '123456',
           type: OtpType.sms,
-        );
-        fail('Should have thrown an exception');
-      } on AuthException catch (e) {
-        expect(e.message, 'The OTP provided is invalid or has expired');
-      }
+        ),
+        throwsA(isA<AuthException>().having((e) => e.message, 'message',
+            'The OTP provided is invalid or has expired')),
+      );
     });
 
     test(
@@ -347,15 +334,14 @@ void main() {
         asyncStorage: TestAsyncStorage(),
       );
 
-      try {
-        await client.signInWithPassword(
+      await expectLater(
+        () => client.signInWithPassword(
           phone: testPhone,
           password: 'wrong-password',
-        );
-        fail('Should have thrown an exception');
-      } on AuthException catch (e) {
-        expect(e.message, 'Invalid login credentials');
-      }
+        ),
+        throwsA(isA<AuthException>()
+            .having((e) => e.message, 'message', 'Invalid login credentials')),
+      );
     });
 
     test('signUp() with existing phone number throws AuthException', () async {
@@ -365,15 +351,14 @@ void main() {
         asyncStorage: TestAsyncStorage(),
       );
 
-      try {
-        await client.signUp(
+      await expectLater(
+        () => client.signUp(
           phone: testPhone,
           password: testPassword,
-        );
-        fail('Should have thrown an exception');
-      } on AuthException catch (e) {
-        expect(e.message, 'Phone number is already registered');
-      }
+        ),
+        throwsA(isA<AuthException>().having(
+            (e) => e.message, 'message', 'Phone number is already registered')),
+      );
     });
 
     test('signInWithOtp() with empty response', () async {
@@ -395,15 +380,13 @@ void main() {
         asyncStorage: TestAsyncStorage(),
       );
 
-      try {
-        await client.verifyOTP(
+      await expectLater(
+        () => client.verifyOTP(
           token: '123456',
           type: OtpType.sms,
-        );
-        fail('Should have thrown an exception');
-      } catch (e) {
-        expect(e, isA<AssertionError>());
-      }
+        ),
+        throwsA(isA<AssertionError>()),
+      );
     });
 
     test('verifyOTP() with expired token throws AuthException', () async {
@@ -413,16 +396,15 @@ void main() {
         asyncStorage: TestAsyncStorage(),
       );
 
-      try {
-        await client.verifyOTP(
+      await expectLater(
+        () => client.verifyOTP(
           phone: testPhone,
           token: '123456',
           type: OtpType.sms,
-        );
-        fail('Should have thrown an exception');
-      } on AuthException catch (e) {
-        expect(e.message, 'The OTP has expired');
-      }
+        ),
+        throwsA(isA<AuthException>()
+            .having((e) => e.message, 'message', 'The OTP has expired')),
+      );
     });
 
     test('resend() with both email and phone throws assertion error', () async {
@@ -432,16 +414,14 @@ void main() {
         asyncStorage: TestAsyncStorage(),
       );
 
-      try {
-        await client.resend(
+      await expectLater(
+        () => client.resend(
           email: testEmail,
           phone: testPhone,
           type: OtpType.sms,
-        );
-        fail('Should have thrown an exception');
-      } catch (e) {
-        expect(e, isA<AssertionError>());
-      }
+        ),
+        throwsA(isA<AssertionError>()),
+      );
     });
 
     test('signUp() without email or phone throws exception', () async {
@@ -451,12 +431,10 @@ void main() {
         asyncStorage: TestAsyncStorage(),
       );
 
-      try {
-        await client.signUp(password: testPassword);
-        fail('Should have thrown an exception');
-      } catch (e) {
-        expect(e, isA<AssertionError>());
-      }
+      await expectLater(
+        () => client.signUp(password: testPassword),
+        throwsA(isA<AssertionError>()),
+      );
     });
 
     test('signInWithPassword() without email or phone throws exception',
@@ -467,12 +445,11 @@ void main() {
         asyncStorage: TestAsyncStorage(),
       );
 
-      try {
-        await client.signInWithPassword(password: testPassword);
-        fail('Should have thrown an exception');
-      } on AuthException catch (e) {
-        expect(e.message.contains('You must provide either an'), isTrue);
-      }
+      await expectLater(
+        () => client.signInWithPassword(password: testPassword),
+        throwsA(isA<AuthException>().having((e) => e.message, 'message',
+            contains('You must provide either an'))),
+      );
     });
 
     test('empty response on server error', () async {
@@ -482,12 +459,11 @@ void main() {
         asyncStorage: TestAsyncStorage(),
       );
 
-      try {
-        await client.signInWithOtp(phone: testPhone);
-        fail('Should have thrown an exception');
-      } on AuthException catch (e) {
-        expect(e.statusCode, '500');
-      }
+      await expectLater(
+        () => client.signInWithOtp(phone: testPhone),
+        throwsA(isA<AuthException>()
+            .having((e) => e.statusCode, 'statusCode', '500')),
+      );
     });
 
     test('response with null session', () async {
@@ -497,16 +473,15 @@ void main() {
         asyncStorage: TestAsyncStorage(),
       );
 
-      try {
-        await client.verifyOTP(
+      await expectLater(
+        () => client.verifyOTP(
           email: testEmail,
           token: '123456',
           type: OtpType.email,
-        );
-        fail('Should have thrown an exception');
-      } on AuthException catch (e) {
-        expect(e.message, 'An error occurred on token verification.');
-      }
+        ),
+        throwsA(isA<AuthException>().having((e) => e.message, 'message',
+            'An error occurred on token verification.')),
+      );
     });
   });
 

--- a/packages/gotrue/test/passkey_test.dart
+++ b/packages/gotrue/test/passkey_test.dart
@@ -286,13 +286,12 @@ void main() {
       );
       addTearDown(disabledClient.dispose);
 
-      try {
-        await disabledClient.passkey.startAuthentication();
-        fail('Expected AuthApiException');
-      } on AuthApiException catch (error) {
-        expect(error.code, 'passkey_disabled');
-        expect(error.statusCode, '404');
-      }
+      await expectLater(
+        () => disabledClient.passkey.startAuthentication(),
+        throwsA(isA<AuthApiException>()
+            .having((e) => e.code, 'code', 'passkey_disabled')
+            .having((e) => e.statusCode, 'statusCode', '404')),
+      );
     });
   });
 }

--- a/packages/gotrue/test/provider_test.dart
+++ b/packages/gotrue/test/provider_test.dart
@@ -108,28 +108,29 @@ void main() {
     });
 
     test('parse provider callback url with missing param error', () async {
-      try {
-        final accessToken = session.accessToken;
-        final url =
-            'http://my-callback-url.com?page=welcome&foo=bar#access_token=$accessToken';
-        await client.getSessionFromUrl(Uri.parse(url));
-        fail('Passed provider with missing param');
-      } catch (error) {
-        expect(error, isA<AuthException>());
-        expect((error as AuthException).message, 'No expires_in detected.');
-      }
+      await expectLater(
+        () async {
+          final accessToken = session.accessToken;
+          final url =
+              'http://my-callback-url.com?page=welcome&foo=bar#access_token=$accessToken';
+          await client.getSessionFromUrl(Uri.parse(url));
+        },
+        throwsA(isA<AuthException>()
+            .having((e) => e.message, 'message', 'No expires_in detected.')),
+      );
     });
 
     test('parse provider callback url with error', () async {
       const errorDesc = 'my_error_description';
-      try {
-        const url =
-            'http://my-callback-url.com?page=welcome&foo=bar#error_description=$errorDesc';
-        await client.getSessionFromUrl(Uri.parse(url));
-        fail('Passed provider with error');
-      } on AuthException catch (error) {
-        expect(error.message, errorDesc);
-      }
+      await expectLater(
+        () async {
+          const url =
+              'http://my-callback-url.com?page=welcome&foo=bar#error_description=$errorDesc';
+          await client.getSessionFromUrl(Uri.parse(url));
+        },
+        throwsA(isA<AuthException>()
+            .having((e) => e.message, 'message', errorDesc)),
+      );
     });
   });
 }

--- a/packages/gotrue/test/refresh_token_race_test.dart
+++ b/packages/gotrue/test/refresh_token_race_test.dart
@@ -263,7 +263,7 @@ void main() {
 
       // 1. setInitialSession loads the expired session (but doesn't refresh)
       await client.setInitialSession(expiredSession);
-      expect(client.currentSession?.isExpired, true);
+      expect(client.currentSession?.isExpired, isTrue);
 
       // 2. Start auto-refresh (simulates didChangeAppLifecycleState(resumed))
       client.startAutoRefresh();
@@ -301,7 +301,7 @@ void main() {
 
       // 1. Set initial session (doesn't refresh)
       await client.setInitialSession(expiredSession);
-      expect(client.currentSession?.isExpired, true);
+      expect(client.currentSession?.isExpired, isTrue);
       expect(httpClient.requestCount, 0);
 
       // 2. First refresh succeeds
@@ -311,7 +311,7 @@ void main() {
       // 3. Verify the session now has a NEW refresh token
       final newToken = client.currentSession?.refreshToken;
       expect(newToken, isNot('-yeS4omysFs9tpUYBws9Rg'));
-      expect(client.currentSession?.isExpired, false);
+      expect(client.currentSession?.isExpired, isFalse);
 
       // 4. Manually mark the current token as "already used" on the server
       // This simulates a race condition where another request (e.g., auto-refresh)
@@ -325,7 +325,7 @@ void main() {
 
       // Session should still be valid (the error handler returned current session)
       expect(client.currentSession, isNotNull);
-      expect(client.currentSession?.isExpired, false);
+      expect(client.currentSession?.isExpired, isFalse);
     });
 
     test('FIXED: signedOut event is NOT emitted when session is still valid',
@@ -344,7 +344,7 @@ void main() {
       // Capture the valid session after refresh
       final validSession = client.currentSession;
       expect(validSession, isNotNull);
-      expect(validSession!.isExpired, false);
+      expect(validSession!.isExpired, isFalse);
 
       // Listen for auth state changes AFTER first successful refresh
       final authEvents = <AuthChangeEvent>[];
@@ -412,7 +412,7 @@ void main() {
           reason: 'Refresh attempts should be handled without errors');
 
       // Session should be valid
-      expect(client.currentSession?.isExpired, false);
+      expect(client.currentSession?.isExpired, isFalse);
     });
 
     test(

--- a/packages/gotrue/test/src/constants_test.dart
+++ b/packages/gotrue/test/src/constants_test.dart
@@ -283,20 +283,20 @@ void main() {
     });
 
     test('enums support equality comparison', () {
-      expect(AuthChangeEvent.signedIn == AuthChangeEvent.signedIn, isTrue);
-      expect(AuthChangeEvent.signedIn == AuthChangeEvent.signedOut, isFalse);
+      expect(AuthChangeEvent.signedIn, AuthChangeEvent.signedIn);
+      expect(AuthChangeEvent.signedIn, isNot(AuthChangeEvent.signedOut));
 
-      expect(GenerateLinkType.signup == GenerateLinkType.signup, isTrue);
-      expect(GenerateLinkType.signup == GenerateLinkType.invite, isFalse);
+      expect(GenerateLinkType.signup, GenerateLinkType.signup);
+      expect(GenerateLinkType.signup, isNot(GenerateLinkType.invite));
 
-      expect(OtpType.sms == OtpType.sms, isTrue);
-      expect(OtpType.sms == OtpType.email, isFalse);
+      expect(OtpType.sms, OtpType.sms);
+      expect(OtpType.sms, isNot(OtpType.email));
 
-      expect(OtpChannel.sms == OtpChannel.sms, isTrue);
-      expect(OtpChannel.sms == OtpChannel.whatsapp, isFalse);
+      expect(OtpChannel.sms, OtpChannel.sms);
+      expect(OtpChannel.sms, isNot(OtpChannel.whatsapp));
 
-      expect(SignOutScope.global == SignOutScope.global, isTrue);
-      expect(SignOutScope.global == SignOutScope.local, isFalse);
+      expect(SignOutScope.global, SignOutScope.global);
+      expect(SignOutScope.global, isNot(SignOutScope.local));
     });
 
     test('enums can be used in sets and maps', () {

--- a/packages/gotrue/test/src/gotrue_mfa_api_test.dart
+++ b/packages/gotrue/test/src/gotrue_mfa_api_test.dart
@@ -81,7 +81,7 @@ void main() {
 
     final res = await client.mfa.challenge(factorId: factorId1);
 
-    expect(res.expiresAt.isAfter(DateTime.now()), true);
+    expect(res.expiresAt.isAfter(DateTime.now()), isTrue);
   });
 
   test('verify', () async {
@@ -127,7 +127,7 @@ void main() {
     final res = await client.mfa.listFactors();
 
     expect(res.totp.length, 1);
-    expect(res.phone.length, 0);
+    expect(res.phone, isEmpty);
     expect(res.all.length, 1);
     expect(res.all.first.id, factorId2);
     expect(res.all.first.status, FactorStatus.verified);
@@ -172,10 +172,10 @@ void main() {
     expect(phoneFactor.status, FactorStatus.unverified);
 
     // Verified phone factors should be empty since we haven't verified yet
-    expect(listRes.phone.length, 0);
+    expect(listRes.phone, isEmpty);
 
     // But the factor should appear in the all list
-    expect(listRes.all.any((f) => f.factorType == FactorType.phone), true);
+    expect(listRes.all.any((f) => f.factorType == FactorType.phone), isTrue);
   });
 
   test('aal1 for only password', () async {

--- a/packages/gotrue/test/src/helper_test.dart
+++ b/packages/gotrue/test/src/helper_test.dart
@@ -199,25 +199,23 @@ void main() {
       });
 
       test('provides helpful error message', () {
-        try {
-          validateUuid('invalid-id');
-          fail('Expected ArgumentError');
-        } catch (e) {
-          expect(e, isA<ArgumentError>());
-          expect(e.toString(), contains('Invalid id: invalid-id'));
-          expect(e.toString(), contains('must be a valid UUID'));
-        }
+        expect(
+          () => validateUuid('invalid-id'),
+          throwsA(isA<ArgumentError>()
+              .having((e) => e.toString(), 'toString()',
+                  contains('Invalid id: invalid-id'))
+              .having((e) => e.toString(), 'toString()',
+                  contains('must be a valid UUID'))),
+        );
       });
 
       test('error message includes the invalid ID', () {
         const invalidId = 'test-invalid-uuid-123';
-        try {
-          validateUuid(invalidId);
-          fail('Expected ArgumentError');
-        } catch (e) {
-          expect(e, isA<ArgumentError>());
-          expect(e.toString(), contains(invalidId));
-        }
+        expect(
+          () => validateUuid(invalidId),
+          throwsA(isA<ArgumentError>()
+              .having((e) => e.toString(), 'toString()', contains(invalidId))),
+        );
       });
     });
 

--- a/packages/postgrest/test/basic_test.dart
+++ b/packages/postgrest/test/basic_test.dart
@@ -315,22 +315,20 @@ void main() {
     });
 
     test('missing table', () async {
-      try {
-        await postgrest.from('missing_table').select();
-        fail('found missing table');
-      } on PostgrestException catch (error) {
-        expect(error.code, 'PGRST205');
-      }
+      await expectLater(
+        () => postgrest.from('missing_table').select(),
+        throwsA(
+          isA<PostgrestException>().having((e) => e.code, 'code', 'PGRST205'),
+        ),
+      );
     });
 
     test('connection error', () async {
       final postgrest = PostgrestClient('http://this.url.does.not.exist');
-      try {
-        await postgrest.from('user').select();
-        fail('Success on connection error');
-      } catch (error) {
-        expect(error, isA<SocketException>());
-      }
+      await expectLater(
+        () => postgrest.from('user').select(),
+        throwsA(isA<SocketException>()),
+      );
     });
 
     test('Prefer: return=minimal', () async {
@@ -416,12 +414,10 @@ void main() {
     });
 
     test('execute without table operation', () async {
-      try {
-        await postgrest.from('users');
-        fail('can not execute without table operation');
-      } catch (e) {
-        expect(e, isA<ArgumentError>());
-      }
+      await expectLater(
+        () => postgrest.from('users'),
+        throwsA(isA<ArgumentError>()),
+      );
     });
 
     test('select from uppercase table name', () async {
@@ -487,50 +483,40 @@ void main() {
     });
 
     test('basic select table', () async {
-      try {
-        await postgrestCustomHttpClient.from('users').select();
-        fail('Table was able to be selected, even tho it does not exist');
-      } on PostgrestException catch (error) {
-        expect(error.code, '420');
-      }
+      await expectLater(
+        () => postgrestCustomHttpClient.from('users').select(),
+        throwsA(isA<PostgrestException>().having((e) => e.code, 'code', '420')),
+      );
     });
     test('basic select table with converter', () async {
-      try {
-        await postgrestCustomHttpClient
+      await expectLater(
+        () => postgrestCustomHttpClient
             .from('users')
             .select()
-            .withConverter((data) => data);
-        fail('Table was able to be selected, even tho it does not exist');
-      } on PostgrestException catch (error) {
-        expect(error.code, '420');
-      }
+            .withConverter((data) => data),
+        throwsA(isA<PostgrestException>().having((e) => e.code, 'code', '420')),
+      );
     });
     test('basic stored procedure call', () async {
-      try {
-        await postgrestCustomHttpClient
-            .rpc<String>('get_status', params: {'name_param': 'supabot'});
-        fail(
-            'Stored procedure was able to be called, even tho it does not exist');
-      } on PostgrestException catch (error) {
-        expect(error.code, '420');
-        expect(customHttpClient.lastRequest?.method, "POST");
-      }
+      await expectLater(
+        () => postgrestCustomHttpClient
+            .rpc<String>('get_status', params: {'name_param': 'supabot'}),
+        throwsA(isA<PostgrestException>().having((e) => e.code, 'code', '420')),
+      );
+      expect(customHttpClient.lastRequest?.method, "POST");
     });
 
     test('stored procedure call in read-only access mode', () async {
-      try {
-        await postgrestCustomHttpClient.rpc<String>(
+      await expectLater(
+        () => postgrestCustomHttpClient.rpc<String>(
           'get_status',
           params: {'name_param': 'supabot'},
           get: true,
-        );
-        fail(
-            'Stored procedure was able to be called, even tho it does not exist');
-      } on PostgrestException catch (error) {
-        expect(error.code, '420');
-        expect(customHttpClient.lastRequest?.method, "GET");
-        expect(customHttpClient.lastBody, isEmpty);
-      }
+        ),
+        throwsA(isA<PostgrestException>().having((e) => e.code, 'code', '420')),
+      );
+      expect(customHttpClient.lastRequest?.method, "GET");
+      expect(customHttpClient.lastBody, isEmpty);
     });
   });
 }

--- a/packages/postgrest/test/filter_test.dart
+++ b/packages/postgrest/test/filter_test.dart
@@ -28,7 +28,7 @@ void main() {
         .not('status', 'eq', 'OFFLINE');
     expect(res, isNotEmpty);
     for (final item in res) {
-      expect(item['status'] != ('OFFLINE'), true);
+      expect(item['status'], isNot('OFFLINE'));
     }
   });
 
@@ -40,8 +40,8 @@ void main() {
     expect(res, isNotEmpty);
 
     for (final item in res) {
-      expect(item['username'] != ('supabot'), true);
-      expect(item['username'] != ('kiwicopple'), true);
+      expect(item['username'], isNot('supabot'));
+      expect(item['username'], isNot('kiwicopple'));
     }
   });
 
@@ -63,7 +63,7 @@ void main() {
       expect(
         ((item['interests'] ?? []) as List)
             .contains(['baseball', 'basketball']),
-        false,
+        isFalse,
       );
     }
   });
@@ -78,7 +78,7 @@ void main() {
     for (final item in res) {
       expect(
         item['username'] == ('supabot') || item['status'] == ('OFFLINE'),
-        true,
+        isTrue,
       );
     }
   });
@@ -92,7 +92,7 @@ void main() {
       expect(res, isNotEmpty);
 
       for (final item in res) {
-        expect(item['username'] == ('supabot'), true);
+        expect(item['username'], 'supabot');
       }
     });
 
@@ -104,7 +104,7 @@ void main() {
       expect(res, isNotEmpty);
 
       for (final item in res) {
-        expect(item['username'] == ('supabot'), true);
+        expect(item['username'], 'supabot');
       }
     });
   });
@@ -118,7 +118,7 @@ void main() {
       expect(res, isNotEmpty);
 
       for (final item in res) {
-        expect(item['username'] == ('supabot'), false);
+        expect(item['username'], isNot('supabot'));
       }
     });
 
@@ -139,7 +139,7 @@ void main() {
     expect(res, isNotEmpty);
 
     for (final item in res) {
-      expect((item['id'] as int) > 1, true);
+      expect((item['id'] as int) > 1, isTrue);
     }
   });
 
@@ -148,7 +148,7 @@ void main() {
     expect(res, isNotEmpty);
 
     for (final item in res) {
-      expect((item['id'] as int) < 1, false);
+      expect((item['id'] as int) < 1, isFalse);
     }
   });
 
@@ -156,7 +156,7 @@ void main() {
     final res = await postgrest.from('messages').select('id').lt('id', 2);
     expect(res, isNotEmpty);
     for (final item in res) {
-      expect((item['id'] as int) < 2, true);
+      expect((item['id'] as int) < 2, isTrue);
     }
   });
 
@@ -164,7 +164,7 @@ void main() {
     final res = await postgrest.from('messages').select('id').lte('id', 2);
     expect(res, isNotEmpty);
     for (final item in res) {
-      expect((item['id'] as int) > 2, false);
+      expect((item['id'] as int) > 2, isFalse);
     }
   });
 
@@ -175,7 +175,7 @@ void main() {
         .like('username', '%supa%');
     expect(res, isNotEmpty);
     for (final item in res) {
-      expect((item['username'] as String).contains('supa'), true);
+      expect((item['username'] as String).contains('supa'), isTrue);
     }
   });
 
@@ -200,7 +200,7 @@ void main() {
     for (final item in res) {
       expect(
           item['username'].contains('supa') || item['username'].contains('wai'),
-          true);
+          isTrue);
     }
   });
 
@@ -212,7 +212,7 @@ void main() {
     expect(res, isNotEmpty);
     for (final item in res) {
       final user = (item['username'] as String).toLowerCase();
-      expect(user.contains('supa'), true);
+      expect(user.contains('supa'), isTrue);
     }
   });
 
@@ -238,7 +238,7 @@ void main() {
       expect(
           item['username'].toLowerCase().contains('supa') ||
               item['username'].toLowerCase().contains('wai'),
-          true);
+          isTrue);
     }
   });
 
@@ -260,7 +260,7 @@ void main() {
     for (final item in res) {
       expect(
         item['status'] == 'ONLINE' || item['status'] == 'OFFLINE',
-        true,
+        isTrue,
       );
     }
   });
@@ -337,7 +337,7 @@ void main() {
         .rangeGt('age_range', '[2,25)');
     expect(res, isNotEmpty);
     for (final item in res) {
-      expect(item['username'] != 'supabot', true);
+      expect(item['username'], isNot('supabot'));
     }
   });
 
@@ -348,7 +348,7 @@ void main() {
         .rangeGte('age_range', '[2,25)');
     expect(res, isNotEmpty);
     for (final item in res) {
-      expect(item['username'] != 'supabot', true);
+      expect(item['username'], isNot('supabot'));
     }
   });
 
@@ -359,7 +359,7 @@ void main() {
         .rangeLte('age_range', '[2,25)');
     expect(res, isNotEmpty);
     for (final item in res) {
-      expect(item['username'] == 'supabot', true);
+      expect(item['username'], 'supabot');
     }
   });
 
@@ -463,7 +463,7 @@ void main() {
       for (final item in res) {
         expect(
           item['username'] == 'supabot' || item['username'] == 'kiwicopple',
-          true,
+          isTrue,
         );
       }
     });
@@ -484,7 +484,7 @@ void main() {
         .matchRegex('username', '^supa.*');
     expect(res, isNotEmpty);
     for (final item in res) {
-      expect((item['username'] as String).startsWith('supa'), true);
+      expect((item['username'] as String).startsWith('supa'), isTrue);
     }
   });
 
@@ -495,8 +495,8 @@ void main() {
         .imatchRegex('username', '^SUPA.*');
     expect(res, isNotEmpty);
     for (final item in res) {
-      expect(
-          (item['username'] as String).toLowerCase().startsWith('supa'), true);
+      expect((item['username'] as String).toLowerCase().startsWith('supa'),
+          isTrue);
     }
   });
 
@@ -507,7 +507,7 @@ void main() {
         .isDistinct('status', 'ONLINE');
     expect(res, isNotEmpty);
     for (final item in res) {
-      expect(item['status'] != 'ONLINE', true);
+      expect(item['status'], isNot('ONLINE'));
     }
   });
   test('filter on rpc', () async {

--- a/packages/postgrest/test/transforms_test.dart
+++ b/packages/postgrest/test/transforms_test.dart
@@ -264,63 +264,52 @@ void main() {
     });
 
     test('maybeSingle with multiple rows throws', () async {
-      try {
-        await postgrest.from('users').select().maybeSingle();
-        fail('maybeSingle with multiple rows did not throw.');
-      } on PostgrestException catch (error) {
-        expect(error.code, '406');
-      } catch (error) {
-        fail(
-            'maybeSingle with multiple rows threw ${error.runtimeType} instead of PostgrestException.');
-      }
+      await expectLater(
+        () => postgrest.from('users').select().maybeSingle(),
+        throwsA(
+          isA<PostgrestException>().having((e) => e.code, 'code', '406'),
+        ),
+      );
     });
     test('maybeSingle with multiple inserts throws', () async {
-      try {
-        await postgrest
+      await expectLater(
+        () => postgrest
             .from('channels')
             .insert([
               {'data': {}, 'slug': 'channel1'},
               {'data': {}, 'slug': 'channel2'},
             ])
             .select()
-            .maybeSingle();
-        fail('Query did not throw.');
-      } on PostgrestException catch (error) {
-        expect(error.code, '406');
-      } catch (error) {
-        fail('Query threw ${error.runtimeType} instead of PostgrestException.');
-      }
+            .maybeSingle(),
+        throwsA(
+          isA<PostgrestException>().having((e) => e.code, 'code', '406'),
+        ),
+      );
     });
 
     test(
         'maybeSingle followed by another transformer preserves the maybeSingle status',
         () async {
-      try {
-        // maybeSingle followed by another transformer preserves the maybeSingle status
-        // and should throw when the returned data is more than 2 rows.
-        await postgrest.from('channels').select().maybeSingle().limit(2);
-        fail('Query did not throw.');
-      } on PostgrestException catch (error) {
-        expect(error.code, '406');
-      } catch (error) {
-        fail('Query threw ${error.runtimeType} instead of PostgrestException.');
-      }
+      await expectLater(
+        () => postgrest.from('channels').select().maybeSingle().limit(2),
+        throwsA(
+          isA<PostgrestException>().having((e) => e.code, 'code', '406'),
+        ),
+      );
     });
 
     test('maybeSingle with converter throws if more than 1 rows were returned',
         () async {
-      try {
-        await postgrest
+      await expectLater(
+        () => postgrest
             .from('channels')
             .select()
             .maybeSingle()
-            .withConverter((data) => data?.entries.length);
-        fail('Query did not throw');
-      } on PostgrestException catch (error) {
-        expect(error.code, '406');
-      } catch (error) {
-        fail('Query threw ${error.runtimeType} instead of PostgrestException.');
-      }
+            .withConverter((data) => data?.entries.length),
+        throwsA(
+          isA<PostgrestException>().having((e) => e.code, 'code', '406'),
+        ),
+      );
     });
   });
 

--- a/packages/postgrest/test/upsert_test.dart
+++ b/packages/postgrest/test/upsert_test.dart
@@ -67,14 +67,12 @@ void main() {
         }
       ];
 
-      try {
-        await postgrest.from('imported_data').upsert(duplicateData).select();
-        fail(
-            'Expected upsert without onConflict to fail due to unique constraint violation');
-      } on PostgrestException catch (error) {
-        // Should fail with unique constraint violation
-        expect(error.code, '23505'); // PostgreSQL unique violation error code
-      }
+      await expectLater(
+        () => postgrest.from('imported_data').upsert(duplicateData).select(),
+        throwsA(
+          isA<PostgrestException>().having((e) => e.code, 'code', '23505'),
+        ),
+      );
 
       // Step 3: UPSERT with first row from test data (with onConflict) - should succeed
       final updatedData = [
@@ -169,8 +167,8 @@ void main() {
       expect(batchUpsertResult.length, 2);
       expect(batchUpsertResult[0]['status'], 'batch_updated');
       expect(batchUpsertResult[1]['status'], 'batch_updated');
-      expect(batchUpsertResult[0]['data']['updated'], true);
-      expect(batchUpsertResult[1]['data']['updated'], true);
+      expect(batchUpsertResult[0]['data']['updated'], isTrue);
+      expect(batchUpsertResult[1]['data']['updated'], isTrue);
     });
   });
 }

--- a/packages/realtime_client/test/channel_test.dart
+++ b/packages/realtime_client/test/channel_test.dart
@@ -29,7 +29,7 @@ void main() {
     });
 
     test('sets defaults', () {
-      expect(channel.isClosed, true);
+      expect(channel.isClosed, isTrue);
       expect(channel.topic, 'topic');
       expect(channel.params, {
         'config': {
@@ -70,7 +70,7 @@ void main() {
     test('sets state to joining', () {
       channel.subscribe();
 
-      expect(channel.isJoining, true);
+      expect(channel.isJoining, isTrue);
     });
 
     test('sets joinedOnce to true', () {
@@ -349,12 +349,12 @@ void main() {
     });
 
     test("sets state to closed on 'ok' event", () {
-      expect(channel.isClosed, false);
+      expect(channel.isClosed, isFalse);
 
       channel.unsubscribe();
       channel.joinPush.trigger('ok', {});
 
-      expect(channel.isClosed, true);
+      expect(channel.isClosed, isTrue);
     });
 
     test("able to unsubscribe from * subscription", () {
@@ -364,7 +364,7 @@ void main() {
       channel.unsubscribe();
       channel.joinPush.trigger('ok', {});
 
-      expect(socket.channels.length, 0);
+      expect(socket.channels, isEmpty);
     });
   });
 
@@ -442,7 +442,7 @@ void main() {
 
         expect(payload, containsPair('myKey', 'myValue'));
         expect(message, containsPair('topic', 'myTopic'));
-        expect(private, true);
+        expect(private, isTrue);
 
         await req.response.close();
         break;
@@ -757,7 +757,7 @@ void main() {
       expect(message['topic'], 'myTopic');
       expect(message['event'], 'test');
       expect(message['payload'], {'myKey': 'myValue'});
-      expect(message['private'], true);
+      expect(message['private'], isTrue);
 
       req.response.statusCode = 202;
       await req.response.close();

--- a/packages/realtime_client/test/realtime_integration_test.dart
+++ b/packages/realtime_client/test/realtime_integration_test.dart
@@ -233,8 +233,8 @@ void main() {
           final update =
               await updates.future.timeout(const Duration(seconds: 20));
           expect(update.eventType, PostgresChangeEvent.update);
-          expect(update.newRecord['is_complete'], true);
-          expect(update.oldRecord['is_complete'], false);
+          expect(update.newRecord['is_complete'], isTrue);
+          expect(update.oldRecord['is_complete'], isFalse);
 
           await db
               .execute("DELETE FROM public.todos WHERE task = 'write tests'");
@@ -283,7 +283,7 @@ void main() {
           final payload =
               await matched.future.timeout(const Duration(seconds: 20));
           expect(payload.newRecord['task'], 'matched');
-          expect(payload.newRecord['is_complete'], true);
+          expect(payload.newRecord['is_complete'], isTrue);
         });
       });
     });

--- a/packages/realtime_client/test/socket_test.dart
+++ b/packages/realtime_client/test/socket_test.dart
@@ -73,8 +73,8 @@ void main() {
     test('sets defaults', () async {
       final socket =
           RealtimeClient('wss://example.com/socket', params: {'apikey': '123'});
-      expect(socket.channels.length, 0);
-      expect(socket.sendBuffer.length, 0);
+      expect(socket.channels, isEmpty);
+      expect(socket.sendBuffer, isEmpty);
       expect(socket.ref, 0);
       expect(socket.endPoint, 'wss://example.com/socket/websocket');
       expect(socket.stateChangeCallbacks, {
@@ -91,7 +91,7 @@ void main() {
           String? msg,
           dynamic data,
         ),
-        false,
+        isFalse,
       );
       expect(
         socket.headers['X-Client-Info']!.split('/').first,
@@ -109,8 +109,8 @@ void main() {
         logger: (kind, msg, data) => print('[$kind] $msg $data'),
         headers: {'X-Client-Info': 'supabase-dart/0.0.0'},
       );
-      expect(socket.channels.length, 0);
-      expect(socket.sendBuffer.length, 0);
+      expect(socket.channels, isEmpty);
+      expect(socket.sendBuffer, isEmpty);
       expect(socket.ref, 0);
       expect(socket.endPoint, 'wss://example.com/socket/websocket');
       expect(socket.stateChangeCallbacks, {
@@ -127,7 +127,7 @@ void main() {
           String? msg,
           dynamic data,
         ),
-        true,
+        isTrue,
       );
       expect(socket.headers['X-Client-Info'], 'supabase-dart/0.0.0');
     });
@@ -374,7 +374,7 @@ void main() {
     });
 
     test('adds channel to sockets channels list', () {
-      expect(socket.channels.length, 0);
+      expect(socket.channels, isEmpty);
 
       final channel = socket.channel(
         tTopic,
@@ -461,7 +461,7 @@ void main() {
       mockedSocket.connect();
       mockedSocket.connState = SocketStates.connecting;
 
-      expect(mockedSocket.sendBuffer.length, 0);
+      expect(mockedSocket.sendBuffer, isEmpty);
 
       final message =
           Message(topic: topic, payload: payload, event: event, ref: ref);

--- a/packages/storage_client/test/basic_test.dart
+++ b/packages/storage_client/test/basic_test.dart
@@ -349,11 +349,13 @@ void main() {
       );
     });
     test('should list buckets', () async {
-      try {
-        await client.listBuckets();
-      } catch (e) {
-        expect((e as dynamic).statusCode, "420");
-      }
+      await expectLater(
+        () => client.listBuckets(),
+        throwsA(
+          isA<StorageException>()
+              .having((e) => e.statusCode, 'statusCode', '420'),
+        ),
+      );
     });
   });
 

--- a/packages/storage_client/test/client_test.dart
+++ b/packages/storage_client/test/client_test.dart
@@ -63,12 +63,10 @@ void main() {
   });
 
   test('Get bucket with wrong id', () async {
-    try {
-      await storage.getBucket('not-exist-id');
-      fail('Bucket that does not exist was found');
-    } catch (error) {
-      expect(error, isNotNull);
-    }
+    await expectLater(
+      () => storage.getBucket('not-exist-id'),
+      throwsA(isNotNull),
+    );
   });
 
   test('Create new bucket', () async {
@@ -87,7 +85,7 @@ void main() {
       const BucketOptions(public: true),
     );
     final response = await storage.getBucket(newPublicBucketName);
-    expect(response.public, true);
+    expect(response.public, isTrue);
     expect(response.name, newPublicBucketName);
   });
 
@@ -201,15 +199,15 @@ void main() {
           .uploadToSignedUrl(response.path, response.token, file);
 
       expect(uploadedPath, uploadPath);
-      try {
-        await storage
+      await expectLater(
+        () => storage
             .from(newBucketName)
-            .uploadToSignedUrl(response.path, response.token, file);
-      } on StorageException catch (error) {
-        expect(error.error, 'Duplicate');
-        expect(error.message, 'The resource already exists');
-        expect(error.statusCode, '409');
-      }
+            .uploadToSignedUrl(response.path, response.token, file),
+        throwsA(isA<StorageException>()
+            .having((e) => e.error, 'error', 'Duplicate')
+            .having((e) => e.message, 'message', 'The resource already exists')
+            .having((e) => e.statusCode, 'statusCode', '409')),
+      );
     });
   });
 
@@ -419,12 +417,11 @@ void main() {
       final storage = SupabaseStorageClient(
           storageUrl, {'Authorization': 'Bearer $storageKey'});
 
-      try {
-        await storage.from('bucket2').download(uploadPath);
-        fail('File that does not exist was found');
-      } on StorageException catch (error) {
-        expect(error.statusCode, '400');
-      }
+      await expectLater(
+        () => storage.from('bucket2').download(uploadPath),
+        throwsA(isA<StorageException>()
+            .having((e) => e.statusCode, 'statusCode', '400')),
+      );
       await storage
           .from(newBucketName)
           .copy(uploadPath, uploadPath, destinationBucket: 'bucket2');
@@ -439,12 +436,11 @@ void main() {
       final storage = SupabaseStorageClient(
           storageUrl, {'Authorization': 'Bearer $storageKey'});
 
-      try {
-        await storage.from('bucket2').download('$uploadPath 3');
-        fail('File that does not exist was found');
-      } on StorageException catch (error) {
-        expect(error.statusCode, '400');
-      }
+      await expectLater(
+        () => storage.from('bucket2').download('$uploadPath 3'),
+        throwsA(isA<StorageException>()
+            .having((e) => e.statusCode, 'statusCode', '400')),
+      );
       await storage
           .from(newBucketName)
           .move(uploadPath, '$uploadPath 3', destinationBucket: 'bucket2');
@@ -453,12 +449,11 @@ void main() {
       } catch (error) {
         fail('File that was moved was not found');
       }
-      try {
-        await storage.from(newBucketName).download(uploadPath);
-        fail('File that was moved was found');
-      } on StorageException catch (error) {
-        expect(error.statusCode, '400');
-      }
+      await expectLater(
+        () => storage.from(newBucketName).download(uploadPath),
+        throwsA(isA<StorageException>()
+            .having((e) => e.statusCode, 'statusCode', '400')),
+      );
     });
   });
 
@@ -484,10 +479,10 @@ void main() {
   test('check if object exists', () async {
     await storage.from(newBucketName).upload('$uploadPath-exists', file);
     final res = await storage.from(newBucketName).exists('$uploadPath-exists');
-    expect(res, true);
+    expect(res, isTrue);
 
     final res2 = await storage.from(newBucketName).exists('not-exist');
-    expect(res2, false);
+    expect(res2, isFalse);
   });
 
   group('setHeader', () {

--- a/packages/supabase/test/realtime_test.dart
+++ b/packages/supabase/test/realtime_test.dart
@@ -171,8 +171,8 @@ void main() {
       );
 
       expect(
-        supabase.getChannels().length,
-        isZero,
+        supabase.getChannels(),
+        isEmpty,
       );
     });
   });

--- a/packages/supabase_flutter/test/storage_test.dart
+++ b/packages/supabase_flutter/test/storage_test.dart
@@ -28,14 +28,14 @@ void main() {
       test('hasAccessToken returns false when no session exists', () async {
         final localStorage = await createFreshLocalStorage();
         final result = await localStorage.hasAccessToken();
-        expect(result, false);
+        expect(result, isFalse);
       });
 
       test('hasAccessToken returns true when session exists', () async {
         final localStorage = await createFreshLocalStorage();
         await localStorage.persistSession(testSessionValue);
         final result = await localStorage.hasAccessToken();
-        expect(result, true);
+        expect(result, isTrue);
       });
 
       test('accessToken returns null when no session exists', () async {
@@ -57,7 +57,7 @@ void main() {
 
         // Verify the session was stored by checking through localStorage's own methods
         final hasToken = await localStorage.hasAccessToken();
-        expect(hasToken, true);
+        expect(hasToken, isTrue);
 
         final storedValue = await localStorage.accessToken();
         expect(storedValue, testSessionValue);
@@ -67,11 +67,11 @@ void main() {
         final localStorage = await createFreshLocalStorage();
         // First store a session
         await localStorage.persistSession(testSessionValue);
-        expect(await localStorage.hasAccessToken(), true);
+        expect(await localStorage.hasAccessToken(), isTrue);
 
         // Then remove it
         await localStorage.removePersistedSession();
-        expect(await localStorage.hasAccessToken(), false);
+        expect(await localStorage.hasAccessToken(), isFalse);
         expect(await localStorage.accessToken(), null);
       });
     });

--- a/packages/supabase_flutter/test/supabase_flutter_test.dart
+++ b/packages/supabase_flutter/test/supabase_flutter_test.dart
@@ -139,7 +139,7 @@ void main() {
 
     test('hasAccessToken returns false', () async {
       final result = await localStorage.hasAccessToken();
-      expect(result, false);
+      expect(result, isFalse);
     });
 
     test('accessToken returns null', () async {
@@ -163,7 +163,7 @@ void main() {
 
       // Check if there's a token (should be false)
       final hasToken = await localStorage.hasAccessToken();
-      expect(hasToken, false);
+      expect(hasToken, isFalse);
 
       // Get the token (should be null)
       final token = await localStorage.accessToken();
@@ -174,7 +174,7 @@ void main() {
 
       // Check if there's a token after persisting (should still be false)
       final hasTokenAfterPersist = await localStorage.hasAccessToken();
-      expect(hasTokenAfterPersist, false);
+      expect(hasTokenAfterPersist, isFalse);
 
       // Get the token after persisting (should still be null)
       final tokenAfterPersist = await localStorage.accessToken();
@@ -185,7 +185,7 @@ void main() {
 
       // Check if there's a token after removing (should still be false)
       final hasTokenAfterRemove = await localStorage.hasAccessToken();
-      expect(hasTokenAfterRemove, false);
+      expect(hasTokenAfterRemove, isFalse);
     });
   });
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Test quality cleanup. No production code changes; only test files are touched.

## What is the current behavior?

Several test suites used non-idiomatic assertions:

- boolean-literal expectations, e.g. `expect(x, true)` / `expect(x, false)`
- equality checks done inside the actual argument, e.g. `expect(a == b, true)`
- length-zero emptiness checks, e.g. `expect(x.length, 0)`
- exception assertions written as `try { await ...; fail('...'); } catch (e) { expect(e, ...) }`

## What is the new behavior?

These are replaced with the proper matchers across all packages:

- `expect(x, isTrue)` / `expect(x, isFalse)`
- `expect(a, b)` / `expect(a, isNot(b))`
- `expect(x, isEmpty)`
- `expectLater(() => ..., throwsA(isA<T>().having((e) => e.field, 'field', value)))`

Approximate counts: ~47 boolean matchers, ~22 direct equality, ~8 emptiness, ~43 exception conversions across 22 test files in functions_client, gotrue, postgrest, realtime_client, storage_client, supabase, and supabase_flutter.

A few `fail()` calls were intentionally left in place because they are not exception-testing patterns (one sits inside an `await for` stream loop, two assert that a download succeeds after copy/move).

## How was the change verified?

- `dart analyze` / `flutter analyze` on every affected package's `test/` directory: no issues.
- `dart format` on all changed files: already conformant.
- All mock-based suites pass. Server-dependent integration suites were not run locally but analyze cleanly; the conversions are mechanical and preserve assertion meaning.