### PR TITLE
ci: enable --fatal-infos for analyze

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -138,7 +138,7 @@ jobs:
       - name: Analyze
         if: ${{ matrix.sdk == 'stable' }}
         working-directory: packages/${{ matrix.package.name }}
-        run: dart analyze --fatal-warnings .
+        run: dart analyze --fatal-infos .
 
       - name: Setup Supabase CLI
         if: ${{ matrix.package.backend }}
@@ -271,7 +271,7 @@ jobs:
 
       - name: Run analyzer
         if: ${{ matrix.flutter-version == 'latest'}}
-        run: flutter analyze --fatal-warnings .
+        run: flutter analyze .
 
       - name: Run unit tests
         shell: bash


### PR DESCRIPTION
Stacked on #1438 (last in the DCM lint stack).

## What
- `dart analyze`: add `--fatal-infos` so analyzer info-level diagnostics fail CI for the non-Flutter Dart packages. (`--fatal-warnings` is already on by default for `dart analyze`, so it's dropped.)
- `flutter analyze`: reduced to a bare `flutter analyze .` — it already defaults **both** `--fatal-infos` and `--fatal-warnings` to on, so it fails on infos, warnings and errors without any flags.

## Why
`dart analyze` does not treat infos as fatal by default, so infos (e.g. `unnecessary_this`) could slip through. The DCM lint stack cleaned up the repo's remaining infos, so this keeps them from creeping back.

## Verification
`dart analyze --fatal-infos` passes for all 7 Dart packages; `flutter analyze` passes for supabase_flutter.

Must merge after the rest of the stack (info cleanups land in #1432/#1433).