### PR TITLE
fix(gotrue)!: assert asyncStorage is provided for PKCE flow in the constructor

### DIFF
--- a/packages/supabase/lib/src/supabase_client.dart
+++ b/packages/supabase/lib/src/supabase_client.dart
@@ -46,9 +46,11 @@ import 'trace_http_client.dart';
 ///
 /// The pkce flow is used by default and keeps its code verifiers in the
 /// `AuthAsyncStorage` passed to the `pkceAsyncStorage` field of [authOptions].
-/// Pass a `MemoryAuthAsyncStorage` when the flow starts and completes within
-/// the same process, or a persistent implementation when the code is exchanged
-/// after a restart.
+/// Pass a persistent implementation whenever the flow can leave the process
+/// before the code comes back, which covers every email link and every
+/// redirect to an OAuth provider. `MemoryAuthAsyncStorage` only suits flows
+/// that start and complete in the same process, such as tests and command line
+/// tools that keep a redirect listener open.
 /// {@endtemplate}
 class SupabaseClient {
   final String _supabaseKey;

--- a/packages/supabase/lib/src/supabase_client.dart
+++ b/packages/supabase/lib/src/supabase_client.dart
@@ -44,9 +44,9 @@ import 'trace_http_client.dart';
 /// Pass an instance of `YAJsonIsolate` to [isolate] to use your own persisted
 /// isolate instance. A new instance will be created if [isolate] is omitted.
 ///
-/// Pass an instance of `AuthAsyncStorage` to the `pkceAsyncStorage` field of
-/// [authOptions] and set its `authFlowType` field to `AuthFlowType.pkce` in
-/// order to perform auth actions with pkce flow.
+/// The pkce flow is used by default. It stores its code verifiers in the
+/// `pkceAsyncStorage` field of [authOptions], which falls back to an in-memory
+/// storage when none is given.
 /// {@endtemplate}
 class SupabaseClient {
   final String _supabaseKey;
@@ -331,7 +331,9 @@ class SupabaseClient {
       headers: authHeaders,
       autoRefreshToken: autoRefreshToken,
       httpClient: _authApiHttpClient,
-      asyncStorage: authAsyncStorage,
+      asyncStorage:
+          authAsyncStorage ??
+          (authFlowType == AuthFlowType.pkce ? MemoryAuthAsyncStorage() : null),
       flowType: authFlowType,
     );
   }

--- a/packages/supabase/lib/src/supabase_client.dart
+++ b/packages/supabase/lib/src/supabase_client.dart
@@ -44,9 +44,11 @@ import 'trace_http_client.dart';
 /// Pass an instance of `YAJsonIsolate` to [isolate] to use your own persisted
 /// isolate instance. A new instance will be created if [isolate] is omitted.
 ///
-/// The pkce flow is used by default. It stores its code verifiers in the
-/// `pkceAsyncStorage` field of [authOptions], which falls back to an in-memory
-/// storage when none is given.
+/// The pkce flow is used by default and keeps its code verifiers in the
+/// `AuthAsyncStorage` passed to the `pkceAsyncStorage` field of [authOptions].
+/// Pass a `MemoryAuthAsyncStorage` when the flow starts and completes within
+/// the same process, or a persistent implementation when the code is exchanged
+/// after a restart.
 /// {@endtemplate}
 class SupabaseClient {
   final String _supabaseKey;
@@ -331,9 +333,7 @@ class SupabaseClient {
       headers: authHeaders,
       autoRefreshToken: autoRefreshToken,
       httpClient: _authApiHttpClient,
-      asyncStorage:
-          authAsyncStorage ??
-          (authFlowType == AuthFlowType.pkce ? MemoryAuthAsyncStorage() : null),
+      asyncStorage: authAsyncStorage,
       flowType: authFlowType,
     );
   }

--- a/packages/supabase/lib/src/supabase_client_options.dart
+++ b/packages/supabase/lib/src/supabase_client_options.dart
@@ -38,10 +38,17 @@ class AuthClientOptions {
   /// Storage for the code verifiers of the pkce flow, required when
   /// [authFlowType] is [AuthFlowType.pkce].
   ///
-  /// Pass a [MemoryAuthAsyncStorage] when the flow starts and completes within
-  /// the same process. A persistent implementation is needed when the code is
-  /// exchanged after a restart, which is what `supabase_flutter` does with
-  /// shared preferences.
+  /// A persistent implementation is needed whenever the flow can leave the
+  /// process before the code comes back. Email links do so by definition, and
+  /// so does a redirect to an OAuth provider, since the app may be reaped
+  /// while it waits and the page context is gone after a web redirect.
+  /// `supabase_flutter` therefore defaults this to shared preferences.
+  ///
+  /// [MemoryAuthAsyncStorage] only suits flows that start and complete in the
+  /// same process, such as tests and command line tools that keep a redirect
+  /// listener open. It is also unfit for a server handling more than one user
+  /// at a time, because the verifier is held under a single key that
+  /// concurrent sign-ins overwrite.
   final AuthAsyncStorage? pkceAsyncStorage;
   final AuthFlowType authFlowType;
 

--- a/packages/supabase/lib/src/supabase_client_options.dart
+++ b/packages/supabase/lib/src/supabase_client_options.dart
@@ -37,8 +37,8 @@ class AuthClientOptions {
 
   /// Storage for the code verifiers of the pkce flow.
   ///
-  /// Defaults to a [MemoryAuthAsyncStorage], which only carries a flow that
-  /// starts and completes within the same process. Pass a persistent
+  /// Defaults to a [MemoryAuthAsyncStorage], which only supports flows that
+  /// start and complete within the same process. Pass a persistent
   /// implementation when the code is exchanged after a restart, which is what
   /// `supabase_flutter` does with shared preferences.
   final AuthAsyncStorage? pkceAsyncStorage;

--- a/packages/supabase/lib/src/supabase_client_options.dart
+++ b/packages/supabase/lib/src/supabase_client_options.dart
@@ -34,6 +34,13 @@ class PostgrestClientOptions {
 
 class AuthClientOptions {
   final bool autoRefreshToken;
+
+  /// Storage for the code verifiers of the pkce flow.
+  ///
+  /// Defaults to a [MemoryAuthAsyncStorage], which only carries a flow that
+  /// starts and completes within the same process. Pass a persistent
+  /// implementation when the code is exchanged after a restart, which is what
+  /// `supabase_flutter` does with shared preferences.
   final AuthAsyncStorage? pkceAsyncStorage;
   final AuthFlowType authFlowType;
 

--- a/packages/supabase/lib/src/supabase_client_options.dart
+++ b/packages/supabase/lib/src/supabase_client_options.dart
@@ -35,12 +35,13 @@ class PostgrestClientOptions {
 class AuthClientOptions {
   final bool autoRefreshToken;
 
-  /// Storage for the code verifiers of the pkce flow.
+  /// Storage for the code verifiers of the pkce flow, required when
+  /// [authFlowType] is [AuthFlowType.pkce].
   ///
-  /// Defaults to a [MemoryAuthAsyncStorage], which only supports flows that
-  /// start and complete within the same process. Pass a persistent
-  /// implementation when the code is exchanged after a restart, which is what
-  /// `supabase_flutter` does with shared preferences.
+  /// Pass a [MemoryAuthAsyncStorage] when the flow starts and completes within
+  /// the same process. A persistent implementation is needed when the code is
+  /// exchanged after a restart, which is what `supabase_flutter` does with
+  /// shared preferences.
   final AuthAsyncStorage? pkceAsyncStorage;
   final AuthFlowType authFlowType;
 

--- a/packages/supabase/test/client_test.dart
+++ b/packages/supabase/test/client_test.dart
@@ -1,8 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:supabase/src/supabase_client.dart' as real;
-import 'package:supabase/supabase.dart' hide SupabaseClient;
+import 'package:supabase/supabase.dart';
 import 'package:supabase_common/supabase_common.dart';
 import 'package:test/test.dart';
 import 'package:yet_another_json_isolate/yet_another_json_isolate.dart';
@@ -184,6 +183,17 @@ void main() {
   });
 
   group('auth', () {
+    test('the pkce flow works without passing a pkceAsyncStorage', () async {
+      final supabase = SupabaseClient('http://localhost:1', 'supabaseKey');
+      addTearDown(supabase.dispose);
+
+      final response = await supabase.auth.getOAuthSignInUrl(
+        provider: OAuthProvider.github,
+      );
+
+      expect(response.url.queryParameters, contains('code_challenge'));
+    });
+
     test('properly set Authorization header', () async {
       final (:sessionString, :accessToken) = getSessionData(
         DateTime.now().add(Duration(hours: 1)),
@@ -469,30 +479,4 @@ void main() {
       });
     });
   });
-}
-
-class SupabaseClient extends real.SupabaseClient {
-  SupabaseClient(
-    super.supabaseUrl,
-    super.supabaseKey, {
-    super.postgrestOptions,
-    AuthClientOptions authOptions = const AuthClientOptions(),
-    super.storageOptions,
-    super.functionsOptions,
-    super.realtimeClientOptions,
-    super.accessToken,
-    super.headers,
-    super.httpClient,
-    super.isolate,
-  }) : super(
-         authOptions: AuthClientOptions(
-           autoRefreshToken: authOptions.autoRefreshToken,
-           pkceAsyncStorage: authOptions.pkceAsyncStorage,
-           authFlowType:
-               authOptions.authFlowType == AuthFlowType.pkce &&
-                   authOptions.pkceAsyncStorage == null
-               ? AuthFlowType.implicit
-               : authOptions.authFlowType,
-         ),
-       );
 }

--- a/packages/supabase/test/client_test.dart
+++ b/packages/supabase/test/client_test.dart
@@ -1,7 +1,8 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:supabase/supabase.dart';
+import 'package:supabase/src/supabase_client.dart' as real;
+import 'package:supabase/supabase.dart' hide SupabaseClient;
 import 'package:supabase_common/supabase_common.dart';
 import 'package:test/test.dart';
 import 'package:yet_another_json_isolate/yet_another_json_isolate.dart';
@@ -468,4 +469,30 @@ void main() {
       });
     });
   });
+}
+
+class SupabaseClient extends real.SupabaseClient {
+  SupabaseClient(
+    super.supabaseUrl,
+    super.supabaseKey, {
+    super.postgrestOptions,
+    AuthClientOptions authOptions = const AuthClientOptions(),
+    super.storageOptions,
+    super.functionsOptions,
+    super.realtimeClientOptions,
+    super.accessToken,
+    super.headers,
+    super.httpClient,
+    super.isolate,
+  }) : super(
+         authOptions: AuthClientOptions(
+           autoRefreshToken: authOptions.autoRefreshToken,
+           pkceAsyncStorage: authOptions.pkceAsyncStorage,
+           authFlowType:
+               authOptions.authFlowType == AuthFlowType.pkce &&
+                   authOptions.pkceAsyncStorage == null
+               ? AuthFlowType.implicit
+               : authOptions.authFlowType,
+         ),
+       );
 }

--- a/packages/supabase/test/client_test.dart
+++ b/packages/supabase/test/client_test.dart
@@ -1,7 +1,8 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:supabase/supabase.dart';
+import 'package:supabase/src/supabase_client.dart' as real;
+import 'package:supabase/supabase.dart' hide SupabaseClient;
 import 'package:supabase_common/supabase_common.dart';
 import 'package:test/test.dart';
 import 'package:yet_another_json_isolate/yet_another_json_isolate.dart';
@@ -183,8 +184,27 @@ void main() {
   });
 
   group('auth', () {
-    test('the pkce flow works without passing a pkceAsyncStorage', () async {
-      final supabase = SupabaseClient('http://localhost:1', 'supabaseKey');
+    test('the pkce flow asserts when no pkceAsyncStorage is given', () {
+      expect(
+        () => real.SupabaseClient('http://localhost:1', 'supabaseKey'),
+        throwsA(
+          isA<AssertionError>().having(
+            (error) => error.message,
+            'message',
+            contains('You need to provide asyncStorage to perform pkce flow.'),
+          ),
+        ),
+      );
+    });
+
+    test('the pkce flow works with a MemoryAuthAsyncStorage', () async {
+      final supabase = real.SupabaseClient(
+        'http://localhost:1',
+        'supabaseKey',
+        authOptions: AuthClientOptions(
+          pkceAsyncStorage: MemoryAuthAsyncStorage(),
+        ),
+      );
       addTearDown(supabase.dispose);
 
       final response = await supabase.auth.getOAuthSignInUrl(
@@ -479,4 +499,29 @@ void main() {
       });
     });
   });
+}
+
+/// A [real.SupabaseClient] that falls back to an in-memory pkce storage, so the
+/// tests below do not have to pass one at every construction site.
+class SupabaseClient extends real.SupabaseClient {
+  SupabaseClient(
+    super.supabaseUrl,
+    super.supabaseKey, {
+    super.postgrestOptions,
+    AuthClientOptions authOptions = const AuthClientOptions(),
+    super.storageOptions,
+    super.functionsOptions,
+    super.realtimeClientOptions,
+    super.accessToken,
+    super.headers,
+    super.httpClient,
+    super.isolate,
+  }) : super(
+         authOptions: AuthClientOptions(
+           autoRefreshToken: authOptions.autoRefreshToken,
+           pkceAsyncStorage:
+               authOptions.pkceAsyncStorage ?? MemoryAuthAsyncStorage(),
+           authFlowType: authOptions.authFlowType,
+         ),
+       );
 }

--- a/packages/supabase/test/mock_test.dart
+++ b/packages/supabase/test/mock_test.dart
@@ -372,13 +372,11 @@ void main() {
       headers: {
         'X-Client-Info': 'supabase-flutter/0.0.0',
       },
-      authOptions: const AuthClientOptions(authFlowType: AuthFlowType.implicit),
     );
     customHeadersClient = SupabaseClient(
       'http://${mockServer.address.host}:${mockServer.port}',
       apiKey,
       headers: {'X-Client-Info': 'supabase-flutter/0.0.0', ...customHeaders},
-      authOptions: const AuthClientOptions(authFlowType: AuthFlowType.implicit),
     );
     hasListener = false;
   });
@@ -850,9 +848,6 @@ void main() {
           'http://${errorServer.address.host}:${errorServer.port}',
           'test-key',
           headers: {'X-Client-Info': 'supabase-flutter/0.0.0'},
-          authOptions: const AuthClientOptions(
-            authFlowType: AuthFlowType.implicit,
-          ),
         );
 
         final stream = errorClient.from('todos').stream(primaryKey: ['id']);
@@ -884,9 +879,6 @@ void main() {
             throw Exception('Token retrieval failed');
           },
           headers: {'X-Client-Info': 'supabase-flutter/0.0.0'},
-          authOptions: const AuthClientOptions(
-            authFlowType: AuthFlowType.implicit,
-          ),
         );
 
         // Should handle token errors gracefully
@@ -905,9 +897,6 @@ void main() {
           'http://${mockServer.address.host}:${mockServer.port}',
           'test-key',
           headers: {'X-Client-Info': 'supabase-flutter/0.0.0'},
-          authOptions: const AuthClientOptions(
-            authFlowType: AuthFlowType.implicit,
-          ),
         );
 
         // First dispose should succeed

--- a/packages/supabase/test/mock_test.dart
+++ b/packages/supabase/test/mock_test.dart
@@ -372,11 +372,13 @@ void main() {
       headers: {
         'X-Client-Info': 'supabase-flutter/0.0.0',
       },
+      authOptions: const AuthClientOptions(authFlowType: AuthFlowType.implicit),
     );
     customHeadersClient = SupabaseClient(
       'http://${mockServer.address.host}:${mockServer.port}',
       apiKey,
       headers: {'X-Client-Info': 'supabase-flutter/0.0.0', ...customHeaders},
+      authOptions: const AuthClientOptions(authFlowType: AuthFlowType.implicit),
     );
     hasListener = false;
   });
@@ -848,6 +850,9 @@ void main() {
           'http://${errorServer.address.host}:${errorServer.port}',
           'test-key',
           headers: {'X-Client-Info': 'supabase-flutter/0.0.0'},
+          authOptions: const AuthClientOptions(
+            authFlowType: AuthFlowType.implicit,
+          ),
         );
 
         final stream = errorClient.from('todos').stream(primaryKey: ['id']);
@@ -879,6 +884,9 @@ void main() {
             throw Exception('Token retrieval failed');
           },
           headers: {'X-Client-Info': 'supabase-flutter/0.0.0'},
+          authOptions: const AuthClientOptions(
+            authFlowType: AuthFlowType.implicit,
+          ),
         );
 
         // Should handle token errors gracefully
@@ -897,6 +905,9 @@ void main() {
           'http://${mockServer.address.host}:${mockServer.port}',
           'test-key',
           headers: {'X-Client-Info': 'supabase-flutter/0.0.0'},
+          authOptions: const AuthClientOptions(
+            authFlowType: AuthFlowType.implicit,
+          ),
         );
 
         // First dispose should succeed

--- a/packages/supabase/test/realtime_test.dart
+++ b/packages/supabase/test/realtime_test.dart
@@ -27,6 +27,9 @@ void main() {
       supabase = SupabaseClient(
         'http://${mockServer.address.host}:${mockServer.port}',
         'supabaseKey',
+        authOptions: const AuthClientOptions(
+          authFlowType: AuthFlowType.implicit,
+        ),
       );
 
       channel = supabase.channel('realtime');

--- a/packages/supabase/test/realtime_test.dart
+++ b/packages/supabase/test/realtime_test.dart
@@ -27,9 +27,6 @@ void main() {
       supabase = SupabaseClient(
         'http://${mockServer.address.host}:${mockServer.port}',
         'supabaseKey',
-        authOptions: const AuthClientOptions(
-          authFlowType: AuthFlowType.implicit,
-        ),
       );
 
       channel = supabase.channel('realtime');

--- a/packages/supabase/test/stream_filter_test.dart
+++ b/packages/supabase/test/stream_filter_test.dart
@@ -8,8 +8,6 @@ import 'package:web_socket_channel/io.dart';
 
 import 'package:supabase_common/testing.dart';
 
-import 'utils.dart';
-
 /// Asserts how the filters of `stream()` are sent to the realtime server and to
 /// PostgREST, without needing either of them to be running.
 void main() {
@@ -38,7 +36,6 @@ void main() {
     supabase = SupabaseClient(
       'http://${InternetAddress.loopbackIPv4.address}:${mockServer.port}',
       localStackServiceRoleKey,
-      authOptions: AuthClientOptions(pkceAsyncStorage: TestAsyncStorage()),
     );
   });
 

--- a/packages/supabase/test/stream_filter_test.dart
+++ b/packages/supabase/test/stream_filter_test.dart
@@ -8,6 +8,8 @@ import 'package:web_socket_channel/io.dart';
 
 import 'package:supabase_common/testing.dart';
 
+import 'utils.dart';
+
 /// Asserts how the filters of `stream()` are sent to the realtime server and to
 /// PostgREST, without needing either of them to be running.
 void main() {
@@ -36,6 +38,7 @@ void main() {
     supabase = SupabaseClient(
       'http://${InternetAddress.loopbackIPv4.address}:${mockServer.port}',
       localStackServiceRoleKey,
+      authOptions: AuthClientOptions(pkceAsyncStorage: TestAsyncStorage()),
     );
   });
 

--- a/packages/supabase/test/stream_integration_test.dart
+++ b/packages/supabase/test/stream_integration_test.dart
@@ -8,8 +8,6 @@ import 'package:test/test.dart';
 
 import 'package:supabase_common/testing.dart';
 
-import 'utils.dart';
-
 late SupabaseClient _supabase;
 
 void main() {
@@ -543,11 +541,8 @@ void main() {
 const _streamTimeout = Duration(seconds: 10);
 const _warmUpPrefix = 'warm_up_';
 
-SupabaseClient _createClient() => SupabaseClient(
-  localStackUrl,
-  localStackServiceRoleKey,
-  authOptions: AuthClientOptions(pkceAsyncStorage: TestAsyncStorage()),
-);
+SupabaseClient _createClient() =>
+    SupabaseClient(localStackUrl, localStackServiceRoleKey);
 
 /// Listens to [stream] and asserts that it emits [expectedSnapshots] in order,
 /// where every snapshot is the result of [project] applied to the emitted rows.

--- a/packages/supabase/test/stream_integration_test.dart
+++ b/packages/supabase/test/stream_integration_test.dart
@@ -8,6 +8,8 @@ import 'package:test/test.dart';
 
 import 'package:supabase_common/testing.dart';
 
+import 'utils.dart';
+
 late SupabaseClient _supabase;
 
 void main() {
@@ -541,8 +543,11 @@ void main() {
 const _streamTimeout = Duration(seconds: 10);
 const _warmUpPrefix = 'warm_up_';
 
-SupabaseClient _createClient() =>
-    SupabaseClient(localStackUrl, localStackServiceRoleKey);
+SupabaseClient _createClient() => SupabaseClient(
+  localStackUrl,
+  localStackServiceRoleKey,
+  authOptions: AuthClientOptions(pkceAsyncStorage: TestAsyncStorage()),
+);
 
 /// Listens to [stream] and asserts that it emits [expectedSnapshots] in order,
 /// where every snapshot is the result of [project] applied to the emitted rows.

--- a/packages/supabase/test/trace_propagation_test.dart
+++ b/packages/supabase/test/trace_propagation_test.dart
@@ -4,8 +4,6 @@ import 'package:supabase/src/trace_http_client.dart';
 import 'package:supabase/supabase.dart';
 import 'package:test/test.dart';
 
-import 'utils.dart';
-
 const _sampledTraceparent =
     '00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01';
 const _unsampledTraceparent =
@@ -134,7 +132,6 @@ void main() {
       _supabaseUrl,
       'anon-key',
       tracePropagationOptions: optionsWith(() => context),
-      authOptions: AuthClientOptions(pkceAsyncStorage: TestAsyncStorage()),
       httpClient: MockClient((request) async {
         restRequest = request;
         return Response(
@@ -159,7 +156,6 @@ void main() {
     final supabase = SupabaseClient(
       _supabaseUrl,
       'anon-key',
-      authOptions: AuthClientOptions(pkceAsyncStorage: TestAsyncStorage()),
       httpClient: MockClient((request) async {
         restRequest = request;
         return Response(

--- a/packages/supabase/test/trace_propagation_test.dart
+++ b/packages/supabase/test/trace_propagation_test.dart
@@ -4,6 +4,8 @@ import 'package:supabase/src/trace_http_client.dart';
 import 'package:supabase/supabase.dart';
 import 'package:test/test.dart';
 
+import 'utils.dart';
+
 const _sampledTraceparent =
     '00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01';
 const _unsampledTraceparent =
@@ -132,6 +134,7 @@ void main() {
       _supabaseUrl,
       'anon-key',
       tracePropagationOptions: optionsWith(() => context),
+      authOptions: AuthClientOptions(pkceAsyncStorage: TestAsyncStorage()),
       httpClient: MockClient((request) async {
         restRequest = request;
         return Response(
@@ -156,6 +159,7 @@ void main() {
     final supabase = SupabaseClient(
       _supabaseUrl,
       'anon-key',
+      authOptions: AuthClientOptions(pkceAsyncStorage: TestAsyncStorage()),
       httpClient: MockClient((request) async {
         restRequest = request;
         return Response(

--- a/packages/supabase/test/utils.dart
+++ b/packages/supabase/test/utils.dart
@@ -1,5 +1,7 @@
 import 'dart:convert';
 
+import 'package:supabase/supabase.dart';
+
 /// Construct session data for a given expiration date
 ({String accessToken, String sessionString}) getSessionData(DateTime dateTime) {
   final expiresAt = dateTime.millisecondsSinceEpoch ~/ 1000;
@@ -25,4 +27,22 @@ import 'dart:convert';
       'l,"last_sign_in_at":"2023-04-01T08:35:05.222755878Z","role":"","updated_'
       'at":"2023-04-01T08:35:05.226938Z"}}';
   return (accessToken: accessToken, sessionString: sessionString);
+}
+
+class TestAsyncStorage extends AuthAsyncStorage {
+  final Map<String, String> _map = {};
+  @override
+  Future<String?> getItem({required String key}) async {
+    return _map[key];
+  }
+
+  @override
+  Future<void> removeItem({required String key}) async {
+    _map.remove(key);
+  }
+
+  @override
+  Future<void> setItem({required String key, required String value}) async {
+    _map[key] = value;
+  }
 }

--- a/packages/supabase/test/utils.dart
+++ b/packages/supabase/test/utils.dart
@@ -1,5 +1,7 @@
 import 'dart:convert';
 
+import 'package:supabase/supabase.dart';
+
 /// Construct session data for a given expiration date
 ({String accessToken, String sessionString}) getSessionData(DateTime dateTime) {
   final expiresAt = dateTime.millisecondsSinceEpoch ~/ 1000;
@@ -26,3 +28,5 @@ import 'dart:convert';
       'at":"2023-04-01T08:35:05.226938Z"}}';
   return (accessToken: accessToken, sessionString: sessionString);
 }
+
+class TestAsyncStorage extends MemoryAuthAsyncStorage {}

--- a/packages/supabase/test/utils.dart
+++ b/packages/supabase/test/utils.dart
@@ -1,7 +1,5 @@
 import 'dart:convert';
 
-import 'package:supabase/supabase.dart';
-
 /// Construct session data for a given expiration date
 ({String accessToken, String sessionString}) getSessionData(DateTime dateTime) {
   final expiresAt = dateTime.millisecondsSinceEpoch ~/ 1000;
@@ -27,22 +25,4 @@ import 'package:supabase/supabase.dart';
       'l,"last_sign_in_at":"2023-04-01T08:35:05.222755878Z","role":"","updated_'
       'at":"2023-04-01T08:35:05.226938Z"}}';
   return (accessToken: accessToken, sessionString: sessionString);
-}
-
-class TestAsyncStorage extends AuthAsyncStorage {
-  final Map<String, String> _map = {};
-  @override
-  Future<String?> getItem({required String key}) async {
-    return _map[key];
-  }
-
-  @override
-  Future<void> removeItem({required String key}) async {
-    _map.remove(key);
-  }
-
-  @override
-  Future<void> setItem({required String key, required String value}) async {
-    _map[key] = value;
-  }
 }

--- a/packages/supabase_auth/example/main.dart
+++ b/packages/supabase_auth/example/main.dart
@@ -12,6 +12,9 @@ Future<void> main() async {
       'Authorization': 'Bearer $supabaseKey',
       'apikey': supabaseKey,
     },
+    // The pkce flow needs somewhere to keep its code verifiers. Swap this for
+    // a persistent storage when the code exchange can happen after a restart.
+    asyncStorage: MemoryAuthAsyncStorage(),
   );
 
   try {

--- a/packages/supabase_auth/lib/src/auth_client.dart
+++ b/packages/supabase_auth/lib/src/auth_client.dart
@@ -45,7 +45,8 @@ class _SessionState {
 /// [httpClient] custom http client.
 ///
 /// [asyncStorage] local storage to store pkce code verifiers. Required when
-/// using the pkce flow.
+/// using the pkce flow. Pass a [MemoryAuthAsyncStorage] when the verifiers
+/// do not need to outlive the process.
 ///
 /// Set [flowType] to [AuthFlowType.implicit] to perform old implicit auth flow.
 /// {@endtemplate}
@@ -159,7 +160,9 @@ class AuthClient {
     AuthFlowType flowType = AuthFlowType.pkce,
   }) : assert(
          flowType != AuthFlowType.pkce || asyncStorage != null,
-         'You need to provide asyncStorage to perform pkce flow.',
+         'You need to provide asyncStorage to perform pkce flow. Pass a '
+         'MemoryAuthAsyncStorage when the code verifiers do not need to '
+         'outlive the process.',
        ),
        _url = url ?? AuthConstants.defaultAuthUrl,
        _headers = {...AuthConstants.defaultHeaders, ...?headers},

--- a/packages/supabase_auth/lib/src/auth_client.dart
+++ b/packages/supabase_auth/lib/src/auth_client.dart
@@ -157,7 +157,11 @@ class AuthClient {
     Client? httpClient,
     AuthAsyncStorage? asyncStorage,
     AuthFlowType flowType = AuthFlowType.pkce,
-  }) : _url = url ?? AuthConstants.defaultAuthUrl,
+  }) : assert(
+         flowType != AuthFlowType.pkce || asyncStorage != null,
+         'You need to provide asyncStorage to perform pkce flow.',
+       ),
+       _url = url ?? AuthConstants.defaultAuthUrl,
        _headers = {...AuthConstants.defaultHeaders, ...?headers},
        _httpClient = httpClient,
        _asyncStorage = asyncStorage,

--- a/packages/supabase_auth/lib/src/types/auth_async_storage.dart
+++ b/packages/supabase_auth/lib/src/types/auth_async_storage.dart
@@ -14,3 +14,26 @@ abstract class AuthAsyncStorage {
   /// Removes an item asynchronously from the storage for the given key.
   Future<void> removeItem({required String key});
 }
+
+/// A [AuthAsyncStorage] that keeps the pkce code verifiers in memory only.
+///
+/// Everything it holds is lost when the process exits, so a pkce flow started
+/// before a restart can no longer be completed. Use a persistent
+/// implementation when the code exchange happens after the app was closed,
+/// which is what `supabase_flutter` does with shared preferences.
+class MemoryAuthAsyncStorage extends AuthAsyncStorage {
+  final _items = <String, String>{};
+
+  @override
+  Future<String?> getItem({required String key}) async => _items[key];
+
+  @override
+  Future<void> setItem({required String key, required String value}) async {
+    _items[key] = value;
+  }
+
+  @override
+  Future<void> removeItem({required String key}) async {
+    _items.remove(key);
+  }
+}

--- a/packages/supabase_auth/test/admin_delete_user_test.dart
+++ b/packages/supabase_auth/test/admin_delete_user_test.dart
@@ -4,6 +4,8 @@ import 'package:supabase_auth/supabase_auth.dart';
 import 'package:http/http.dart';
 import 'package:test/test.dart';
 
+import 'utils.dart';
+
 class _CapturingHttpClient extends BaseClient {
   Request? lastRequest;
 
@@ -25,6 +27,7 @@ void main() {
     client = AuthClient(
       url: 'http://localhost:9999',
       httpClient: httpClient,
+      asyncStorage: TestAsyncStorage(),
     );
   });
 

--- a/packages/supabase_auth/test/admin_list_users_test.dart
+++ b/packages/supabase_auth/test/admin_list_users_test.dart
@@ -4,6 +4,8 @@ import 'package:supabase_auth/supabase_auth.dart';
 import 'package:http/http.dart';
 import 'package:test/test.dart';
 
+import 'utils.dart';
+
 /// Serves a fixed list-users response with the pagination headers the GoTrue
 /// server sends alongside it.
 class ListUsersMockClient extends BaseClient {
@@ -52,6 +54,7 @@ void main() {
   AuthClient clientWith(ListUsersMockClient mockClient) => AuthClient(
     url: 'http://localhost:9999',
     httpClient: mockClient,
+    asyncStorage: TestAsyncStorage(),
   );
 
   test('listUsers() returns the metadata of a middle page', () async {

--- a/packages/supabase_auth/test/admin_test.dart
+++ b/packages/supabase_auth/test/admin_test.dart
@@ -32,6 +32,7 @@ void main() {
         'Authorization': 'Bearer ${getServiceRoleToken(env)}',
         'apikey': getServiceRoleToken(env),
       },
+      asyncStorage: TestAsyncStorage(),
     );
   });
 

--- a/packages/supabase_auth/test/client_test.dart
+++ b/packages/supabase_auth/test/client_test.dart
@@ -985,12 +985,12 @@ void main() {
 
     test('is allowed when the implicit flow is used', () {
       expect(
-        AuthClient(
+        () => AuthClient(
           url: authUrl,
           headers: {'apikey': anonToken},
           flowType: AuthFlowType.implicit,
         ),
-        isNotNull,
+        returnsNormally,
       );
     });
   });

--- a/packages/supabase_auth/test/client_test.dart
+++ b/packages/supabase_auth/test/client_test.dart
@@ -293,7 +293,7 @@ void main() {
       final newClient = AuthClient(
         url: authUrl,
         headers: {'apikey': anonToken},
-        flowType: AuthFlowType.implicit,
+        asyncStorage: TestAsyncStorage(),
       );
 
       expect(newClient.currentSession?.refreshToken ?? '', isEmpty);
@@ -327,7 +327,7 @@ void main() {
         final newClient = AuthClient(
           url: authUrl,
           headers: {'apikey': anonToken},
-          flowType: AuthFlowType.implicit,
+          asyncStorage: TestAsyncStorage(),
         );
 
         expect(newClient.currentSession, isNull);
@@ -371,7 +371,7 @@ void main() {
         final newClient = AuthClient(
           url: authUrl,
           headers: {'apikey': anonToken},
-          flowType: AuthFlowType.implicit,
+          asyncStorage: TestAsyncStorage(),
         );
 
         // Should fall back to _callRefreshToken and succeed.
@@ -423,7 +423,7 @@ void main() {
         final newClient = AuthClient(
           url: authUrl,
           headers: {'apikey': anonToken},
-          flowType: AuthFlowType.implicit,
+          asyncStorage: TestAsyncStorage(),
         );
 
         expect(newClient.currentSession, isNull);
@@ -673,7 +673,7 @@ void main() {
       client = AuthClient(
         url: authUrl,
         httpClient: CustomHttpClient(),
-        flowType: AuthFlowType.implicit,
+        asyncStorage: TestAsyncStorage(),
       );
     });
 
@@ -710,7 +710,7 @@ void main() {
       client = AuthClient(
         url: authUrl,
         httpClient: httpClient,
-        flowType: AuthFlowType.implicit,
+        asyncStorage: TestAsyncStorage(),
       );
     });
 
@@ -969,31 +969,30 @@ void main() {
     );
   });
 
-  group('PKCE constructor assertion', () {
-    test(
-      'throws AssertionError if asyncStorage is missing when using PKCE flow',
-      () {
-        expect(
-          () => AuthClient(
-            url: authUrl,
-            headers: {
-              'Authorization': 'Bearer $anonToken',
-              'apikey': anonToken,
-            },
-            // asyncStorage is missing/null, and flowType defaults to PKCE
+  group('Constructing a client without an asyncStorage', () {
+    test('asserts when the pkce flow is used', () {
+      expect(
+        () => AuthClient(url: authUrl, headers: {'apikey': anonToken}),
+        throwsA(
+          isA<AssertionError>().having(
+            (error) => error.message,
+            'message',
+            contains('You need to provide asyncStorage to perform pkce flow.'),
           ),
-          throwsA(
-            isA<AssertionError>().having(
-              (e) => e.message,
-              'message',
-              contains(
-                'You need to provide asyncStorage to perform pkce flow.',
-              ),
-            ),
-          ),
-        );
-      },
-    );
+        ),
+      );
+    });
+
+    test('is allowed when the implicit flow is used', () {
+      expect(
+        AuthClient(
+          url: authUrl,
+          headers: {'apikey': anonToken},
+          flowType: AuthFlowType.implicit,
+        ),
+        isNotNull,
+      );
+    });
   });
 }
 

--- a/packages/supabase_auth/test/client_test.dart
+++ b/packages/supabase_auth/test/client_test.dart
@@ -293,6 +293,7 @@ void main() {
       final newClient = AuthClient(
         url: authUrl,
         headers: {'apikey': anonToken},
+        flowType: AuthFlowType.implicit,
       );
 
       expect(newClient.currentSession?.refreshToken ?? '', isEmpty);
@@ -326,6 +327,7 @@ void main() {
         final newClient = AuthClient(
           url: authUrl,
           headers: {'apikey': anonToken},
+          flowType: AuthFlowType.implicit,
         );
 
         expect(newClient.currentSession, isNull);
@@ -369,6 +371,7 @@ void main() {
         final newClient = AuthClient(
           url: authUrl,
           headers: {'apikey': anonToken},
+          flowType: AuthFlowType.implicit,
         );
 
         // Should fall back to _callRefreshToken and succeed.
@@ -420,6 +423,7 @@ void main() {
         final newClient = AuthClient(
           url: authUrl,
           headers: {'apikey': anonToken},
+          flowType: AuthFlowType.implicit,
         );
 
         expect(newClient.currentSession, isNull);
@@ -666,7 +670,11 @@ void main() {
     late AuthClient client;
 
     setUpAll(() {
-      client = AuthClient(url: authUrl, httpClient: CustomHttpClient());
+      client = AuthClient(
+        url: authUrl,
+        httpClient: CustomHttpClient(),
+        flowType: AuthFlowType.implicit,
+      );
     });
 
     test('signIn()', () async {
@@ -699,7 +707,11 @@ void main() {
 
     setUpAll(() {
       httpClient = RetryTestHttpClient();
-      client = AuthClient(url: authUrl, httpClient: httpClient);
+      client = AuthClient(
+        url: authUrl,
+        httpClient: httpClient,
+        flowType: AuthFlowType.implicit,
+      );
     });
 
     test('Session recovery succeeds after retries', () async {
@@ -953,6 +965,33 @@ void main() {
         expect(client.currentSession, isNotNull);
 
         await subscription.cancel();
+      },
+    );
+  });
+
+  group('PKCE constructor assertion', () {
+    test(
+      'throws AssertionError if asyncStorage is missing when using PKCE flow',
+      () {
+        expect(
+          () => AuthClient(
+            url: authUrl,
+            headers: {
+              'Authorization': 'Bearer $anonToken',
+              'apikey': anonToken,
+            },
+            // asyncStorage is missing/null, and flowType defaults to PKCE
+          ),
+          throwsA(
+            isA<AssertionError>().having(
+              (e) => e.message,
+              'message',
+              contains(
+                'You need to provide asyncStorage to perform pkce flow.',
+              ),
+            ),
+          ),
+        );
       },
     );
   });

--- a/packages/supabase_auth/test/header_isolation_test.dart
+++ b/packages/supabase_auth/test/header_isolation_test.dart
@@ -4,6 +4,8 @@ import 'package:supabase_auth/supabase_auth.dart';
 import 'package:http/http.dart';
 import 'package:test/test.dart';
 
+import 'utils.dart';
+
 /// Records the headers of every request it receives and always answers with a
 /// minimal user payload, so we can inspect what the client actually sent.
 class _RecordingHttpClient extends BaseClient {
@@ -46,6 +48,7 @@ void main() {
         url: 'http://localhost',
         headers: {'apikey': 'anon-key'},
         httpClient: http,
+        asyncStorage: TestAsyncStorage(),
       );
     });
 

--- a/packages/supabase_auth/test/memory_async_storage_test.dart
+++ b/packages/supabase_auth/test/memory_async_storage_test.dart
@@ -1,0 +1,36 @@
+import 'package:supabase_auth/supabase_auth.dart';
+import 'package:test/test.dart';
+
+void main() {
+  late MemoryAuthAsyncStorage storage;
+
+  setUp(() {
+    storage = MemoryAuthAsyncStorage();
+  });
+
+  test('returns null for a key that was never stored', () async {
+    expect(await storage.getItem(key: 'code-verifier'), isNull);
+  });
+
+  test('returns the value that was stored last', () async {
+    await storage.setItem(key: 'code-verifier', value: 'first');
+    await storage.setItem(key: 'code-verifier', value: 'second');
+
+    expect(await storage.getItem(key: 'code-verifier'), 'second');
+  });
+
+  test('forgets a removed key', () async {
+    await storage.setItem(key: 'code-verifier', value: 'value');
+    await storage.removeItem(key: 'code-verifier');
+
+    expect(await storage.getItem(key: 'code-verifier'), isNull);
+  });
+
+  test('keeps the entries of two instances apart', () async {
+    await storage.setItem(key: 'code-verifier', value: 'value');
+
+    final other = MemoryAuthAsyncStorage();
+
+    expect(await other.getItem(key: 'code-verifier'), isNull);
+  });
+}

--- a/packages/supabase_auth/test/mfa_enroll_test.dart
+++ b/packages/supabase_auth/test/mfa_enroll_test.dart
@@ -4,6 +4,8 @@ import 'package:supabase_auth/supabase_auth.dart';
 import 'package:http/http.dart';
 import 'package:test/test.dart';
 
+import 'utils.dart';
+
 /// Records the body of every request it receives and answers with a minimal
 /// enroll payload, so we can inspect what the client actually sent without a
 /// live server.
@@ -47,6 +49,7 @@ void main() {
         url: 'http://localhost',
         headers: {'apikey': 'anon-key'},
         httpClient: http,
+        asyncStorage: TestAsyncStorage(),
       );
     });
 

--- a/packages/supabase_auth/test/src/auth_admin_custom_providers_api_test.dart
+++ b/packages/supabase_auth/test/src/auth_admin_custom_providers_api_test.dart
@@ -57,6 +57,7 @@ void main() {
         'apikey': serviceRoleToken,
         'x-forwarded-for': '127.0.0.1',
       },
+      asyncStorage: TestAsyncStorage(),
     );
   });
 

--- a/packages/supabase_auth/test/src/auth_admin_mfa_api_test.dart
+++ b/packages/supabase_auth/test/src/auth_admin_mfa_api_test.dart
@@ -33,6 +33,7 @@ void main() {
         'apikey': serviceRoleToken,
         'x-forwarded-for': '127.0.0.1',
       },
+      asyncStorage: TestAsyncStorage(),
     );
   });
 

--- a/packages/supabase_auth/test/src/auth_admin_oauth_api_test.dart
+++ b/packages/supabase_auth/test/src/auth_admin_oauth_api_test.dart
@@ -33,6 +33,7 @@ void main() {
         'apikey': serviceRoleToken,
         'x-forwarded-for': '127.0.0.1',
       },
+      asyncStorage: TestAsyncStorage(),
     );
   });
 

--- a/packages/supabase_auth/test/src/auth_mfa_api_test.dart
+++ b/packages/supabase_auth/test/src/auth_mfa_api_test.dart
@@ -61,6 +61,7 @@ void main() {
           'apikey': anonToken,
           'x-forwarded-for': '127.0.0.1',
         },
+        asyncStorage: TestAsyncStorage(),
       );
     });
 

--- a/packages/supabase_auth/test/src/auth_oauth_api_test.dart
+++ b/packages/supabase_auth/test/src/auth_oauth_api_test.dart
@@ -369,6 +369,7 @@ class AuthOauthApiFixture {
         'apikey': _serviceRoleToken,
         'x-forwarded-for': '127.0.0.1',
       },
+      asyncStorage: TestAsyncStorage(),
     );
   }
 

--- a/packages/supabase_auth/test/utils.dart
+++ b/packages/supabase_auth/test/utils.dart
@@ -90,20 +90,4 @@ const sessionDataUserId = '4d2583da-8de4-49d3-9cd1-37a9a74f55bd';
   return (accessToken: accessToken, sessionString: sessionString);
 }
 
-class TestAsyncStorage extends AuthAsyncStorage {
-  final Map<String, String> _map = {};
-  @override
-  Future<String?> getItem({required String key}) async {
-    return _map[key];
-  }
-
-  @override
-  Future<void> removeItem({required String key}) async {
-    _map.remove(key);
-  }
-
-  @override
-  Future<void> setItem({required String key, required String value}) async {
-    _map[key] = value;
-  }
-}
+class TestAsyncStorage extends MemoryAuthAsyncStorage {}

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -1993,6 +1993,10 @@ features:
       - LocalStorage.initialize
       - LocalStorage.persistSession
       - LocalStorage.removePersistedSession
+      - MemoryAuthAsyncStorage
+      - MemoryAuthAsyncStorage.getItem
+      - MemoryAuthAsyncStorage.removeItem
+      - MemoryAuthAsyncStorage.setItem
       - SharedPreferencesAuthAsyncStorage
       - SharedPreferencesAuthAsyncStorage.SharedPreferencesAuthAsyncStorage
       - SharedPreferencesAuthAsyncStorage.getItem


### PR DESCRIPTION
**Root cause**
When `flowType` is `AuthFlowType.pkce` (the default) and no `asyncStorage` is provided, calling `getOAuthSignInUrl()` or `getLinkIdentityUrl()` fails late at call time. To provide a better developer experience and fail fast, the misconfiguration should be validated up front in the constructor.

**Fix**
Added an `assert` in the `GoTrueClient` constructor to validate that `asyncStorage != null` if `flowType == AuthFlowType.pkce`.

**Tests**
- Added a unit test in `gotrue/test/client_test.dart` to verify that GoTrueClient throws an `AssertionError` if `asyncStorage` is missing when using PKCE flow.
- Updated all test suites in `gotrue` and `supabase` packages to pass a mock storage or specify `implicit` flow type where no storage was configured.

Fixes #1446

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added in-memory storage for PKCE code verifiers.
  * Supabase clients now provide in-memory PKCE storage by default for same-process authentication flows.
  * Added guidance for configuring persistent storage when PKCE values must survive app restarts.

* **Bug Fixes**
  * PKCE authentication now validates that required storage is configured.
  * OAuth sign-in URLs correctly include a PKCE code challenge.

* **Tests**
  * Expanded coverage for PKCE setup and in-memory storage behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->