### PR TITLE
chore: enable six DCM rules and fix the violations

### DIFF
--- a/packages/gotrue/test/client_test.dart
+++ b/packages/gotrue/test/client_test.dart
@@ -640,11 +640,9 @@ void main() {
       } on ClientException {
         // the method should throw
       }
-      await for (final AuthState event in client.onAuthStateChange) {
-        expect(httpClient.retryCount, 4);
-        expect(event.event, AuthChangeEvent.tokenRefreshed);
-        break;
-      }
+      final event = await client.onAuthStateChange.first;
+      expect(httpClient.retryCount, 4);
+      expect(event.event, AuthChangeEvent.tokenRefreshed);
     });
   });
 

--- a/packages/postgrest/lib/src/postgrest_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_builder.dart
@@ -134,12 +134,10 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
     final execHeaders = {..._headers};
 
     if (_count != null) {
-      if (execHeaders['Prefer'] != null) {
-        final oldPreferHeader = execHeaders['Prefer'];
-        execHeaders['Prefer'] = '$oldPreferHeader,count=${_count.name}';
-      } else {
-        execHeaders['Prefer'] = 'count=${_count.name}';
-      }
+      final oldPreferHeader = execHeaders['Prefer'];
+      execHeaders['Prefer'] = oldPreferHeader != null
+          ? '$oldPreferHeader,count=${_count.name}'
+          : 'count=${_count.name}';
     }
 
     if (method == null) {

--- a/packages/postgrest/lib/src/postgrest_query_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_query_builder.dart
@@ -94,11 +94,7 @@ class PostgrestQueryBuilder<T> extends RawPostgrestBuilder<T, T, T> {
     bool defaultToNull = true,
   }) {
     final newHeaders = {..._headers};
-    newHeaders['Prefer'] = '';
-
-    if (!defaultToNull) {
-      newHeaders['Prefer'] = 'missing=default';
-    }
+    newHeaders['Prefer'] = defaultToNull ? '' : 'missing=default';
 
     Uri url = _url;
     if (values is List) {

--- a/packages/postgrest/lib/src/postgrest_transform_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_transform_builder.dart
@@ -169,12 +169,9 @@ class PostgrestTransformBuilder<T> extends RawPostgrestBuilder<T, T, T> {
     // Temporary fix for https://github.com/supabase/supabase-flutter/issues/560
     // Issue persists e.g. for `.insert([...]).select().maybeSingle()`
     final newHeaders = {..._headers};
-
-    if (_method == HttpMethod.get) {
-      newHeaders['Accept'] = 'application/json';
-    } else {
-      newHeaders['Accept'] = 'application/vnd.pgrst.object+json';
-    }
+    newHeaders['Accept'] = _method == HttpMethod.get
+        ? 'application/json'
+        : 'application/vnd.pgrst.object+json';
 
     return PostgrestTransformBuilder(
       _copyWithType(
@@ -268,18 +265,21 @@ class PostgrestTransformBuilder<T> extends RawPostgrestBuilder<T, T, T> {
     final newHeaders = {..._headers};
 
     // Add handling=strict and max-affected headers
-    if (newHeaders['Prefer'] != null) {
-      var preferHeader = newHeaders['Prefer']!;
-      if (!preferHeader.contains('handling=strict')) {
-        preferHeader += ',handling=strict';
+    final existingPrefer = newHeaders['Prefer'];
+    final String preferHeader;
+    if (existingPrefer != null) {
+      var header = existingPrefer;
+      if (!header.contains('handling=strict')) {
+        header += ',handling=strict';
       }
-      if (!preferHeader.contains('max-affected=')) {
-        preferHeader += ',max-affected=$value';
+      if (!header.contains('max-affected=')) {
+        header += ',max-affected=$value';
       }
-      newHeaders['Prefer'] = preferHeader;
+      preferHeader = header;
     } else {
-      newHeaders['Prefer'] = 'handling=strict,max-affected=$value';
+      preferHeader = 'handling=strict,max-affected=$value';
     }
+    newHeaders['Prefer'] = preferHeader;
 
     return PostgrestTransformBuilder(_copyWith(headers: newHeaders));
   }

--- a/packages/realtime_client/lib/src/realtime_client.dart
+++ b/packages/realtime_client/lib/src/realtime_client.dart
@@ -379,7 +379,7 @@ class RealtimeClient {
       case SocketStates.disconnected:
         return 'disconnected';
       case SocketStates.closed:
-      default:
+      case null:
         return 'closed';
     }
   }

--- a/packages/realtime_client/lib/src/realtime_presence.dart
+++ b/packages/realtime_client/lib/src/realtime_presence.dart
@@ -308,7 +308,6 @@ class RealtimePresence {
     for (final key in state.keys) {
       final presences = state[key]!;
 
-      // if (presences.keys.contains('metas')) {
       if (presences is Map) {
         newStateMap[key] =
             (presences['metas'] as List).map<Presence>((presence) {

--- a/packages/supabase/lib/src/supabase_stream_builder.dart
+++ b/packages/supabase/lib/src/supabase_stream_builder.dart
@@ -219,7 +219,7 @@ class SupabaseStreamBuilder extends Stream<SupabaseStreamEvent> {
                     _addStream();
                   }
                   break;
-                default:
+                case PostgresChangeEvent.all:
                   break;
               }
             })

--- a/packages/supabase_flutter/lib/src/supabase.dart
+++ b/packages/supabase_flutter/lib/src/supabase.dart
@@ -256,7 +256,8 @@ class Supabase {
             _pendingLifecycleOperation = _pendingLifecycleOperation
                 .then((_) => _processLifecycle(state))
                 .catchError((_) {});
-          default:
+          case AppLifecycleState.inactive:
+          case AppLifecycleState.hidden:
             break;
         }
       },

--- a/packages/supabase_flutter/lib/src/supabase_auth.dart
+++ b/packages/supabase_flutter/lib/src/supabase_auth.dart
@@ -168,7 +168,8 @@ class SupabaseAuth with WidgetsBindingObserver {
         if (kIsWeb || Platform.isAndroid || Platform.isIOS) {
           Supabase.instance.client.auth.stopAutoRefresh();
         }
-      default:
+      case AppLifecycleState.inactive:
+      case AppLifecycleState.hidden:
     }
   }
 

--- a/packages/supabase_lints/lib/analysis_options.yaml
+++ b/packages/supabase_lints/lib/analysis_options.yaml
@@ -19,21 +19,15 @@ dcm:
     - recommended
   rules:
     avoid-accessing-collections-by-constant-index: false
-    avoid-commented-out-code: false
-    avoid-constant-conditions: false
     avoid-duplicate-initializers: false
     avoid-duplicate-test-assertions: false
     avoid-dynamic: false
-    avoid-missing-enum-constant-in-map: false
     avoid-never-passed-parameters: false
     avoid-nullable-interpolation: false
     avoid-throw-in-catch-block: false
     avoid-unassigned-stream-subscriptions: false
-    avoid-unconditional-break: false
-    avoid-unnecessary-reassignment: false
     avoid-unsafe-collection-methods: false
     avoid-unused-parameters: false
-    avoid-wildcard-cases-with-enums: false
     move-variable-closer-to-its-usage: false
     no-empty-block: false
     prefer-correct-callback-field-name: false


### PR DESCRIPTION
Part of SDK-1077 (ratcheting down the disabled DCM rule list).

Enables six more DCM rules in the shared `supabase_lints` config and fixes the few existing violations. Two of these rules had zero violations; the other four had only a handful each.

## Rules enabled

| Rule | Violations fixed |
|---|---|
| `avoid-constant-conditions` | 0 |
| `avoid-missing-enum-constant-in-map` | 0 |
| `avoid-commented-out-code` | 1 |
| `avoid-unconditional-break` | 1 |
| `avoid-unnecessary-reassignment` | 4 |
| `avoid-wildcard-cases-with-enums` | 4 |

## Changes

- **postgrest**: collapse the `Prefer`/`Accept` header `if`/`else` reassignments into single assignments (ternary, or a single trailing assignment in `maxAffected`). Behavior is unchanged.
- **realtime_client**: drop a commented-out line in `RealtimePresence`; replace the redundant `default` in `connectionState` with explicit `SocketStates.closed`/`null` cases.
- **supabase / supabase_flutter**: enumerate the remaining enum values (`PostgresChangeEvent.all`, `AppLifecycleState.inactive`/`.hidden`) instead of using a wildcard `default`.
- **gotrue test**: replace an `await for` loop with an unconditional `break` with `.first`.

## Notes

- `avoid-unnecessary-type-assertions` (already enabled, not part of this PR) surfaces two hits in `postgrest_builder.dart` on the `onError is! Function(...)` checks in `then()`. It looks like a false positive (it mirrors the Dart SDK's own `Future.then` signature check), but worth a look separately.
- Integration tests requiring a local PostgREST server were not run locally; the postgrest changes are behavior-preserving refactors and the unit tests pass.