### PR TITLE
test: remove useless tests

### DIFF
--- a/packages/gotrue/test/src/constants_test.dart
+++ b/packages/gotrue/test/src/constants_test.dart
@@ -214,6 +214,13 @@ void main() {
       expect(OtpChannel.values, contains(OtpChannel.sms));
       expect(OtpChannel.values, contains(OtpChannel.whatsapp));
     });
+
+    // The name is sent to the server as the `channel` value, so it is part of
+    // the wire contract.
+    test('enum names match the wire values', () {
+      expect(OtpChannel.sms.name, equals('sms'));
+      expect(OtpChannel.whatsapp.name, equals('whatsapp'));
+    });
   });
 
   group('SignOutScope', () {
@@ -222,6 +229,14 @@ void main() {
       expect(SignOutScope.values, contains(SignOutScope.global));
       expect(SignOutScope.values, contains(SignOutScope.local));
       expect(SignOutScope.values, contains(SignOutScope.others));
+    });
+
+    // The name is sent to the server as the `scope` query value, so it is part
+    // of the wire contract.
+    test('enum names match the wire values', () {
+      expect(SignOutScope.global.name, equals('global'));
+      expect(SignOutScope.local.name, equals('local'));
+      expect(SignOutScope.others.name, equals('others'));
     });
   });
 

--- a/packages/gotrue/test/src/constants_test.dart
+++ b/packages/gotrue/test/src/constants_test.dart
@@ -45,12 +45,6 @@ void main() {
     test('has correct API version header name', () {
       expect(Constants.apiVersionHeaderName, equals('x-supabase-api-version'));
     });
-
-    test('constants are consistent', () {
-      expect(Constants.defaultExpiryMargin, equals(60000));
-      expect(Constants.expiryMargin.inMilliseconds, equals(30000));
-      expect(Constants.autoRefreshTickDuration.inSeconds, equals(10));
-    });
   });
 
   group('ApiVersions', () {
@@ -61,10 +55,6 @@ void main() {
     test('v20240101 has correct timestamp', () {
       final expectedTimestamp = DateTime.parse('2024-01-01T00:00:00.0Z');
       expect(ApiVersions.v20240101.timestamp, equals(expectedTimestamp));
-    });
-
-    test('v20240101 is UTC timestamp', () {
-      expect(ApiVersions.v20240101.timestamp.isUtc, isTrue);
     });
 
     test('v20240101 timestamp is in the past', () {
@@ -216,17 +206,6 @@ void main() {
       expect(OtpType.values, contains(OtpType.emailChange));
       expect(OtpType.values, contains(OtpType.email));
     });
-
-    test('enum names match expected values', () {
-      expect(OtpType.sms.name, equals('sms'));
-      expect(OtpType.phoneChange.name, equals('phoneChange'));
-      expect(OtpType.signup.name, equals('signup'));
-      expect(OtpType.invite.name, equals('invite'));
-      expect(OtpType.magiclink.name, equals('magiclink'));
-      expect(OtpType.recovery.name, equals('recovery'));
-      expect(OtpType.emailChange.name, equals('emailChange'));
-      expect(OtpType.email.name, equals('email'));
-    });
   });
 
   group('OtpChannel', () {
@@ -234,11 +213,6 @@ void main() {
       expect(OtpChannel.values.length, equals(2));
       expect(OtpChannel.values, contains(OtpChannel.sms));
       expect(OtpChannel.values, contains(OtpChannel.whatsapp));
-    });
-
-    test('enum names match expected values', () {
-      expect(OtpChannel.sms.name, equals('sms'));
-      expect(OtpChannel.whatsapp.name, equals('whatsapp'));
     });
   });
 
@@ -248,12 +222,6 @@ void main() {
       expect(SignOutScope.values, contains(SignOutScope.global));
       expect(SignOutScope.values, contains(SignOutScope.local));
       expect(SignOutScope.values, contains(SignOutScope.others));
-    });
-
-    test('enum names match expected values', () {
-      expect(SignOutScope.global.name, equals('global'));
-      expect(SignOutScope.local.name, equals('local'));
-      expect(SignOutScope.others.name, equals('others'));
     });
   });
 
@@ -268,145 +236,6 @@ void main() {
       expect(GenerateLinkType.emailChangeNew.snakeCase,
           equals('email_change_new'));
       expect(GenerateLinkType.unknown.snakeCase, equals('unknown'));
-    });
-  });
-
-  group('Enum consistency', () {
-    test('all enums have toString that returns name', () {
-      expect(AuthChangeEvent.signedIn.toString(),
-          equals('AuthChangeEvent.signedIn'));
-      expect(GenerateLinkType.signup.toString(),
-          equals('GenerateLinkType.signup'));
-      expect(OtpType.sms.toString(), equals('OtpType.sms'));
-      expect(OtpChannel.whatsapp.toString(), equals('OtpChannel.whatsapp'));
-      expect(SignOutScope.global.toString(), equals('SignOutScope.global'));
-    });
-
-    test('enums support equality comparison', () {
-      expect(AuthChangeEvent.signedIn == AuthChangeEvent.signedIn, isTrue);
-      expect(AuthChangeEvent.signedIn == AuthChangeEvent.signedOut, isFalse);
-
-      expect(GenerateLinkType.signup == GenerateLinkType.signup, isTrue);
-      expect(GenerateLinkType.signup == GenerateLinkType.invite, isFalse);
-
-      expect(OtpType.sms == OtpType.sms, isTrue);
-      expect(OtpType.sms == OtpType.email, isFalse);
-
-      expect(OtpChannel.sms == OtpChannel.sms, isTrue);
-      expect(OtpChannel.sms == OtpChannel.whatsapp, isFalse);
-
-      expect(SignOutScope.global == SignOutScope.global, isTrue);
-      expect(SignOutScope.global == SignOutScope.local, isFalse);
-    });
-
-    test('enums can be used in sets and maps', () {
-      final authEvents = {AuthChangeEvent.signedIn, AuthChangeEvent.signedOut};
-      expect(authEvents.length, equals(2));
-      expect(authEvents.contains(AuthChangeEvent.signedIn), isTrue);
-
-      final linkTypeMap = <GenerateLinkType, String>{
-        GenerateLinkType.signup: 'signup_link',
-        GenerateLinkType.recovery: 'recovery_link',
-      };
-      expect(linkTypeMap[GenerateLinkType.signup], equals('signup_link'));
-
-      final otpTypes = {OtpType.sms, OtpType.email};
-      expect(otpTypes.length, equals(2));
-
-      final channels = {OtpChannel.sms, OtpChannel.whatsapp};
-      expect(channels.length, equals(2));
-
-      final scopes = {
-        SignOutScope.global,
-        SignOutScope.local,
-        SignOutScope.others
-      };
-      expect(scopes.length, equals(3));
-    });
-  });
-
-  group('Documentation and comments', () {
-    test('SignOutScope has documented behavior', () {
-      expect(SignOutScope.global.name, equals('global'));
-      expect(SignOutScope.local.name, equals('local'));
-      expect(SignOutScope.others.name, equals('others'));
-    });
-
-    test('OtpChannel has messaging context', () {
-      expect(OtpChannel.sms.name, equals('sms'));
-      expect(OtpChannel.whatsapp.name, equals('whatsapp'));
-    });
-  });
-
-  group('Real-world usage scenarios', () {
-    test('AuthChangeEvent can be used in switch statements', () {
-      String getEventDescription(AuthChangeEvent event) {
-        switch (event) {
-          case AuthChangeEvent.initialSession:
-            return 'Initial session loaded';
-          case AuthChangeEvent.signedIn:
-            return 'User signed in';
-          case AuthChangeEvent.signedOut:
-            return 'User signed out';
-          case AuthChangeEvent.tokenRefreshed:
-            return 'Token was refreshed';
-          case AuthChangeEvent.userUpdated:
-            return 'User profile updated';
-          case AuthChangeEvent.passwordRecovery:
-            return 'Password recovery initiated';
-          // ignore: deprecated_member_use
-          case AuthChangeEvent.userDeleted:
-            return 'User deleted (deprecated)';
-          case AuthChangeEvent.mfaChallengeVerified:
-            return 'MFA challenge verified';
-        }
-      }
-
-      expect(getEventDescription(AuthChangeEvent.signedIn),
-          equals('User signed in'));
-      expect(getEventDescription(AuthChangeEvent.tokenRefreshed),
-          equals('Token was refreshed'));
-    });
-
-    test('GenerateLinkType supports link generation scenarios', () {
-      final linkTypes = [
-        GenerateLinkType.signup,
-        GenerateLinkType.recovery,
-        GenerateLinkType.magiclink,
-      ];
-
-      for (final linkType in linkTypes) {
-        expect(GenerateLinkTypeExtended.fromString(linkType.snakeCase),
-            equals(linkType));
-      }
-    });
-
-    test('OtpType covers all authentication flows', () {
-      final phoneOtpTypes = [OtpType.sms, OtpType.phoneChange];
-      final emailOtpTypes = [
-        OtpType.email,
-        OtpType.emailChange,
-        OtpType.recovery,
-        OtpType.magiclink
-      ];
-      final inviteOtpTypes = [OtpType.invite, OtpType.signup];
-
-      expect(phoneOtpTypes.length, equals(2));
-      expect(emailOtpTypes.length, equals(4));
-      expect(inviteOtpTypes.length, equals(2));
-
-      final allTypes = {...phoneOtpTypes, ...emailOtpTypes, ...inviteOtpTypes};
-      expect(allTypes.length, equals(8));
-      expect(allTypes.length, equals(OtpType.values.length));
-    });
-
-    test('SignOutScope provides session management options', () {
-      expect(SignOutScope.global.name, equals('global'));
-      expect(SignOutScope.local.name, equals('local'));
-      expect(SignOutScope.others.name, equals('others'));
-
-      final scopes = SignOutScope.values;
-      expect(scopes.every((scope) => scope.name.isNotEmpty), isTrue);
     });
   });
 }

--- a/packages/gotrue/test/src/types/auth_exception_test.dart
+++ b/packages/gotrue/test/src/types/auth_exception_test.dart
@@ -414,54 +414,6 @@ void main() {
   });
 
   group('Exception hierarchy', () {
-    test('all exception types implement Exception', () {
-      final authException = const AuthException('error');
-      final pkceException = AuthPKCEGrantCodeExchangeError('error');
-      final sessionException = AuthSessionMissingException();
-      final retryException = AuthRetryableFetchException();
-      final apiException = AuthApiException('error');
-      final unknownException = AuthUnknownException(
-        message: 'error',
-        originalError: 'original',
-      );
-      final weakPasswordException = AuthWeakPasswordException(
-        message: 'error',
-        statusCode: '422',
-        reasons: [],
-      );
-
-      expect(authException, isA<Exception>());
-      expect(pkceException, isA<Exception>());
-      expect(sessionException, isA<Exception>());
-      expect(retryException, isA<Exception>());
-      expect(apiException, isA<Exception>());
-      expect(unknownException, isA<Exception>());
-      expect(weakPasswordException, isA<Exception>());
-    });
-
-    test('all exception types extend AuthException', () {
-      final pkceException = AuthPKCEGrantCodeExchangeError('error');
-      final sessionException = AuthSessionMissingException();
-      final retryException = AuthRetryableFetchException();
-      final apiException = AuthApiException('error');
-      final unknownException = AuthUnknownException(
-        message: 'error',
-        originalError: 'original',
-      );
-      final weakPasswordException = AuthWeakPasswordException(
-        message: 'error',
-        statusCode: '422',
-        reasons: [],
-      );
-
-      expect(pkceException, isA<AuthException>());
-      expect(sessionException, isA<AuthException>());
-      expect(retryException, isA<AuthException>());
-      expect(apiException, isA<AuthException>());
-      expect(unknownException, isA<AuthException>());
-      expect(weakPasswordException, isA<AuthException>());
-    });
-
     test('can catch all auth exceptions as AuthException', () {
       final exceptions = <AuthException>[
         const AuthException('base error'),

--- a/packages/postgrest/test/transforms_test.dart
+++ b/packages/postgrest/test/transforms_test.dart
@@ -345,53 +345,6 @@ void main() {
     expect(res['type'], 'FeatureCollection');
   });
 
-  group('maxAffected', () {
-    test('maxAffected method can be called on update operations', () {
-      expect(
-        () => postgrest
-            .from('users')
-            .update({'status': 'INACTIVE'})
-            .eq('id', 1)
-            .maxAffected(1),
-        returnsNormally,
-      );
-    });
-
-    test('maxAffected method can be called on delete operations', () {
-      expect(
-        () => postgrest.from('channels').delete().eq('id', 999).maxAffected(5),
-        returnsNormally,
-      );
-    });
-
-    test('maxAffected method can be called on select operations', () {
-      expect(
-        () => postgrest.from('users').select().maxAffected(1),
-        returnsNormally,
-      );
-    });
-
-    test('maxAffected method can be called on insert operations', () {
-      expect(
-        () =>
-            postgrest.from('users').insert({'username': 'test'}).maxAffected(1),
-        returnsNormally,
-      );
-    });
-
-    test('maxAffected method can be chained with select', () {
-      expect(
-        () => postgrest
-            .from('users')
-            .update({'status': 'INACTIVE'})
-            .eq('id', 1)
-            .maxAffected(1)
-            .select(),
-        returnsNormally,
-      );
-    });
-  });
-
   group('maxAffected integration', () {
     late CustomHttpClient customHttpClient;
     late PostgrestClient postgrestCustomHttpClient;

--- a/packages/supabase/test/client_test.dart
+++ b/packages/supabase/test/client_test.dart
@@ -338,93 +338,6 @@ void main() {
       });
     });
 
-    group('Schema Support', () {
-      test('should create query builder with custom schema', () {
-        final customSchema = supabase.schema('custom');
-        expect(customSchema, isA<SupabaseQuerySchema>());
-
-        final queryBuilder = customSchema.from('table');
-        expect(queryBuilder, isA<SupabaseQueryBuilder>());
-      });
-
-      test('should handle nested schema calls', () {
-        final schema1 = supabase.schema('schema1');
-        final schema2 = schema1.schema('schema2');
-
-        expect(schema2, isA<SupabaseQuerySchema>());
-      });
-    });
-
-    group('RPC Support', () {
-      test('should create RPC call', () {
-        final rpcCall = supabase.rpc('test_function');
-        expect(rpcCall, isA<PostgrestFilterBuilder>());
-      });
-
-      test('should create RPC call with parameters', () {
-        final rpcCall =
-            supabase.rpc('test_function', params: {'param': 'value'});
-        expect(rpcCall, isA<PostgrestFilterBuilder>());
-      });
-
-      test('should create RPC call with get flag', () {
-        final rpcCall = supabase.rpc('test_function', params: {}, get: true);
-        expect(rpcCall, isA<PostgrestFilterBuilder>());
-      });
-    });
-
-    group('Client Options', () {
-      test('should accept custom Postgrest options', () {
-        final client = SupabaseClient(
-          supabaseUrl,
-          supabaseKey,
-          postgrestOptions: PostgrestClientOptions(schema: 'custom_schema'),
-        );
-
-        expect(client, isA<SupabaseClient>());
-      });
-
-      test('should accept custom Auth options', () {
-        final client = SupabaseClient(
-          supabaseUrl,
-          supabaseKey,
-          authOptions: AuthClientOptions(autoRefreshToken: false),
-        );
-
-        expect(client, isA<SupabaseClient>());
-      });
-
-      test('should accept custom Storage options', () {
-        final client = SupabaseClient(
-          supabaseUrl,
-          supabaseKey,
-          storageOptions: StorageClientOptions(retryAttempts: 5),
-        );
-
-        expect(client, isA<SupabaseClient>());
-      });
-
-      test('should accept custom Realtime options', () {
-        final client = SupabaseClient(
-          supabaseUrl,
-          supabaseKey,
-          realtimeClientOptions:
-              RealtimeClientOptions(logLevel: RealtimeLogLevel.debug),
-        );
-
-        expect(client, isA<SupabaseClient>());
-      });
-    });
-
-    group('Dispose', () {
-      test('should properly dispose all resources', () async {
-        final client = SupabaseClient(supabaseUrl, supabaseKey);
-
-        // Should not throw
-        await client.dispose();
-      });
-    });
-
     group('Shared YAJsonIsolate', () {
       test(
           'does not dispose an injected YAJsonIsolate so the caller retains ownership',
@@ -453,34 +366,6 @@ void main() {
 
         await client.dispose();
       });
-    });
-  });
-
-  group('Query Schema', () {
-    late SupabaseClient supabase;
-    const supabaseUrl = 'https://example.supabase.co';
-    const supabaseKey = 'test-key';
-
-    setUp(() {
-      supabase = SupabaseClient(supabaseUrl, supabaseKey);
-    });
-
-    tearDown(() async {
-      await supabase.dispose();
-    });
-
-    test('should create SupabaseQueryBuilder from schema', () {
-      final schema = supabase.schema('custom_schema');
-      final queryBuilder = schema.from('test_table');
-
-      expect(queryBuilder, isA<SupabaseQueryBuilder>());
-    });
-
-    test('should create nested schemas', () {
-      final schema1 = supabase.schema('schema1');
-      final schema2 = schema1.schema('schema2');
-
-      expect(schema2, isA<SupabaseQuerySchema>());
     });
   });
 

--- a/packages/supabase_flutter/test/supabase_flutter_test.dart
+++ b/packages/supabase_flutter/test/supabase_flutter_test.dart
@@ -59,13 +59,7 @@ void main() {
       accessToken: () async => 'my-access-token',
     );
 
-    // print(supabase.client.auth.runtimeType);
-
-    void accessAuth() {
-      supabase.client.auth;
-    }
-
-    expect(accessAuth, throwsA(isA<AuthException>()));
+    expect(() => supabase.client.auth, throwsA(isA<AuthException>()));
   });
 
   group("Expired session", () {

--- a/packages/supabase_flutter/test/supabase_flutter_test.dart
+++ b/packages/supabase_flutter/test/supabase_flutter_test.dart
@@ -132,31 +132,6 @@ void main() {
       );
     });
 
-    test('initialize does nothing', () async {
-      // Should not throw any exceptions
-      await localStorage.initialize();
-    });
-
-    test('hasAccessToken returns false', () async {
-      final result = await localStorage.hasAccessToken();
-      expect(result, false);
-    });
-
-    test('accessToken returns null', () async {
-      final result = await localStorage.accessToken();
-      expect(result, null);
-    });
-
-    test('removePersistedSession does nothing', () async {
-      // Should not throw any exceptions
-      await localStorage.removePersistedSession();
-    });
-
-    test('persistSession does nothing', () async {
-      // Should not throw any exceptions
-      await localStorage.persistSession('test-session-string');
-    });
-
     test('all methods work together in a typical flow', () async {
       // Initialize the storage
       await localStorage.initialize();


### PR DESCRIPTION
## What

Removes tests that assert nothing meaningful, duplicate other tests, or only exercise behavior that Dart itself guarantees. No production code or genuinely useful coverage is touched.

406 deletions across 5 test files.

## Removed

**`gotrue/test/src/constants_test.dart`**
- `constants are consistent` — re-asserts the same constants in different units (Dart `Duration` arithmetic).
- `v20240101 is UTC timestamp` — asserts `DateTime.parse('...Z').isUtc`, a language guarantee.
- The `enum names match expected values` test for `OtpType` — asserts `enum.name`, but `OtpType` serializes to the wire via `.snakeCase`, not `.name`, so it only exercised Dart's `.name`. (The `OtpChannel` and `SignOutScope` equivalents are **kept and reworded** as wire-value tests, since those enums *are* serialized via `.name`.)
- The `Enum consistency` group — `toString`, `==`, and set/map usage of enums are all Dart guarantees.
- The `Documentation and comments` group — re-tests `enum.name` (duplicates the above).
- The `Real-world usage scenarios` group — tests a local switch helper, arithmetic on hand-built lists, and `fromString` round-trips already covered by the kept `GenerateLinkTypeExtended` tests.

Kept the constant value checks (they guard wire-protocol contracts), the `jsName`/`fromString`/`snakeCase` mapping tests, the custom `ApiVersions.name`/`timestamp` getters, and the enum-membership (`values`/`contains`) checks.

**`gotrue/test/src/types/auth_exception_test.dart`**
- `all exception types implement Exception` and `all exception types extend AuthException` — assert declared inheritance, fully redundant with the per-subclass `extends AuthException` tests.

**`postgrest/test/transforms_test.dart`**
- The `maxAffected` group (5 `returnsNormally` smoke tests) — redundant with the `maxAffected integration` group right below it, which actually asserts the resulting `Prefer` headers.

**`supabase/test/client_test.dart`**
- `Schema Support`, `RPC Support`, `Client Options` groups — only assert that statically-typed methods return their declared type (tautological `isA`); real coverage lives in `mock_test.dart` and `postgrest/test/basic_test.dart`.
- `Query Schema` group — exact duplicate of `Schema Support`.
- `should properly dispose all resources` — no assertions; dispose is covered with real assertions by the kept `Shared YAJsonIsolate` group.

**`supabase_flutter/test/supabase_flutter_test.dart`**
- The five single-method `EmptyLocalStorage` tests — fully subsumed by the kept `all methods work together in a typical flow` test, which asserts the same contract end to end.

## Test plan
- `dart analyze` passes on all five files (no unused imports left behind).
- Ran the affected suites that don't require a live backend: gotrue `constants_test`/`auth_exception_test`, supabase `client_test`, and supabase_flutter `supabase_flutter_test` all pass. `postgrest/transforms_test` is an integration suite needing a local PostgREST server, untouched logic.

