### PR TITLE
fix(gotrue): copy request header/query maps before mutating them

### DIFF
--- a/packages/gotrue/lib/src/fetch.dart
+++ b/packages/gotrue/lib/src/fetch.dart
@@ -120,7 +120,10 @@ class GotrueFetch {
     RequestMethodType method, {
     GotrueRequestOptions? options,
   }) async {
-    final headers = options?.headers ?? {};
+    // Copy the maps before mutating them. Callers pass the client's shared
+    // header/query maps by reference, so writing `Authorization`, the API
+    // version or `redirect_to` directly would leak into every later request.
+    final headers = {...?options?.headers};
 
     // Set the API version header if not already set
     if (!headers.containsKey(Constants.apiVersionHeaderName)) {
@@ -131,7 +134,7 @@ class GotrueFetch {
       headers['Authorization'] = 'Bearer ${options!.jwt}';
     }
 
-    final qs = options?.query ?? {};
+    final qs = {...?options?.query};
     if (options?.redirectTo != null) {
       qs['redirect_to'] = options!.redirectTo!;
     }

--- a/packages/gotrue/test/header_isolation_test.dart
+++ b/packages/gotrue/test/header_isolation_test.dart
@@ -1,0 +1,70 @@
+import 'dart:convert';
+
+import 'package:gotrue/gotrue.dart';
+import 'package:http/http.dart';
+import 'package:test/test.dart';
+
+/// Records the headers of every request it receives and always answers with a
+/// minimal user payload, so we can inspect what the client actually sent.
+class _RecordingHttpClient extends BaseClient {
+  final List<Map<String, String>> requestHeaders = [];
+
+  @override
+  Future<StreamedResponse> send(BaseRequest request) async {
+    requestHeaders.add(Map.of(request.headers));
+    return StreamedResponse(
+      Stream.value(utf8.encode(jsonEncode({
+        'id': '18bc7a4e-c095-4573-93dc-e0be29bada97',
+        'aud': 'authenticated',
+        'role': 'authenticated',
+        'email': 'fake1@email.com',
+        'app_metadata': {
+          'provider': 'email',
+          'providers': ['email'],
+        },
+        'user_metadata': <String, dynamic>{},
+        'created_at': '2023-04-01T09:38:59.784028Z',
+      }))),
+      200,
+      request: request,
+    );
+  }
+}
+
+void main() {
+  group('GoTrueClient header isolation', () {
+    late _RecordingHttpClient http;
+    late GoTrueClient client;
+
+    setUp(() {
+      http = _RecordingHttpClient();
+      client = GoTrueClient(
+        url: 'http://localhost',
+        headers: {'apikey': 'anon-key'},
+        httpClient: http,
+      );
+    });
+
+    test('a jwt-bearing call sends the token but never persists it', () async {
+      await client.getUser('user-access-token');
+
+      // The token reached the wire for this single request...
+      expect(
+        http.requestHeaders.single['Authorization'],
+        'Bearer user-access-token',
+      );
+      // ...but it must not be baked into the shared header map, where it would
+      // ride along on every later request, including after sign out.
+      expect(client.headers.containsKey('Authorization'), isFalse);
+      expect(client.headers.containsKey('Content-Type'), isFalse);
+    });
+
+    test('client headers are unchanged across repeated calls', () async {
+      final before = Map.of(client.headers);
+      await client.getUser('token-a');
+      await client.getUser('token-b');
+
+      expect(client.headers, before);
+    });
+  });
+}


### PR DESCRIPTION
## What

`GotrueFetch.request()` now copies the request header and query maps before mutating them, so per-request values (`Authorization`, the API version header, `Content-Type`, `redirect_to`) no longer leak into the client's shared `_headers`.

## Why

`GoTrueClient` keeps a single `_headers` map and passes it **by reference** to almost every request (`headers: _headers`). `request()` aliased that map and wrote into it directly:

- `headers['Authorization'] = 'Bearer ${options.jwt}'` for any jwt-bearing call
- the `x-supabase-api-version` header
- `headers['Content-Type']` for non-GET requests (in `_handleRequest`)

So after any authenticated call — `getUser(jwt)`, `updateUser`, MFA, passkeys — the user's access token stayed in the client's default headers and was sent on every later request, including unauthenticated endpoints and requests made *after* `signOut`. Because requests interleave on the event loop, a no-jwt request could also pick up another in-flight request's token. The query map was aliased the same way through `redirect_to`.

## Not a breaking change

The copies are local to `request()`; the headers actually sent on each request are identical to before. The only thing that changes is that the shared map is no longer polluted — which is purely a fix.

## Tests

Added `packages/gotrue/test/header_isolation_test.dart`: after `getUser(jwt)` the token is present on the wire but absent from `client.headers`, and the header map is unchanged across repeated calls. Without the fix both assertions fail.