### PR TITLE
feat(gotrue): add user-facing OAuth 2.1 server authorization API

### DIFF
--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -21,6 +21,7 @@ import 'broadcast_stub.dart' if (dart.library.js_interop) './broadcast_web.dart'
     as web;
 import 'version.dart';
 
+part 'gotrue_oauth_api.dart';
 part 'gotrue_mfa_api.dart';
 part 'gotrue_passkey_api.dart';
 
@@ -55,6 +56,9 @@ class GoTrueClient {
 
   /// Namespace for the GoTrue MFA API methods.
   late final GoTrueMFAApi mfa;
+
+  /// Namespace for the GoTrue OAuth methods.
+  late final GoTrueOAuthApi oauth;
 
   /// Namespace for the passkey (WebAuthn) API methods.
   ///
@@ -168,6 +172,7 @@ class GoTrueClient {
       headers: _headers,
       httpClient: httpClient,
     );
+    oauth = GoTrueOAuthApi(client: this, fetch: _fetch);
     mfa = GoTrueMFAApi(client: this, fetch: _fetch);
     passkey = GoTruePasskeyApi(client: this, fetch: _fetch);
     if (_autoRefreshToken) {

--- a/packages/gotrue/lib/src/gotrue_oauth_api.dart
+++ b/packages/gotrue/lib/src/gotrue_oauth_api.dart
@@ -35,7 +35,7 @@ class OAuthAuthorizationDetailsResponse {
   final OAuthAuthorizedClient client;
 
   /// The OAuth User requesting authorization.
-  final User? user;
+  final User user;
 
   /// The scopes requested by the OAuth client, if any.
   final String? scope;
@@ -47,17 +47,27 @@ class OAuthAuthorizationDetailsResponse {
     required this.authorizationId,
     required this.client,
     required this.redirectUri,
-    this.user,
+    required this.user,
     this.scope,
   });
 
   factory OAuthAuthorizationDetailsResponse.fromJson(
     Map<String, dynamic> json,
   ) {
+    final user = json['user'] == null ? null : User.fromJson(json['user']);
+
+    if (user == null) {
+      throw ArgumentError.value(
+        json,
+        'json',
+        'The provided JSON should contain a parseable user object',
+      );
+    }
+
     return OAuthAuthorizationDetailsResponse(
       authorizationId: json['authorization_id'] as String,
       client: OAuthAuthorizedClient.fromJson(json['client']),
-      user: User.fromJson(json['user']),
+      user: user,
       scope: json['scope'] as String?,
       redirectUri: json['redirect_uri'] as String,
     );

--- a/packages/gotrue/lib/src/gotrue_oauth_api.dart
+++ b/packages/gotrue/lib/src/gotrue_oauth_api.dart
@@ -1,0 +1,203 @@
+part of 'gotrue_client.dart';
+
+/// OAuth client object returned from the OAuth 2.1 server when the client is
+/// authorized.
+/// Only relevant when the OAuth 2.1 server is enabled in Supabase Auth.
+class OAuthAuthorizedClient {
+  /// Unique identifier for the OAuth client
+  final String clientId;
+
+  /// Human-readable name of the OAuth client
+  final String? clientName;
+
+  const OAuthAuthorizedClient({
+    required this.clientId,
+    this.clientName,
+  });
+
+  factory OAuthAuthorizedClient.fromJson(Map<String, dynamic> json) {
+    return OAuthAuthorizedClient(
+      clientId: json['id'] as String,
+      clientName: json['name'] as String?,
+    );
+  }
+}
+
+/// Response type representing the details of a pending OAuth authorization
+/// request.
+///
+/// Only relevant when the OAuth 2.1 server is enabled in Supabase Auth.
+class OAuthAuthorizationDetailsResponse {
+  /// The unique identifier for this authorization request.
+  final String authorizationId;
+
+  /// The OAuth client requesting authorization.
+  final OAuthAuthorizedClient client;
+
+  /// The OAuth User requesting authorization.
+  final User? user;
+
+  /// The scopes requested by the OAuth client, if any.
+  final String? scope;
+
+  /// The redirect URI to be used after the authorization decision.
+  final String redirectUri;
+
+  const OAuthAuthorizationDetailsResponse({
+    required this.authorizationId,
+    required this.client,
+    required this.redirectUri,
+    this.user,
+    this.scope,
+  });
+
+  factory OAuthAuthorizationDetailsResponse.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    return OAuthAuthorizationDetailsResponse(
+      authorizationId: json['authorization_id'] as String,
+      client: OAuthAuthorizedClient.fromJson(json['client']),
+      user: User.fromJson(json['user']),
+      scope: json['scope'] as String?,
+      redirectUri: json['redirect_uri'] as String,
+    );
+  }
+}
+
+/// Response type for an OAuth authorization consent decision (approve or deny).
+///
+/// Only relevant when the OAuth 2.1 server is enabled in Supabase Auth.
+class OAuthConsentResponse {
+  /// The URL to redirect the user to after the authorization decision.
+  ///
+  /// On approval this will contain the authorization code; on denial it will
+  /// carry an `access_denied` error — both in the form the OAuth client
+  /// registered to receive.
+  ///
+  /// This field is `null` if [skipBrowserRedirect] was `false` (the default)
+  /// and the SDK performed the redirect automatically.
+  final String? redirectUrl;
+
+  const OAuthConsentResponse({this.redirectUrl});
+
+  factory OAuthConsentResponse.fromJson(Map<String, dynamic> json) {
+    return OAuthConsentResponse(
+      redirectUrl: json['redirect_url'] as String?,
+    );
+  }
+}
+
+/// {@template gotrue_oauth_server_api}
+/// API namespace for the OAuth 2.1 authorization server consent flow.
+///
+/// Use these methods when your Supabase project is acting as an OAuth 2.1
+/// server.
+/// The typical flow is:
+///
+/// 1. The third-party OAuth client redirects the user to your app's
+///    authorization path, which extracts the `authorization_id` from the
+///    query parameters.
+/// 2. Call [getAuthorizationDetails] to retrieve the requesting client's
+///    details and the requested scopes for display in the consent UI.
+/// 3. Call [approveAuthorization] or [denyAuthorization] according to the
+///    user's decision.
+///
+/// ```dart
+/// // 1. Extract the authorization_id from the incoming redirect URL.
+/// final authorizationId = Uri.parse(currentUrl).queryParameters['authorization_id']!;
+///
+/// // 2. Show the consent screen.
+/// final details = await supabase.auth.oauthServer.getAuthorizationDetails(authorizationId);
+/// print('App "${details.client.clientName}" requests: ${details.scope}');
+///
+/// // 3. Act on the user's decision.
+/// final consent = await supabase.auth.oauthServer.approveAuthorization(authorizationId);
+/// // Redirect the user to consent.redirectUrl (when skipBrowserRedirect is true).
+/// ```
+///
+/// These methods require a signed-in user and only work when the OAuth 2.1
+/// server feature is enabled in your Supabase Auth configuration.
+/// {@endtemplate}
+class GoTrueOAuthApi {
+  final GotrueFetch _fetch;
+  final GoTrueClient _client;
+
+  const GoTrueOAuthApi({
+    required GoTrueClient client,
+    required GotrueFetch fetch,
+  })  : _client = client,
+        _fetch = fetch;
+
+  /// Retrieves details about an OAuth authorization request.
+  /// Only relevant when the OAuth 2.1 server is enabled in Supabase Auth.
+  ///
+  /// Returns authorization details including client info, scopes, and user information.
+  /// If the response includes only a redirect_url field, it means consent was already given - the caller
+  /// should handle the redirect manually if needed.
+  Future<OAuthAuthorizationDetailsResponse> getAuthorizationDetails(
+    String authorizationId,
+  ) async {
+    final session = _client.currentSession;
+
+    final data = await _fetch.request(
+      '${_client._url}/oauth/authorizations/$authorizationId',
+      RequestMethodType.get,
+      options: GotrueRequestOptions(
+        headers: _client._headers,
+        jwt: session?.accessToken,
+      ),
+    );
+
+    return OAuthAuthorizationDetailsResponse.fromJson(data);
+  }
+
+  /// Approves a pending OAuth authorization request.
+  ///
+  /// [authorizationId] is the unique identifier for the pending authorization
+  /// request.
+  ///
+  /// Only relevant when the OAuth 2.1 server is enabled in Supabase Auth.
+  Future<OAuthConsentResponse> approveAuthorization(
+    String authorizationId,
+  ) async {
+    final session = _client.currentSession;
+
+    final data = await _fetch.request(
+      '${_client._url}/oauth/authorizations/$authorizationId/consent',
+      RequestMethodType.post,
+      options: GotrueRequestOptions(
+          headers: _client._headers,
+          jwt: session?.accessToken,
+          body: {
+            'action': 'approve',
+          }),
+    );
+
+    return OAuthConsentResponse.fromJson(data);
+  }
+
+  /// Denies a pending OAuth authorization request.
+  ///
+  /// [authorizationId] is the unique identifier for the pending authorization
+  /// request.
+  ///
+  /// Only relevant when the OAuth 2.1 server is enabled in Supabase Auth.
+  Future<OAuthConsentResponse> denyAuthorization(
+    String authorizationId,
+  ) async {
+    final session = _client.currentSession;
+
+    final data = await _fetch.request(
+      '${_client._url}/oauth/authorizations/$authorizationId/consent',
+      RequestMethodType.post,
+      options: GotrueRequestOptions(
+          headers: _client._headers,
+          jwt: session?.accessToken,
+          body: {
+            'action': 'deny',
+          }),
+    );
+
+    return OAuthConsentResponse.fromJson(data);
+  }
+}

--- a/packages/gotrue/lib/src/gotrue_oauth_api.dart
+++ b/packages/gotrue/lib/src/gotrue_oauth_api.dart
@@ -2,6 +2,7 @@ part of 'gotrue_client.dart';
 
 /// OAuth client object returned from the OAuth 2.1 server when the client is
 /// authorized.
+///
 /// Only relevant when the OAuth 2.1 server is enabled in Supabase Auth.
 class OAuthAuthorizedClient {
   /// Unique identifier for the OAuth client
@@ -79,13 +80,6 @@ class OAuthAuthorizationDetailsResponse {
 /// Only relevant when the OAuth 2.1 server is enabled in Supabase Auth.
 class OAuthConsentResponse {
   /// The URL to redirect the user to after the authorization decision.
-  ///
-  /// On approval this will contain the authorization code; on denial it will
-  /// carry an `access_denied` error — both in the form the OAuth client
-  /// registered to receive.
-  ///
-  /// This field is `null` if [skipBrowserRedirect] was `false` (the default)
-  /// and the SDK performed the redirect automatically.
   final String? redirectUrl;
 
   const OAuthConsentResponse({this.redirectUrl});
@@ -122,7 +116,7 @@ class OAuthConsentResponse {
 ///
 /// // 3. Act on the user's decision.
 /// final consent = await supabase.auth.oauth.approveAuthorization(authorizationId);
-/// // Redirect the user to consent.redirectUrl (when skipBrowserRedirect is true).
+/// // Redirect the user to consent.redirectUrl.
 /// ```
 ///
 /// These methods require a signed-in user and only work when the OAuth 2.1

--- a/packages/gotrue/lib/src/gotrue_oauth_api.dart
+++ b/packages/gotrue/lib/src/gotrue_oauth_api.dart
@@ -107,11 +107,11 @@ class OAuthConsentResponse {
 /// final authorizationId = Uri.parse(currentUrl).queryParameters['authorization_id']!;
 ///
 /// // 2. Show the consent screen.
-/// final details = await supabase.auth.oauthServer.getAuthorizationDetails(authorizationId);
+/// final details = await supabase.auth.oauth.getAuthorizationDetails(authorizationId);
 /// print('App "${details.client.clientName}" requests: ${details.scope}');
 ///
 /// // 3. Act on the user's decision.
-/// final consent = await supabase.auth.oauthServer.approveAuthorization(authorizationId);
+/// final consent = await supabase.auth.oauth.approveAuthorization(authorizationId);
 /// // Redirect the user to consent.redirectUrl (when skipBrowserRedirect is true).
 /// ```
 ///

--- a/packages/gotrue/test/src/gotrue_oauth_api_test.dart
+++ b/packages/gotrue/test/src/gotrue_oauth_api_test.dart
@@ -1,0 +1,183 @@
+import 'package:dotenv/dotenv.dart';
+import 'package:gotrue/gotrue.dart';
+import 'package:http/http.dart' as http;
+import 'package:test/test.dart';
+
+import '../utils.dart';
+
+void main() {
+  late GotrueOauthApiFixture fixture;
+
+  setUp(() async {
+    fixture = GotrueOauthApiFixture();
+  });
+
+  group('OAuth server', () {
+    test('get authorization details', () async {
+      final sut = await fixture.build();
+      final clientParams = CreateOAuthClientParams(
+        clientName: 'Test OAuth Client',
+        redirectUris: ['http://127.0.0.1:3000/oauth/callback'],
+        responseTypes: [OAuthClientResponseType.code],
+        scope: 'email',
+      );
+      final client = await fixture.sutCreatesOAuthClient(clientParams);
+      final auth = await fixture.sutLogsIn(password: password, email: email1);
+      final authorizationId = await fixture.sutAuthorizesClient(client);
+
+      final res = await sut.oauth.getAuthorizationDetails(authorizationId);
+
+      expect(res.authorizationId, equals(authorizationId));
+      expect(res.scope, equals(clientParams.scope));
+      expect(res.redirectUri, equals(clientParams.redirectUris.first));
+      expect(res.client.clientId, equals(client.clientId));
+      expect(res.client.clientName, equals(client.clientName));
+      expect(res.user?.id, equals(auth.user?.id));
+      expect(res.user?.email, equals(email1));
+    });
+
+    test('approve authorization request', () async {
+      final sut = await fixture.build();
+      final clientParams = CreateOAuthClientParams(
+        clientName: 'Test OAuth Client',
+        redirectUris: ['http://127.0.0.1:3000/oauth/callback'],
+      );
+      final client = await fixture.sutCreatesOAuthClient(clientParams);
+      final authorizationId = await fixture.sutAuthorizesClient(client);
+      await fixture.sutLogsIn(password: password, email: email1);
+
+      await sut.oauth.getAuthorizationDetails(authorizationId);
+      final res = await sut.oauth.approveAuthorization(authorizationId);
+
+      expect(res.redirectUrl, startsWith(clientParams.redirectUris.first));
+      expect(res.redirectUrl, contains('code='));
+    });
+
+    test('denies authorization request', () async {
+      final sut = await fixture.build();
+      final clientParams = CreateOAuthClientParams(
+        clientName: 'Test OAuth Client',
+        redirectUris: ['http://127.0.0.1:3000/oauth/callback'],
+      );
+      final client = await fixture.sutCreatesOAuthClient(clientParams);
+      final authorizationId = await fixture.sutAuthorizesClient(client);
+      await fixture.sutLogsIn(password: password, email: email1);
+
+      await sut.oauth.getAuthorizationDetails(authorizationId);
+      final res = await sut.oauth.denyAuthorization(authorizationId);
+
+      expect(res.redirectUrl, startsWith(clientParams.redirectUris.first));
+      expect(res.redirectUrl, contains('error=access_denied'));
+      expect(
+        res.redirectUrl,
+        contains('error_description=User+denied+the+request'),
+      );
+    });
+
+    test('approving authorization without getting details throws', () async {
+      final sut = await fixture.build();
+      final clientParams = CreateOAuthClientParams(
+        clientName: 'Test OAuth Client',
+        redirectUris: ['http://127.0.0.1:3000/oauth/callback'],
+      );
+      final client = await fixture.sutCreatesOAuthClient(clientParams);
+      final authorizationId = await fixture.sutAuthorizesClient(client);
+      await fixture.sutLogsIn(password: password, email: email1);
+
+      await expectLater(
+        () async => sut.oauth.approveAuthorization(authorizationId),
+        throwsA(
+          isAnAuthApiException(
+            statusCode: equals('404'),
+            code: equals('oauth_authorization_not_found'),
+          ),
+        ),
+      );
+    });
+  });
+}
+
+class GotrueOauthApiFixture {
+  GotrueOauthApiFixture() {
+    final env = DotEnv();
+    env.load(); // Load env variables from .env file
+
+    _gotrueUrl = env['GOTRUE_URL'] ?? 'http://127.0.0.1:54421/auth/v1';
+    _serviceRoleToken = getServiceRoleToken(env);
+
+    _client = GoTrueClient(
+      url: _gotrueUrl,
+      headers: {
+        'Authorization': 'Bearer $_serviceRoleToken',
+        'apikey': _serviceRoleToken,
+        'x-forwarded-for': '127.0.0.1',
+      },
+    );
+  }
+
+  late final GoTrueClient _client;
+  late final String _gotrueUrl;
+  late final String _serviceRoleToken;
+
+  Future<OAuthClient> sutCreatesOAuthClient(CreateOAuthClientParams request) {
+    return _client.admin.oauth.createClient(request).then((res) => res.client!);
+  }
+
+  Future<String> sutAuthorizesClient(OAuthClient client) async {
+    // Don't follow redirects: the authorize endpoint returns a 302 to the
+    // consent page with authorization_id as a query parameter.
+    final httpClient = http.Client();
+    final request = http.Request(
+      'GET',
+      Uri(
+        scheme: 'http',
+        host: '127.0.0.1',
+        port: 54421,
+        path: '/auth/v1/oauth/authorize',
+        queryParameters: {
+          'response_type': client.responseTypes.first.name,
+          'client_id': client.clientId,
+          'redirect_uri': client.redirectUris.first,
+          'code_challenge': 'pkqGrzhFuuBOcRoR4elYl2ki1EiR3KtBdtQsEZdv8rM',
+          'code_challenge_method': 'S256',
+        },
+      ),
+    )..followRedirects = false;
+
+    final streamed = await httpClient.send(request);
+    httpClient.close();
+
+    final location = streamed.headers['location']!;
+    return Uri.parse(location).queryParameters['authorization_id']!;
+  }
+
+  Future<AuthResponse> sutLogsIn(
+      {required String email, required String password}) {
+    return _client.signInWithPassword(password: password, email: email);
+  }
+
+  Future<void> _reset() async {
+    final res = await http.post(
+        Uri.parse(
+            'http://127.0.0.1:54421/rest/v1/rpc/reset_and_init_auth_data'),
+        headers: {
+          'x-forwarded-for': '127.0.0.1',
+          'apikey': _serviceRoleToken,
+          'Authorization': 'Bearer $_serviceRoleToken',
+        });
+    if (res.body.isNotEmpty) throw res.body;
+  }
+
+  Future<GoTrueClient> build({bool reset = true}) async {
+    if (reset) {
+      await _reset();
+    }
+
+    return _client;
+  }
+}
+
+Matcher isAnAuthApiException({Matcher? statusCode, Matcher? code}) =>
+    isA<AuthApiException>()
+        .having((e) => e.statusCode, 'statusCode', statusCode)
+        .having((e) => e.code, 'code', code);

--- a/packages/gotrue/test/src/gotrue_oauth_api_test.dart
+++ b/packages/gotrue/test/src/gotrue_oauth_api_test.dart
@@ -12,6 +12,60 @@ void main() {
     fixture = GotrueOauthApiFixture();
   });
 
+  group('OAuthAuthorizationDetailsResponse', () {
+    test('can parse a valid JSON', () {
+      final json = {
+        'authorization_id': '6abuj667j4nmdotzu3w2ro5r33xezvae',
+        'redirect_uri': 'http://localhost:50200/onboarding/auth/consent',
+        'client': {
+          'id': '7263e727-435b-4d38-a5ff-a14c954b8680',
+          'name': 'OAuth test client',
+        },
+        'user': {
+          'id': '1bee2038-51fe-4f93-8fbb-442df18657ff',
+          'email': 'translator.user@mail.com'
+        },
+        'scope': 'email'
+      };
+
+      final actual = OAuthAuthorizationDetailsResponse.fromJson(json);
+
+      expect(
+        actual.authorizationId,
+        equals('6abuj667j4nmdotzu3w2ro5r33xezvae'),
+      );
+      expect(actual.scope, equals('email'));
+      expect(
+        actual.redirectUri,
+        equals('http://localhost:50200/onboarding/auth/consent'),
+      );
+      expect(
+        actual.client.clientId,
+        equals('7263e727-435b-4d38-a5ff-a14c954b8680'),
+      );
+      expect(actual.client.clientName, equals('OAuth test client'));
+      expect(actual.user.id, equals('1bee2038-51fe-4f93-8fbb-442df18657ff'));
+      expect(actual.user.email, equals('translator.user@mail.com'));
+    });
+
+    test('throws ArgumentError when user information is missing', () {
+      final json = {
+        'authorization_id': '6abuj667j4nmdotzu3w2ro5r33xezvae',
+        'redirect_uri': 'http://localhost:50200/onboarding/auth/consent',
+        'client': {
+          'id': '7263e727-435b-4d38-a5ff-a14c954b8680',
+          'name': 'OAuth test client',
+        },
+        'scope': 'email'
+      };
+
+      expect(
+        () => OAuthAuthorizationDetailsResponse.fromJson(json),
+        throwsArgumentError,
+      );
+    });
+  });
+
   group('OAuth server', () {
     test('get authorization details', () async {
       final sut = await fixture.build();
@@ -32,8 +86,8 @@ void main() {
       expect(res.redirectUri, equals(clientParams.redirectUris.first));
       expect(res.client.clientId, equals(client.clientId));
       expect(res.client.clientName, equals(client.clientName));
-      expect(res.user?.id, equals(auth.user?.id));
-      expect(res.user?.email, equals(email1));
+      expect(res.user.id, equals(auth.user?.id));
+      expect(res.user.email, equals(email1));
     });
 
     test('approve authorization request', () async {

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -92,9 +92,9 @@ features:
   auth.passkey.sign_in_with_passkey: implemented
 
   # auth — OAuth server (Supabase acting as an OAuth provider)
-  auth.oauth_server.get_authorization_details: not_implemented
-  auth.oauth_server.approve_authorization: not_implemented
-  auth.oauth_server.deny_authorization: not_implemented
+  auth.oauth_server.get_authorization_details: implemented
+  auth.oauth_server.approve_authorization: implemented
+  auth.oauth_server.deny_authorization: implemented
   auth.oauth_server.list_grants: not_implemented
   auth.oauth_server.revoke_grant: not_implemented
 

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -92,9 +92,38 @@ features:
   auth.passkey.sign_in_with_passkey: implemented
 
   # auth — OAuth server (Supabase acting as an OAuth provider)
-  auth.oauth_server.get_authorization_details: implemented
-  auth.oauth_server.approve_authorization: implemented
-  auth.oauth_server.deny_authorization: implemented
+  auth.oauth_server.get_authorization_details:
+    status: implemented
+    symbols:
+      - GoTrueClient.oauth
+      - GoTrueOAuthApi
+      - GoTrueOAuthApi.GoTrueOAuthApi
+      - GoTrueOAuthApi.getAuthorizationDetails
+      - OAuthAuthorizationDetailsResponse
+      - OAuthAuthorizationDetailsResponse.OAuthAuthorizationDetailsResponse
+      - OAuthAuthorizationDetailsResponse.authorizationId
+      - OAuthAuthorizationDetailsResponse.client
+      - OAuthAuthorizationDetailsResponse.fromJson
+      - OAuthAuthorizationDetailsResponse.redirectUri
+      - OAuthAuthorizationDetailsResponse.scope
+      - OAuthAuthorizationDetailsResponse.user
+      - OAuthAuthorizedClient
+      - OAuthAuthorizedClient.OAuthAuthorizedClient
+      - OAuthAuthorizedClient.clientId
+      - OAuthAuthorizedClient.clientName
+      - OAuthAuthorizedClient.fromJson
+  auth.oauth_server.approve_authorization:
+    status: implemented
+    symbols:
+      - GoTrueOAuthApi.approveAuthorization
+      - OAuthConsentResponse
+      - OAuthConsentResponse.OAuthConsentResponse
+      - OAuthConsentResponse.fromJson
+      - OAuthConsentResponse.redirectUrl
+  auth.oauth_server.deny_authorization:
+    status: implemented
+    symbols:
+      - GoTrueOAuthApi.denyAuthorization
   auth.oauth_server.list_grants: not_implemented
   auth.oauth_server.revoke_grant: not_implemented
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Adds the user-facing OAuth 2.1 server authorization consent flow methods:
- `getAuthorizationDetails(authorizationId)` (GET `/oauth/authorizations/{id}`)
- `approveAuthorization(authorizationId)` (POST `/oauth/authorizations/{id}/consent` with action: 'approve')
- `denyAuthorization(authorizationId)` (POST `/oauth/authorizations/{id}/consent` with action: 'deny')

These are exposed on GoTrueClient via `client.oauth`.

## What is the current behavior?

Closes #1475

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

<img width="905" height="277" alt="image" src="https://github.com/user-attachments/assets/bda1703d-4cf6-4da1-81ac-4fc8e9910e51" />
