### PR TITLE
fix(storage): preserve sortBy defaults when list receives a partial sortBy

### DIFF
--- a/packages/storage_client/lib/src/types.dart
+++ b/packages/storage_client/lib/src/types.dart
@@ -236,7 +236,7 @@ class SortBy {
   final String? column;
   final String? order;
 
-  const SortBy({this.column, this.order});
+  const SortBy({this.column = 'name', this.order = 'asc'});
 
   Map<String, dynamic> toMap() {
     return {

--- a/packages/storage_client/lib/src/types.dart
+++ b/packages/storage_client/lib/src/types.dart
@@ -215,10 +215,7 @@ class SearchOptions {
   const SearchOptions({
     this.limit = 100,
     this.offset = 0,
-    this.sortBy = const SortBy(
-      column: 'name',
-      order: 'asc',
-    ),
+    this.sortBy = const SortBy(),
     this.search,
   });
 
@@ -240,8 +237,8 @@ class SortBy {
 
   Map<String, dynamic> toMap() {
     return {
-      'column': column,
-      'order': order,
+      'column': column ?? 'name',
+      'order': order ?? 'asc',
     };
   }
 }

--- a/packages/storage_client/test/client_test.dart
+++ b/packages/storage_client/test/client_test.dart
@@ -1,5 +1,7 @@
+import 'dart:convert';
 import 'dart:io';
 
+import 'package:http/http.dart' as http;
 import 'package:mime/mime.dart';
 import "package:path/path.dart" show join;
 import 'package:storage_client/storage_client.dart';
@@ -663,6 +665,74 @@ void main() {
       await fileApi.list();
 
       expect(fileApi.headers, equals(headersBefore));
+    });
+  });
+
+  group('list sortBy defaults', () {
+    late CustomHttpClient customHttpClient;
+    late SupabaseStorageClient client;
+
+    setUp(() {
+      customHttpClient = CustomHttpClient();
+      client = SupabaseStorageClient(
+        storageUrl,
+        {'Authorization': 'Bearer $storageKey'},
+        httpClient: customHttpClient,
+      );
+    });
+
+    Map<String, dynamic> sentSortBy() {
+      final request = customHttpClient.receivedRequests.first as http.Request;
+      final body = jsonDecode(request.body) as Map<String, dynamic>;
+      return body['sortBy'] as Map<String, dynamic>;
+    }
+
+    test('fills in order when only column is provided', () async {
+      customHttpClient.response = [];
+      customHttpClient.statusCode = 200;
+
+      await client.from('test-bucket').list(
+            searchOptions: const SearchOptions(
+              sortBy: SortBy(column: 'updated_at'),
+            ),
+          );
+
+      expect(sentSortBy(), {'column': 'updated_at', 'order': 'asc'});
+    });
+
+    test('fills in column when only order is provided', () async {
+      customHttpClient.response = [];
+      customHttpClient.statusCode = 200;
+
+      await client.from('test-bucket').list(
+            searchOptions: const SearchOptions(
+              sortBy: SortBy(order: 'desc'),
+            ),
+          );
+
+      expect(sentSortBy(), {'column': 'name', 'order': 'desc'});
+    });
+
+    test('uses defaults when no options are provided', () async {
+      customHttpClient.response = [];
+      customHttpClient.statusCode = 200;
+
+      await client.from('test-bucket').list();
+
+      expect(sentSortBy(), {'column': 'name', 'order': 'asc'});
+    });
+
+    test('preserves a complete sortBy', () async {
+      customHttpClient.response = [];
+      customHttpClient.statusCode = 200;
+
+      await client.from('test-bucket').list(
+            searchOptions: const SearchOptions(
+              sortBy: SortBy(column: 'created_at', order: 'desc'),
+            ),
+          );
+
+      expect(sentSortBy(), {'column': 'created_at', 'order': 'desc'});
     });
   });
 }

--- a/packages/storage_client/test/client_test.dart
+++ b/packages/storage_client/test/client_test.dart
@@ -722,6 +722,19 @@ void main() {
       expect(sentSortBy(), {'column': 'name', 'order': 'asc'});
     });
 
+    test('fills in fields passed explicitly as null', () async {
+      customHttpClient.response = [];
+      customHttpClient.statusCode = 200;
+
+      await client.from('test-bucket').list(
+            searchOptions: const SearchOptions(
+              sortBy: SortBy(column: null, order: null),
+            ),
+          );
+
+      expect(sentSortBy(), {'column': 'name', 'order': 'asc'});
+    });
+
     test('preserves a complete sortBy', () async {
       customHttpClient.response = [];
       customHttpClient.statusCode = 200;


### PR DESCRIPTION
## What

`storage.from(bucket).list()` rejected a partially-specified `SortBy` with a 400.

`SortBy`'s constructor had no default for `column`/`order`, so `SortBy(column: 'updated_at')` left `order` as `null`. Since `SearchOptions.toMap()` always emits both keys and the storage client serializes with `json.encode` (which keeps nulls), the request body sent:

```json
"sortBy": { "column": "updated_at", "order": null }
```

The Storage server requires both `column` and `order`, so it returned a 400.

This mirrors supabase-js [#2454](https://github.com/supabase/supabase-js/pull/2454) (commit `42b7bbc`), which deep-merges the partial `sortBy` onto the defaults.

## Fix

Give `SortBy` constructor defaults so any partially-specified `SortBy` fills in the missing field, which is the idiomatic Dart equivalent of the JS deep-merge and works wherever `SortBy` is constructed:

```dart
const SortBy({this.column = 'name', this.order = 'asc'});
```

Behavior:

- `SortBy(column: 'updated_at')` → `{column: 'updated_at', order: 'asc'}`
- `SortBy(order: 'desc')` → `{column: 'name', order: 'desc'}`
- `list()` with no options → `{column: 'name', order: 'asc'}` (unchanged)

No breaking change for callers passing a complete `SortBy`.

## Tests

Added a `list sortBy defaults` group in `client_test.dart` (using the in-memory `CustomHttpClient` to inspect the request body) covering partial column, partial order, no options, and complete sortBy.

Closes SDK-1089
