### PR TITLE
refactor(realtime_client): extract broadcast headers and body builders

### DIFF
--- a/packages/postgrest/lib/src/postgrest_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_builder.dart
@@ -432,9 +432,7 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
     Function? onError,
   }) {
     if (onError != null &&
-        // ignore: avoid-unnecessary-type-assertions
         onError is! Function(Object, StackTrace) &&
-        // ignore: avoid-unnecessary-type-assertions
         onError is! Function(Object)) {
       return Future.error(ArgumentError.value(
         onError,

--- a/packages/realtime_client/lib/src/realtime_channel.dart
+++ b/packages/realtime_client/lib/src/realtime_channel.dart
@@ -547,30 +547,10 @@ class RealtimeChannel {
     required Map<String, dynamic> payload,
     Duration? timeout,
   }) async {
-    // ignore: avoid-inferrable-type-arguments
-    final headers = <String, String>{
-      'Content-Type': 'application/json',
-      if (socket.params['apikey'] != null) 'apikey': socket.params['apikey']!,
-      ...socket.headers,
-      if (socket.accessToken != null)
-        'Authorization': 'Bearer ${socket.accessToken}',
-    };
-
-    final body = {
-      'messages': [
-        {
-          'topic': subTopic,
-          'event': event,
-          'payload': payload,
-          'private': _private,
-        }
-      ]
-    };
-
     final response = await (socket.httpClient?.post ?? post)(
       Uri.parse(broadcastEndpointURL),
-      headers: headers,
-      body: json.encode(body),
+      headers: _broadcastHeaders,
+      body: json.encode(_broadcastBody(event, payload)),
     ).timeout(
       timeout ?? _timeout,
       onTimeout: () => throw TimeoutException('Request timeout'),
@@ -640,29 +620,11 @@ class RealtimeChannel {
             'Please use httpSend() explicitly for REST delivery.',
       );
 
-      // ignore: avoid-inferrable-type-arguments
-      final headers = <String, String>{
-        'Content-Type': 'application/json',
-        if (socket.params['apikey'] != null) 'apikey': socket.params['apikey']!,
-        ...socket.headers,
-        if (socket.accessToken != null)
-          'Authorization': 'Bearer ${socket.accessToken}',
-      };
-      final body = {
-        'messages': [
-          {
-            'topic': subTopic,
-            'payload': payload,
-            'event': event,
-            'private': _private,
-          }
-        ]
-      };
       try {
         final response = await (socket.httpClient?.post ?? post)(
           Uri.parse(broadcastEndpointURL),
-          headers: headers,
-          body: json.encode(body),
+          headers: _broadcastHeaders,
+          body: json.encode(_broadcastBody(event, payload)),
         );
         if (200 <= response.statusCode && response.statusCode < 300) {
           completer.complete(ChannelResponse.ok);
@@ -704,6 +666,30 @@ class RealtimeChannel {
       });
     }
     return completer.future;
+  }
+
+  Map<String, String> get _broadcastHeaders => {
+        'Content-Type': 'application/json',
+        if (socket.params['apikey'] != null) 'apikey': socket.params['apikey']!,
+        ...socket.headers,
+        if (socket.accessToken != null)
+          'Authorization': 'Bearer ${socket.accessToken}',
+      };
+
+  Map<String, dynamic> _broadcastBody(
+    String? event,
+    Map<String, dynamic> payload,
+  ) {
+    return {
+      'messages': [
+        {
+          'topic': subTopic,
+          'event': event,
+          'payload': payload,
+          'private': _private,
+        }
+      ]
+    };
   }
 
   @internal


### PR DESCRIPTION
## What

`httpSend()` and the REST fallback inside `send()` built identical broadcast request headers and near-identical message bodies. This extracts the duplication into:

- `Map<String, String> get _broadcastHeaders`
- `Map<String, dynamic> _broadcastBody(String? event, Map<String, dynamic> payload)`

Both call sites now use these helpers.

## Notes

- No behavior change. The two body literals previously differed only in key order (`event`/`payload`), which is irrelevant for JSON encoding.
- The `// ignore: avoid-inferrable-type-arguments` comments are no longer needed since the map literal type is now inferred from the getter's return type.

## Verification

- `dart analyze lib` and `dcm analyze` pass with no issues.
- All realtime_client unit tests pass. (The integration test fails locally only because it needs a running realtime server: `Connection refused`.)

---
**Note:** This branch also includes a one-line removal of two stale `avoid-unnecessary-type-assertions` ignores in `postgrest_builder.dart`. They are flagged as unused by the DCM version used in CI (a pre-existing failure on `main`, present on every PR). Including it here keeps this PR's pipeline green; it can drop out cleanly once another PR carrying the same fix lands.