### PR TITLE
fix(gotrue): throw AuthException when asyncStorage is missing during PKCE flow

### DIFF
--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -370,12 +370,13 @@ class GoTrueClient {
 
   /// Verifies the PKCE code verifyer and retrieves a session.
   Future<AuthSessionUrlResponse> exchangeCodeForSession(String authCode) async {
-    assert(
-      _asyncStorage != null,
-      'You need to provide asyncStorage to perform pkce flow.',
-    );
+    if (_asyncStorage == null) {
+      throw AuthException(
+        'You need to provide asyncStorage to perform pkce flow.',
+      );
+    }
 
-    final codeVerifierRawString = await _asyncStorage!.getItem(
+    final codeVerifierRawString = await _asyncStorage.getItem(
       key: '${Constants.defaultStorageKey}-code-verifier',
     );
     if (codeVerifierRawString == null) {
@@ -425,12 +426,13 @@ class GoTrueClient {
     if (_flowType != AuthFlowType.pkce) {
       return null;
     }
-    assert(
-      _asyncStorage != null,
-      'You need to provide asyncStorage to perform pkce flow.',
-    );
+    if (_asyncStorage == null) {
+      throw AuthException(
+        'You need to provide asyncStorage to perform pkce flow.',
+      );
+    }
     final codeVerifier = generatePKCEVerifier();
-    await _asyncStorage!.setItem(
+    await _asyncStorage.setItem(
       key: '${Constants.defaultStorageKey}-code-verifier',
       value: storageEventName == null
           ? codeVerifier

--- a/packages/gotrue/test/client_test.dart
+++ b/packages/gotrue/test/client_test.dart
@@ -793,4 +793,29 @@ void main() {
       await sub.cancel();
     });
   });
+
+  group('PKCE with missing asyncStorage', () {
+    late GoTrueClient client;
+
+    setUp(() {
+      client = GoTrueClient(
+        url: gotrueUrl,
+        headers: {'Authorization': 'Bearer $anonToken', 'apikey': anonToken},
+        // asyncStorage is deliberately left null/omitted
+      );
+    });
+
+    test(
+        'getOAuthSignInUrl throws AuthException instead of null operator crash',
+        () async {
+      expect(
+        () => client.getOAuthSignInUrl(provider: OAuthProvider.github),
+        throwsA(isA<AuthException>().having(
+          (e) => e.message,
+          'message',
+          contains('You need to provide asyncStorage to perform pkce flow.'),
+        )),
+      );
+    });
+  });
 }


### PR DESCRIPTION
**Root cause**
When gotrue client is initialized without an `asyncStorage` (e.g. standalone usage) but flowType defaults to PKCE, calling `getOAuthSignInUrl` or other PKCE flow methods uses asserts to check if `asyncStorage` is not null. However, asserts are disabled in release builds, causing the app to crash with a `Null check operator used on a null value` error when it attempts to call `_asyncStorage!.setItem` or `_asyncStorage!.getItem`.

**Fix**
Replaced developer-only `assert(_asyncStorage != null, ...)` checks with explicit runtime null checks that throw a descriptive `AuthException`.

**Tests**
Added a unit test verifying `getOAuthSignInUrl` throws a descriptive `AuthException` when `asyncStorage` is missing.

Fixes #1319