### PR TITLE
chore: enable unawaited_futures and discarded_futures lints

### DIFF
--- a/packages/gotrue/lib/src/broadcast_web.dart
+++ b/packages/gotrue/lib/src/broadcast_web.dart
@@ -28,7 +28,7 @@ BroadcastChannel getBroadcastChannel(String broadcastKey) {
     },
     close: () {
       broadcast.close();
-      controller.close();
+      unawaited(controller.close());
     },
   );
 }

--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -1395,10 +1395,10 @@ class GoTrueClient {
   @mustCallSuper
   void dispose() {
     _isDisposed = true;
-    _onAuthStateChangeController.close();
-    _onAuthStateChangeControllerSync.close();
+    unawaited(_onAuthStateChangeController.close());
+    unawaited(_onAuthStateChangeControllerSync.close());
     _broadcastChannel?.close();
-    _broadcastChannelSubscription?.cancel();
+    unawaited(_broadcastChannelSubscription?.cancel());
     for (final completer in _pendingRefreshes.values) {
       if (!completer.isCompleted) {
         completer.completeError(AuthException('Disposed'), StackTrace.current);
@@ -1431,7 +1431,7 @@ class GoTrueClient {
     completer.future.ignore();
     _pendingRefreshes[refreshToken] = completer;
 
-    _executeRefresh(refreshToken, completer);
+    unawaited(_executeRefresh(refreshToken, completer));
 
     return completer.future;
   }

--- a/packages/gotrue/test/otp_mock_test.dart
+++ b/packages/gotrue/test/otp_mock_test.dart
@@ -556,19 +556,19 @@ void main() {
       expect(mockClient.lastRequestBody?['type'], 'phone_change');
     });
 
-    test('OtpChannel enum converts to correct string values', () {
+    test('OtpChannel enum converts to correct string values', () async {
       // Test enum conversion to string
       expect(OtpChannel.sms.name, 'sms');
       expect(OtpChannel.whatsapp.name, 'whatsapp');
 
       // Test that the enum is used correctly in the request
-      client.signInWithOtp(
+      await client.signInWithOtp(
         phone: testPhone,
         channel: OtpChannel.whatsapp,
       );
       expect(mockClient.lastChannelUsed, 'whatsapp');
 
-      client.signInWithOtp(
+      await client.signInWithOtp(
         phone: testPhone,
         channel: OtpChannel.sms,
       );

--- a/packages/postgrest/lib/src/postgrest_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_builder.dart
@@ -408,13 +408,15 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
   Stream<T> asStream() {
     final controller = StreamController<T>.broadcast();
 
-    then((value) {
-      controller.add(value);
-    }).catchError((Object error, StackTrace stack) {
-      controller.addError(error, stack);
-    }).whenComplete(() {
-      controller.close();
-    });
+    unawaited(
+      then((value) {
+        controller.add(value);
+      }).catchError((Object error, StackTrace stack) {
+        controller.addError(error, stack);
+      }).whenComplete(() {
+        unawaited(controller.close());
+      }),
+    );
 
     return controller.stream;
   }

--- a/packages/realtime_client/example/main.dart
+++ b/packages/realtime_client/example/main.dart
@@ -35,13 +35,13 @@ Future<void> main() async {
   socket.onMessage((message) => print('MESSAGE $message'));
 
   // on connect and subscribe
-  socket.connect();
+  await socket.connect();
   channel.subscribe((a, [_]) => print('SUBSCRIBED'));
 
   // delay 20s to receive events from server
   await Future.delayed(const Duration(seconds: 20));
 
   // on unsubscribe and disconnect
-  channel.unsubscribe();
-  socket.disconnect();
+  await channel.unsubscribe();
+  await socket.disconnect();
 }

--- a/packages/realtime_client/lib/src/realtime_channel.dart
+++ b/packages/realtime_client/lib/src/realtime_channel.dart
@@ -135,7 +135,7 @@ class RealtimeChannel {
     Duration? timeout,
   ]) {
     if (!socket.isConnected) {
-      socket.connect();
+      unawaited(socket.connect());
     }
     if (joinedOnce == true) {
       throw "tried to subscribe multiple times. 'subscribe' can only be called a single time per channel instance";
@@ -220,7 +220,7 @@ class RealtimeChannel {
               id: serverPostgresFilter['id']?.toString(),
             ));
           } else {
-            unsubscribe();
+            unawaited(unsubscribe());
             if (callback != null) {
               callback(
                 RealtimeSubscribeStatus.channelError,

--- a/packages/realtime_client/lib/src/realtime_client.dart
+++ b/packages/realtime_client/lib/src/realtime_client.dart
@@ -317,7 +317,7 @@ class RealtimeClient {
   Future<String> removeChannel(RealtimeChannel channel) async {
     final status = await channel.unsubscribe();
     if (channels.isEmpty) {
-      await disconnect();
+      unawaited(disconnect());
     }
     return status;
   }
@@ -325,7 +325,7 @@ class RealtimeClient {
   Future<List<String>> removeAllChannels() async {
     final values =
         await Future.wait(channels.map((channel) => channel.unsubscribe()));
-    await disconnect();
+    unawaited(disconnect());
     return values;
   }
 

--- a/packages/realtime_client/lib/src/realtime_client.dart
+++ b/packages/realtime_client/lib/src/realtime_client.dart
@@ -317,7 +317,7 @@ class RealtimeClient {
   Future<String> removeChannel(RealtimeChannel channel) async {
     final status = await channel.unsubscribe();
     if (channels.isEmpty) {
-      disconnect();
+      await disconnect();
     }
     return status;
   }
@@ -325,7 +325,7 @@ class RealtimeClient {
   Future<List<String>> removeAllChannels() async {
     final values =
         await Future.wait(channels.map((channel) => channel.unsubscribe()));
-    disconnect();
+    await disconnect();
     return values;
   }
 
@@ -514,7 +514,7 @@ class RealtimeClient {
     );
     if (dupChannel != null) {
       log('transport', 'leaving duplicate topic "$topic"');
-      dupChannel.unsubscribe();
+      unawaited(dupChannel.unsubscribe());
     }
   }
 
@@ -604,7 +604,7 @@ class RealtimeClient {
         'transport',
         'heartbeat timeout. Attempting to re-establish conn',
       );
-      conn?.sink.close(Constants.wsCloseNormal, 'heartbeat timeout');
+      unawaited(conn?.sink.close(Constants.wsCloseNormal, 'heartbeat timeout'));
       return;
     }
     pendingHeartbeatRef = makeRef();

--- a/packages/realtime_client/test/channel_test.dart
+++ b/packages/realtime_client/test/channel_test.dart
@@ -381,7 +381,7 @@ void main() {
     });
 
     tearDown(() async {
-      await socket.disconnect();
+      unawaited(socket.disconnect());
       await channel.unsubscribe();
     });
 

--- a/packages/realtime_client/test/channel_test.dart
+++ b/packages/realtime_client/test/channel_test.dart
@@ -339,7 +339,7 @@ void main() {
       final anotherChannel = socket.channel('another');
       expect(socket.channels.length, 2);
 
-      channel.unsubscribe();
+      unawaited(channel.unsubscribe());
       channel.joinPush.trigger('ok', {});
 
       expect(socket.channels.length, 1);
@@ -349,7 +349,7 @@ void main() {
     test("sets state to closed on 'ok' event", () {
       expect(channel.isClosed, isFalse);
 
-      channel.unsubscribe();
+      unawaited(channel.unsubscribe());
       channel.joinPush.trigger('ok', {});
 
       expect(channel.isClosed, isTrue);
@@ -359,7 +359,7 @@ void main() {
       channel.onEvents('*', ChannelFilter(), (payload, [ref]) {});
       expect(socket.channels.length, 1);
 
-      channel.unsubscribe();
+      unawaited(channel.unsubscribe());
       channel.joinPush.trigger('ok', {});
 
       expect(socket.channels, isEmpty);
@@ -381,7 +381,7 @@ void main() {
     });
 
     tearDown(() async {
-      socket.disconnect();
+      await socket.disconnect();
       await channel.unsubscribe();
     });
 
@@ -395,15 +395,17 @@ void main() {
       channel.subscribe((status, [error]) async {
         if (status == RealtimeSubscribeStatus.subscribed) {
           final completer = Completer<ChannelResponse>();
-          channel.send(
-            type: RealtimeListenTypes.broadcast,
-            payload: {
-              'myKey': 'myValue',
-            },
-          ).then(
-            (value) => completer.complete(value),
-            onError: (Object e, StackTrace stackTrace) =>
-                completer.completeError(e, stackTrace),
+          unawaited(
+            channel.send(
+              type: RealtimeListenTypes.broadcast,
+              payload: {
+                'myKey': 'myValue',
+              },
+            ).then(
+              (value) => completer.complete(value),
+              onError: (Object e, StackTrace stackTrace) =>
+                  completer.completeError(e, stackTrace),
+            ),
           );
 
           await for (final HttpRequest req in mockServer) {
@@ -420,15 +422,17 @@ void main() {
         'send message via http request to Broadcast endpoint when not subscribed to channel',
         () async {
       final completer = Completer<ChannelResponse>();
-      channel.send(
-        type: RealtimeListenTypes.broadcast,
-        payload: {
-          'myKey': 'myValue',
-        },
-      ).then(
-        (value) => completer.complete(value),
-        onError: (Object e, StackTrace stackTrace) =>
-            completer.completeError(e, stackTrace),
+      unawaited(
+        channel.send(
+          type: RealtimeListenTypes.broadcast,
+          payload: {
+            'myKey': 'myValue',
+          },
+        ).then(
+          (value) => completer.complete(value),
+          onError: (Object e, StackTrace stackTrace) =>
+              completer.completeError(e, stackTrace),
+        ),
       );
 
       await for (final HttpRequest req in mockServer) {
@@ -819,11 +823,11 @@ void main() {
       channel = socket.channel('topic');
 
       // Don't await the server - let it hang to trigger timeout
-      mockServer.first.then((req) async {
+      unawaited(mockServer.first.then((req) async {
         await Future.delayed(const Duration(seconds: 1));
         req.response.statusCode = 202;
         await req.response.close();
-      });
+      }));
 
       await expectLater(
         channel.httpSend(

--- a/packages/realtime_client/test/mock_test.dart
+++ b/packages/realtime_client/test/mock_test.dart
@@ -147,9 +147,8 @@ void main() {
           webSocket!.add(deleteString);
         });
       } else {
-        request.response
-          ..statusCode = HttpStatus.ok
-          ..close();
+        request.response.statusCode = HttpStatus.ok;
+        await request.response.close();
       }
     }
   }
@@ -157,7 +156,7 @@ void main() {
   tearDown(() async {
     await client.removeAllChannels();
 
-    listener?.cancel();
+    await listener?.cancel();
 
     // Wait for the realtime updates to come through
     await Future.delayed(Duration(milliseconds: 100));
@@ -175,7 +174,7 @@ void main() {
       );
       hasListener = false;
       hasSentData = false;
-      handleMultitenantRealtimeRequests(mockServer);
+      unawaited(handleMultitenantRealtimeRequests(mockServer));
     });
 
     test('.on()', () {
@@ -412,9 +411,8 @@ void main() {
           webSocket!.add(deleteString);
         });
       } else {
-        request.response
-          ..statusCode = HttpStatus.ok
-          ..close();
+        request.response.statusCode = HttpStatus.ok;
+        await request.response.close();
       }
     }
   }
@@ -428,7 +426,7 @@ void main() {
       );
       hasListener = false;
       hasSentData = false;
-      handleSingleTenantRealtimeRequests(mockServer);
+      unawaited(handleSingleTenantRealtimeRequests(mockServer));
     });
 
     test('.on()', () {

--- a/packages/realtime_client/test/realtime_integration_test.dart
+++ b/packages/realtime_client/test/realtime_integration_test.dart
@@ -39,7 +39,7 @@ void main() {
         client.onOpen(() {
           if (!opened.isCompleted) opened.complete();
         });
-        client.connect();
+        await client.connect();
         await opened.future.timeout(const Duration(seconds: 10));
         expect(client.isConnected, isTrue);
       });

--- a/packages/realtime_client/test/socket_test.dart
+++ b/packages/realtime_client/test/socket_test.dart
@@ -59,7 +59,7 @@ void main() {
         channel!.sink.add(request);
       });
     }, onDone: () {
-      channel?.sink.close();
+      unawaited(channel?.sink.close());
     });
   });
 
@@ -181,8 +181,8 @@ void main() {
       socket = RealtimeClient('ws://localhost:${mockServer.port}');
     });
 
-    tearDown(() {
-      socket.disconnect();
+    tearDown(() async {
+      await socket.disconnect();
     });
 
     test('establishes websocket connection with endpoint', () async {
@@ -212,7 +212,7 @@ void main() {
         lastMsg = m;
       });
 
-      socket.connect();
+      await socket.connect();
       await Future.delayed(const Duration(milliseconds: 200));
       expect(opens, 1);
 
@@ -221,7 +221,7 @@ void main() {
       await Future.delayed(const Duration(seconds: 1));
       expect(lastMsg['event'], 'heartbeat');
 
-      socket.disconnect();
+      await socket.disconnect();
       await Future.delayed(const Duration(seconds: 1));
       expect(closes, 1);
     });
@@ -233,15 +233,15 @@ void main() {
           lastErr = e;
         });
 
-      erroneousSocket.connect();
+      unawaited(erroneousSocket.connect());
 
       expect(lastErr, isA<WebSocketException>());
     });
 
     test('is idempotent', () {
-      socket.connect();
+      unawaited(socket.connect());
       final conn = socket.conn;
-      socket.connect();
+      unawaited(socket.connect());
       expect(socket.conn, conn);
     });
   });
@@ -252,8 +252,8 @@ void main() {
       socket = RealtimeClient('ws://localhost:${mockServer.port}');
     });
 
-    tearDown(() {
-      socket.disconnect();
+    tearDown(() async {
+      await socket.disconnect();
     });
 
     test('removes existing connection', () async {
@@ -267,8 +267,8 @@ void main() {
 
     test('calls callback', () async {
       int closes = 0;
-      socket.connect();
-      socket.disconnect();
+      unawaited(socket.connect());
+      unawaited(socket.disconnect());
       closes += 1;
 
       expect(closes, 1);
@@ -291,10 +291,10 @@ void main() {
       const tCode = 12;
       const tReason = 'reason';
 
-      mockedSocket.connect();
+      await mockedSocket.connect();
       mockedSocket.connState = SocketStates.open;
       await Future.delayed(const Duration(milliseconds: 200));
-      mockedSocket.disconnect(code: tCode, reason: tReason);
+      await mockedSocket.disconnect(code: tCode, reason: tReason);
       await Future.delayed(const Duration(milliseconds: 200));
 
       verify(
@@ -350,8 +350,8 @@ void main() {
       socket = RealtimeClient(socketEndpoint);
     });
 
-    tearDown(() {
-      socket.disconnect();
+    tearDown(() async {
+      await socket.disconnect();
     });
 
     test('returns channel with given topic and params', () {
@@ -444,7 +444,7 @@ void main() {
     });
 
     test('sends data to connection when connected', () {
-      mockedSocket.connect();
+      unawaited(mockedSocket.connect());
       mockedSocket.connState = SocketStates.open;
 
       final message =
@@ -456,7 +456,7 @@ void main() {
     });
 
     test('buffers data when not connected', () async {
-      mockedSocket.connect();
+      unawaited(mockedSocket.connect());
       mockedSocket.connState = SocketStates.connecting;
 
       expect(mockedSocket.sendBuffer, isEmpty);
@@ -475,7 +475,7 @@ void main() {
     });
 
     test('sends a broadcast with a binary payload as a binary frame', () {
-      mockedSocket.connect();
+      unawaited(mockedSocket.connect());
       mockedSocket.connState = SocketStates.open;
 
       final binaryPayload = Uint8List.fromList([1, 2, 3]);
@@ -506,7 +506,7 @@ void main() {
         transport: (url, headers) => legacyChannel,
         version: RealtimeProtocolVersion.v1,
       );
-      legacySocket.connect();
+      unawaited(legacySocket.connect());
       legacySocket.connState = SocketStates.open;
 
       final legacyData = json.encode({
@@ -536,7 +536,7 @@ void main() {
         transport: (url, headers) => customChannel,
         encode: (_) => 'custom-frame',
       );
-      customSocket.connect();
+      unawaited(customSocket.connect());
       customSocket.connState = SocketStates.open;
 
       customSocket.push(
@@ -629,8 +629,8 @@ void main() {
       socket = RealtimeClient(socketEndpoint);
     });
 
-    tearDown(() {
-      socket.disconnect();
+    tearDown(() async {
+      await socket.disconnect();
     });
 
     test('returns next message ref', () {
@@ -781,7 +781,7 @@ void main() {
       when(() => mockedSink.close()).thenAnswer((_) => Future.value());
       when(() => mockedSocketChannel.ready).thenAnswer((_) => Future.value());
 
-      mockedSocket.connect();
+      unawaited(mockedSocket.connect());
     });
 
     //! Unimplemented Test: closes socket when heartbeat is not ack'd within heartbeat window

--- a/packages/storage_client/test/client_test.dart
+++ b/packages/storage_client/test/client_test.dart
@@ -369,7 +369,7 @@ void main() {
           ));
 
       final uploadFuture = storage.from(bucketName).upload(uploadPath, file);
-      expectLater(uploadFuture, throwsException);
+      await expectLater(uploadFuture, throwsException);
     });
 
     test('can upload a file with a valid mime type', () async {
@@ -401,7 +401,7 @@ void main() {
           fileOptions: FileOptions(
             contentType: 'image/jpeg',
           ));
-      expectLater(uploadFuture, throwsException);
+      await expectLater(uploadFuture, throwsException);
     });
   });
 

--- a/packages/supabase/example/web/main.dart
+++ b/packages/supabase/example/web/main.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:typed_data';
 
 import 'package:supabase/supabase.dart';
@@ -43,7 +44,7 @@ void exampleUsage(SupabaseClient supabase) async {
       .subscribe();
 
   // remember to remove channel when no longer needed
-  supabase.removeChannel(realtimeChannel);
+  unawaited(supabase.removeChannel(realtimeChannel));
 
   // stream
   final streamSubscription = supabase
@@ -56,7 +57,7 @@ void exampleUsage(SupabaseClient supabase) async {
       });
 
   // remember to remove subscription
-  streamSubscription.cancel();
+  unawaited(streamSubscription.cancel());
 
   // Upload file to bucket "public" with dart:io
 

--- a/packages/supabase/lib/src/supabase_stream_builder.dart
+++ b/packages/supabase/lib/src/supabase_stream_builder.dart
@@ -155,8 +155,8 @@ class SupabaseStreamBuilder extends Stream<SupabaseStreamEvent> {
       },
       onCancel: () {
         _log.fine('stream controller for table: $_table got closed');
-        _channel?.unsubscribe();
-        _streamController?.close();
+        unawaited(_channel?.unsubscribe());
+        unawaited(_streamController?.close());
         _streamController = null;
       },
     );
@@ -229,12 +229,12 @@ class SupabaseStreamBuilder extends Stream<SupabaseStreamEvent> {
           // Reload all data after a reconnect from postgrest
           // First data from postgrest gets loaded before the realtime connect
           if (_wasSubscribed) {
-            _getPostgrestData();
+            unawaited(_getPostgrestData());
           }
           _wasSubscribed = true;
           break;
         case RealtimeSubscribeStatus.closed:
-          _streamController?.close();
+          unawaited(_streamController?.close());
           break;
         case RealtimeSubscribeStatus.timedOut:
         case RealtimeSubscribeStatus.channelError:
@@ -242,7 +242,7 @@ class SupabaseStreamBuilder extends Stream<SupabaseStreamEvent> {
           break;
       }
     });
-    _getPostgrestData();
+    unawaited(_getPostgrestData());
   }
 
   Future<void> _getPostgrestData() async {
@@ -290,8 +290,8 @@ class SupabaseStreamBuilder extends Stream<SupabaseStreamEvent> {
       _addException(error, stackTrace);
       // In case the postgrest call fails, there is no need to keep the
       // realtime connection open
-      _channel?.unsubscribe();
-      _streamController?.close();
+      unawaited(_channel?.unsubscribe());
+      unawaited(_streamController?.close());
     }
   }
 
@@ -373,7 +373,7 @@ class SupabaseStreamBuilder extends Stream<SupabaseStreamEvent> {
         }
         if (newValue is Future<E>) {
           subscription.pause();
-          newValue.then(add, onError: addError).whenComplete(resume);
+          unawaited(newValue.then(add, onError: addError).whenComplete(resume));
         } else {
           controller.add(newValue);
         }
@@ -407,7 +407,9 @@ class SupabaseStreamBuilder extends Stream<SupabaseStreamEvent> {
         }
         if (newStream != null) {
           subscription.pause();
-          controller.addStream(newStream).whenComplete(subscription.resume);
+          unawaited(controller
+              .addStream(newStream)
+              .whenComplete(subscription.resume));
         }
       });
       controller.onCancel = subscription.cancel;

--- a/packages/supabase/test/client_test.dart
+++ b/packages/supabase/test/client_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:supabase/supabase.dart';
@@ -151,10 +152,10 @@ void main() {
       await supabase.auth.recoverSession(sessionString);
 
       // Make some requests
-      supabase.from("test").select().then((value) => null);
-      supabase.rpc("test").select().then((value) => null);
-      supabase.functions.invoke("test").then((value) => null);
-      supabase.storage.from("test").list().then((value) => null);
+      unawaited(supabase.from("test").select().then((value) => null));
+      unawaited(supabase.rpc("test").select().then((value) => null));
+      unawaited(supabase.functions.invoke("test").then((value) => null));
+      unawaited(supabase.storage.from("test").list().then((value) => null));
 
       var count = 0;
 
@@ -168,7 +169,7 @@ void main() {
         }
       }
 
-      mockServer.close();
+      await mockServer.close();
     });
 
     test('call recoverSession', () async {
@@ -186,10 +187,10 @@ void main() {
       await Future.delayed(Duration(seconds: 11));
 
       // Make some requests
-      supabase.from("test").select().then((value) => null);
-      supabase.rpc("test").select().then((value) => null);
-      supabase.functions.invoke("test").then((value) => null);
-      supabase.storage.from("test").list().then((value) => null);
+      unawaited(supabase.from("test").select().then((value) => null));
+      unawaited(supabase.rpc("test").select().then((value) => null));
+      unawaited(supabase.functions.invoke("test").then((value) => null));
+      unawaited(supabase.storage.from("test").list().then((value) => null));
 
       var count = 0;
       var gotTokenRefresh = false;
@@ -209,8 +210,8 @@ void main() {
           req.response
             ..statusCode = HttpStatus.ok
             ..headers.contentType = ContentType.json
-            ..write(sessionString)
-            ..close();
+            ..write(sessionString);
+          await req.response.close();
         } else {
           expect(req.headers.value('Authorization')?.split(" ").last,
               secondAccessToken);
@@ -221,7 +222,7 @@ void main() {
         }
       }
 
-      mockServer.close();
+      await mockServer.close();
     });
 
     test('create a client with third-party auth accessToken', () async {

--- a/packages/supabase/test/mock_test.dart
+++ b/packages/supabase/test/mock_test.dart
@@ -51,8 +51,8 @@ void main() {
         request.response
           ..statusCode = HttpStatus.ok
           ..headers.contentType = ContentType.json
-          ..write(jsonString)
-          ..close();
+          ..write(jsonString);
+        await request.response.close();
       } else if (url == '/rest/v1/todos?select=%2A' ||
           url == '/rest/v1/rpc/todos?select=%2A') {
         final jsonString = jsonEncode([
@@ -62,8 +62,8 @@ void main() {
         request.response
           ..statusCode = HttpStatus.ok
           ..headers.contentType = ContentType.json
-          ..write(jsonString)
-          ..close();
+          ..write(jsonString);
+        await request.response.close();
       } else if (url == '/rest/v1/todos?select=%2A&status=eq.true') {
         final jsonString = jsonEncode([
           {'id': 1, 'task': 'task 1', 'status': true},
@@ -71,8 +71,8 @@ void main() {
         request.response
           ..statusCode = HttpStatus.ok
           ..headers.contentType = ContentType.json
-          ..write(jsonString)
-          ..close();
+          ..write(jsonString);
+        await request.response.close();
       } else if (url == '/rest/v1/todos?select=%2A&order=id.desc.nullslast') {
         final jsonString = jsonEncode([
           {'id': 2, 'task': 'task 2', 'status': false},
@@ -81,8 +81,8 @@ void main() {
         request.response
           ..statusCode = HttpStatus.ok
           ..headers.contentType = ContentType.json
-          ..write(jsonString)
-          ..close();
+          ..write(jsonString);
+        await request.response.close();
       } else if (url ==
           '/rest/v1/todos?select=%2A&order=id.desc.nullslast&limit=2') {
         final jsonString = jsonEncode([
@@ -92,15 +92,15 @@ void main() {
         request.response
           ..statusCode = HttpStatus.ok
           ..headers.contentType = ContentType.json
-          ..write(jsonString)
-          ..close();
+          ..write(jsonString);
+        await request.response.close();
       } else if (url.contains('rest')) {
         // Just return an empty string as dummy data if any other rest request
         request.response
           ..statusCode = HttpStatus.ok
           ..headers.contentType = ContentType.json
-          ..write('[]')
-          ..close();
+          ..write('[]');
+        await request.response.close();
       } else if (url.contains('realtime')) {
         webSocket = await WebSocketTransformer.upgrade(request);
         if (hasListener) {
@@ -330,9 +330,8 @@ void main() {
           webSocket!.add(ignoredDeleteString);
         });
       } else {
-        request.response
-          ..statusCode = HttpStatus.ok
-          ..close();
+        request.response.statusCode = HttpStatus.ok;
+        await request.response.close();
       }
     }
   }
@@ -377,7 +376,7 @@ void main() {
 
   group('basic test', () {
     setUp(() async {
-      handleRequests(mockServer);
+      unawaited(handleRequests(mockServer));
     });
 
     test('test mock server', () async {
@@ -631,7 +630,7 @@ void main() {
                 schema: 'public',
                 table: 'todos',
                 callback: (payload) {
-                  supabase.from('todos');
+                  unawaited(supabase.from('todos'));
                 })
             .subscribe();
 
@@ -644,7 +643,7 @@ void main() {
 
   group('realtime filter', () {
     test('can filter stream results with eq', () {
-      handleRequests(mockServer, expectedFilter: 'status=eq.true');
+      unawaited(handleRequests(mockServer, expectedFilter: 'status=eq.true'));
       final stream =
           supabase.from('todos').stream(primaryKey: ['id']).eq('status', true);
       expect(
@@ -662,35 +661,35 @@ void main() {
     });
 
     test('can filter stream results with neq', () {
-      handleRequests(mockServer, expectedFilter: 'id=neq.2');
+      unawaited(handleRequests(mockServer, expectedFilter: 'id=neq.2'));
       final stream =
           supabase.from('todos').stream(primaryKey: ['id']).neq('id', 2);
       expect(stream, emits(isList));
     });
 
     test('can filter stream results with gt', () {
-      handleRequests(mockServer, expectedFilter: 'id=gt.2');
+      unawaited(handleRequests(mockServer, expectedFilter: 'id=gt.2'));
       final stream =
           supabase.from('todos').stream(primaryKey: ['id']).gt('id', 2);
       expect(stream, emits(isList));
     });
 
     test('can filter stream results with gte', () {
-      handleRequests(mockServer, expectedFilter: 'id=gte.2');
+      unawaited(handleRequests(mockServer, expectedFilter: 'id=gte.2'));
       final stream =
           supabase.from('todos').stream(primaryKey: ['id']).gte('id', 2);
       expect(stream, emits(isList));
     });
 
     test('can filter stream results with lt', () {
-      handleRequests(mockServer, expectedFilter: 'id=lt.2');
+      unawaited(handleRequests(mockServer, expectedFilter: 'id=lt.2'));
       final stream =
           supabase.from('todos').stream(primaryKey: ['id']).lt('id', 2);
       expect(stream, emits(isList));
     });
 
     test('can filter stream results with lte', () {
-      handleRequests(mockServer, expectedFilter: 'id=lte.2');
+      unawaited(handleRequests(mockServer, expectedFilter: 'id=lte.2'));
       final stream =
           supabase.from('todos').stream(primaryKey: ['id']).lte('id', 2);
       expect(stream, emits(isList));
@@ -699,7 +698,7 @@ void main() {
 
   group('stream() channel config', () {
     test('forwards channelConfig.private=true to realtime join payload', () {
-      handleRequests(mockServer, expectedPrivate: true);
+      unawaited(handleRequests(mockServer, expectedPrivate: true));
 
       final stream =
           supabase.from('todos').stream(primaryKey: ['id'], private: true);
@@ -708,7 +707,7 @@ void main() {
     });
 
     test('uses default private=false when channelConfig is omitted', () {
-      handleRequests(mockServer, expectedPrivate: false);
+      unawaited(handleRequests(mockServer, expectedPrivate: false));
 
       final stream = supabase.from('todos').stream(primaryKey: ['id']);
 
@@ -718,7 +717,7 @@ void main() {
 
   group('Deprecated execute method', () {
     test('should work with deprecated execute method', () {
-      handleRequests(mockServer);
+      unawaited(handleRequests(mockServer));
       final streamBuilder = supabase.from('todos').stream(primaryKey: ['id']);
       final stream = streamBuilder.execute();
       expect(stream, emits(isList));
@@ -752,17 +751,16 @@ void main() {
         final errorServer = await HttpServer.bind('localhost', 0);
 
         // Setup server to return error for rest requests
-        errorServer.listen((request) {
+        errorServer.listen((request) async {
           if (request.uri.path.contains('/rest/')) {
             request.response
               ..statusCode = HttpStatus.unauthorized
               ..headers.contentType = ContentType.json
-              ..write('{"error": "Unauthorized"}')
-              ..close();
+              ..write('{"error": "Unauthorized"}');
+            await request.response.close();
           } else {
-            request.response
-              ..statusCode = HttpStatus.ok
-              ..close();
+            request.response.statusCode = HttpStatus.ok;
+            await request.response.close();
           }
         });
 

--- a/packages/supabase/test/utilities_test.dart
+++ b/packages/supabase/test/utilities_test.dart
@@ -91,12 +91,12 @@ void main() {
 
     setUp(() async {
       mockServer = await HttpServer.bind('localhost', 0);
-      mockServer.listen((request) {
+      mockServer.listen((request) async {
         request.response
           ..statusCode = HttpStatus.ok
           ..headers.contentType = ContentType.json
-          ..write('{"success": true}')
-          ..close();
+          ..write('{"success": true}');
+        await request.response.close();
       });
 
       authClient = AuthHttpClient(

--- a/packages/supabase_flutter/lib/src/hot_restart_cleanup_web.dart
+++ b/packages/supabase_flutter/lib/src/hot_restart_cleanup_web.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:js_interop';
 
 import 'package:supabase_flutter/supabase_flutter.dart';
@@ -16,9 +17,9 @@ external JSFunction? supabaseFlutterClientToDispose;
 /// logged.
 void markClientToDispose(SupabaseClient client) {
   void dispose() {
-    client.realtime.disconnect(
-        code: 1000, reason: 'Closed due to Flutter Web hot-restart');
-    client.dispose();
+    unawaited(client.realtime.disconnect(
+        code: 1000, reason: 'Closed due to Flutter Web hot-restart'));
+    unawaited(client.dispose());
   }
 
   supabaseFlutterClientToDispose = dispose.toJS;

--- a/packages/supabase_flutter/lib/src/local_storage.dart
+++ b/packages/supabase_flutter/lib/src/local_storage.dart
@@ -64,7 +64,7 @@ class EmptyLocalStorage extends LocalStorage {
 /// A [LocalStorage] implementation that implements SharedPreferences as the
 /// storage method.
 class SharedPreferencesLocalStorage extends LocalStorage {
-  late final SharedPreferences _prefs;
+  late final SharedPreferences _preferences;
 
   SharedPreferencesLocalStorage({required this.persistSessionKey});
 
@@ -76,7 +76,7 @@ class SharedPreferencesLocalStorage extends LocalStorage {
   Future<void> initialize() async {
     if (!_useWebLocalStorage) {
       WidgetsFlutterBinding.ensureInitialized();
-      _prefs = await SharedPreferences.getInstance();
+      _preferences = await SharedPreferences.getInstance();
     }
   }
 
@@ -85,7 +85,7 @@ class SharedPreferencesLocalStorage extends LocalStorage {
     if (_useWebLocalStorage) {
       return web.hasAccessToken(persistSessionKey);
     }
-    return _prefs.containsKey(persistSessionKey);
+    return _preferences.containsKey(persistSessionKey);
   }
 
   @override
@@ -93,7 +93,7 @@ class SharedPreferencesLocalStorage extends LocalStorage {
     if (_useWebLocalStorage) {
       return web.accessToken(persistSessionKey);
     }
-    return _prefs.getString(persistSessionKey);
+    return _preferences.getString(persistSessionKey);
   }
 
   @override
@@ -101,7 +101,7 @@ class SharedPreferencesLocalStorage extends LocalStorage {
     if (_useWebLocalStorage) {
       web.removePersistedSession(persistSessionKey);
     } else {
-      await _prefs.remove(persistSessionKey);
+      await _preferences.remove(persistSessionKey);
     }
   }
 
@@ -111,7 +111,7 @@ class SharedPreferencesLocalStorage extends LocalStorage {
       web.persistSession(persistSessionKey, persistSessionString);
       return;
     }
-    await _prefs.setString(persistSessionKey, persistSessionString);
+    await _preferences.setString(persistSessionKey, persistSessionString);
   }
 }
 
@@ -123,12 +123,12 @@ class SharedPreferencesGotrueAsyncStorage extends GotrueAsyncStorage {
 
   final Completer<void> _initializationCompleter = Completer();
 
-  late final SharedPreferences _prefs;
+  late final SharedPreferences _preferences;
 
   Future<void> _initialize() async {
     try {
       WidgetsFlutterBinding.ensureInitialized();
-      _prefs = await SharedPreferences.getInstance();
+      _preferences = await SharedPreferences.getInstance();
       _initializationCompleter.complete();
     } catch (error, stackTrace) {
       _initializationCompleter.completeError(error, stackTrace);
@@ -138,18 +138,18 @@ class SharedPreferencesGotrueAsyncStorage extends GotrueAsyncStorage {
   @override
   Future<String?> getItem({required String key}) async {
     await _initializationCompleter.future;
-    return _prefs.getString(key);
+    return _preferences.getString(key);
   }
 
   @override
   Future<void> removeItem({required String key}) async {
     await _initializationCompleter.future;
-    await _prefs.remove(key);
+    await _preferences.remove(key);
   }
 
   @override
   Future<void> setItem({required String key, required String value}) async {
     await _initializationCompleter.future;
-    await _prefs.setString(key, value);
+    await _preferences.setString(key, value);
   }
 }

--- a/packages/supabase_flutter/lib/src/local_storage.dart
+++ b/packages/supabase_flutter/lib/src/local_storage.dart
@@ -126,9 +126,13 @@ class SharedPreferencesGotrueAsyncStorage extends GotrueAsyncStorage {
   late final SharedPreferences _prefs;
 
   Future<void> _initialize() async {
-    WidgetsFlutterBinding.ensureInitialized();
-    _prefs = await SharedPreferences.getInstance();
-    _initializationCompleter.complete();
+    try {
+      WidgetsFlutterBinding.ensureInitialized();
+      _prefs = await SharedPreferences.getInstance();
+      _initializationCompleter.complete();
+    } catch (error, stackTrace) {
+      _initializationCompleter.completeError(error, stackTrace);
+    }
   }
 
   @override

--- a/packages/supabase_flutter/lib/src/local_storage.dart
+++ b/packages/supabase_flutter/lib/src/local_storage.dart
@@ -118,7 +118,7 @@ class SharedPreferencesLocalStorage extends LocalStorage {
 /// local storage to store pkce flow code verifier.
 class SharedPreferencesGotrueAsyncStorage extends GotrueAsyncStorage {
   SharedPreferencesGotrueAsyncStorage() {
-    _initialize();
+    unawaited(_initialize());
   }
 
   final Completer<void> _initializationCompleter = Completer();

--- a/packages/supabase_flutter/lib/src/supabase.dart
+++ b/packages/supabase_flutter/lib/src/supabase.dart
@@ -199,8 +199,8 @@ class Supabase {
   Future<void> dispose() async {
     _targetLifecycleState = null;
     await _restoreSessionCancellableOperation?.cancel();
-    _logSubscription?.cancel();
-    client.dispose();
+    await _logSubscription?.cancel();
+    await client.dispose();
     _instance._supabaseAuth?.dispose();
     _lifecycleListener?.dispose();
     _isInitialized = false;

--- a/packages/supabase_flutter/lib/src/supabase_auth.dart
+++ b/packages/supabase_flutter/lib/src/supabase_auth.dart
@@ -84,7 +84,7 @@ class SupabaseAuth with WidgetsBindingObserver {
 
     _authSubscription = Supabase.instance.client.auth.onAuthStateChange.listen(
       (data) {
-        _onAuthStateChange(data.event, data.session);
+        unawaited(_onAuthStateChange(data.event, data.session));
       },
       onError: (error, stackTrace) {
         // Errors are already logged by GoTrueClient.notifyException before
@@ -169,11 +169,17 @@ class SupabaseAuth with WidgetsBindingObserver {
     }
   }
 
-  void _onAuthStateChange(AuthChangeEvent event, Session? session) {
-    if (session != null) {
-      unawaited(_localStorage.persistSession(jsonEncode(session.toJson())));
-    } else if (event == AuthChangeEvent.signedOut) {
-      unawaited(_localStorage.removePersistedSession());
+  Future<void> _onAuthStateChange(
+      AuthChangeEvent event, Session? session) async {
+    try {
+      if (session != null) {
+        await _localStorage.persistSession(jsonEncode(session.toJson()));
+      } else if (event == AuthChangeEvent.signedOut) {
+        await _localStorage.removePersistedSession();
+      }
+    } catch (error, stackTrace) {
+      _log.warning(
+          'Error while persisting auth state change', error, stackTrace);
     }
   }
 

--- a/packages/supabase_flutter/lib/src/supabase_auth.dart
+++ b/packages/supabase_flutter/lib/src/supabase_auth.dart
@@ -148,7 +148,7 @@ class SupabaseAuth with WidgetsBindingObserver {
     if (!kIsWeb && Platform.environment.containsKey('FLUTTER_TEST')) {
       _initialDeeplinkIsHandled = false;
     }
-    _authSubscription?.cancel();
+    unawaited(_authSubscription?.cancel());
     _stopDeeplinkObserver();
     _widgetsBindingInstance.removeObserver(this);
   }
@@ -171,9 +171,9 @@ class SupabaseAuth with WidgetsBindingObserver {
 
   void _onAuthStateChange(AuthChangeEvent event, Session? session) {
     if (session != null) {
-      _localStorage.persistSession(jsonEncode(session.toJson()));
+      unawaited(_localStorage.persistSession(jsonEncode(session.toJson())));
     } else if (event == AuthChangeEvent.signedOut) {
-      _localStorage.removePersistedSession();
+      unawaited(_localStorage.removePersistedSession());
     }
   }
 
@@ -202,7 +202,7 @@ class SupabaseAuth with WidgetsBindingObserver {
   void _stopDeeplinkObserver() {
     if (_deeplinkSubscription != null) {
       _log.fine('Stopping deeplink observer');
-      _deeplinkSubscription?.cancel();
+      unawaited(_deeplinkSubscription?.cancel());
     }
   }
 
@@ -215,7 +215,7 @@ class SupabaseAuth with WidgetsBindingObserver {
       _deeplinkSubscription = _appLinks.uriLinkStream.listen(
         (Uri? uri) {
           if (uri != null) {
-            _handleDeeplink(uri);
+            unawaited(_handleDeeplink(uri));
           }
         },
         onError: (Object err, StackTrace stackTrace) {

--- a/packages/supabase_flutter/test/deep_link_test.dart
+++ b/packages/supabase_flutter/test/deep_link_test.dart
@@ -27,6 +27,11 @@ void main() {
         mockEventChannel: true,
         initialLink: 'com.supabase://callback/?code=my-code-verifier',
       );
+      final pkceAsyncStorage = MockAsyncStorage();
+      await pkceAsyncStorage.setItem(
+        key: 'supabase.auth.token-code-verifier',
+        value: 'raw-code-verifier',
+      );
       await Supabase.initialize(
         url: supabaseUrl,
         publishableKey: supabaseKey,
@@ -34,10 +39,7 @@ void main() {
         httpClient: pkceHttpClient,
         authOptions: FlutterAuthClientOptions(
           localStorage: const MockEmptyLocalStorage(),
-          pkceAsyncStorage: MockAsyncStorage()
-            ..setItem(
-                key: 'supabase.auth.token-code-verifier',
-                value: 'raw-code-verifier'),
+          pkceAsyncStorage: pkceAsyncStorage,
         ),
       );
     });

--- a/packages/supabase_flutter/test/widget_test_stubs.dart
+++ b/packages/supabase_flutter/test/widget_test_stubs.dart
@@ -125,7 +125,7 @@ void mockAppLink({
       // ignore: function-always-returns-null
       (MethodCall methodCall) async {
         // ignore: invalid_null_aware_operator
-        TestDefaultBinaryMessengerBinding.instance?.defaultBinaryMessenger
+        await TestDefaultBinaryMessengerBinding.instance?.defaultBinaryMessenger
             .handlePlatformMessage(
           eventChannel.name,
           const StandardMethodCodec().encodeSuccessEnvelope(initialLink),

--- a/packages/supabase_lints/lib/analysis_options.yaml
+++ b/packages/supabase_lints/lib/analysis_options.yaml
@@ -6,6 +6,11 @@
 # so new code is not held to a rule the rest of the codebase does not yet pass.
 include: package:lints/recommended.yaml
 
+linter:
+  rules:
+    unawaited_futures: true
+    discarded_futures: true
+
 formatter:
   trailing_commas: preserve
 

--- a/packages/yet_another_json_isolate/example/yet_another_json_isolate_example.dart
+++ b/packages/yet_another_json_isolate/example/yet_another_json_isolate_example.dart
@@ -10,5 +10,5 @@ void main() async {
 
   final str = await isolate.encode(json);
   print(str);
-  isolate.dispose();
+  await isolate.dispose();
 }

--- a/packages/yet_another_json_isolate/lib/src/_isolates_io.dart
+++ b/packages/yet_another_json_isolate/lib/src/_isolates_io.dart
@@ -51,7 +51,7 @@ class YAJsonIsolate {
 
   Future<dynamic> decode(String json) async {
     if (!_createdIsolate.isCompleted) {
-      if (!_hasStartedInitialize) initialize();
+      if (!_hasStartedInitialize) await initialize();
       await _createdIsolate.future;
     }
     _sendPort.send([json, false]);
@@ -60,7 +60,7 @@ class YAJsonIsolate {
 
   Future<String> encode(Object? json) async {
     if (!_createdIsolate.isCompleted) {
-      if (!_hasStartedInitialize) initialize();
+      if (!_hasStartedInitialize) await initialize();
       await _createdIsolate.future;
     }
     _sendPort.send([json, true]);


### PR DESCRIPTION
## What

Enables the Dart linter rules [`unawaited_futures`](https://dart.dev/tools/linter-rules/unawaited_futures) and [`discarded_futures`](https://dart.dev/tools/linter-rules/discarded_futures) in the shared `supabase_lints` config, and resolves every resulting violation across the packages.

```yaml
linter:
  rules:
    unawaited_futures: true
    discarded_futures: true
```

## Why

Without these rules, a `Future` that is created but never awaited (or wrapped in `unawaited(...)`) silently drops its result. If that future throws, the exception becomes an unhandled async error instead of propagating to the caller, so failures get lost. `unawaited_futures` catches this in `async` bodies and `discarded_futures` covers synchronous bodies, so the two together close the gap.

## How

Each of the ~111 flagged sites was resolved by judgment, not blanket replacement:

- **`await`** where the result or errors matter and awaiting preserves behavior without changing a public signature (for example `removeChannel`/`removeAllChannels`, `dispose()` in already-async code, and `yet_another_json_isolate`'s `decode`/`encode`, which now propagate isolate-spawn failures that were previously dropped).
- **`unawaited(...)`** for genuine fire-and-forget calls that must not block: cleanup in `dispose()`/`close` callbacks, synchronous listener callbacks (auth state, deep links, app lifecycle), realtime socket sends/heartbeat/reconnect, the stream-pumping in `postgrest_builder.asStream()` and `supabase_stream_builder`, and constructor-kicked initialization.
- Tests and examples were mostly switched to `await`, with `unawaited(...)` only where a test deliberately fires without waiting.

No public API signatures were changed.

## Verification

- `dart analyze`: 0 `unawaited_futures`, 0 `discarded_futures`, 0 new errors/warnings across all packages.
- `dart analyze --fatal-infos`: clean.
- `dart format lib test -l 80 --set-exit-if-changed`: passes.