### PR TITLE
ci: use merged SDK compliance workflow

### DIFF
--- a/.github/workflows/validate-capabilities.yml
+++ b/.github/workflows/validate-capabilities.yml
@@ -1,11 +1,8 @@
-name: Validate SDK Compliance
+name: SDK Compliance
 
 on:
   workflow_dispatch:
   pull_request:
-    paths:
-      - 'sdk-compliance.yaml'
-      - '.github/workflows/validate-capabilities.yml'
 
 permissions:
   contents: read
@@ -15,3 +12,5 @@ jobs:
     permissions:
       contents: read
     uses: supabase/sdk/.github/workflows/validate-sdk-compliance.yml@main
+    with:
+      language: dart


### PR DESCRIPTION
## Summary

The `supabase/sdk` repo merged its two reusable workflows (`validate-sdk-compliance.yml` and `check-api-compliance.yml`) into a single `validate-sdk-compliance.yml` workflow. The old `check-api-compliance.yml` has been deleted.

This PR updates our caller workflow to match the new interface:

- Renames the workflow to `SDK Compliance` (matches the new reusable workflow name)
- Adds `with: language: dart` (now required by the merged workflow)
- Removes the `paths:` filter from the `pull_request` trigger — the merged workflow's `check` job uses `github.event.pull_request.base.sha` to compare branches, so it must run on every PR to have access to that context

## Known limitation

`dart` is not yet a supported language in the `supabase/sdk` parse scripts (only `swift` and `javascript` are currently supported). The `check` job in the reusable workflow will fail until dart parsing support is added there. **This PR should be merged only after dart support is available in `supabase/sdk`**, or once the `check` job is made non-blocking for unsupported languages.

Manual `workflow_dispatch` runs will also not have a PR base SHA, so the `check` job may fail on manual dispatch — this is an acceptable trade-off for now.