### PR TITLE
fix(postgrest): return structured error for non-JSON body on 2xx responses

### DIFF
--- a/packages/postgrest/lib/src/postgrest_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_builder.dart
@@ -253,7 +253,16 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
               body = jsonDecode(response.body);
             }
           } on FormatException catch (_) {
-            body = null;
+            // A 2xx status does not guarantee a JSON body. A proxy or gateway
+            // can return an HTML error page or a truncated response with a
+            // success status. Surface the raw body as a structured error
+            // instead of crashing with an opaque type error or silently
+            // returning null.
+            throw PostgrestException(
+              message: response.body,
+              code: '${response.statusCode}',
+              details: response.reasonPhrase,
+            );
           }
         }
       }

--- a/packages/postgrest/test/basic_test.dart
+++ b/packages/postgrest/test/basic_test.dart
@@ -526,5 +526,30 @@ void main() {
       expect(customHttpClient.lastRequest?.method, "GET");
       expect(customHttpClient.lastBody, isEmpty);
     });
+
+    test('non-JSON body on 2xx response throws a structured error', () async {
+      await expectLater(
+        () => postgrestCustomHttpClient.from('non-json-succ').select(),
+        throwsA(
+          isA<PostgrestException>().having((e) => e.code, 'code', '200').having(
+                (e) => e.message,
+                'message',
+                '<html><body>502 Bad Gateway</body></html>',
+              ),
+        ),
+      );
+    });
+
+    test('non-JSON body on 2xx response with maybeSingle throws', () async {
+      await expectLater(
+        () => postgrestCustomHttpClient
+            .from('non-json-succ')
+            .select()
+            .maybeSingle(),
+        throwsA(
+          isA<PostgrestException>().having((e) => e.code, 'code', '200'),
+        ),
+      );
+    });
   });
 }

--- a/packages/postgrest/test/custom_http_client.dart
+++ b/packages/postgrest/test/custom_http_client.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:http/http.dart';
@@ -16,6 +17,17 @@ class CustomHttpClient extends BaseClient {
         Stream.empty(),
         200,
         request: request,
+      );
+    }
+
+    if (request.url.path.endsWith("non-json-succ")) {
+      return StreamedResponse(
+        Stream.value(
+          utf8.encode('<html><body>502 Bad Gateway</body></html>'),
+        ),
+        200,
+        request: request,
+        reasonPhrase: 'OK',
       );
     }
     //Return custom status code to check for usage of this client.


### PR DESCRIPTION
## What

When a PostgREST request succeeds (2xx status) but the response body is not valid JSON (for example, an HTML `502 Bad Gateway` page from a proxy, or a truncated response), the SDK now throws a structured `PostgrestException` carrying the raw body, status code, and reason phrase.

## Why

The previous handling caught the `FormatException` and set `body = null`, which behaved badly:
- For `.select()` (return type `PostgrestList`), the `null` flowed into `PostgrestList.from(null)` and crashed with an opaque `TypeError`.
- For `.maybeSingle()`/`.single()`, it silently returned `null`, making a proxy's HTML error page indistinguishable from "no rows".

This is the Dart equivalent of the supabase-js structured-error / `throwOnError` behavior, since the Dart builder always throws on error rather than returning a `{data, error}` shape.

## Not a breaking change

CSV and `pgrst.plan+text` bodies are handled before the JSON decode, so the only bodies reaching this branch are genuinely malformed. Today those either crash with an opaque error or return a misleading `null`, so converting them into a clean `PostgrestException` is a bug fix.

## Tests

Added a `non-json-succ` mock route returning `200` with an HTML body, covering both `.select()` and `.maybeSingle()` paths.

Closes SDK-1029. Parity with supabase/supabase-js#2398.