### PR TITLE
chore: enable avoid-passing-async-when-sync-expected lint

### DIFF
--- a/packages/realtime_client/lib/src/push.dart
+++ b/packages/realtime_client/lib/src/push.dart
@@ -101,7 +101,7 @@ class Push {
     });
   }
 
-  void trigger(String status, dynamic response) {
+  void trigger(String status, Map<String, dynamic> response) {
     if (_refEvent != null) {
       _channel.trigger(_refEvent!, {'status': status, 'response': response});
     }

--- a/packages/realtime_client/lib/src/realtime_channel.dart
+++ b/packages/realtime_client/lib/src/realtime_channel.dart
@@ -174,7 +174,7 @@ class RealtimeChannel {
     joinPush
         .receive(
       'ok',
-      (response) => unawaited(_handleJoinOk(response, callback)),
+      (response) => unawaited(_handleJoinOk(response as Map, callback)),
     )
         .receive('error', (error) {
       if (callback != null) {
@@ -194,7 +194,7 @@ class RealtimeChannel {
   }
 
   Future<void> _handleJoinOk(
-    dynamic response,
+    Map response,
     void Function(RealtimeSubscribeStatus status, Object? error)? callback,
   ) async {
     final serverPostgresFilters = response['postgres_changes'];

--- a/packages/realtime_client/lib/src/realtime_channel.dart
+++ b/packages/realtime_client/lib/src/realtime_channel.dart
@@ -171,74 +171,12 @@ class RealtimeChannel {
     joinedOnce = true;
     rejoin(timeout ?? _timeout);
 
-    joinPush.receive(
+    joinPush
+        .receive(
       'ok',
-      (response) async {
-        final serverPostgresFilters = response['postgres_changes'];
-        if (socket.accessToken != null) {
-          try {
-            // ignore: avoid-passing-self-as-argument
-            await socket.setAuth(socket.accessToken);
-          } on FormatException catch (e) {
-            // The cached access token may have expired by the time the
-            // channel rejoins (e.g. after the device wakes from a long
-            // sleep). Auth state listeners will re-call setAuth with a
-            // fresh token shortly after, so swallow this specific error
-            // to avoid surfacing it as an uncaught exception. The same
-            // filter is applied in `SupabaseClient._handleTokenChanged`.
-            if (!e.message.contains('InvalidJWTToken')) {
-              rethrow;
-            }
-          }
-        }
-
-        if (serverPostgresFilters == null) {
-          if (callback != null) {
-            callback(RealtimeSubscribeStatus.subscribed, null);
-          }
-          return;
-        }
-        final clientPostgresBindings = _bindings['postgres_changes'];
-        final bindingsLen = clientPostgresBindings?.length ?? 0;
-        final newPostgresBindings = <Binding>[];
-
-        for (var i = 0; i < bindingsLen; i++) {
-          final clientPostgresBinding = clientPostgresBindings![i];
-
-          final event = clientPostgresBinding.filter['event'];
-          final schema = clientPostgresBinding.filter['schema'];
-          final table = clientPostgresBinding.filter['table'];
-          final filter = clientPostgresBinding.filter['filter'];
-          final serverPostgresFilter = serverPostgresFilters[i];
-
-          if (serverPostgresFilter != null &&
-              serverPostgresFilter['event'] == event &&
-              serverPostgresFilter['schema'] == schema &&
-              serverPostgresFilter['table'] == table &&
-              serverPostgresFilter['filter'] == filter) {
-            newPostgresBindings.add(clientPostgresBinding.copyWith(
-              id: serverPostgresFilter['id']?.toString(),
-            ));
-          } else {
-            unawaited(unsubscribe());
-            if (callback != null) {
-              callback(
-                RealtimeSubscribeStatus.channelError,
-                Exception(
-                    'mismatch between server and client bindings for postgres changes'),
-              );
-            }
-            return;
-          }
-        }
-
-        _bindings['postgres_changes'] = newPostgresBindings;
-
-        if (callback != null) {
-          callback(RealtimeSubscribeStatus.subscribed, null);
-        }
-      },
-    ).receive('error', (error) {
+      (response) => unawaited(_handleJoinOk(response, callback)),
+    )
+        .receive('error', (error) {
       if (callback != null) {
         callback(
           RealtimeSubscribeStatus.channelError,
@@ -253,6 +191,75 @@ class RealtimeChannel {
       if (callback != null) callback(RealtimeSubscribeStatus.timedOut, null);
     });
     return this;
+  }
+
+  Future<void> _handleJoinOk(
+    dynamic response,
+    void Function(RealtimeSubscribeStatus status, Object? error)? callback,
+  ) async {
+    final serverPostgresFilters = response['postgres_changes'];
+    if (socket.accessToken != null) {
+      try {
+        // ignore: avoid-passing-self-as-argument
+        await socket.setAuth(socket.accessToken);
+      } on FormatException catch (e) {
+        // The cached access token may have expired by the time the
+        // channel rejoins (e.g. after the device wakes from a long
+        // sleep). Auth state listeners will re-call setAuth with a
+        // fresh token shortly after, so swallow this specific error
+        // to avoid surfacing it as an uncaught exception. The same
+        // filter is applied in `SupabaseClient._handleTokenChanged`.
+        if (!e.message.contains('InvalidJWTToken')) {
+          rethrow;
+        }
+      }
+    }
+
+    if (serverPostgresFilters == null) {
+      if (callback != null) {
+        callback(RealtimeSubscribeStatus.subscribed, null);
+      }
+      return;
+    }
+    final clientPostgresBindings = _bindings['postgres_changes'];
+    final bindingsLen = clientPostgresBindings?.length ?? 0;
+    final newPostgresBindings = <Binding>[];
+
+    for (var i = 0; i < bindingsLen; i++) {
+      final clientPostgresBinding = clientPostgresBindings![i];
+
+      final event = clientPostgresBinding.filter['event'];
+      final schema = clientPostgresBinding.filter['schema'];
+      final table = clientPostgresBinding.filter['table'];
+      final filter = clientPostgresBinding.filter['filter'];
+      final serverPostgresFilter = serverPostgresFilters[i];
+
+      if (serverPostgresFilter != null &&
+          serverPostgresFilter['event'] == event &&
+          serverPostgresFilter['schema'] == schema &&
+          serverPostgresFilter['table'] == table &&
+          serverPostgresFilter['filter'] == filter) {
+        newPostgresBindings.add(clientPostgresBinding.copyWith(
+          id: serverPostgresFilter['id']?.toString(),
+        ));
+      } else {
+        unawaited(unsubscribe());
+        if (callback != null) {
+          callback(
+            RealtimeSubscribeStatus.channelError,
+            Exception(
+                'mismatch between server and client bindings for postgres changes'),
+          );
+        }
+        return;
+      }
+    }
+
+    _bindings['postgres_changes'] = newPostgresBindings;
+
+    if (callback != null) {
+      callback(RealtimeSubscribeStatus.subscribed, null);
+    }
   }
 
   List<SinglePresenceState> presenceState() {

--- a/packages/realtime_client/lib/src/realtime_channel.dart
+++ b/packages/realtime_client/lib/src/realtime_channel.dart
@@ -174,7 +174,8 @@ class RealtimeChannel {
     joinPush
         .receive(
       'ok',
-      (response) => unawaited(_handleJoinOk(response as Map, callback)),
+      (response) =>
+          unawaited(_handleJoinOk(response as Map<String, dynamic>, callback)),
     )
         .receive('error', (error) {
       if (callback != null) {
@@ -194,7 +195,7 @@ class RealtimeChannel {
   }
 
   Future<void> _handleJoinOk(
-    Map response,
+    Map<String, dynamic> response,
     void Function(RealtimeSubscribeStatus status, Object? error)? callback,
   ) async {
     final serverPostgresFilters = response['postgres_changes'];

--- a/packages/realtime_client/lib/src/realtime_client.dart
+++ b/packages/realtime_client/lib/src/realtime_client.dart
@@ -204,10 +204,7 @@ class RealtimeClient {
     this.reconnectAfterMs =
         reconnectAfterMs ?? RetryTimer.createRetryFunction();
     reconnectTimer = RetryTimer(
-      () async {
-        await disconnect();
-        await connect();
-      },
+      () => unawaited(_reconnect()),
       this.reconnectAfterMs,
     );
   }
@@ -269,6 +266,11 @@ class RealtimeClient {
       /// General error handling
       _onConnError(e);
     }
+  }
+
+  Future<void> _reconnect() async {
+    await disconnect();
+    await connect();
   }
 
   /// Disconnects the socket with status [code] and [reason] for the disconnect
@@ -526,7 +528,7 @@ class RealtimeClient {
     if (heartbeatTimer != null) heartbeatTimer!.cancel();
     heartbeatTimer = Timer.periodic(
       Duration(milliseconds: heartbeatIntervalMs),
-      (Timer t) async => await sendHeartbeat(),
+      (Timer t) => unawaited(sendHeartbeat()),
     );
     for (final callback in stateChangeCallbacks['open']!) {
       callback();

--- a/packages/realtime_client/test/channel_test.dart
+++ b/packages/realtime_client/test/channel_test.dart
@@ -392,69 +392,71 @@ void main() {
     });
 
     test('send message via ws conn when subscribed to channel', () async {
+      final subscribed = Completer<void>();
       channel.subscribe((status, [error]) {
-        if (status != RealtimeSubscribeStatus.subscribed) {
-          return;
+        if (status == RealtimeSubscribeStatus.subscribed) {
+          subscribed.complete();
         }
-        unawaited(() async {
-          final completer = Completer<ChannelResponse>();
-          unawaited(
-            channel.send(
-              type: RealtimeListenTypes.broadcast,
-              payload: {
-                'myKey': 'myValue',
-              },
-            ).then(
-              (value) => completer.complete(value),
-              onError: (Object e, StackTrace stackTrace) =>
-                  completer.completeError(e, stackTrace),
-            ),
-          );
-
-          await for (final HttpRequest req in mockServer) {
-            expect(req.uri.toString(), startsWith('/realtime/v1/websocket'));
-            await req.response.close();
-            break;
-          }
-          expect(await completer.future, ChannelResponse.ok);
-        }());
       });
+
+      // Accept the websocket the client opens on subscribe, then reply to the
+      // channel join so it transitions to subscribed.
+      final serverSocket =
+          await mockServer.first.then(WebSocketTransformer.upgrade);
+      final broadcast = Completer<List<dynamic>>();
+      serverSocket.listen((frame) {
+        final message = jsonDecode(frame as String) as List;
+        switch (message[3]) {
+          case 'phx_join':
+            serverSocket.add(jsonEncode([
+              message[0],
+              message[1],
+              message[2],
+              'phx_reply',
+              {'status': 'ok', 'response': <String, dynamic>{}},
+            ]));
+          case 'broadcast':
+            broadcast.complete(message);
+        }
+      });
+      await subscribed.future;
+
+      // Once subscribed, broadcasts are pushed over the websocket instead of
+      // falling back to the REST endpoint.
+      final sendResult = await channel.send(
+        type: RealtimeListenTypes.broadcast,
+        payload: {'myKey': 'myValue'},
+      );
+      expect(sendResult, ChannelResponse.ok);
+
+      final message = await broadcast.future;
+      expect(message[2], 'realtime:myTopic');
+      expect(message[3], 'broadcast');
+      expect(message[4], containsPair('myKey', 'myValue'));
     });
 
     test(
         'send message via http request to Broadcast endpoint when not subscribed to channel',
         () async {
-      final completer = Completer<ChannelResponse>();
-      unawaited(
-        channel.send(
-          type: RealtimeListenTypes.broadcast,
-          payload: {
-            'myKey': 'myValue',
-          },
-        ).then(
-          (value) => completer.complete(value),
-          onError: (Object e, StackTrace stackTrace) =>
-              completer.completeError(e, stackTrace),
-        ),
+      final requestFuture = mockServer.first;
+      final sendFuture = channel.send(
+        type: RealtimeListenTypes.broadcast,
+        payload: {'myKey': 'myValue'},
       );
 
-      await for (final HttpRequest req in mockServer) {
-        expect(req.uri.toString(), '/realtime/v1/api/broadcast');
-        expect(req.headers.value('apikey'), 'supabaseKey');
+      final request = await requestFuture;
+      expect(request.uri.toString(), '/realtime/v1/api/broadcast');
+      expect(request.headers.value('apikey'), 'supabaseKey');
 
-        final body = json.decode(await utf8.decodeStream(req));
-        final message = body['messages'].first;
-        final payload = message['payload'];
-        final private = message['private'];
+      final body = json.decode(await utf8.decodeStream(request));
+      final message = body['messages'].first;
+      expect(message['payload'], containsPair('myKey', 'myValue'));
+      expect(message, containsPair('topic', 'myTopic'));
+      expect(message['private'], isTrue);
 
-        expect(payload, containsPair('myKey', 'myValue'));
-        expect(message, containsPair('topic', 'myTopic'));
-        expect(private, isTrue);
+      await request.response.close();
 
-        await req.response.close();
-        break;
-      }
-      expect(await completer.future, ChannelResponse.ok);
+      expect(await sendFuture, ChannelResponse.ok);
     });
   });
 

--- a/packages/realtime_client/test/channel_test.dart
+++ b/packages/realtime_client/test/channel_test.dart
@@ -392,8 +392,11 @@ void main() {
     });
 
     test('send message via ws conn when subscribed to channel', () async {
-      channel.subscribe((status, [error]) async {
-        if (status == RealtimeSubscribeStatus.subscribed) {
+      channel.subscribe((status, [error]) {
+        if (status != RealtimeSubscribeStatus.subscribed) {
+          return;
+        }
+        unawaited(() async {
           final completer = Completer<ChannelResponse>();
           unawaited(
             channel.send(
@@ -414,7 +417,7 @@ void main() {
             break;
           }
           expect(await completer.future, ChannelResponse.ok);
-        }
+        }());
       });
     });
 

--- a/packages/realtime_client/test/mock_test.dart
+++ b/packages/realtime_client/test/mock_test.dart
@@ -24,127 +24,137 @@ void main() {
           return;
         }
         hasListener = true;
-        listener = webSocket!.listen((message) async {
-          if (hasSentData) {
-            return;
-          }
-          hasSentData = true;
+        listener = webSocket!.listen((message) {
+          unawaited(() async {
+            if (hasSentData) {
+              return;
+            }
+            hasSentData = true;
 
-          /// Protocol 2.0.0 text frames are positional arrays:
-          /// [join_ref, ref, topic, event, payload].
-          ///
-          /// `filter` might be there or not depending on whether is a filter set
-          /// to the realtime subscription, so include the filter if the request
-          /// includes a filter.
-          final requestJson = jsonDecode(message as String) as List;
-          final requestPayload = requestJson[4] as Map;
-          final String? postgresFilter =
-              requestPayload['config']['postgres_changes'].first['filter'];
+            /// Protocol 2.0.0 text frames are positional arrays:
+            /// [join_ref, ref, topic, event, payload].
+            ///
+            /// `filter` might be there or not depending on whether is a filter set
+            /// to the realtime subscription, so include the filter if the request
+            /// includes a filter.
+            final requestJson = jsonDecode(message as String) as List;
+            final requestPayload = requestJson[4] as Map;
+            final String? postgresFilter =
+                requestPayload['config']['postgres_changes'].first['filter'];
 
-          final topic = requestJson[2];
+            final topic = requestJson[2];
 
-          // Send an insert event
-          if (postgresFilter == null) {
-            await Future.delayed(Duration(milliseconds: 300));
-            final insertString = jsonEncode([
+            // Send an insert event
+            if (postgresFilter == null) {
+              await Future.delayed(Duration(milliseconds: 300));
+              final insertString = jsonEncode([
+                null,
+                null,
+                topic,
+                'postgres_changes',
+                {
+                  'ids': [77086988],
+                  'data': {
+                    'commit_timestamp': '2021-08-01T08:00:20Z',
+                    'record': {'id': 3, 'task': 'task 3', 'status': 't'},
+                    'schema': 'public',
+                    'table': 'todos',
+                    'type': 'INSERT',
+                    if (postgresFilter != null) 'filter': postgresFilter,
+                    'columns': [
+                      {
+                        'name': 'id',
+                        'type': 'int4',
+                        'type_modifier': 4294967295,
+                      },
+                      {
+                        'name': 'task',
+                        'type': 'text',
+                        'type_modifier': 4294967295,
+                      },
+                      {
+                        'name': 'status',
+                        'type': 'bool',
+                        'type_modifier': 4294967295,
+                      },
+                    ],
+                  },
+                },
+              ]);
+              webSocket!.add(insertString);
+            }
+
+            // Send an update event for id = 2
+            await Future.delayed(Duration(milliseconds: 10));
+            final updateString = jsonEncode([
               null,
               null,
               topic,
               'postgres_changes',
               {
-                'ids': [77086988],
+                'ids': [25993878],
                 'data': {
-                  'commit_timestamp': '2021-08-01T08:00:20Z',
-                  'record': {'id': 3, 'task': 'task 3', 'status': 't'},
-                  'schema': 'public',
-                  'table': 'todos',
-                  'type': 'INSERT',
-                  if (postgresFilter != null) 'filter': postgresFilter,
                   'columns': [
-                    {
-                      'name': 'id',
-                      'type': 'int4',
-                      'type_modifier': 4294967295,
-                    },
+                    {'name': 'id', 'type': 'int4', 'type_modifier': 4294967295},
                     {
                       'name': 'task',
                       'type': 'text',
-                      'type_modifier': 4294967295,
+                      'type_modifier': 4294967295
                     },
                     {
                       'name': 'status',
                       'type': 'bool',
-                      'type_modifier': 4294967295,
+                      'type_modifier': 4294967295
                     },
                   ],
+                  'commit_timestamp': '2021-08-01T08:00:30Z',
+                  'errors': null,
+                  'old_record': {'id': 2},
+                  'record': {'id': 2, 'task': 'task 2 updated', 'status': 'f'},
+                  'schema': 'public',
+                  'table': 'todos',
+                  'type': 'UPDATE',
+                  if (postgresFilter != null) 'filter': postgresFilter,
                 },
               },
             ]);
-            webSocket!.add(insertString);
-          }
+            webSocket!.add(updateString);
 
-          // Send an update event for id = 2
-          await Future.delayed(Duration(milliseconds: 10));
-          final updateString = jsonEncode([
-            null,
-            null,
-            topic,
-            'postgres_changes',
-            {
-              'ids': [25993878],
-              'data': {
-                'columns': [
-                  {'name': 'id', 'type': 'int4', 'type_modifier': 4294967295},
-                  {'name': 'task', 'type': 'text', 'type_modifier': 4294967295},
-                  {
-                    'name': 'status',
-                    'type': 'bool',
-                    'type_modifier': 4294967295
-                  },
-                ],
-                'commit_timestamp': '2021-08-01T08:00:30Z',
-                'errors': null,
-                'old_record': {'id': 2},
-                'record': {'id': 2, 'task': 'task 2 updated', 'status': 'f'},
-                'schema': 'public',
-                'table': 'todos',
-                'type': 'UPDATE',
-                if (postgresFilter != null) 'filter': postgresFilter,
+            // Send delete event for id=2
+            await Future.delayed(Duration(milliseconds: 10));
+            final deleteString = jsonEncode([
+              null,
+              null,
+              topic,
+              'postgres_changes',
+              {
+                'data': {
+                  'columns': [
+                    {'name': 'id', 'type': 'int4', 'type_modifier': 4294967295},
+                    {
+                      'name': 'task',
+                      'type': 'text',
+                      'type_modifier': 4294967295
+                    },
+                    {
+                      'name': 'status',
+                      'type': 'bool',
+                      'type_modifier': 4294967295
+                    },
+                  ],
+                  'commit_timestamp': '2022-09-14T02:12:52Z',
+                  'errors': null,
+                  'old_record': {'id': 2},
+                  'schema': 'public',
+                  'table': 'todos',
+                  'type': 'DELETE',
+                  if (postgresFilter != null) 'filter': postgresFilter,
+                },
+                'ids': [48673474]
               },
-            },
-          ]);
-          webSocket!.add(updateString);
-
-          // Send delete event for id=2
-          await Future.delayed(Duration(milliseconds: 10));
-          final deleteString = jsonEncode([
-            null,
-            null,
-            topic,
-            'postgres_changes',
-            {
-              'data': {
-                'columns': [
-                  {'name': 'id', 'type': 'int4', 'type_modifier': 4294967295},
-                  {'name': 'task', 'type': 'text', 'type_modifier': 4294967295},
-                  {
-                    'name': 'status',
-                    'type': 'bool',
-                    'type_modifier': 4294967295
-                  },
-                ],
-                'commit_timestamp': '2022-09-14T02:12:52Z',
-                'errors': null,
-                'old_record': {'id': 2},
-                'schema': 'public',
-                'table': 'todos',
-                'type': 'DELETE',
-                if (postgresFilter != null) 'filter': postgresFilter,
-              },
-              'ids': [48673474]
-            },
-          ]);
-          webSocket!.add(deleteString);
+            ]);
+            webSocket!.add(deleteString);
+          }());
         });
       } else {
         request.response.statusCode = HttpStatus.ok;
@@ -308,43 +318,68 @@ void main() {
           return;
         }
         hasListener = true;
-        listener = webSocket!.listen((message) async {
-          if (hasSentData) {
-            return;
-          }
-          hasSentData = true;
+        listener = webSocket!.listen((message) {
+          unawaited(() async {
+            if (hasSentData) {
+              return;
+            }
+            hasSentData = true;
 
-          /// Protocol 2.0.0 text frames are positional arrays:
-          /// [join_ref, ref, topic, event, payload].
-          ///
-          /// `filter` might be there or not depending on whether is a filter set
-          /// to the realtime subscription, so include the filter if the request
-          /// includes a filter.
-          final requestJson = jsonDecode(message as String) as List;
-          final requestPayload = requestJson[4] as Map;
+            /// Protocol 2.0.0 text frames are positional arrays:
+            /// [join_ref, ref, topic, event, payload].
+            ///
+            /// `filter` might be there or not depending on whether is a filter set
+            /// to the realtime subscription, so include the filter if the request
+            /// includes a filter.
+            final requestJson = jsonDecode(message as String) as List;
+            final requestPayload = requestJson[4] as Map;
 
-          final String? postgresFilter =
-              requestPayload['config']['postgres_changes'].first['filter'];
+            final String? postgresFilter =
+                requestPayload['config']['postgres_changes'].first['filter'];
 
-          final topic = requestJson[2];
+            final topic = requestJson[2];
 
-          final replyString = jsonEncode([
-            null,
-            "1",
-            topic,
-            "phx_reply",
-            {"response": {}, "status": "ok"},
-          ]);
-          webSocket!.add(replyString);
+            final replyString = jsonEncode([
+              null,
+              "1",
+              topic,
+              "phx_reply",
+              {"response": {}, "status": "ok"},
+            ]);
+            webSocket!.add(replyString);
 
-          // Send an insert event
-          if (postgresFilter == null) {
-            await Future.delayed(Duration(milliseconds: 300));
-            final insertString = jsonEncode([
+            // Send an insert event
+            if (postgresFilter == null) {
+              await Future.delayed(Duration(milliseconds: 300));
+              final insertString = jsonEncode([
+                null,
+                null,
+                topic,
+                "INSERT",
+                {
+                  "columns": [
+                    {"name": "id", "type": "int4"},
+                    {"name": "task", "type": "text"},
+                    {"name": "status", "type": "bool"}
+                  ],
+                  "commit_timestamp": "2022-09-24T05:42:01.303668+00:00",
+                  "errors": null,
+                  "record": {"id": 1, "status": true, "task": "task 1"},
+                  "schema": "public",
+                  "table": "todos",
+                  "type": "INSERT"
+                },
+              ]);
+              webSocket!.add(insertString);
+            }
+
+            // Send an update event for id = 2
+            await Future.delayed(Duration(milliseconds: 10));
+            final updateString = jsonEncode([
               null,
               null,
               topic,
-              "INSERT",
+              "UPDATE",
               {
                 "columns": [
                   {"name": "id", "type": "int4"},
@@ -353,62 +388,39 @@ void main() {
                 ],
                 "commit_timestamp": "2022-09-24T05:42:01.303668+00:00",
                 "errors": null,
-                "record": {"id": 1, "status": true, "task": "task 1"},
+                "old_record": {"id": 2},
+                "record": {"id": 2, "status": false, "task": "task 2 updated"},
                 "schema": "public",
                 "table": "todos",
-                "type": "INSERT"
+                "type": "UPDATE"
               },
             ]);
-            webSocket!.add(insertString);
-          }
+            webSocket!.add(updateString);
 
-          // Send an update event for id = 2
-          await Future.delayed(Duration(milliseconds: 10));
-          final updateString = jsonEncode([
-            null,
-            null,
-            topic,
-            "UPDATE",
-            {
-              "columns": [
-                {"name": "id", "type": "int4"},
-                {"name": "task", "type": "text"},
-                {"name": "status", "type": "bool"}
-              ],
-              "commit_timestamp": "2022-09-24T05:42:01.303668+00:00",
-              "errors": null,
-              "old_record": {"id": 2},
-              "record": {"id": 2, "status": false, "task": "task 2 updated"},
-              "schema": "public",
-              "table": "todos",
-              "type": "UPDATE"
-            },
-          ]);
-          webSocket!.add(updateString);
-
-          // Send delete event for id=2
-          await Future.delayed(Duration(milliseconds: 10));
-          final deleteString = jsonEncode([
-            null,
-            null,
-            topic,
-            "DELETE",
-            {
-              "columns": [
-                {"name": "id", "type": "int4"},
-                {"name": "task", "type": "text"},
-                {"name": "status", "type": "bool"}
-              ],
-              "commit_timestamp": "2022-09-24T05:42:01.303668+00:00",
-              "errors": null,
-              "old_record": {"id": 2},
-              "record": {},
-              "schema": "public",
-              "table": "todos",
-              "type": "DELETE"
-            },
-          ]);
-          webSocket!.add(deleteString);
+            // Send delete event for id=2
+            await Future.delayed(Duration(milliseconds: 10));
+            final deleteString = jsonEncode([
+              null,
+              null,
+              topic,
+              "DELETE",
+              {
+                "columns": [
+                  {"name": "id", "type": "int4"},
+                  {"name": "task", "type": "text"},
+                  {"name": "status", "type": "bool"}
+                ],
+                "commit_timestamp": "2022-09-24T05:42:01.303668+00:00",
+                "errors": null,
+                "old_record": {"id": 2},
+                "record": {},
+                "schema": "public",
+                "table": "todos",
+                "type": "DELETE"
+              },
+            ]);
+            webSocket!.add(deleteString);
+          }());
         });
       } else {
         request.response.statusCode = HttpStatus.ok;

--- a/packages/supabase/lib/src/supabase_client.dart
+++ b/packages/supabase/lib/src/supabase_client.dart
@@ -372,8 +372,10 @@ class SupabaseClient {
   void _listenForAuthEvents() {
     // ignore: invalid_use_of_internal_member
     _authStateSubscription = auth.onAuthStateChangeSync.listen(
-      (data) async {
-        await _handleTokenChanged(data.event, data.session?.accessToken);
+      (data) {
+        unawaited(
+          _handleTokenChanged(data.event, data.session?.accessToken),
+        );
       },
       onError: (error, stack) {},
     );

--- a/packages/supabase/lib/src/supabase_stream_builder.dart
+++ b/packages/supabase/lib/src/supabase_stream_builder.dart
@@ -356,7 +356,7 @@ class SupabaseStreamBuilder extends Stream<SupabaseStreamEvent> {
     controller.onListen = () {
       StreamSubscription<SupabaseStreamEvent> subscription = listen(null,
           onError: controller.addError, // Avoid Zone error replacement.
-          onDone: controller.close);
+          onDone: () => unawaited(controller.close()));
       FutureOr<void> add(E value) {
         controller.add(value);
       }
@@ -396,7 +396,7 @@ class SupabaseStreamBuilder extends Stream<SupabaseStreamEvent> {
     controller.onListen = () {
       StreamSubscription<SupabaseStreamEvent> subscription = listen(null,
           onError: controller.addError, // Avoid Zone error replacement.
-          onDone: controller.close);
+          onDone: () => unawaited(controller.close()));
       subscription.onData((SupabaseStreamEvent event) {
         Stream<E>? newStream;
         try {

--- a/packages/supabase/test/mock_test.dart
+++ b/packages/supabase/test/mock_test.dart
@@ -107,227 +107,245 @@ void main() {
           return;
         }
         hasListener = true;
-        listener = webSocket!.listen((message) async {
-          /// Protocol 2.0.0 text frames are positional arrays:
-          /// [join_ref, ref, topic, event, payload].
-          ///
-          /// `filter` might be there or not depending on whether is a filter set
-          /// to the realtime subscription, so include the filter if the request
-          /// includes a filter.
-          final requestJson = jsonDecode(message as String) as List;
-          final ref = requestJson[1];
-          final topic = requestJson[2];
-          final event = requestJson[3];
-          final requestPayload = requestJson[4] as Map;
+        listener = webSocket!.listen((message) {
+          unawaited(() async {
+            /// Protocol 2.0.0 text frames are positional arrays:
+            /// [join_ref, ref, topic, event, payload].
+            ///
+            /// `filter` might be there or not depending on whether is a filter set
+            /// to the realtime subscription, so include the filter if the request
+            /// includes a filter.
+            final requestJson = jsonDecode(message as String) as List;
+            final ref = requestJson[1];
+            final topic = requestJson[2];
+            final event = requestJson[3];
+            final requestPayload = requestJson[4] as Map;
 
-          if (event == 'phx_leave') {
-            listeners.remove(topic);
-            return;
-          }
-          if (listeners.contains(topic)) {
-            return;
-          }
-          listeners.add(topic);
+            if (event == 'phx_leave') {
+              listeners.remove(topic);
+              return;
+            }
+            if (listeners.contains(topic)) {
+              return;
+            }
+            listeners.add(topic);
 
-          final String? realtimeFilter =
-              requestPayload['config']['postgres_changes'].first['filter'];
-          final bool isPrivate = requestPayload['config']['private'] as bool;
+            final String? realtimeFilter =
+                requestPayload['config']['postgres_changes'].first['filter'];
+            final bool isPrivate = requestPayload['config']['private'] as bool;
 
-          if (expectedFilter != null) {
-            expect(realtimeFilter, expectedFilter);
-          }
-          if (expectedPrivate != null) {
-            expect(isPrivate, expectedPrivate);
-          }
+            if (expectedFilter != null) {
+              expect(realtimeFilter, expectedFilter);
+            }
+            if (expectedPrivate != null) {
+              expect(isPrivate, expectedPrivate);
+            }
 
-          final replyString = jsonEncode([
-            null,
-            ref,
-            topic,
-            'phx_reply',
-            {
-              'response': {
-                'postgres_changes': [
-                  {
-                    'id': 77086988,
-                    'event': '*',
-                    'schema': 'public',
-                    'table': 'todos',
-                    if (realtimeFilter != null) 'filter': realtimeFilter,
-                  },
-                ]
+            final replyString = jsonEncode([
+              null,
+              ref,
+              topic,
+              'phx_reply',
+              {
+                'response': {
+                  'postgres_changes': [
+                    {
+                      'id': 77086988,
+                      'event': '*',
+                      'schema': 'public',
+                      'table': 'todos',
+                      if (realtimeFilter != null) 'filter': realtimeFilter,
+                    },
+                  ]
+                },
+                'status': 'ok'
               },
-              'status': 'ok'
-            },
-          ]);
-          webSocket!.add(replyString);
+            ]);
+            webSocket!.add(replyString);
 
-          // Send an insert event
-          await Future.delayed(Duration(milliseconds: 10));
-          final insertString = jsonEncode([
-            null,
-            null,
-            topic,
-            'postgres_changes',
-            {
-              'ids': [77086988],
-              'data': {
-                'commit_timestamp': '2021-08-01T08:00:20Z',
-                'record': {'id': 3, 'task': 'task 3', 'status': 't'},
-                'schema': 'public',
-                'table': 'todos',
-                'type': 'INSERT',
-                if (realtimeFilter != null) 'filter': realtimeFilter,
-                'columns': [
-                  {
-                    'name': 'id',
-                    'type': 'int4',
-                    'type_modifier': 4294967295,
-                  },
-                  {
-                    'name': 'task',
-                    'type': 'text',
-                    'type_modifier': 4294967295,
-                  },
-                  {
-                    'name': 'status',
-                    'type': 'bool',
-                    'type_modifier': 4294967295,
-                  },
-                ],
+            // Send an insert event
+            await Future.delayed(Duration(milliseconds: 10));
+            final insertString = jsonEncode([
+              null,
+              null,
+              topic,
+              'postgres_changes',
+              {
+                'ids': [77086988],
+                'data': {
+                  'commit_timestamp': '2021-08-01T08:00:20Z',
+                  'record': {'id': 3, 'task': 'task 3', 'status': 't'},
+                  'schema': 'public',
+                  'table': 'todos',
+                  'type': 'INSERT',
+                  if (realtimeFilter != null) 'filter': realtimeFilter,
+                  'columns': [
+                    {
+                      'name': 'id',
+                      'type': 'int4',
+                      'type_modifier': 4294967295,
+                    },
+                    {
+                      'name': 'task',
+                      'type': 'text',
+                      'type_modifier': 4294967295,
+                    },
+                    {
+                      'name': 'status',
+                      'type': 'bool',
+                      'type_modifier': 4294967295,
+                    },
+                  ],
+                },
               },
-            },
-          ]);
-          webSocket!.add(insertString);
+            ]);
+            webSocket!.add(insertString);
 
-          // Send an update event for id = 2
-          await Future.delayed(Duration(milliseconds: 10));
-          final updateString = jsonEncode([
-            null,
-            null,
-            topic,
-            'postgres_changes',
-            {
-              'ids': [77086988],
-              'data': {
-                'columns': [
-                  {'name': 'id', 'type': 'int4', 'type_modifier': 4294967295},
-                  {'name': 'task', 'type': 'text', 'type_modifier': 4294967295},
-                  {
-                    'name': 'status',
-                    'type': 'bool',
-                    'type_modifier': 4294967295
-                  },
-                ],
-                'commit_timestamp': '2021-08-01T08:00:30Z',
-                'errors': null,
-                'old_record': {'id': 2},
-                'record': {'id': 2, 'task': 'task 2 updated', 'status': 'f'},
-                'schema': 'public',
-                'table': 'todos',
-                'type': 'UPDATE',
-                if (realtimeFilter != null) 'filter': realtimeFilter,
+            // Send an update event for id = 2
+            await Future.delayed(Duration(milliseconds: 10));
+            final updateString = jsonEncode([
+              null,
+              null,
+              topic,
+              'postgres_changes',
+              {
+                'ids': [77086988],
+                'data': {
+                  'columns': [
+                    {'name': 'id', 'type': 'int4', 'type_modifier': 4294967295},
+                    {
+                      'name': 'task',
+                      'type': 'text',
+                      'type_modifier': 4294967295
+                    },
+                    {
+                      'name': 'status',
+                      'type': 'bool',
+                      'type_modifier': 4294967295
+                    },
+                  ],
+                  'commit_timestamp': '2021-08-01T08:00:30Z',
+                  'errors': null,
+                  'old_record': {'id': 2},
+                  'record': {'id': 2, 'task': 'task 2 updated', 'status': 'f'},
+                  'schema': 'public',
+                  'table': 'todos',
+                  'type': 'UPDATE',
+                  if (realtimeFilter != null) 'filter': realtimeFilter,
+                },
               },
-            },
-          ]);
-          webSocket!.add(updateString);
+            ]);
+            webSocket!.add(updateString);
 
-          // Send delete event for id=2
-          await Future.delayed(Duration(milliseconds: 10));
-          final deleteString = jsonEncode([
-            null,
-            null,
-            topic,
-            'postgres_changes',
-            {
-              'data': {
-                'columns': [
-                  {'name': 'id', 'type': 'int4', 'type_modifier': 4294967295},
-                  {'name': 'task', 'type': 'text', 'type_modifier': 4294967295},
-                  {
-                    'name': 'status',
-                    'type': 'bool',
-                    'type_modifier': 4294967295
-                  },
-                ],
-                'commit_timestamp': '2022-09-14T02:12:52Z',
-                'errors': null,
-                'old_record': {'id': 2},
-                'schema': 'public',
-                'table': 'todos',
-                'type': 'DELETE',
-                if (realtimeFilter != null) 'filter': realtimeFilter,
+            // Send delete event for id=2
+            await Future.delayed(Duration(milliseconds: 10));
+            final deleteString = jsonEncode([
+              null,
+              null,
+              topic,
+              'postgres_changes',
+              {
+                'data': {
+                  'columns': [
+                    {'name': 'id', 'type': 'int4', 'type_modifier': 4294967295},
+                    {
+                      'name': 'task',
+                      'type': 'text',
+                      'type_modifier': 4294967295
+                    },
+                    {
+                      'name': 'status',
+                      'type': 'bool',
+                      'type_modifier': 4294967295
+                    },
+                  ],
+                  'commit_timestamp': '2022-09-14T02:12:52Z',
+                  'errors': null,
+                  'old_record': {'id': 2},
+                  'schema': 'public',
+                  'table': 'todos',
+                  'type': 'DELETE',
+                  if (realtimeFilter != null) 'filter': realtimeFilter,
+                },
+                'ids': [77086988]
               },
-              'ids': [77086988]
-            },
-          ]);
-          webSocket!.add(deleteString);
+            ]);
+            webSocket!.add(deleteString);
 
-          /// Send an update event for id = 4
-          /// Record with id = 4 did not exist in the initial data fetch,
-          /// so the SDK should insert the record in the in memory cache
-          await Future.delayed(Duration(milliseconds: 10));
-          final updateId4 = jsonEncode([
-            null,
-            null,
-            topic,
-            'postgres_changes',
-            {
-              'ids': [77086988],
-              'data': {
-                'columns': [
-                  {'name': 'id', 'type': 'int4', 'type_modifier': 4294967295},
-                  {'name': 'task', 'type': 'text', 'type_modifier': 4294967295},
-                  {
-                    'name': 'status',
-                    'type': 'bool',
-                    'type_modifier': 4294967295
-                  },
-                ],
-                'commit_timestamp': '2021-08-01T08:00:30Z',
-                'errors': null,
-                'old_record': {'id': 4},
-                'record': {'id': 4, 'task': 'task 4', 'status': 't'},
-                'schema': 'public',
-                'table': 'todos',
-                'type': 'UPDATE',
-                if (realtimeFilter != null) 'filter': realtimeFilter,
+            /// Send an update event for id = 4
+            /// Record with id = 4 did not exist in the initial data fetch,
+            /// so the SDK should insert the record in the in memory cache
+            await Future.delayed(Duration(milliseconds: 10));
+            final updateId4 = jsonEncode([
+              null,
+              null,
+              topic,
+              'postgres_changes',
+              {
+                'ids': [77086988],
+                'data': {
+                  'columns': [
+                    {'name': 'id', 'type': 'int4', 'type_modifier': 4294967295},
+                    {
+                      'name': 'task',
+                      'type': 'text',
+                      'type_modifier': 4294967295
+                    },
+                    {
+                      'name': 'status',
+                      'type': 'bool',
+                      'type_modifier': 4294967295
+                    },
+                  ],
+                  'commit_timestamp': '2021-08-01T08:00:30Z',
+                  'errors': null,
+                  'old_record': {'id': 4},
+                  'record': {'id': 4, 'task': 'task 4', 'status': 't'},
+                  'schema': 'public',
+                  'table': 'todos',
+                  'type': 'UPDATE',
+                  if (realtimeFilter != null) 'filter': realtimeFilter,
+                },
               },
-            },
-          ]);
-          webSocket!.add(updateId4);
+            ]);
+            webSocket!.add(updateId4);
 
-          // Send delete event for id=5
-          /// Should be ignored by the SDK
-          await Future.delayed(Duration(milliseconds: 10));
-          final ignoredDeleteString = jsonEncode([
-            null,
-            null,
-            topic,
-            'postgres_changes',
-            {
-              'data': {
-                'columns': [
-                  {'name': 'id', 'type': 'int4', 'type_modifier': 4294967295},
-                  {'name': 'task', 'type': 'text', 'type_modifier': 4294967295},
-                  {
-                    'name': 'status',
-                    'type': 'bool',
-                    'type_modifier': 4294967295
-                  },
-                ],
-                'commit_timestamp': '2022-09-14T02:12:52Z',
-                'errors': null,
-                'old_record': {'id': 5},
-                'schema': 'public',
-                'table': 'todos',
-                'type': 'DELETE',
-                if (realtimeFilter != null) 'filter': realtimeFilter,
+            // Send delete event for id=5
+            /// Should be ignored by the SDK
+            await Future.delayed(Duration(milliseconds: 10));
+            final ignoredDeleteString = jsonEncode([
+              null,
+              null,
+              topic,
+              'postgres_changes',
+              {
+                'data': {
+                  'columns': [
+                    {'name': 'id', 'type': 'int4', 'type_modifier': 4294967295},
+                    {
+                      'name': 'task',
+                      'type': 'text',
+                      'type_modifier': 4294967295
+                    },
+                    {
+                      'name': 'status',
+                      'type': 'bool',
+                      'type_modifier': 4294967295
+                    },
+                  ],
+                  'commit_timestamp': '2022-09-14T02:12:52Z',
+                  'errors': null,
+                  'old_record': {'id': 5},
+                  'schema': 'public',
+                  'table': 'todos',
+                  'type': 'DELETE',
+                  if (realtimeFilter != null) 'filter': realtimeFilter,
+                },
+                'ids': [77086988]
               },
-              'ids': [77086988]
-            },
-          ]);
-          webSocket!.add(ignoredDeleteString);
+            ]);
+            webSocket!.add(ignoredDeleteString);
+          }());
         });
       } else {
         request.response.statusCode = HttpStatus.ok;
@@ -751,16 +769,16 @@ void main() {
         final errorServer = await HttpServer.bind('localhost', 0);
 
         // Setup server to return error for rest requests
-        errorServer.listen((request) async {
+        errorServer.listen((request) {
           if (request.uri.path.contains('/rest/')) {
             request.response
               ..statusCode = HttpStatus.unauthorized
               ..headers.contentType = ContentType.json
               ..write('{"error": "Unauthorized"}');
-            await request.response.close();
+            unawaited(request.response.close());
           } else {
             request.response.statusCode = HttpStatus.ok;
-            await request.response.close();
+            unawaited(request.response.close());
           }
         });
 

--- a/packages/supabase/test/utilities_test.dart
+++ b/packages/supabase/test/utilities_test.dart
@@ -1,5 +1,6 @@
 // ignore_for_file: deprecated_member_use_from_same_package
 
+import 'dart:async';
 import 'dart:io';
 
 import 'package:http/http.dart' as http;
@@ -91,12 +92,12 @@ void main() {
 
     setUp(() async {
       mockServer = await HttpServer.bind('localhost', 0);
-      mockServer.listen((request) async {
+      mockServer.listen((request) {
         request.response
           ..statusCode = HttpStatus.ok
           ..headers.contentType = ContentType.json
           ..write('{"success": true}');
-        await request.response.close();
+        unawaited(request.response.close());
       });
 
       authClient = AuthHttpClient(

--- a/packages/supabase_flutter/test/widget_test_stubs.dart
+++ b/packages/supabase_flutter/test/widget_test_stubs.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:dart_jsonwebtoken/dart_jsonwebtoken.dart';
@@ -23,10 +24,10 @@ class _MockWidgetState extends State<MockWidget> {
   Widget build(BuildContext context) {
     return isSignedIn
         ? TextButton(
-            onPressed: () async {
-              try {
-                await Supabase.instance.client.auth.signOut();
-              } catch (_) {}
+            onPressed: () {
+              unawaited(
+                Supabase.instance.client.auth.signOut().catchError((_) {}),
+              );
             },
             child: const Text('Sign out'),
           )

--- a/packages/supabase_lints/lib/analysis_options.yaml
+++ b/packages/supabase_lints/lib/analysis_options.yaml
@@ -27,7 +27,6 @@ dcm:
     avoid-missing-enum-constant-in-map: false
     avoid-never-passed-parameters: false
     avoid-nullable-interpolation: false
-    avoid-passing-async-when-sync-expected: false
     avoid-throw-in-catch-block: false
     avoid-unassigned-stream-subscriptions: false
     avoid-unconditional-break: false


### PR DESCRIPTION
> Stacked on top of #1454. Review/merge that one first; the base will retarget to `main` automatically once it lands.

## What

Enables the DCM rule [`avoid-passing-async-when-sync-expected`](https://dcm.dev/docs/rules/common/avoid-passing-async-when-sync-expected/) (removing it from the ratchet list in `supabase_lints`) and resolves the 13 resulting violations.

## Why

When an `async` callback is passed where a synchronous one is expected, the returned `Future` is discarded, so if it throws the error is silently lost. This is the same class of problem as the `unawaited_futures`/`discarded_futures` lints in #1454, just at call sites that take a callback. Enabling it closes the remaining async-safety gap.

## How

Each of the 13 sites was made synchronous, and the inner async work was either wrapped in `unawaited(...)` (genuine fire-and-forget) or extracted into a dedicated method, preserving existing behavior and error handling. Highlights:

- `realtime_channel.dart`: extracted the `joinPush.receive('ok', ...)` body into `_handleJoinOk(...)` (the `InvalidJWTToken` setAuth handling is preserved verbatim).
- `realtime_client.dart`: extracted reconnect into `_reconnect()`, heartbeat timer callback made sync with `unawaited(sendHeartbeat())`.
- `supabase_client.dart`: `onAuthStateChangeSync` listener made sync with `unawaited(_handleTokenChanged(...))`.
- `supabase_stream_builder.dart`: `onDone: controller.close` → `onDone: () => unawaited(controller.close())` in the asyncMap/asyncExpand reimplementations.
- Remaining sites are in test mock servers and a widget-test stub.

No public API signatures were changed.

## Verification

- `dcm analyze`: 0 `avoid-passing-async-when-sync-expected` across all packages.
- `dart analyze`: clean, no new `unawaited_futures`/`discarded_futures`.
- Tests: realtime_client (channel/socket/mock), supabase (mock/utilities), and supabase_flutter suites all pass.