### PR TITLE
fix(gotrue): don't throw in verifyOTP when secure email/phone change returns no session

### DIFF
--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -607,16 +607,19 @@ class GoTrueClient {
 
     final authResponse = AuthResponse.fromJson(response);
 
-    if (authResponse.session == null) {
-      throw AuthException('An error occurred on token verification.');
+    // A secure email or phone change verifies in two steps: the server accepts
+    // the first OTP without returning a session and only issues one once the
+    // second OTP is verified. In that case there is nothing to persist yet, so
+    // return the intermediate response instead of treating it as an error.
+    final session = authResponse.session;
+    if (session != null) {
+      _saveSession(session);
+      notifyAllSubscribers(
+        type == OtpType.recovery
+            ? AuthChangeEvent.passwordRecovery
+            : AuthChangeEvent.signedIn,
+      );
     }
-
-    _saveSession(authResponse.session!);
-    notifyAllSubscribers(
-      type == OtpType.recovery
-          ? AuthChangeEvent.passwordRecovery
-          : AuthChangeEvent.signedIn,
-    );
 
     return authResponse;
   }

--- a/packages/gotrue/test/otp_mock_test.dart
+++ b/packages/gotrue/test/otp_mock_test.dart
@@ -466,22 +466,24 @@ void main() {
       );
     });
 
-    test('response with null session', () async {
+    test('response with null session returns the intermediate response',
+        () async {
       final client = GoTrueClient(
         url: 'https://example.com',
         httpClient: NullSessionClient(testEmail),
         asyncStorage: TestAsyncStorage(),
       );
 
-      await expectLater(
-        () => client.verifyOTP(
-          email: testEmail,
-          token: '123456',
-          type: OtpType.email,
-        ),
-        throwsA(isA<AuthException>().having((e) => e.message, 'message',
-            'An error occurred on token verification.')),
+      // Verifying the first OTP of a secure email change does not return a
+      // session. This should not throw, the intermediate response is returned
+      // so the second OTP can subsequently be verified.
+      final response = await client.verifyOTP(
+        email: testEmail,
+        token: '123456',
+        type: OtpType.emailChange,
       );
+
+      expect(response.session, isNull);
     });
   });
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

Closes #981.

When secure email change is enabled, the email-change OTP flow is two-step: the server accepts the **first** OTP and returns a `200` with no session (`{msg: "Confirmation link accepted. Please proceed to confirm link sent to the other email"}`), only issuing a session once the **second** OTP is verified.

`verifyOTP` assumed every successful verification returns a session and threw `AuthException('An error occurred on token verification.')` whenever `session == null`, breaking the legitimate intermediate step.

## What is the new behavior?

`verifyOTP` now only saves the session and notifies subscribers when a session is actually present, and returns the intermediate response otherwise. This matches the `auth-js` client, which does not throw on a null session.

## Additional context

- No API surface change: the signature and `AuthResponse` return type are unchanged. Genuine server errors are still surfaced earlier by the fetch layer (non-2xx responses), so this only affects the previously-broken intermediate success case. Not a breaking change.
- The secondary report in the issue (a `500`/`AuthRetryableFetchException` when supplying a *wrong* OTP) stems from a runtime panic in the Go `auth` server's `/verify` handler, not the Flutter client, so it is out of scope here.
- Updated the existing `response with null session` test to verify the intermediate response is returned instead of throwing.