### PR TITLE
fix(supabase_flutter): backfill requireResidentKey when omitted by the server

### DIFF
--- a/packages/supabase_flutter/lib/src/passkey/passkey_options_mapper.dart
+++ b/packages/supabase_flutter/lib/src/passkey/passkey_options_mapper.dart
@@ -5,10 +5,13 @@ import 'package:passkeys_platform_interface/types/types.dart';
 ///
 /// The Supabase API returns options in the W3C
 /// `PublicKeyCredentialCreationOptionsJSON` format, which already uses the same
-/// field names as [RegisterRequestType.fromJson]. The only adjustments needed
-/// are stripping base64url padding from the challenge and credential ids (the
-/// plugin rejects padded values) and ensuring every excluded credential carries
-/// a `transports` list (the plugin requires it).
+/// field names as [RegisterRequestType.fromJson]. The adjustments needed are
+/// stripping base64url padding from the challenge and credential ids (the
+/// plugin rejects padded values), ensuring every excluded credential carries
+/// a `transports` list (the plugin requires it), and backfilling
+/// `authenticatorSelection.requireResidentKey` (the plugin requires it, but
+/// the WebAuthn spec has treated it as optional since Level 2, so the server
+/// may omit it).
 RegisterRequestType passkeyRegisterRequestFromOptions(
   Map<String, dynamic> options,
 ) {
@@ -22,6 +25,12 @@ RegisterRequestType passkeyRegisterRequestFromOptions(
   final excludeCredentials = json['excludeCredentials'];
   if (excludeCredentials is List) {
     json['excludeCredentials'] = _normalizeCredentials(excludeCredentials);
+  }
+
+  final authenticatorSelection = json['authenticatorSelection'];
+  if (authenticatorSelection is Map) {
+    json['authenticatorSelection'] =
+        _normalizeAuthenticatorSelection(authenticatorSelection);
   }
 
   return RegisterRequestType.fromJson(json);
@@ -69,6 +78,21 @@ List<Map<String, dynamic>> _normalizeCredentials(List<dynamic> credentials) {
 
     return normalized;
   }).toList();
+}
+
+/// Backfills `requireResidentKey` when the server omits it, deriving it from
+/// `residentKey` per the WebAuthn spec's backwards compatibility guidance:
+/// `true` if `residentKey` is `"required"`, `false` otherwise.
+Map<String, dynamic> _normalizeAuthenticatorSelection(
+  Map<dynamic, dynamic> authenticatorSelection,
+) {
+  final normalized = Map<String, dynamic>.from(authenticatorSelection);
+
+  if (normalized['requireResidentKey'] is! bool) {
+    normalized['requireResidentKey'] = normalized['residentKey'] == 'required';
+  }
+
+  return normalized;
 }
 
 String _stripBase64UrlPadding(String value) {

--- a/packages/supabase_flutter/test/passkey_options_mapper_test.dart
+++ b/packages/supabase_flutter/test/passkey_options_mapper_test.dart
@@ -66,6 +66,49 @@ void main() {
         ['internal', 'hybrid'],
       );
     });
+
+    test(
+      'defaults missing requireResidentKey to false when residentKey is not required',
+      () {
+        final options = baseOptions()
+          ..['authenticatorSelection'] = {
+            'residentKey': 'preferred',
+            'userVerification': 'preferred',
+          };
+
+        final request = passkeyRegisterRequestFromOptions(options);
+
+        expect(request.authSelectionType?.requireResidentKey, false);
+      },
+    );
+
+    test(
+      'derives missing requireResidentKey from a required residentKey',
+      () {
+        final options = baseOptions()
+          ..['authenticatorSelection'] = {
+            'residentKey': 'required',
+            'userVerification': 'preferred',
+          };
+
+        final request = passkeyRegisterRequestFromOptions(options);
+
+        expect(request.authSelectionType?.requireResidentKey, true);
+      },
+    );
+
+    test('keeps a provided requireResidentKey as is', () {
+      final options = baseOptions()
+        ..['authenticatorSelection'] = {
+          'residentKey': 'preferred',
+          'requireResidentKey': true,
+          'userVerification': 'preferred',
+        };
+
+      final request = passkeyRegisterRequestFromOptions(options);
+
+      expect(request.authSelectionType?.requireResidentKey, true);
+    });
   });
 
   group('passkeyAuthenticateRequestFromOptions', () {


### PR DESCRIPTION
## Summary
- `authenticatorSelection.requireResidentKey` has been optional and deprecated in the WebAuthn spec since Level 2, so the Supabase Auth server may correctly omit it. The `passkeys_platform_interface` plugin still requires it as a non-nullable `bool`, so passing the raw server response through crashed `registerPasskey()` with a null cast error.
- `passkeyRegisterRequestFromOptions` now normalizes `authenticatorSelection`, deriving `requireResidentKey` from `residentKey` when the server omits it (`true` if `residentKey == "required"`, otherwise `false`), matching the WebAuthn spec's backwards compatibility guidance.

Fixes #1496

## Test plan
- [x] Added unit tests in `passkey_options_mapper_test.dart` covering: default to `false`, derive `true` from a required `residentKey`, and preserving a provided value.
- [x] `flutter test test/passkey_options_mapper_test.dart` passes (10/10).
- [x] `flutter analyze` clean on changed files.