### PR TITLE
fix(functions_client): use case-insensitive check for Content-Type header in invoke()

### DIFF
--- a/packages/functions_client/lib/src/functions_client.dart
+++ b/packages/functions_client/lib/src/functions_client.dart
@@ -117,8 +117,9 @@ class FunctionsClient {
         'x-region': effectiveRegion,
     };
 
-    if (body != null &&
-        (headers == null || !headers.containsKey("Content-Type"))) {
+    final hasContentType =
+        finalHeaders.keys.any((k) => k.toLowerCase() == 'content-type');
+    if (body != null && !hasContentType) {
       finalHeaders['Content-Type'] = switch (body) {
         Uint8List() => 'application/octet-stream',
         String() => 'text/plain',

--- a/packages/functions_client/lib/src/functions_client.dart
+++ b/packages/functions_client/lib/src/functions_client.dart
@@ -117,9 +117,8 @@ class FunctionsClient {
         'x-region': effectiveRegion,
     };
 
-    final hasContentType =
-        finalHeaders.keys.any((k) => k.toLowerCase() == 'content-type');
-    if (body != null && !hasContentType) {
+    if (body != null &&
+        !finalHeaders.keys.any((k) => k.toLowerCase() == 'content-type')) {
       finalHeaders['Content-Type'] = switch (body) {
         Uint8List() => 'application/octet-stream',
         String() => 'text/plain',

--- a/packages/functions_client/test/functions_dart_test.dart
+++ b/packages/functions_client/test/functions_dart_test.dart
@@ -247,6 +247,17 @@ void main() {
         expect(req.headers['Content-Type'], 'custom/type');
       });
 
+      test('custom lowercase content-type header overrides defaults', () async {
+        await functionsCustomHttpClient.invoke(
+          'function',
+          body: {'key': 'value'},
+          headers: {'content-type': 'application/custom+json'},
+        );
+
+        final req = customHttpClient.receivedRequests.last;
+        expect(req.headers['content-type'], 'application/custom+json');
+      });
+
       test('custom headers merge with defaults', () async {
         await functionsCustomHttpClient.invoke(
           'function',


### PR DESCRIPTION
## Description

Closes #1487

Per RFC 7230, HTTP header names are case-insensitive. Previously, `FunctionsClient.invoke()` checked whether a `Content-Type` header was provided using exact string match: `!headers.containsKey("Content-Type")`.

If a caller passed a custom content-type header with lowercase or mixed casing (such as `headers: {'content-type': 'application/custom+json'}`), the check failed to detect it. Consequently, the default content-type for the body type was assigned to `finalHeaders['Content-Type']`, overwriting the caller's custom header when headers were set on the request.

## Fix

Switched the check to a case-insensitive lookup over `finalHeaders.keys` before setting default body content types.

## Test Plan

Added a unit test in `packages/functions_client/test/functions_dart_test.dart` verifying that passing `headers: {'content-type': 'application/custom+json'}` correctly overrides default headers. All 37 tests in the package pass.