### PR TITLE
fix(postgrest): escape quotes and backslashes in list filter values

### DIFF
--- a/packages/postgrest/lib/src/postgrest_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_builder.dart
@@ -410,7 +410,13 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
     if (filter.every((element) => element is num)) {
       return filter.map((s) => '$s').join(',');
     }
-    return filter.map((s) => '"$s"').join(',');
+    // Escape `\` and `"` inside each element before quoting, otherwise a value
+    // containing a double quote (e.g. `a"b`) produces a malformed PostgREST
+    // filter like `in.("a"b")`. This matches PostgREST/PostgreSQL array quoting.
+    return filter.map((s) {
+      final escaped = '$s'.replaceAll(r'\', r'\\').replaceAll('"', r'\"');
+      return '"$escaped"';
+    }).join(',');
   }
 
   @override

--- a/packages/postgrest/test/filter_escape_test.dart
+++ b/packages/postgrest/test/filter_escape_test.dart
@@ -1,0 +1,35 @@
+import 'dart:convert';
+
+import 'package:http/http.dart';
+import 'package:postgrest/postgrest.dart';
+import 'package:test/test.dart';
+
+/// Captures the URL of the request the builder generates and returns an empty
+/// result set, so we can assert on the query string without a live server.
+class _CapturingClient extends BaseClient {
+  Uri? lastUrl;
+
+  @override
+  Future<StreamedResponse> send(BaseRequest request) async {
+    lastUrl = request.url;
+    return StreamedResponse(
+      Stream.value(utf8.encode('[]')),
+      200,
+      request: request,
+      headers: {'content-type': 'application/json'},
+    );
+  }
+}
+
+void main() {
+  test('escapes double quotes and backslashes in list filter values', () async {
+    final mock = _CapturingClient();
+    final client = PostgrestClient('http://localhost:3000', httpClient: mock);
+
+    await client.from('t').select().inFilter('name', [r'a"b\c']);
+
+    // The `"` and `\` are backslash-escaped so the element stays a single,
+    // well-formed quoted value rather than `in.("a"b\c")`.
+    expect(mock.lastUrl!.queryParameters['name'], r'in.("a\"b\\c")');
+  });
+}


### PR DESCRIPTION
## What

List filter values are now backslash-escaped before being quoted, so values containing `"` or `\` produce well-formed PostgREST filters instead of malformed ones.

## Why

`_cleanFilterArray` quoted each non-numeric element without escaping:

```dart
return filter.map((s) => '"$s"').join(',');
```

So `inFilter('name', ['a"b'])` generated `in.("a"b")`. PostgREST treats the inner `"` as the end of the quoted element, so the filter is mis-parsed and the query silently returns wrong results (or errors). The same helper backs list `eq`/`neq`, `contains`/`containedBy`/`overlaps`, `not`, and rpc array arguments, so all of them are affected.

The fix escapes `\` and `"` within each element, matching PostgREST/PostgreSQL array-literal quoting:

```dart
final escaped = '$s'.replaceAll(r'\', r'\\').replaceAll('"', r'\"');
return '"$escaped"';
```

## Not a breaking change

Values without `"` or `\` are unaffected — the escaping is a no-op for them, so existing valid filters generate identical query strings. Only values that are currently broken change.

## Tests

Added `packages/postgrest/test/filter_escape_test.dart`: `inFilter('name', [r'a"b\c'])` with a capturing mock client, asserting the generated query is `in.("a\"b\\c")`. Without the fix it's the malformed `in.("a"b\c")`.