### PR TITLE
fix(auth): recognize error query parameter in auth callback redirects

### DIFF
--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -884,8 +884,12 @@ class GoTrueClient {
     final errorDescription = url.queryParameters['error_description'];
     final errorCode = url.queryParameters['error_code'];
     final error = url.queryParameters['error'];
-    if (errorDescription != null) {
-      throw AuthException(errorDescription, statusCode: errorCode, code: error);
+    if (error != null || errorDescription != null || errorCode != null) {
+      throw AuthException(
+        errorDescription ?? 'Error in URL with unspecified error_description',
+        statusCode: errorCode,
+        code: error,
+      );
     }
 
     final authCode = url.queryParameters['code'];

--- a/packages/gotrue/test/provider_test.dart
+++ b/packages/gotrue/test/provider_test.dart
@@ -132,5 +132,20 @@ void main() {
             .having((e) => e.message, 'message', errorDesc)),
       );
     });
+
+    test('parse provider callback url with error query parameter', () async {
+      await expectLater(
+        () async {
+          const url =
+              'http://my-callback-url.com?error=access_denied&error_code=403';
+          await client.getSessionFromUrl(Uri.parse(url));
+        },
+        throwsA(isA<AuthException>()
+            .having((e) => e.code, 'code', 'access_denied')
+            .having((e) => e.statusCode, 'statusCode', '403')
+            .having((e) => e.message, 'message',
+                'Error in URL with unspecified error_description')),
+      );
+    });
   });
 }

--- a/packages/supabase_flutter/lib/src/supabase_auth.dart
+++ b/packages/supabase_flutter/lib/src/supabase_auth.dart
@@ -195,6 +195,8 @@ class SupabaseAuth with WidgetsBindingObserver {
 
     return hasParameter('access_token') ||
         hasParameter('code') ||
+        hasParameter('error') ||
+        hasParameter('error_code') ||
         hasParameter('error_description');
   }
 

--- a/packages/supabase_flutter/test/deep_link_test.dart
+++ b/packages/supabase_flutter/test/deep_link_test.dart
@@ -3,6 +3,8 @@
 /// Tests for deep link handling on non-browser platforms.
 library;
 
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
@@ -96,6 +98,49 @@ void main() {
         Supabase.instance.client.auth.currentUser?.email,
         'new@email.com',
       );
+    });
+  });
+
+  group('Deep Link with error query parameter', () {
+    late final Completer<AuthException> errorCompleter;
+
+    setUp(() async {
+      errorCompleter = Completer<AuthException>();
+
+      mockAppLink(
+        mockMethodChannel: false,
+        mockEventChannel: true,
+        initialLink: 'com.supabase://callback/?error=access_denied'
+            '&error_code=403',
+      );
+      await Supabase.initialize(
+        url: supabaseUrl,
+        publishableKey: supabaseKey,
+        debug: false,
+        httpClient: GetUserHttpClient('new@email.com'),
+        authOptions: FlutterAuthClientOptions(
+          localStorage: const MockEmptyLocalStorage(),
+          pkceAsyncStorage: MockAsyncStorage(),
+        ),
+      );
+
+      Supabase.instance.client.auth.onAuthStateChange.listen(
+        (_) {},
+        onError: (error) {
+          if (error is AuthException && !errorCompleter.isCompleted) {
+            errorCompleter.complete(error);
+          }
+        },
+      );
+    });
+
+    test(
+        'Error query parameter triggers `getSessionFromUrl` and surfaces an '
+        'AuthException', () async {
+      final exception =
+          await errorCompleter.future.timeout(const Duration(seconds: 5));
+      expect(exception.code, 'access_denied');
+      expect(exception.statusCode, '403');
     });
   });
 }


### PR DESCRIPTION
## What

OAuth error redirects can arrive as query parameters without an `error_description` (e.g. `?error=access_denied`), per [RFC 6749 §4.1.2.1](https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.2.1) where `error_description` is optional but `error` is required.

Previously these bare `?error=` redirects were silently dropped in two places:

1. **`supabase_auth.dart` → `_isAuthCallbackDeeplink`** only matched `error_description`, so a `?error=access_denied` deep link was never recognized as an auth callback.
2. **`gotrue_client.dart` → `getSessionFromUrl`** only threw when `error_description != null`, so even if the gate passed, a bare `?error=` fell through to the misleading `"No access_token detected."` instead of surfacing the actual OAuth error.

The result was that the user saw no feedback when an OAuth provider returned an error without a description.

## Changes

- Widened the deep link gate to also match `error` and `error_code`.
- Made `getSessionFromUrl` throw for any of `error` / `error_code` / `error_description`, with a fallback message when no description is given. The `error` -> `code` and `error_code` -> `statusCode` mapping is preserved.

## Tests

- `packages/gotrue/test/provider_test.dart`: new case for `?error=access_denied&error_code=403` asserting the `AuthException` carries the code and status.
- `packages/supabase_flutter/test/deep_link_test.dart`: new group asserting a `?error=` deep link triggers `getSessionFromUrl` and surfaces the `AuthException` on `onAuthStateChange`.

## Parity

Ports [supabase-js#2407](https://github.com/supabase/supabase-js/pull/2407) to Dart/Flutter.

Resolves SDK-1032 (and its duplicate SDK-1044).
