### PR TITLE
refactor: dedupe bucket payload and OAuth launch logic

### DIFF
--- a/packages/postgrest/lib/src/postgrest_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_builder.dart
@@ -432,9 +432,7 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
     Function? onError,
   }) {
     if (onError != null &&
-        // ignore: avoid-unnecessary-type-assertions
         onError is! Function(Object, StackTrace) &&
-        // ignore: avoid-unnecessary-type-assertions
         onError is! Function(Object)) {
       return Future.error(ArgumentError.value(
         onError,

--- a/packages/storage_client/lib/src/storage_bucket_api.dart
+++ b/packages/storage_client/lib/src/storage_bucket_api.dart
@@ -13,6 +13,18 @@ class StorageBucketApi {
     storageFetch = Fetch(httpClient);
   }
 
+  Map<String, dynamic> _bucketPayload(String id, BucketOptions bucketOptions) {
+    return {
+      'id': id,
+      'name': id,
+      'public': bucketOptions.public,
+      if (bucketOptions.fileSizeLimit != null)
+        'file_size_limit': bucketOptions.fileSizeLimit,
+      if (bucketOptions.allowedMimeTypes != null)
+        'allowed_mime_types': bucketOptions.allowedMimeTypes,
+    };
+  }
+
   /// Retrieves the details of all Storage buckets within an existing project.
   Future<List<Bucket>> listBuckets() async {
     final FetchOptions options = FetchOptions(headers: headers);
@@ -58,15 +70,7 @@ class StorageBucketApi {
     final FetchOptions options = FetchOptions(headers: headers);
     final response = await storageFetch.post(
       '$url/bucket',
-      {
-        'id': id,
-        'name': id,
-        'public': bucketOptions.public,
-        if (bucketOptions.fileSizeLimit != null)
-          'file_size_limit': bucketOptions.fileSizeLimit,
-        if (bucketOptions.allowedMimeTypes != null)
-          'allowed_mime_types': bucketOptions.allowedMimeTypes,
-      },
+      _bucketPayload(id, bucketOptions),
       options: options,
     );
     final bucketId = (response as Map<String, dynamic>)['name'] as String;
@@ -85,15 +89,7 @@ class StorageBucketApi {
     final FetchOptions options = FetchOptions(headers: headers);
     final response = await storageFetch.put(
       '$url/bucket/$id',
-      {
-        'id': id,
-        'name': id,
-        'public': bucketOptions.public,
-        if (bucketOptions.fileSizeLimit != null)
-          'file_size_limit': bucketOptions.fileSizeLimit,
-        if (bucketOptions.allowedMimeTypes != null)
-          'allowed_mime_types': bucketOptions.allowedMimeTypes,
-      },
+      _bucketPayload(id, bucketOptions),
       options: options,
     );
     final message = (response as Map<String, dynamic>)['message'] as String;

--- a/packages/supabase_flutter/lib/src/supabase_auth.dart
+++ b/packages/supabase_flutter/lib/src/supabase_auth.dart
@@ -321,7 +321,17 @@ extension GoTrueClientSignInProvider on GoTrueClient {
       scopes: scopes,
       queryParams: queryParams,
     );
-    final uri = Uri.parse(res.url);
+    return _launchAuthUrl(res.url, provider, authScreenLaunchMode);
+  }
+
+  /// Launches the [url] for an OAuth or identity-linking flow, forcing an
+  /// external browser for Google on Android.
+  Future<bool> _launchAuthUrl(
+    String url,
+    OAuthProvider provider,
+    LaunchMode authScreenLaunchMode,
+  ) {
+    final uri = Uri.parse(url);
 
     LaunchMode launchMode = authScreenLaunchMode;
 
@@ -333,12 +343,11 @@ extension GoTrueClientSignInProvider on GoTrueClient {
       launchMode = LaunchMode.externalApplication;
     }
 
-    final result = await launchUrl(
+    return launchUrl(
       uri,
       mode: launchMode,
       webOnlyWindowName: '_self',
     );
-    return result;
   }
 
   /// Attempts a single-sign on using an enterprise Identity Provider. A
@@ -402,23 +411,6 @@ extension GoTrueClientSignInProvider on GoTrueClient {
       scopes: scopes,
       queryParams: queryParams,
     );
-    final uri = Uri.parse(res.url);
-
-    LaunchMode launchMode = authScreenLaunchMode;
-
-    // `Platform.isAndroid` throws on web, so adding a guard for web here.
-    final isAndroid = !kIsWeb && Platform.isAndroid;
-
-    // Google login has to be performed on external browser window on Android
-    if (provider == OAuthProvider.google && isAndroid) {
-      launchMode = LaunchMode.externalApplication;
-    }
-
-    final result = await launchUrl(
-      uri,
-      mode: launchMode,
-      webOnlyWindowName: '_self',
-    );
-    return result;
+    return _launchAuthUrl(res.url, provider, authScreenLaunchMode);
   }
 }


### PR DESCRIPTION
## What

Two more duplicated blocks extracted into helpers:

- **`storage_client`** — `createBucket` and `updateBucket` built the same request payload map. Extracted into `_bucketPayload(id, bucketOptions)`.
- **`supabase_flutter`** — `signInWithOAuth` and `linkIdentity` had identical launch logic (parse URL, force external browser for Google on Android, `launchUrl`). Extracted into `_launchAuthUrl(url, provider, authScreenLaunchMode)`.

No behavior change.

## Verification

- `dart analyze lib` and `dcm analyze` pass with no issues for both packages.
- All `supabase_flutter` tests pass (51) and all `storage_client` unit tests pass. (The storage integration tests fail locally only because they need a running storage server: `Connection refused`.)

---
**Note:** This branch also removes two stale `avoid-unnecessary-type-assertions` ignores in `postgrest_builder.dart`. They are flagged as unused by the DCM version used in CI (a pre-existing failure on `main`, present on every PR). Including it keeps this PR's pipeline green; it drops out cleanly once another PR carrying the same fix lands.