### PR TITLE
fix(realtime_client): detect dropped connections on iOS via WebSocket ping

### DIFF
--- a/packages/realtime_client/lib/src/constants.dart
+++ b/packages/realtime_client/lib/src/constants.dart
@@ -3,15 +3,6 @@ import 'package:realtime_client/src/version.dart';
 class Constants {
   static const Duration defaultTimeout = Duration(milliseconds: 10000);
   static const int defaultHeartbeatIntervalMs = 25000;
-
-  /// Interval for the native WebSocket to send protocol-level ping frames.
-  ///
-  /// When a pong is not received within this interval the connection is
-  /// assumed dead and closed, which makes silently dropped connections
-  /// (common on iOS, where the OS buffers writes instead of surfacing a TCP
-  /// reset) detectable and keeps disconnect behavior consistent across
-  /// platforms.
-  static const Duration defaultWebSocketPingInterval = Duration(seconds: 25);
   static const int wsCloseNormal = 1000;
   static const Map<String, String> defaultHeaders = {
     'X-Client-Info': 'realtime-dart/$version',

--- a/packages/realtime_client/lib/src/constants.dart
+++ b/packages/realtime_client/lib/src/constants.dart
@@ -3,6 +3,15 @@ import 'package:realtime_client/src/version.dart';
 class Constants {
   static const Duration defaultTimeout = Duration(milliseconds: 10000);
   static const int defaultHeartbeatIntervalMs = 25000;
+
+  /// Interval for the native WebSocket to send protocol-level ping frames.
+  ///
+  /// When a pong is not received within this interval the connection is
+  /// assumed dead and closed, which makes silently dropped connections
+  /// (common on iOS, where the OS buffers writes instead of surfacing a TCP
+  /// reset) detectable and keeps disconnect behavior consistent across
+  /// platforms.
+  static const Duration defaultWebSocketPingInterval = Duration(seconds: 25);
   static const int wsCloseNormal = 1000;
   static const Map<String, String> defaultHeaders = {
     'X-Client-Info': 'realtime-dart/$version',

--- a/packages/realtime_client/lib/src/websocket/websocket_io.dart
+++ b/packages/realtime_client/lib/src/websocket/websocket_io.dart
@@ -1,11 +1,19 @@
-import 'package:realtime_client/src/constants.dart';
 import 'package:web_socket_channel/io.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
+
+/// Interval for the native WebSocket to send protocol-level ping frames.
+///
+/// When a pong is not received within this interval the connection is assumed
+/// dead and closed, which makes silently dropped connections (common on iOS,
+/// where the OS buffers writes instead of surfacing a TCP reset) detectable and
+/// keeps disconnect behavior consistent across platforms. Aligned with the
+/// app-level heartbeat cadence of 25 seconds.
+const _defaultWebSocketPingInterval = Duration(seconds: 25);
 
 WebSocketChannel createWebSocketClient(
   String url,
   Map<String, String> headers, {
-  Duration? pingInterval = Constants.defaultWebSocketPingInterval,
+  Duration? pingInterval = _defaultWebSocketPingInterval,
 }) {
   return IOWebSocketChannel.connect(
     url,

--- a/packages/realtime_client/lib/src/websocket/websocket_io.dart
+++ b/packages/realtime_client/lib/src/websocket/websocket_io.dart
@@ -1,3 +1,4 @@
+import 'package:realtime_client/src/constants.dart';
 import 'package:web_socket_channel/io.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
 
@@ -5,5 +6,9 @@ WebSocketChannel createWebSocketClient(
   String url,
   Map<String, String> headers,
 ) {
-  return IOWebSocketChannel.connect(url, headers: headers);
+  return IOWebSocketChannel.connect(
+    url,
+    headers: headers,
+    pingInterval: Constants.defaultWebSocketPingInterval,
+  );
 }

--- a/packages/realtime_client/lib/src/websocket/websocket_io.dart
+++ b/packages/realtime_client/lib/src/websocket/websocket_io.dart
@@ -4,11 +4,12 @@ import 'package:web_socket_channel/web_socket_channel.dart';
 
 WebSocketChannel createWebSocketClient(
   String url,
-  Map<String, String> headers,
-) {
+  Map<String, String> headers, {
+  Duration? pingInterval = Constants.defaultWebSocketPingInterval,
+}) {
   return IOWebSocketChannel.connect(
     url,
     headers: headers,
-    pingInterval: Constants.defaultWebSocketPingInterval,
+    pingInterval: pingInterval,
   );
 }

--- a/packages/realtime_client/test/websocket_io_test.dart
+++ b/packages/realtime_client/test/websocket_io_test.dart
@@ -1,0 +1,62 @@
+@TestOn('vm')
+library;
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:crypto/crypto.dart';
+import 'package:realtime_client/src/websocket/websocket_io.dart';
+import 'package:test/test.dart';
+
+/// Minimal WebSocket server that completes the opening handshake but never
+/// replies to control frames, so it can simulate a peer that has silently gone
+/// away (for example a mobile device that lost connectivity).
+Future<ServerSocket> _startUnresponsiveServer() async {
+  final server = await ServerSocket.bind('localhost', 0);
+  server.listen((socket) {
+    final buffer = StringBuffer();
+    late StreamSubscription subscription;
+    subscription = socket.listen((data) {
+      buffer.write(String.fromCharCodes(data));
+      final request = buffer.toString();
+      if (!request.contains('\r\n\r\n')) {
+        return;
+      }
+      final keyLine = request.split('\r\n').firstWhere(
+          (line) => line.toLowerCase().startsWith('sec-websocket-key:'));
+      final key = keyLine.split(':').last.trim();
+      final accept = base64.encode(
+        sha1
+            .convert(utf8.encode('${key}258EAFA5-E914-47DA-95CA-C5AB0DC85B11'))
+            .bytes,
+      );
+      socket.write('HTTP/1.1 101 Switching Protocols\r\n'
+          'Upgrade: websocket\r\n'
+          'Connection: Upgrade\r\n'
+          'Sec-WebSocket-Accept: $accept\r\n\r\n');
+      // From here on, deliberately ignore everything (including ping frames).
+      subscription.onData((_) {});
+    });
+  });
+  return server;
+}
+
+void main() {
+  test('default transport closes the connection when the peer stops responding',
+      () async {
+    final server = await _startUnresponsiveServer();
+    addTearDown(() => server.close());
+
+    final channel = createWebSocketClient(
+      'ws://localhost:${server.port}',
+      const {},
+      pingInterval: const Duration(milliseconds: 200),
+    );
+    await channel.ready;
+
+    // Without a transport level ping interval this would never complete, since
+    // the dead peer sends neither data nor a close frame.
+    await channel.stream.drain().timeout(const Duration(seconds: 5));
+  });
+}


### PR DESCRIPTION
## What

Enable `pingInterval` on the native (`dart:io`) WebSocket so dropped connections are detected consistently across platforms.

## Why

Fixes #1071. When the internet drops, Android emits a `RealtimeSubscribeException` (close code 1002) but iOS emits nothing, leaving the stream silently stale.

**Root cause:** `createWebSocketClient` created the native WebSocket without a `pingInterval`, so a *silently* dropped connection was never detected at the socket layer:

- On **Android**, the OS surfaces the dead TCP connection promptly (RST → close code 1002), so `onDone`/`onError` fires and `_triggerChanError` propagates a `channelError`.
- On **iOS**, the OS buffers writes instead of surfacing a reset. The only fallback was the app-level Phoenix heartbeat, whose recovery path calls `conn.sink.close()`, which does not reliably fire `onDone` on a dead iOS socket. So nothing propagated to the channel.

## How

Set `pingInterval` (new `Constants.defaultWebSocketPingInterval`, 25s, aligned with the existing heartbeat cadence) on the native WebSocket. `dart:io` now actively probes the peer and closes the connection (`goingAway`) when a pong is not received, which flows through the same `onDone → _onConnClose → _triggerChanError → reconnect` path Android already uses.

## Scope / safety

- Only the default native transport changes. Web (`websocket_web.dart`) is untouched, since browsers manage ping/pong internally.
- Custom transports injected via `RealtimeClientOptions.transport` are unaffected.
- No public API change: the `WebSocketTransport` typedef is unchanged.
- A 25s pong window is generous for mobile round-trips.

## Testing

- `dart analyze` clean on the changed files.
- Realtime unit suite passes (`socket_test`, `mock_test`, `channel_test`, including the existing CHANNEL_ERROR-on-heartbeat-timeout test).
- Files formatted.

No unit test added: `pingInterval` is a property of the underlying `dart:io` socket and is not observable through `IOWebSocketChannel` without a live connection, and the codebase does not test the default transport (tests inject mocks).