### PR TITLE
docs: add Supabase logo to supabase_flutter README so it renders on pub.dev

### DIFF
--- a/packages/supabase_flutter/README.md
+++ b/packages/supabase_flutter/README.md
@@ -1,13 +1,28 @@
-# `supabase_flutter`
+<br />
+<p align="center">
+  <a href="https://supabase.com">
+    <img alt="Supabase Logo" width="300" src="https://raw.githubusercontent.com/supabase/supabase/master/packages/common/assets/images/logo-preview.jpg">
+  </a>
+
+  <h1 align="center">supabase_flutter</h1>
+
+  <p align="center">
+    Flutter client library for <a href="https://supabase.com">Supabase</a>.
+  </p>
+
+  <p align="center">
+    <a href="https://supabase.com/docs/guides/with-flutter">Guides</a>
+    ·
+    <a href="https://supabase.com/docs/reference/dart/introduction">Reference Docs</a>
+  </p>
+</p>
+
+<div align="center">
 
 [![pub package](https://img.shields.io/pub/v/supabase_flutter.svg)](https://pub.dev/packages/supabase_flutter)
 [![pub test](https://github.com/supabase/supabase-flutter/workflows/Test/badge.svg)](https://github.com/supabase/supabase-flutter/actions?query=workflow%3ATest)
 
----
-
-Flutter Client library for [Supabase](https://supabase.com/).
-
-- Documentation: https://supabase.com/docs/reference/dart/introduction
+</div>
 
 ## Getting Started
 


### PR DESCRIPTION
## What

Adds the Supabase logo to the top of the `supabase_flutter` package README using a single plain `<img>` tag.

## Why

The `supabase_flutter` package README had no logo on its pub.dev page. The approach used elsewhere (a `<picture>` element with `prefers-color-scheme` `<source>`s pointing at SVGs) does not render on pub.dev, since pub.dev does not render SVGs or `<picture>`/`<source>` elements in READMEs.

This follows the same pattern Flame uses: a single plain `<img>` pointing at a raster image. `logo-preview.jpg` carries its own dark background, so it reads well on both the light and dark pub.dev themes.

The header now matches the style used in `supabase-js` and `supabase_auth_ui`.