### PR TITLE
test(gotrue): model real email_change first-confirmation response in verifyOTP

### DIFF
--- a/packages/gotrue/test/mocks/otp_mock_client.dart
+++ b/packages/gotrue/test/mocks/otp_mock_client.dart
@@ -451,19 +451,16 @@ class CustomServerErrorClient extends BaseClient {
 }
 
 /// Custom HTTP client for testing null session
+/// Models the first confirmation of a secure email change, where GoTrue
+/// returns a `200` with `{msg, code}` and neither a user nor a session.
 class NullSessionClient extends BaseClient {
-  final String email;
-
-  NullSessionClient(this.email);
-
   @override
   Future<StreamedResponse> send(BaseRequest request) async {
     return StreamedResponse(
       Stream.value(utf8.encode(jsonEncode({
-        'user': {
-          'id': 'user-id',
-          'email': email,
-        },
+        'msg': 'Confirmation link accepted. Please proceed to confirm link '
+            'sent to the other email',
+        'code': 200,
       }))),
       200,
       request: request,

--- a/packages/gotrue/test/otp_mock_test.dart
+++ b/packages/gotrue/test/otp_mock_test.dart
@@ -479,13 +479,14 @@ void main() {
         () async {
       final client = GoTrueClient(
         url: 'https://example.com',
-        httpClient: NullSessionClient(testEmail),
+        httpClient: NullSessionClient(),
         asyncStorage: TestAsyncStorage(),
       );
 
-      // Verifying the first OTP of a secure email change does not return a
-      // session. This should not throw, the intermediate response is returned
-      // so the second OTP can subsequently be verified.
+      // Verifying the first OTP of a secure email change returns a `{msg, code}`
+      // payload with neither a user nor a session. This should not throw, the
+      // intermediate response is returned so the second OTP can subsequently be
+      // verified.
       final response = await client.verifyOTP(
         email: testEmail,
         token: '123456',
@@ -493,6 +494,7 @@ void main() {
       );
 
       expect(response.session, isNull);
+      expect(response.user, isNull);
     });
   });
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Test improvement (verifies an already-correct behavior).

Resolves SDK-1020.

## Triage notes

SDK-1020 is an auto-generated parity issue mirroring two `supabase-js` fixes:

1. **`verifyOtp({type: 'email_change'})` first confirmation** should return `{user: null, session: null}` when GoTrue replies `200` with `{msg, code}`.
2. **`signUp()` when confirmation is required** should return `{user: <User>, session: null}` when GoTrue returns the bare user (no `access_token`).

Both behaviors are **already correct** in supabase-flutter, because the Dart models are null-safe by design:

- `Session.fromJson` returns `null` when there is no `access_token`.
- `User.fromJson` returns `null` when there is no `id`.
- `AuthResponse.fromJson` composes the two, so `{msg, code}` yields `{user: null, session: null}` and a bare user yields `{user: <User>, session: null}`.

Fix 1 was additionally hardened in #1448 (verifyOTP no longer throws on a null session). Fix 2 is already covered by the existing `signUp() with autoConfirm off with email` test, which asserts a null session and a non-null user.

## What does this PR change?

The only gap against the acceptance criteria was that the email_change verifyOTP test used an unrealistic mock body (`{user: {id, email}}`) and never asserted the user was null. This PR:

- Updates `NullSessionClient` to return the real GoTrue first-confirmation payload (`{msg, code}`, no user, no session).
- Asserts `verifyOTP` returns both a null user and a null session for that shape.

No production code changes, no API surface changes, non-breaking.