### PR TITLE
test: e2e compliance check validation (will be closed)

### DIFF
--- a/.github/workflows/validate-capabilities.yml
+++ b/.github/workflows/validate-capabilities.yml
@@ -11,6 +11,7 @@ jobs:
   validate:
     permissions:
       contents: read
-    uses: supabase/sdk/.github/workflows/validate-sdk-compliance.yml@main
+    uses: supabase/sdk/.github/workflows/validate-sdk-compliance.yml@claude/sweet-benz-56ab2d
     with:
       language: dart
+      sdk-ref: claude/sweet-benz-56ab2d

--- a/.github/workflows/validate-capabilities.yml
+++ b/.github/workflows/validate-capabilities.yml
@@ -1,11 +1,8 @@
-name: Validate SDK Compliance
+name: SDK Compliance
 
 on:
   workflow_dispatch:
   pull_request:
-    paths:
-      - 'sdk-compliance.yaml'
-      - '.github/workflows/validate-capabilities.yml'
 
 permissions:
   contents: read
@@ -15,3 +12,5 @@ jobs:
     permissions:
       contents: read
     uses: supabase/sdk/.github/workflows/validate-sdk-compliance.yml@main
+    with:
+      language: dart

--- a/.github/workflows/validate-capabilities.yml
+++ b/.github/workflows/validate-capabilities.yml
@@ -1,4 +1,4 @@
-name: SDK Compliance
+name: Validate SDK Compliance
 
 on:
   workflow_dispatch:

--- a/packages/supabase/lib/src/supabase_e2e_test_client.dart
+++ b/packages/supabase/lib/src/supabase_e2e_test_client.dart
@@ -1,0 +1,8 @@
+/// Temporary class for E2E compliance check testing — will be removed.
+class SupabaseE2eTestClient {
+  /// Creates a new instance.
+  SupabaseE2eTestClient();
+
+  /// Does something new.
+  void doSomethingNew() {}
+}


### PR DESCRIPTION
Temporary test PR to verify the compliance check correctly rejects new public API symbols not registered in sdk-compliance.yaml.

Added `SupabaseE2eTestClient` to `packages/supabase/lib/src/` — this should trigger the ❌ failure case. Will be closed after verification.