### PR TITLE
fix(postgrest): avoid leading comma in Prefer header for modifier+select

### DIFF
--- a/packages/postgrest/lib/src/postgrest_transform_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_transform_builder.dart
@@ -46,7 +46,10 @@ class PostgrestTransformBuilder<T> extends RawPostgrestBuilder<T, T, T> {
     final url = overrideSearchParams('select', cleanedColumns);
     final prefer = newHeaders['Prefer'];
     newHeaders['Prefer'] = [
-      if (prefer != null) prefer,
+      // `insert()`, `update()` and `delete()` seed `Prefer` with an empty
+      // string. Skipping empty values avoids emitting a malformed header with
+      // a leading comma (e.g. `,return=representation`).
+      if (prefer != null && prefer.isNotEmpty) prefer,
       'return=representation',
     ].join(',');
     return PostgrestTransformBuilder(

--- a/packages/postgrest/test/prefer_header_test.dart
+++ b/packages/postgrest/test/prefer_header_test.dart
@@ -1,0 +1,70 @@
+import 'package:postgrest/postgrest.dart';
+import 'package:test/test.dart';
+
+import 'custom_http_client.dart';
+import 'test_utils.dart';
+
+/// `insert()`, `update()` and `delete()` seed the `Prefer` header with an empty
+/// string. A trailing `.select()` appends `return=representation`, and must not
+/// let the empty seed leak into the header as a leading comma
+/// (`,return=representation`), which is what supabase-js avoids by treating the
+/// empty string as falsy.
+void main() {
+  late CustomHttpClient customHttpClient;
+  late PostgrestClient postgrest;
+
+  setUp(() {
+    customHttpClient = CustomHttpClient();
+    postgrest = PostgrestClient(
+      rootUrl,
+      headers: apiHeaders,
+      httpClient: customHttpClient,
+    );
+  });
+
+  String? sentPrefer() => customHttpClient.lastRequest!.headers['Prefer'];
+
+  test('insert().select() sends a clean Prefer header', () async {
+    try {
+      await postgrest.from('users').insert({'username': 'foo'}).select();
+    } catch (_) {
+      // The custom client answers with a non-2xx status; we only care about
+      // the request headers that were sent.
+    }
+
+    expect(sentPrefer(), 'return=representation');
+  });
+
+  test('update().select() sends a clean Prefer header', () async {
+    try {
+      await postgrest
+          .from('users')
+          .update({'status': 'INACTIVE'})
+          .eq('id', 1)
+          .select();
+    } catch (_) {}
+
+    expect(sentPrefer(), 'return=representation');
+  });
+
+  test('delete().select() sends a clean Prefer header', () async {
+    try {
+      await postgrest.from('users').delete().eq('id', 1).select();
+    } catch (_) {}
+
+    expect(sentPrefer(), 'return=representation');
+  });
+
+  test('upsert().select() keeps its existing Prefer preferences', () async {
+    try {
+      await postgrest
+          .from('users')
+          .upsert({'id': 1, 'username': 'foo'}).select();
+    } catch (_) {}
+
+    final prefer = sentPrefer()!;
+    expect(prefer, isNot(startsWith(',')));
+    expect(prefer, contains('resolution=merge-duplicates'));
+    expect(prefer, contains('return=representation'));
+  });
+}


### PR DESCRIPTION
## What

`insert()`, `update()` and `delete()` seed the request's `Prefer` header with an empty string. When a `.select()` is chained onto one of them, `PostgrestTransformBuilder.select()` appended `return=representation` onto that empty seed, producing a malformed header with a leading comma:

```
Prefer: ,return=representation
```

This forwards a stray empty preference token to PostgREST on every `insert().select()`, `update().select()` and `delete().select()` call. This changes `select()` to skip empty `Prefer` values, so only `return=representation` is sent.

## Why

`insert()`/`update()`/`delete()` set `Prefer` to `''` (query builder), then `select()` did:

```dart
final prefer = newHeaders['Prefer']; // '' — not null
newHeaders['Prefer'] = [
  if (prefer != null) prefer,          // '' survives the null check
  'return=representation',
].join(',');                            // => ',return=representation'
```

`supabase-js` avoids this because it guards with `if (this.headers['Prefer'])`, where the empty string is falsy. The Dart port only checked for `null`, so the empty seed leaked through. The fix guards with `prefer != null && prefer.isNotEmpty`, matching the reference behaviour.

## Not a breaking change

The header value is now the intended `return=representation` (and, for `upsert().select()`, still keeps `resolution=...,return=representation`). Only the erroneous leading comma is removed; no public API changes.

## Tests

Added `packages/postgrest/test/prefer_header_test.dart` covering `insert/update/delete().select()` (each asserts an exact `Prefer: return=representation`) and `upsert().select()` (asserts no leading comma and that existing preferences are preserved). The tests fail on the old code (`Actual: ',return=representation'`) and pass with the fix. `dart format` and `dart analyze --fatal-warnings` are clean.
