### PR TITLE
docs(gotrue): clarify Session.expiresAt is in seconds

### DIFF
--- a/packages/gotrue/lib/src/types/session.dart
+++ b/packages/gotrue/lib/src/types/session.dart
@@ -67,8 +67,12 @@ class Session {
     };
   }
 
-  /// A timestamp of when the token will expire. Returned when a login is
-  /// confirmed.
+  /// The Unix timestamp, in **seconds**, of when the token will expire.
+  /// Returned when a login is confirmed.
+  ///
+  /// To convert this to a [DateTime], multiply by 1000 since
+  /// [DateTime.fromMillisecondsSinceEpoch] expects milliseconds:
+  /// `DateTime.fromMillisecondsSinceEpoch(expiresAt * 1000)`.
   late int? expiresAt = _expiresAt;
 
   int? get _expiresAt {


### PR DESCRIPTION
## Description

Clarifies the doc comment for `Session.expiresAt` to state that the value is a Unix timestamp in **seconds**, and shows the correct conversion to `DateTime`.

## Context

While investigating #1202 ("Session expiresAt always corrupted after hot restart"), I verified the reported symptom is **not a library bug**:

- `Session.expiresAt` is derived from the access token's JWT `exp` claim (unix seconds), not from the persisted `expires_at` JSON value. `Session.fromJson` doesn't even read `expires_at`, so persistence/deserialization cannot corrupt it.
- Every internal consumer (`isExpired`, the auto-refresh tick, `supabase_client.dart`) correctly multiplies by 1000.
- The reporter's logged `1970-...` date decodes to a millisecond value that is exactly a valid 2026 **seconds** timestamp, i.e. their own code passed `expires_at` (seconds) into `DateTime.fromMillisecondsSinceEpoch` without `* 1000`.

The real underlying problem is an ergonomics footgun: the previous doc comment didn't state the unit. This PR fixes that.

No behavior change; existing `session_test.dart` tests pass.

Refs #1202