### PR TITLE
feat(realtime): update httpSend to per-event broadcast URL with binary support

### DIFF
--- a/packages/realtime_client/lib/src/realtime_channel.dart
+++ b/packages/realtime_client/lib/src/realtime_channel.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:typed_data';
 
 import 'package:http/http.dart';
 import 'package:meta/meta.dart';
@@ -525,9 +526,14 @@ class RealtimeChannel {
   /// This method always uses the REST API endpoint regardless of WebSocket connection state.
   /// Useful when you want to guarantee REST delivery or when gradually migrating from implicit REST fallback.
   ///
+  /// Payloads that are [TypedData] (e.g. [Uint8List]) or [ByteBuffer] are sent
+  /// as `application/octet-stream`; all other payloads are JSON-encoded.
+  ///
   /// [event] is the name of the broadcast event.
   /// [payload] is the payload to be sent (required).
   /// [timeout] is an optional timeout duration.
+  ///
+  /// Requires a Realtime server running v2.97.0 or newer.
   ///
   /// Returns a [Future] that resolves when the message is sent successfully,
   /// or throws an error if the message fails to send.
@@ -544,20 +550,43 @@ class RealtimeChannel {
   /// ```
   Future<void> httpSend({
     required String event,
-    required Map<String, dynamic> payload,
+    required Object payload,
     Duration? timeout,
   }) async {
-    final response = await (socket.httpClient?.post ?? post)(
-      Uri.parse(broadcastEndpointURL),
-      headers: _broadcastHeaders,
-      body: json.encode(_broadcastBody(event, payload)),
-    ).timeout(
+    final isBinary = payload is TypedData || payload is ByteBuffer;
+
+    final headers = {
+      ..._broadcastHeaders,
+      'Content-Type':
+          isBinary ? 'application/octet-stream' : 'application/json',
+    };
+
+    final url = Uri.parse(
+      '$broadcastEndpointURL'
+      '/${Uri.encodeComponent(subTopic)}'
+      '/events/${Uri.encodeComponent(event)}'
+      '${_private ? '?private=true' : ''}',
+    );
+
+    final body = isBinary ? _asBytes(payload) : json.encode(payload);
+
+    final response = await (socket.httpClient?.post ?? post)(url,
+            headers: headers, body: body)
+        .timeout(
       timeout ?? _timeout,
       onTimeout: () => throw TimeoutException('Request timeout'),
     );
 
     if (response.statusCode == 202) {
       return;
+    }
+
+    if (response.statusCode == 404) {
+      throw Exception(
+        'httpSend() requires Realtime server v2.97.0 or newer; the endpoint '
+        'returned 404. Update your Supabase CLI to a recent version, or upgrade '
+        'the Realtime server in your self-hosted setup.',
+      );
     }
 
     String errorMessage = response.reasonPhrase ?? 'Unknown error';
@@ -571,6 +600,14 @@ class RealtimeChannel {
     }
 
     throw Exception(errorMessage);
+  }
+
+  Uint8List _asBytes(Object payload) {
+    if (payload is ByteBuffer) {
+      return payload.asUint8List();
+    }
+    final typed = payload as TypedData;
+    return typed.buffer.asUint8List(typed.offsetInBytes, typed.lengthInBytes);
   }
 
   /// Sends a realtime broadcast message.

--- a/packages/realtime_client/lib/src/realtime_channel.dart
+++ b/packages/realtime_client/lib/src/realtime_channel.dart
@@ -526,11 +526,13 @@ class RealtimeChannel {
   /// This method always uses the REST API endpoint regardless of WebSocket connection state.
   /// Useful when you want to guarantee REST delivery or when gradually migrating from implicit REST fallback.
   ///
-  /// Payloads that are [TypedData] (e.g. [Uint8List]) or [ByteBuffer] are sent
-  /// as `application/octet-stream`; all other payloads are JSON-encoded.
+  /// [payload] must be either a `Map<String, dynamic>`, which is JSON-encoded,
+  /// or binary data ([TypedData] such as [Uint8List], or [ByteBuffer]), which
+  /// is sent as `application/octet-stream`. Map payloads keep `httpSend`
+  /// consistent with [onBroadcast], which delivers received payloads as
+  /// `Map<String, dynamic>`.
   ///
   /// [event] is the name of the broadcast event.
-  /// [payload] is the payload to be sent (required).
   /// [timeout] is an optional timeout duration.
   ///
   /// Requires a Realtime server running v2.97.0 or newer.
@@ -554,6 +556,12 @@ class RealtimeChannel {
     Duration? timeout,
   }) async {
     final isBinary = payload is TypedData || payload is ByteBuffer;
+
+    assert(
+      isBinary || payload is Map<String, dynamic>,
+      'httpSend payload must be a Map<String, dynamic> or binary '
+      '(TypedData/ByteBuffer)',
+    );
 
     final headers = {
       ..._broadcastHeaders,

--- a/packages/realtime_client/test/channel_test.dart
+++ b/packages/realtime_client/test/channel_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:realtime_client/realtime_client.dart';
 import 'package:realtime_client/src/constants.dart';
@@ -758,15 +759,110 @@ void main() {
           channel.httpSend(event: 'test', payload: {'myKey': 'myValue'});
 
       final req = await requestFuture;
-      expect(req.uri.toString(), '/realtime/v1/api/broadcast');
+      expect(req.uri.path, '/realtime/v1/api/broadcast/myTopic/events/test');
+      expect(req.uri.queryParameters['private'], 'true');
       expect(req.headers.value('apikey'), 'supabaseKey');
+      expect(req.headers.contentType?.mimeType, 'application/json');
 
       final body = json.decode(await utf8.decodeStream(req));
-      final message = body['messages'][0];
-      expect(message['topic'], 'myTopic');
-      expect(message['event'], 'test');
-      expect(message['payload'], {'myKey': 'myValue'});
-      expect(message['private'], isTrue);
+      expect(body, {'myKey': 'myValue'});
+
+      req.response.statusCode = 202;
+      await req.response.close();
+
+      await sendFuture;
+    });
+
+    test('omits private query parameter for public channels', () async {
+      socket = RealtimeClient(
+        'ws://${mockServer.address.host}:${mockServer.port}/realtime/v1',
+        headers: {'apikey': 'supabaseKey'},
+        params: {'apikey': 'supabaseKey'},
+      );
+      channel = socket.channel('myTopic');
+
+      final requestFuture = mockServer.first;
+      final sendFuture =
+          channel.httpSend(event: 'test', payload: {'myKey': 'myValue'});
+
+      final req = await requestFuture;
+      expect(req.uri.path, '/realtime/v1/api/broadcast/myTopic/events/test');
+      expect(req.uri.queryParameters.containsKey('private'), isFalse);
+
+      req.response.statusCode = 202;
+      await req.response.close();
+
+      await sendFuture;
+    });
+
+    test('URL-encodes topic and event names with special characters', () async {
+      socket = RealtimeClient(
+        'ws://${mockServer.address.host}:${mockServer.port}/realtime/v1',
+        headers: {'apikey': 'supabaseKey'},
+        params: {'apikey': 'supabaseKey'},
+      );
+      channel = socket.channel('room:42');
+
+      final requestFuture = mockServer.first;
+      final sendFuture =
+          channel.httpSend(event: 'user/joined', payload: {'id': 1});
+
+      final req = await requestFuture;
+      expect(
+        req.uri.toString(),
+        contains('/api/broadcast/room%3A42/events/user%2Fjoined'),
+      );
+
+      req.response.statusCode = 202;
+      await req.response.close();
+
+      await sendFuture;
+    });
+
+    test('sends Uint8List payload as application/octet-stream', () async {
+      socket = RealtimeClient(
+        'ws://${mockServer.address.host}:${mockServer.port}/realtime/v1',
+        headers: {'apikey': 'supabaseKey'},
+        params: {'apikey': 'supabaseKey'},
+      );
+      channel = socket.channel('myTopic');
+
+      final bytes = Uint8List.fromList([1, 2, 3, 4]);
+      final requestFuture = mockServer.first;
+      final sendFuture = channel.httpSend(event: 'bin', payload: bytes);
+
+      final req = await requestFuture;
+      expect(req.uri.path, '/realtime/v1/api/broadcast/myTopic/events/bin');
+      expect(req.headers.contentType?.mimeType, 'application/octet-stream');
+
+      final received = await req
+          .fold<List<int>>(<int>[], (acc, chunk) => acc..addAll(chunk));
+      expect(received, equals(bytes));
+
+      req.response.statusCode = 202;
+      await req.response.close();
+
+      await sendFuture;
+    });
+
+    test('sends ByteBuffer payload as application/octet-stream', () async {
+      socket = RealtimeClient(
+        'ws://${mockServer.address.host}:${mockServer.port}/realtime/v1',
+        headers: {'apikey': 'supabaseKey'},
+        params: {'apikey': 'supabaseKey'},
+      );
+      channel = socket.channel('myTopic');
+
+      final bytes = Uint8List.fromList([10, 20, 30]);
+      final requestFuture = mockServer.first;
+      final sendFuture = channel.httpSend(event: 'bin', payload: bytes.buffer);
+
+      final req = await requestFuture;
+      expect(req.headers.contentType?.mimeType, 'application/octet-stream');
+
+      final received = await req
+          .fold<List<int>>(<int>[], (acc, chunk) => acc..addAll(chunk));
+      expect(received, equals(bytes));
 
       req.response.statusCode = 202;
       await req.response.close();


### PR DESCRIPTION
## What

Brings `RealtimeChannel.httpSend()` to parity with supabase-js ([supabase/supabase-js#2400](https://github.com/supabase/supabase-js/pull/2400)).

- Uses the new per-event URL format `POST /api/broadcast/{topic}/events/{event}` instead of the old `POST /api/broadcast` with a `messages` array wrapper.
- Adds `?private=true` query parameter for private channels.
- URL-encodes the topic and event names.
- Sends the payload directly (no `messages` wrapper).
- `TypedData` (e.g. `Uint8List`) and `ByteBuffer` payloads are sent as `application/octet-stream`; everything else is JSON-encoded.
- Returns a clearer error when the server responds with 404 (server too old).

The implicit REST fallback in `send()` is intentionally left on the old format, matching supabase-js, which only changed `httpSend()`.

## Compatibility

- The `payload` parameter type widens from `Map<String, dynamic>` to `Object` to allow binary payloads. This is backward compatible: existing calls passing a map still compile.
- The new endpoint requires Realtime server **v2.97.0+** ([supabase/realtime#1864](https://github.com/supabase/realtime/pull/1864)). This matches supabase-js, which shipped the same change as a minor `feat`.

## Test plan

- Updated `httpSend` tests for the new URL format and direct payload body.
- Added tests for the `private` query parameter (present for private, absent for public), URL-encoding of special characters, and `Uint8List`/`ByteBuffer` binary payloads.

Closes SDK-1018