### PR TITLE
fix(realtime): detect dropped connections on iOS via WebSocket ping interval

### DIFF
--- a/packages/realtime_client/lib/src/constants.dart
+++ b/packages/realtime_client/lib/src/constants.dart
@@ -3,6 +3,14 @@ import 'package:realtime_client/src/version.dart';
 class Constants {
   static const Duration defaultTimeout = Duration(milliseconds: 10000);
   static const int defaultHeartbeatIntervalMs = 25000;
+
+  /// Interval for transport level WebSocket ping frames on platforms that
+  /// support them.
+  ///
+  /// If a ping is not answered by a pong within this interval the connection is
+  /// considered dead and closed, so that dropped connections are detected
+  /// consistently across platforms instead of lingering as half open sockets.
+  static const Duration defaultWebSocketPingInterval = Duration(seconds: 30);
   static const int wsCloseNormal = 1000;
   static const Map<String, String> defaultHeaders = {
     'X-Client-Info': 'realtime-dart/$version',

--- a/packages/realtime_client/lib/src/websocket/websocket_io.dart
+++ b/packages/realtime_client/lib/src/websocket/websocket_io.dart
@@ -1,9 +1,15 @@
+import 'package:realtime_client/src/constants.dart';
 import 'package:web_socket_channel/io.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
 
 WebSocketChannel createWebSocketClient(
   String url,
-  Map<String, String> headers,
-) {
-  return IOWebSocketChannel.connect(url, headers: headers);
+  Map<String, String> headers, {
+  Duration? pingInterval = Constants.defaultWebSocketPingInterval,
+}) {
+  return IOWebSocketChannel.connect(
+    url,
+    headers: headers,
+    pingInterval: pingInterval,
+  );
 }

--- a/packages/realtime_client/test/websocket_io_test.dart
+++ b/packages/realtime_client/test/websocket_io_test.dart
@@ -1,0 +1,62 @@
+@TestOn('vm')
+library;
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:crypto/crypto.dart';
+import 'package:realtime_client/src/websocket/websocket_io.dart';
+import 'package:test/test.dart';
+
+/// Minimal WebSocket server that completes the opening handshake but never
+/// replies to control frames, so it can simulate a peer that has silently gone
+/// away (for example a mobile device that lost connectivity).
+Future<ServerSocket> _startUnresponsiveServer() async {
+  final server = await ServerSocket.bind('localhost', 0);
+  server.listen((socket) {
+    final buffer = StringBuffer();
+    late StreamSubscription subscription;
+    subscription = socket.listen((data) {
+      buffer.write(String.fromCharCodes(data));
+      final request = buffer.toString();
+      if (!request.contains('\r\n\r\n')) {
+        return;
+      }
+      final keyLine = request.split('\r\n').firstWhere(
+          (line) => line.toLowerCase().startsWith('sec-websocket-key:'));
+      final key = keyLine.split(':').last.trim();
+      final accept = base64.encode(
+        sha1
+            .convert(utf8.encode('${key}258EAFA5-E914-47DA-95CA-C5AB0DC85B11'))
+            .bytes,
+      );
+      socket.write('HTTP/1.1 101 Switching Protocols\r\n'
+          'Upgrade: websocket\r\n'
+          'Connection: Upgrade\r\n'
+          'Sec-WebSocket-Accept: $accept\r\n\r\n');
+      // From here on, deliberately ignore everything (including ping frames).
+      subscription.onData((_) {});
+    });
+  });
+  return server;
+}
+
+void main() {
+  test('default transport closes the connection when the peer stops responding',
+      () async {
+    final server = await _startUnresponsiveServer();
+    addTearDown(() => server.close());
+
+    final channel = createWebSocketClient(
+      'ws://localhost:${server.port}',
+      const {},
+      pingInterval: const Duration(milliseconds: 200),
+    );
+    await channel.ready;
+
+    // Without a transport level ping interval this would never complete, since
+    // the dead peer sends neither data nor a close frame.
+    await channel.stream.drain().timeout(const Duration(seconds: 5));
+  });
+}


### PR DESCRIPTION
## What

Sets a default `pingInterval` on the io WebSocket transport so dropped connections are detected consistently across platforms.

Closes #1071

## Why

The default io transport (`websocket_io.dart`) connected without a `pingInterval`, so dart:io had no transport level keepalive. Behavior then diverged by platform when the internet dropped:

- **Android:** the OS surfaces the dropped connection quickly, the stream errors (close code 1002), and the channel emits `channelError` and reconnects.
- **iOS:** a dropped connection lingers as a half open socket. The app level Phoenix heartbeat fires on its interval and calls `conn.sink.close()` on timeout, but on a dead socket that close does not promptly emit `onDone`, so `_onConnClose` never runs and no `channelError` / reconnect is triggered until the OS level TCP timeout (minutes).

## How

With a `pingInterval` set, dart:io sends WebSocket ping frames and, if a pong is not received within the interval, closes the connection with `goingAway`. That flows through the existing `onDone` -> `_onConnClose` -> `channelError` + reconnect path, giving consistent disconnect detection on all platforms.

- `constants.dart`: added `defaultWebSocketPingInterval` (30s).
- `websocket_io.dart`: pass `pingInterval` to `IOWebSocketChannel.connect`, exposed as an optional named parameter so it stays assignable to the public `WebSocketTransport` typedef and can be overridden.
- `test/websocket_io_test.dart`: a raw WebSocket server that completes the handshake but ignores ping frames; the client must detect the dead peer via `pingInterval` and close (without the fix this hangs until timeout).

## Notes

- `pingInterval` is supported down to the minimum pinned `web_socket_channel: >=2.3.0`, so no constraint bump is needed.
- Web (browser) handles disconnect detection itself, so no change there.
- All realtime unit tests pass.