### PR TITLE
fix(gotrue): include code challenge in resend with PKCE flow

### DIFF
--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -734,11 +734,18 @@ class GoTrueClient {
       );
     }
 
+    final codeChallenge =
+        email != null ? await _generatePKCECodeChallenge() : null;
+
     final body = {
       if (email != null) 'email': email,
       if (phone != null) 'phone': phone,
       'type': type.snakeCase,
       'gotrue_meta_security': {'captcha_token': captchaToken},
+      if (email != null) ...{
+        'code_challenge': codeChallenge,
+        'code_challenge_method': codeChallenge != null ? 's256' : null,
+      },
     };
 
     final options = GotrueRequestOptions(

--- a/packages/gotrue/test/mocks/otp_mock_client.dart
+++ b/packages/gotrue/test/mocks/otp_mock_client.dart
@@ -10,6 +10,8 @@ class OtpMockClient extends BaseClient {
   final String accessToken;
   final String refreshToken;
 
+  Map<String, dynamic>? lastResendBody;
+
   OtpMockClient({
     this.phoneNumber = '+11234567890',
     this.email = 'test@example.com',
@@ -264,6 +266,7 @@ class OtpMockClient extends BaseClient {
   }
 
   StreamedResponse _handleResend(Map<String, dynamic>? requestBody) {
+    lastResendBody = requestBody;
     return StreamedResponse(
       Stream.value(utf8.encode(jsonEncode({
         'message': 'OTP resent',

--- a/packages/gotrue/test/otp_mock_test.dart
+++ b/packages/gotrue/test/otp_mock_test.dart
@@ -280,6 +280,46 @@ void main() {
       expect(response, isA<ResendResponse>());
     });
 
+    test('resend() with email in PKCE flow includes code challenge', () async {
+      await client.resend(
+        email: testEmail,
+        type: OtpType.signup,
+      );
+
+      expect(mockClient.lastResendBody?['code_challenge'], isNotNull);
+      expect(mockClient.lastResendBody?['code_challenge_method'], 's256');
+    });
+
+    test('resend() with phone does not include code challenge', () async {
+      await client.resend(
+        phone: testPhone,
+        type: OtpType.sms,
+      );
+
+      expect(mockClient.lastResendBody?.containsKey('code_challenge'), isFalse);
+      expect(
+        mockClient.lastResendBody?.containsKey('code_challenge_method'),
+        isFalse,
+      );
+    });
+
+    test('resend() with email in implicit flow omits code challenge', () async {
+      final implicitClient = GoTrueClient(
+        url: 'https://example.com',
+        httpClient: mockClient,
+        asyncStorage: asyncStorage,
+        flowType: AuthFlowType.implicit,
+      );
+
+      await implicitClient.resend(
+        email: testEmail,
+        type: OtpType.signup,
+      );
+
+      expect(mockClient.lastResendBody?['code_challenge'], isNull);
+      expect(mockClient.lastResendBody?['code_challenge_method'], isNull);
+    });
+
     test('resend() with wrong type for phone throws', () async {
       await expectLater(
         () => client.resend(


### PR DESCRIPTION
## What

When `resend()` is called with an `email` while the client uses the PKCE flow (the default), the `POST /resend` request now includes `code_challenge` and `code_challenge_method`. Without the code challenge, the resent confirmation link cannot be completed via `exchangeCodeForSession`.

This brings the Dart SDK to parity with the supabase-js behavior.

## Behavior

- `resend(email:)` in PKCE flow includes `code_challenge` + `code_challenge_method: s256` in the body.
- Phone resend is unchanged (no code challenge).
- Implicit (non-PKCE) flow is unchanged (fields are null).

## Tests

Added tests covering all three cases above in `otp_mock_test.dart`, and captured the resend body in the OTP mock client for assertions.

Closes SDK-1023

https://linear.app/supabase/issue/SDK-1023/parityauth-resend-with-pkce-flow-should-include-code-challenge-in