### PR TITLE
fix(gotrue): allow TOTP MFA enrollment without an issuer

### DIFF
--- a/packages/gotrue/lib/src/gotrue_mfa_api.dart
+++ b/packages/gotrue/lib/src/gotrue_mfa_api.dart
@@ -57,8 +57,6 @@ class GoTrueMFAApi {
     };
 
     if (factorType == FactorType.totp) {
-      // `issuer` is optional for TOTP factors, matching the server and
-      // supabase-js. Only forward it when the caller provided one.
       if (issuer != null) {
         body['issuer'] = issuer;
       }

--- a/packages/gotrue/lib/src/gotrue_mfa_api.dart
+++ b/packages/gotrue/lib/src/gotrue_mfa_api.dart
@@ -56,13 +56,18 @@ class GoTrueMFAApi {
       'factor_type': factorType.name,
     };
 
-    if (factorType == FactorType.totp && issuer != null) {
-      body['issuer'] = issuer;
-    } else if (factorType == FactorType.phone && phone != null) {
+    if (factorType == FactorType.totp) {
+      // `issuer` is optional for TOTP factors, matching the server and
+      // supabase-js. Only forward it when the caller provided one.
+      if (issuer != null) {
+        body['issuer'] = issuer;
+      }
+    } else if (factorType == FactorType.phone) {
+      if (phone == null) {
+        throw ArgumentError(
+            'Invalid arguments, expected a phone for the phone factor type.');
+      }
       body['phone'] = phone;
-    } else {
-      throw ArgumentError(
-          'Invalid arguments, expected an issuer for totp factor type or phone for phone factor. type');
     }
 
     final data = await _fetch.request(

--- a/packages/gotrue/lib/src/gotrue_mfa_api.dart
+++ b/packages/gotrue/lib/src/gotrue_mfa_api.dart
@@ -66,6 +66,9 @@ class GoTrueMFAApi {
             'Invalid arguments, expected a phone for the phone factor type.');
       }
       body['phone'] = phone;
+    } else {
+      throw ArgumentError(
+          'Invalid arguments, unsupported factor type for enroll: ${factorType.name}.');
     }
 
     final data = await _fetch.request(

--- a/packages/gotrue/test/mfa_enroll_test.dart
+++ b/packages/gotrue/test/mfa_enroll_test.dart
@@ -67,5 +67,14 @@ void main() {
         throwsArgumentError,
       );
     });
+
+    test('a webauthn factor is rejected instead of reaching the network',
+        () async {
+      expect(
+        () => client.mfa.enroll(factorType: FactorType.webauthn),
+        throwsArgumentError,
+      );
+      expect(http.requestBodies, isEmpty);
+    });
   });
 }

--- a/packages/gotrue/test/mfa_enroll_test.dart
+++ b/packages/gotrue/test/mfa_enroll_test.dart
@@ -1,0 +1,71 @@
+import 'dart:convert';
+
+import 'package:gotrue/gotrue.dart';
+import 'package:http/http.dart';
+import 'package:test/test.dart';
+
+/// Records the body of every request it receives and answers with a minimal
+/// enroll payload, so we can inspect what the client actually sent without a
+/// live server.
+class _RecordingHttpClient extends BaseClient {
+  final List<Map<String, dynamic>> requestBodies = [];
+
+  @override
+  Future<StreamedResponse> send(BaseRequest request) async {
+    final body = request is Request && request.body.isNotEmpty
+        ? jsonDecode(request.body) as Map<String, dynamic>
+        : <String, dynamic>{};
+    requestBodies.add(body);
+    return StreamedResponse(
+      Stream.value(utf8.encode(jsonEncode({
+        'id': '3f1e2d4c-1111-2222-3333-444455556666',
+        'type': 'totp',
+        'totp': {
+          'qr_code': 'svg',
+          'secret': 'ABC123',
+          'uri': 'otpauth://totp/Example?secret=ABC123',
+        },
+      }))),
+      200,
+      request: request,
+    );
+  }
+}
+
+void main() {
+  group('GoTrueClient.mfa.enroll', () {
+    late _RecordingHttpClient http;
+    late GoTrueClient client;
+
+    setUp(() {
+      http = _RecordingHttpClient();
+      client = GoTrueClient(
+        url: 'http://localhost',
+        headers: {'apikey': 'anon-key'},
+        httpClient: http,
+      );
+    });
+
+    test('a TOTP factor enrolls without an issuer', () async {
+      // `issuer` is optional for TOTP, so this must reach the network instead
+      // of throwing ArgumentError before the request is sent.
+      await client.mfa.enroll();
+
+      expect(http.requestBodies.single.containsKey('issuer'), isFalse);
+      expect(http.requestBodies.single['factor_type'], 'totp');
+    });
+
+    test('a TOTP factor forwards the issuer when provided', () async {
+      await client.mfa.enroll(issuer: 'MyApp');
+
+      expect(http.requestBodies.single['issuer'], 'MyApp');
+    });
+
+    test('a phone factor still requires a phone number', () async {
+      expect(
+        () => client.mfa.enroll(factorType: FactorType.phone),
+        throwsArgumentError,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## What

`GoTrueMFAApi.enroll()` no longer requires an `issuer` when enrolling a TOTP factor. The canonical call now works:

```dart
final res = await supabase.auth.mfa.enroll(); // factorType defaults to totp
```

## Why

`issuer` is documented as optional for TOTP (`/// [issuer] : Domain which the user is enrolled with (TOTP only).`) and is optional in supabase-js, but the argument validation made it mandatory:

```dart
if (factorType == FactorType.totp && issuer != null) {
  body['issuer'] = issuer;
} else if (factorType == FactorType.phone && phone != null) {
  body['phone'] = phone;
} else {
  throw ArgumentError('Invalid arguments, expected an issuer for totp ...');
}
```

When a TOTP factor is enrolled without an `issuer`, both `if` branches are false, so it falls through to the `else` and throws `ArgumentError` synchronously, before any request is sent. The standard `mfa.enroll()` therefore always failed unless an issuer was passed.

This was an unintended regression from #1188 (Add phone mfa enrollment), which introduced the combined branch. The existing `enroll totp` integration test always passes `issuer: 'MyFriend'`, so it never exercised the no-issuer path.

The fix separates the factor-type handling so TOTP forwards `issuer` only when provided, while phone enrollment keeps its existing requirement that a phone number is supplied. The original `else` also acted as a catch-all that rejected any factor type other than `totp`/`phone` (`webauthn`, `unknown`); splitting the branches without keeping an equivalent catch-all would have silently dropped that validation, letting `enroll(factorType: FactorType.webauthn)` reach the network with an incomplete, unvalidated body instead of failing fast. The fix keeps that catch-all as its own `else`.

## Not a breaking change

- TOTP enrollment with an `issuer` behaves exactly as before (the value is still sent).
- Phone enrollment is unchanged and still throws `ArgumentError` when `phone` is omitted (covered by the existing `enroll phone requires phone number` test).
- Enrolling with an unsupported factor type (`webauthn`, `unknown`) still throws `ArgumentError`, matching the previous behavior; `webauthn` factors are enrolled through the separate `auth.passkey` API, not through `mfa.enroll()`.
- Only the previously-broken TOTP-without-issuer path changes: it now succeeds instead of throwing.

## Tests

Added `packages/gotrue/test/mfa_enroll_test.dart`, an offline test using a recording `BaseClient` that inspects the outgoing request body:

- `enroll()` reaches the network and sends no `issuer` (previously threw `ArgumentError`).
- `enroll(issuer: 'MyApp')` forwards the issuer.
- `enroll(factorType: FactorType.phone)` without a phone still throws `ArgumentError`.
- `enroll(factorType: FactorType.webauthn)` throws `ArgumentError` and never reaches the network.
