### PR TITLE
refactor(gotrue): extract PKCE code challenge generation into a helper

### DIFF
--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -245,20 +245,7 @@ class GoTrueClient {
     final Map<String, dynamic> response;
 
     if (email != null) {
-      String? codeChallenge;
-
-      if (_flowType == AuthFlowType.pkce) {
-        assert(
-          _asyncStorage != null,
-          'You need to provide asyncStorage to perform pkce flow.',
-        );
-        final codeVerifier = generatePKCEVerifier();
-        await _asyncStorage!.setItem(
-          key: '${Constants.defaultStorageKey}-code-verifier',
-          value: codeVerifier,
-        );
-        codeChallenge = generatePKCEChallenge(codeVerifier);
-      }
+      final codeChallenge = await _generatePKCECodeChallenge();
 
       response = await _fetch.request(
         '$_url/signup',
@@ -422,6 +409,30 @@ class GoTrueClient {
     return authSessionUrlResponse;
   }
 
+  /// Generates a PKCE code verifier, persists it, and returns the derived code
+  /// challenge.
+  ///
+  /// Returns `null` when the client is not using the PKCE flow. When
+  /// [storageEventName] is provided it is appended to the stored verifier so it
+  /// can be recovered in [exchangeCodeForSession].
+  Future<String?> _generatePKCECodeChallenge({String? storageEventName}) async {
+    if (_flowType != AuthFlowType.pkce) {
+      return null;
+    }
+    assert(
+      _asyncStorage != null,
+      'You need to provide asyncStorage to perform pkce flow.',
+    );
+    final codeVerifier = generatePKCEVerifier();
+    await _asyncStorage!.setItem(
+      key: '${Constants.defaultStorageKey}-code-verifier',
+      value: storageEventName == null
+          ? codeVerifier
+          : '$codeVerifier/$storageEventName',
+    );
+    return generatePKCEChallenge(codeVerifier);
+  }
+
   /// Allows signing in with an ID token issued by supported providers.
   /// Common supported providers include Apple, Google, Facebook, Kakao, and Keycloak.
   /// The [idToken] is verified for validity and a new session is established.
@@ -496,19 +507,7 @@ class GoTrueClient {
     OtpChannel channel = OtpChannel.sms,
   }) async {
     if (email != null) {
-      String? codeChallenge;
-      if (_flowType == AuthFlowType.pkce) {
-        assert(
-          _asyncStorage != null,
-          'You need to provide asyncStorage to perform pkce flow.',
-        );
-        final codeVerifier = generatePKCEVerifier();
-        await _asyncStorage!.setItem(
-          key: '${Constants.defaultStorageKey}-code-verifier',
-          value: codeVerifier,
-        );
-        codeChallenge = generatePKCEChallenge(codeVerifier);
-      }
+      final codeChallenge = await _generatePKCECodeChallenge();
       await _fetch.request(
         '$_url/otp',
         RequestMethodType.post,
@@ -645,21 +644,7 @@ class GoTrueClient {
       'providerId or domain has to be provided.',
     );
 
-    String? codeChallenge;
-    String? codeChallengeMethod;
-    if (_flowType == AuthFlowType.pkce) {
-      assert(
-        _asyncStorage != null,
-        'You need to provide asyncStorage to perform pkce flow.',
-      );
-      final codeVerifier = generatePKCEVerifier();
-      await _asyncStorage!.setItem(
-        key: '${Constants.defaultStorageKey}-code-verifier',
-        value: codeVerifier,
-      );
-      codeChallenge = generatePKCEChallenge(codeVerifier);
-      codeChallengeMethod = codeVerifier == codeChallenge ? 'plain' : 's256';
-    }
+    final codeChallenge = await _generatePKCECodeChallenge();
 
     final res = await _fetch.request(
       '$_url/sso',
@@ -673,7 +658,7 @@ class GoTrueClient {
             'gotrue_meta_security': {'captcha_token': captchaToken},
           'skip_http_redirect': true,
           'code_challenge': codeChallenge,
-          'code_challenge_method': codeChallengeMethod,
+          'code_challenge_method': codeChallenge != null ? 's256' : null,
         },
         headers: _headers,
       ),
@@ -996,19 +981,9 @@ class GoTrueClient {
     String? redirectTo,
     String? captchaToken,
   }) async {
-    String? codeChallenge;
-    if (_flowType == AuthFlowType.pkce) {
-      assert(
-        _asyncStorage != null,
-        'You need to provide asyncStorage to perform pkce flow.',
-      );
-      final codeVerifier = generatePKCEVerifier();
-      await _asyncStorage!.setItem(
-        key: '${Constants.defaultStorageKey}-code-verifier',
-        value: '$codeVerifier/${AuthChangeEvent.passwordRecovery.name}',
-      );
-      codeChallenge = generatePKCEChallenge(codeVerifier);
-    }
+    final codeChallenge = await _generatePKCECodeChallenge(
+      storageEventName: AuthChangeEvent.passwordRecovery.name,
+    );
 
     final body = {
       'email': email,
@@ -1303,24 +1278,13 @@ class GoTrueClient {
     if (queryParams != null) {
       urlParams.addAll(queryParams);
     }
-    if (_flowType == AuthFlowType.pkce) {
-      assert(
-        _asyncStorage != null,
-        'You need to provide asyncStorage to perform pkce flow.',
-      );
-      final codeVerifier = generatePKCEVerifier();
-      await _asyncStorage!.setItem(
-        key: '${Constants.defaultStorageKey}-code-verifier',
-        value: codeVerifier,
-      );
-
-      final codeChallenge = generatePKCEChallenge(codeVerifier);
-      final flowParams = {
+    final codeChallenge = await _generatePKCECodeChallenge();
+    if (codeChallenge != null) {
+      urlParams.addAll({
         'flow_type': _flowType.name,
         'code_challenge': codeChallenge,
         'code_challenge_method': 's256',
-      };
-      urlParams.addAll(flowParams);
+      });
     }
     if (skipBrowserRedirect) {
       urlParams['skip_http_redirect'] = 'true';

--- a/packages/postgrest/lib/src/postgrest_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_builder.dart
@@ -432,9 +432,7 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
     Function? onError,
   }) {
     if (onError != null &&
-        // ignore: avoid-unnecessary-type-assertions
         onError is! Function(Object, StackTrace) &&
-        // ignore: avoid-unnecessary-type-assertions
         onError is! Function(Object)) {
       return Future.error(ArgumentError.value(
         onError,


### PR DESCRIPTION
## What

The PKCE code-challenge generation logic was duplicated in five places in `gotrue_client.dart` (`signUp`, `signInWithOtp`, `getSSOSignInUrl`, `resetPasswordForEmail`, `_getUrlForProvider`). Each block:

1. checks `_flowType == AuthFlowType.pkce`
2. asserts `_asyncStorage != null`
3. generates a verifier, persists it, and derives the challenge

This extracts that into a single private helper:

```dart
Future<String?> _generatePKCECodeChallenge({String? storageEventName}) async { ... }
```

It returns `null` when not in the PKCE flow, and the optional `storageEventName` covers the one site (`resetPasswordForEmail`) that appends an event name to the stored verifier.

## Notes / behavior

- No behavior change. `getSSOSignInUrl` previously computed `code_challenge_method` as `codeVerifier == codeChallenge ? 'plain' : 's256'`; since `generatePKCEChallenge` always SHA-256-hashes the verifier, that comparison was never true, so the result was always `'s256'`. It now uses the same `codeChallenge != null ? 's256' : null` expression as the other call sites.
- The stored verifier format is preserved exactly (plain verifier, or `verifier/eventName` for password recovery), so `exchangeCodeForSession` recovery still works.

## Verification

- `dart analyze lib` passes with no issues.
- The PKCE unit tests in `client_test.dart` pass. (The integration tests that fail locally do so with `Connection refused` because they require a running local server, unrelated to this change.)

---
**Note:** This branch also includes a one-line removal of two stale `avoid-unnecessary-type-assertions` ignores in `postgrest_builder.dart`. They are flagged as unused by the DCM version used in CI (a pre-existing failure on `main`, present on every PR). Including it here keeps this PR's pipeline green; it can drop out cleanly once another PR carrying the same fix lands.