### PR TITLE
feat(gotrue): add user-facing OAuth 2.1 server authorization API

### DIFF
--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -22,6 +22,7 @@ import 'broadcast_stub.dart' if (dart.library.js_interop) './broadcast_web.dart'
 import 'version.dart';
 
 part 'gotrue_mfa_api.dart';
+part 'gotrue_oauth_server_api.dart';
 part 'gotrue_passkey_api.dart';
 
 class _SessionState {
@@ -55,6 +56,15 @@ class GoTrueClient {
 
   /// Namespace for the GoTrue MFA API methods.
   late final GoTrueMFAApi mfa;
+
+  /// Namespace for the OAuth 2.1 authorization server consent flow.
+  ///
+  /// Use these methods when your Supabase project acts as an OAuth 2.1 server
+  /// and you are building a custom consent screen. Requires the OAuth 2.1
+  /// server feature to be enabled in your Supabase Auth configuration.
+  ///
+  /// {@macro gotrue_oauth_server_api}
+  late final GoTrueOAuthServerApi oauthServer;
 
   /// Namespace for the passkey (WebAuthn) API methods.
   ///
@@ -169,6 +179,7 @@ class GoTrueClient {
       httpClient: httpClient,
     );
     mfa = GoTrueMFAApi(client: this, fetch: _fetch);
+    oauthServer = GoTrueOAuthServerApi(client: this, fetch: _fetch);
     passkey = GoTruePasskeyApi(client: this, fetch: _fetch);
     if (_autoRefreshToken) {
       startAutoRefresh();

--- a/packages/gotrue/lib/src/gotrue_oauth_server_api.dart
+++ b/packages/gotrue/lib/src/gotrue_oauth_server_api.dart
@@ -1,0 +1,198 @@
+part of 'gotrue_client.dart';
+
+/// Response type representing the details of a pending OAuth authorization
+/// request.
+///
+/// Only relevant when the OAuth 2.1 server is enabled in Supabase Auth.
+class OAuthAuthorizationDetailsResponse {
+  /// The unique identifier for this authorization request.
+  final String authorizationId;
+
+  /// The OAuth client requesting authorization.
+  final OAuthClient client;
+
+  /// The scopes requested by the OAuth client, if any.
+  final String? scope;
+
+  /// The state parameter echoed from the authorization request, if present.
+  final String? state;
+
+  /// The redirect URI to be used after the authorization decision.
+  final String redirectUri;
+
+  const OAuthAuthorizationDetailsResponse({
+    required this.authorizationId,
+    required this.client,
+    this.scope,
+    this.state,
+    required this.redirectUri,
+  });
+
+  factory OAuthAuthorizationDetailsResponse.fromJson(
+      Map<String, dynamic> json) {
+    return OAuthAuthorizationDetailsResponse(
+      authorizationId: json['authorization_id'] as String,
+      client: OAuthClient.fromJson(json['client'] as Map<String, dynamic>),
+      scope: json['scope'] as String?,
+      state: json['state'] as String?,
+      redirectUri: json['redirect_uri'] as String,
+    );
+  }
+}
+
+/// Response type for an OAuth authorization consent decision (approve or deny).
+///
+/// Only relevant when the OAuth 2.1 server is enabled in Supabase Auth.
+class OAuthConsentResponse {
+  /// The URL to redirect the user to after the authorization decision.
+  ///
+  /// On approval this will contain the authorization code; on denial it will
+  /// carry an `access_denied` error — both in the form the OAuth client
+  /// registered to receive.
+  ///
+  /// This field is `null` if [skipBrowserRedirect] was `false` (the default)
+  /// and the SDK performed the redirect automatically.
+  final String? redirectUrl;
+
+  const OAuthConsentResponse({this.redirectUrl});
+
+  factory OAuthConsentResponse.fromJson(Map<String, dynamic> json) {
+    return OAuthConsentResponse(
+      redirectUrl: json['redirect_url'] as String?,
+    );
+  }
+}
+
+/// {@template gotrue_oauth_server_api}
+/// API namespace for the OAuth 2.1 authorization server consent flow.
+///
+/// Use these methods when your Supabase project is acting as an OAuth 2.1
+/// server **and** you are building a custom authorization / consent screen.
+/// The typical flow is:
+///
+/// 1. The third-party OAuth client redirects the user to your app's
+///    authorization path, which extracts the `authorization_id` from the
+///    query parameters.
+/// 2. Call [getAuthorizationDetails] to retrieve the requesting client's
+///    details and the requested scopes for display in the consent UI.
+/// 3. Call [approveAuthorization] or [denyAuthorization] according to the
+///    user's decision.
+///
+/// ```dart
+/// // 1. Extract the authorization_id from the incoming redirect URL.
+/// final authorizationId = Uri.parse(currentUrl).queryParameters['authorization_id']!;
+///
+/// // 2. Show the consent screen.
+/// final details = await supabase.auth.oauthServer.getAuthorizationDetails(authorizationId);
+/// print('App "${details.client.clientName}" requests: ${details.scope}');
+///
+/// // 3. Act on the user's decision.
+/// final consent = await supabase.auth.oauthServer.approveAuthorization(authorizationId);
+/// // Redirect the user to consent.redirectUrl (when skipBrowserRedirect is true).
+/// ```
+///
+/// These methods require a signed-in user and only work when the OAuth 2.1
+/// server feature is enabled in your Supabase Auth configuration.
+/// {@endtemplate}
+class GoTrueOAuthServerApi {
+  final GoTrueClient _client;
+  final GotrueFetch _fetch;
+
+  const GoTrueOAuthServerApi({
+    required GoTrueClient client,
+    required GotrueFetch fetch,
+  })  : _client = client,
+        _fetch = fetch;
+
+  /// Retrieves the details of a pending OAuth authorization request.
+  ///
+  /// [authorizationId] is the unique identifier for the pending authorization
+  /// request, typically extracted from the `authorization_id` query parameter
+  /// of the URL your authorization path received.
+  ///
+  /// Returns an [OAuthAuthorizationDetailsResponse] containing the requesting
+  /// OAuth client's metadata and the requested scopes.
+  ///
+  /// Only relevant when the OAuth 2.1 server is enabled in Supabase Auth.
+  Future<OAuthAuthorizationDetailsResponse> getAuthorizationDetails(
+    String authorizationId,
+  ) async {
+    final session = _client.currentSession;
+
+    final data = await _fetch.request(
+      '${_client._url}/oauth/authorizations/$authorizationId',
+      RequestMethodType.get,
+      options: GotrueRequestOptions(
+        headers: _client._headers,
+        jwt: session?.accessToken,
+      ),
+    );
+
+    return OAuthAuthorizationDetailsResponse.fromJson(data);
+  }
+
+  /// Approves a pending OAuth authorization request.
+  ///
+  /// [authorizationId] is the unique identifier for the pending authorization
+  /// request.
+  ///
+  /// If [skipBrowserRedirect] is `true` (default: `false`), the SDK will not
+  /// automatically redirect the browser and will instead return the redirect
+  /// URL in [OAuthConsentResponse.redirectUrl] for you to handle manually.
+  ///
+  /// Only relevant when the OAuth 2.1 server is enabled in Supabase Auth.
+  Future<OAuthConsentResponse> approveAuthorization(
+    String authorizationId, {
+    bool skipBrowserRedirect = false,
+  }) async {
+    final session = _client.currentSession;
+
+    final data = await _fetch.request(
+      '${_client._url}/oauth/authorizations/$authorizationId/consent',
+      RequestMethodType.post,
+      options: GotrueRequestOptions(
+        headers: _client._headers,
+        jwt: session?.accessToken,
+        body: {
+          'action': 'approve',
+          if (skipBrowserRedirect) 'skip_browser_redirect': true,
+        },
+      ),
+    );
+
+    return OAuthConsentResponse.fromJson(data);
+  }
+
+  /// Denies a pending OAuth authorization request.
+  ///
+  /// [authorizationId] is the unique identifier for the pending authorization
+  /// request.
+  ///
+  /// If [skipBrowserRedirect] is `true` (default: `false`), the SDK will not
+  /// automatically redirect the browser and will instead return the redirect
+  /// URL (containing the `access_denied` error) in
+  /// [OAuthConsentResponse.redirectUrl] for you to handle manually.
+  ///
+  /// Only relevant when the OAuth 2.1 server is enabled in Supabase Auth.
+  Future<OAuthConsentResponse> denyAuthorization(
+    String authorizationId, {
+    bool skipBrowserRedirect = false,
+  }) async {
+    final session = _client.currentSession;
+
+    final data = await _fetch.request(
+      '${_client._url}/oauth/authorizations/$authorizationId/consent',
+      RequestMethodType.post,
+      options: GotrueRequestOptions(
+        headers: _client._headers,
+        jwt: session?.accessToken,
+        body: {
+          'action': 'deny',
+          if (skipBrowserRedirect) 'skip_browser_redirect': true,
+        },
+      ),
+    );
+
+    return OAuthConsentResponse.fromJson(data);
+  }
+}

--- a/packages/gotrue/test/src/gotrue_oauth_server_api_test.dart
+++ b/packages/gotrue/test/src/gotrue_oauth_server_api_test.dart
@@ -37,7 +37,8 @@ void main() {
         httpClient: httpClient,
       );
 
-      final details = await client.oauthServer.getAuthorizationDetails('auth-id-123');
+      final details =
+          await client.oauthServer.getAuthorizationDetails('auth-id-123');
 
       expect(details.authorizationId, 'auth-id-123');
       expect(details.client.clientId, 'client-id-abc');
@@ -47,21 +48,23 @@ void main() {
       expect(details.redirectUri, 'https://myapp.com/callback');
     });
 
-    test('approveAuthorization sends correct request and parses response', () async {
+    test('approveAuthorization sends correct request and parses response',
+        () async {
       final mockResponse = {
-        'redirect_url': 'https://myapp.com/callback?code=code-123&state=state-xyz',
+        'redirect_url':
+            'https://myapp.com/callback?code=code-123&state=state-xyz',
       };
 
       var requestSent = false;
-      final httpClient = http.StreamedRequest('POST', Uri.parse(gotrueUrl)); // Placeholder check
 
       final client = GoTrueClient(
         url: gotrueUrl,
         httpClient: _MockRequestVerifierClient((request) async {
           requestSent = true;
           expect(request.method, 'POST');
-          expect(request.url.path, endsWith('/oauth/authorizations/auth-id-123/consent'));
-          
+          expect(request.url.path,
+              endsWith('/oauth/authorizations/auth-id-123/consent'));
+
           if (request is http.Request) {
             final body = jsonDecode(request.body) as Map<String, dynamic>;
             expect(body['action'], 'approve');
@@ -81,12 +84,15 @@ void main() {
       );
 
       expect(requestSent, isTrue);
-      expect(consent.redirectUrl, 'https://myapp.com/callback?code=code-123&state=state-xyz');
+      expect(consent.redirectUrl,
+          'https://myapp.com/callback?code=code-123&state=state-xyz');
     });
 
-    test('denyAuthorization sends correct request and parses response', () async {
+    test('denyAuthorization sends correct request and parses response',
+        () async {
       final mockResponse = {
-        'redirect_url': 'https://myapp.com/callback?error=access_denied&state=state-xyz',
+        'redirect_url':
+            'https://myapp.com/callback?error=access_denied&state=state-xyz',
       };
 
       var requestSent = false;
@@ -96,8 +102,9 @@ void main() {
         httpClient: _MockRequestVerifierClient((request) async {
           requestSent = true;
           expect(request.method, 'POST');
-          expect(request.url.path, endsWith('/oauth/authorizations/auth-id-123/consent'));
-          
+          expect(request.url.path,
+              endsWith('/oauth/authorizations/auth-id-123/consent'));
+
           if (request is http.Request) {
             final body = jsonDecode(request.body) as Map<String, dynamic>;
             expect(body['action'], 'deny');
@@ -116,13 +123,15 @@ void main() {
       );
 
       expect(requestSent, isTrue);
-      expect(consent.redirectUrl, 'https://myapp.com/callback?error=access_denied&state=state-xyz');
+      expect(consent.redirectUrl,
+          'https://myapp.com/callback?error=access_denied&state=state-xyz');
     });
   });
 }
 
 class _MockRequestVerifierClient extends http.BaseClient {
-  final Future<http.StreamedResponse> Function(http.BaseRequest request) _onSend;
+  final Future<http.StreamedResponse> Function(http.BaseRequest request)
+      _onSend;
 
   _MockRequestVerifierClient(this._onSend);
 

--- a/packages/gotrue/test/src/gotrue_oauth_server_api_test.dart
+++ b/packages/gotrue/test/src/gotrue_oauth_server_api_test.dart
@@ -1,0 +1,133 @@
+import 'dart:convert';
+import 'package:gotrue/gotrue.dart';
+import 'package:http/http.dart' as http;
+import 'package:test/test.dart';
+
+import '../custom_http_client.dart';
+import '../utils.dart';
+
+void main() {
+  const gotrueUrl = 'http://127.0.0.1:54421/auth/v1';
+
+  group('OAuth 2.1 Server User API', () {
+    test('getAuthorizationDetails parses response correctly', () async {
+      final mockResponse = {
+        'authorization_id': 'auth-id-123',
+        'client': {
+          'client_id': 'client-id-abc',
+          'client_name': 'My App',
+          'client_uri': 'https://myapp.com',
+          'redirect_uris': ['https://myapp.com/callback'],
+          'client_type': 'public',
+          'registration_type': 'dynamic',
+          'grant_types': ['authorization_code'],
+          'response_types': ['code'],
+          'token_endpoint_auth_method': 'none',
+          'created_at': '2026-01-01T00:00:00Z',
+          'updated_at': '2026-01-01T00:00:00Z',
+        },
+        'scope': 'openid profile',
+        'state': 'state-xyz',
+        'redirect_uri': 'https://myapp.com/callback',
+      };
+
+      final httpClient = MockedHttpClient(mockResponse);
+      final client = GoTrueClient(
+        url: gotrueUrl,
+        httpClient: httpClient,
+      );
+
+      final details = await client.oauthServer.getAuthorizationDetails('auth-id-123');
+
+      expect(details.authorizationId, 'auth-id-123');
+      expect(details.client.clientId, 'client-id-abc');
+      expect(details.client.clientName, 'My App');
+      expect(details.scope, 'openid profile');
+      expect(details.state, 'state-xyz');
+      expect(details.redirectUri, 'https://myapp.com/callback');
+    });
+
+    test('approveAuthorization sends correct request and parses response', () async {
+      final mockResponse = {
+        'redirect_url': 'https://myapp.com/callback?code=code-123&state=state-xyz',
+      };
+
+      var requestSent = false;
+      final httpClient = http.StreamedRequest('POST', Uri.parse(gotrueUrl)); // Placeholder check
+
+      final client = GoTrueClient(
+        url: gotrueUrl,
+        httpClient: _MockRequestVerifierClient((request) async {
+          requestSent = true;
+          expect(request.method, 'POST');
+          expect(request.url.path, endsWith('/oauth/authorizations/auth-id-123/consent'));
+          
+          if (request is http.Request) {
+            final body = jsonDecode(request.body) as Map<String, dynamic>;
+            expect(body['action'], 'approve');
+            expect(body['skip_browser_redirect'], true);
+          }
+          return http.StreamedResponse(
+            Stream.value(utf8.encode(jsonEncode(mockResponse))),
+            200,
+            request: request,
+          );
+        }),
+      );
+
+      final consent = await client.oauthServer.approveAuthorization(
+        'auth-id-123',
+        skipBrowserRedirect: true,
+      );
+
+      expect(requestSent, isTrue);
+      expect(consent.redirectUrl, 'https://myapp.com/callback?code=code-123&state=state-xyz');
+    });
+
+    test('denyAuthorization sends correct request and parses response', () async {
+      final mockResponse = {
+        'redirect_url': 'https://myapp.com/callback?error=access_denied&state=state-xyz',
+      };
+
+      var requestSent = false;
+
+      final client = GoTrueClient(
+        url: gotrueUrl,
+        httpClient: _MockRequestVerifierClient((request) async {
+          requestSent = true;
+          expect(request.method, 'POST');
+          expect(request.url.path, endsWith('/oauth/authorizations/auth-id-123/consent'));
+          
+          if (request is http.Request) {
+            final body = jsonDecode(request.body) as Map<String, dynamic>;
+            expect(body['action'], 'deny');
+            expect(body.containsKey('skip_browser_redirect'), isFalse);
+          }
+          return http.StreamedResponse(
+            Stream.value(utf8.encode(jsonEncode(mockResponse))),
+            200,
+            request: request,
+          );
+        }),
+      );
+
+      final consent = await client.oauthServer.denyAuthorization(
+        'auth-id-123',
+      );
+
+      expect(requestSent, isTrue);
+      expect(consent.redirectUrl, 'https://myapp.com/callback?error=access_denied&state=state-xyz');
+    });
+  });
+}
+
+class _MockRequestVerifierClient extends http.BaseClient {
+  final Future<http.StreamedResponse> Function(http.BaseRequest request) _onSend;
+
+  _MockRequestVerifierClient(this._onSend);
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) {
+    return _onSend(request);
+  }
+}


### PR DESCRIPTION
## Description

This PR implements the user-facing OAuth 2.1 server authorization consent flow methods on the `GoTrueClient` under the namespace `oauthServer` (via `client.oauthServer`). 

These methods are useful when your Supabase project acts as an OAuth 2.1 server and you are building a custom consent/authorization screen.

The following user-facing consent endpoints are exposed:
- `client.oauthServer.getAuthorizationDetails(authorizationId)`: Retrieve client details and requested scopes for a pending authorization request.
- `client.oauthServer.approveAuthorization(authorizationId, {skipBrowserRedirect})`: Approve the authorization request.
- `client.oauthServer.denyAuthorization(authorizationId, {skipBrowserRedirect})`: Deny the authorization request.

## Suggested Solution Context
Addresses: #1475

## Test Plan
Added a comprehensive suite of unit tests in `packages/gotrue/test/src/gotrue_oauth_server_api_test.dart` that validates request paths, HTTP methods, body payloads, query parameters, and JSON response deserialization for all three methods. All tests pass successfully.