### PR TITLE
chore: align package README names, harden headers getter, simplify forEach loops

### DIFF
--- a/packages/gotrue/README.md
+++ b/packages/gotrue/README.md
@@ -1,4 +1,4 @@
-# `gotrue-dart`
+# gotrue
 
 Dart client for the [GoTrue](https://github.com/supabase/gotrue) API.
 

--- a/packages/postgrest/lib/src/postgrest_filter_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_filter_builder.dart
@@ -470,7 +470,9 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   /// ```
   PostgrestFilterBuilder<T> match(Map<String, Object> query) {
     var url = _url;
-    query.forEach((k, v) => url = appendSearchParams(k, 'eq.$v', url));
+    for (final entry in query.entries) {
+      url = appendSearchParams(entry.key, 'eq.${entry.value}', url);
+    }
     return copyWithUrl(url);
   }
 

--- a/packages/realtime_client/README.md
+++ b/packages/realtime_client/README.md
@@ -1,4 +1,4 @@
-# `realtime-dart`
+# realtime_client
 
 Listens to changes in a PostgreSQL Database and via websockets.
 

--- a/packages/realtime_client/lib/src/transformers.dart
+++ b/packages/realtime_client/lib/src/transformers.dart
@@ -80,9 +80,9 @@ Map<String, dynamic> convertChangeData(
     }
   }
 
-  record.forEach((key, value) {
+  for (final key in record.keys) {
     result[key] = convertColumn(key, parsedColumns, record, skipTypes ?? []);
-  });
+  }
   return result;
 }
 

--- a/packages/storage_client/README.md
+++ b/packages/storage_client/README.md
@@ -1,4 +1,4 @@
-# `storage-dart`
+# storage_client
 
 Dart client library to interact with Supabase Storage.
 

--- a/packages/supabase/README.md
+++ b/packages/supabase/README.md
@@ -1,4 +1,4 @@
-# `supabase-dart`
+# supabase
 
 A Dart client for [Supabase](https://supabase.io/).
 

--- a/packages/supabase/lib/src/supabase_client.dart
+++ b/packages/supabase/lib/src/supabase_client.dart
@@ -75,9 +75,7 @@ class SupabaseClient {
   final _log = Logger('supabase.supabase');
 
   /// Getter for the HTTP headers
-  Map<String, String> get headers {
-    return _headers;
-  }
+  Map<String, String> get headers => Map.unmodifiable(_headers);
 
   /// To apply the new headers in existing realtime channels, manually unsubscribe and resubscribe these channels.
   set headers(Map<String, String> newHeaders) {


### PR DESCRIPTION
## What

A small batch of cleanups in the same spirit as #1458 / the recent `functions_client` simplifications.

- **README headings**: `gotrue`, `realtime_client`, `storage_client`, and `supabase` still used the old `*-dart` repo slugs in their first heading. Aligned them to the actual pub package name (matching the earlier `functions-dart` → `functions_client` fix).
- **`SupabaseClient.headers`**: was `get headers { return _headers; }`, returning the internal map directly. Now returns `Map.unmodifiable(_headers)` with arrow syntax, mirroring `functions_client`. This prevents callers from mutating the returned map and silently desyncing from the internal state (header changes must go through the `headers=` setter, which propagates to all sub-clients).
- **`forEach` closures → plain loops**:
  - `postgrest_filter_builder.match()`: dropped the reassign-inside-closure `query.forEach((k, v) => url = ...)` for a `for` loop.
  - `realtime_client` `transformers.convertChangeData`: `record.forEach((key, value) {...})` had an unused `value` parameter → `for (final key in record.keys)`.

## Why

Consistency across package READMEs, and closing a small footgun on the public `headers` getter so external mutation can't quietly diverge from what the sub-clients actually send.

## Verification

- `dart format --set-exit-if-changed`: clean
- `dart analyze lib` on postgrest, realtime_client, supabase: no issues
- Tests: supabase `client_test` (incl. Headers Management), `utilities_test`, `mock_test`, and realtime `transformers_test` pass. Pre-existing integration tests that require a local server are unaffected.

## Note on the `headers` change

This is technically a behavior change on a public getter: external `client.headers['x'] = y` previously no-op'd (the mutation was lost) and now throws. The supported path to change headers remains the `headers=` setter.