### PR TITLE
fix(postgrest): stop seeding Prefer header with an empty string

### DIFF
--- a/packages/postgrest/lib/src/postgrest_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_builder.dart
@@ -30,6 +30,11 @@ enum HttpMethod {
 
 typedef _Nullable<T> = T?;
 
+/// Treats an empty `Prefer` value as absent, so every append site can rely on
+/// a plain null check instead of separately re-checking for emptiness.
+String? _emptyPreferAsNull(String? prefer) =>
+    (prefer == null || prefer.isEmpty) ? null : prefer;
+
 /// The base builder class.
 ///
 /// [T] for the overall return type, so `PostgrestResponse<S>` or [S]
@@ -134,11 +139,10 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
     final execHeaders = {..._headers};
 
     if (_count != null) {
-      final oldPreferHeader = execHeaders['Prefer'];
-      execHeaders['Prefer'] =
-          oldPreferHeader != null && oldPreferHeader.isNotEmpty
-              ? '$oldPreferHeader,count=${_count.name}'
-              : 'count=${_count.name}';
+      final oldPreferHeader = _emptyPreferAsNull(execHeaders['Prefer']);
+      execHeaders['Prefer'] = oldPreferHeader != null
+          ? '$oldPreferHeader,count=${_count.name}'
+          : 'count=${_count.name}';
     }
 
     if (method == null) {

--- a/packages/postgrest/lib/src/postgrest_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_builder.dart
@@ -135,9 +135,10 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
 
     if (_count != null) {
       final oldPreferHeader = execHeaders['Prefer'];
-      execHeaders['Prefer'] = oldPreferHeader != null
-          ? '$oldPreferHeader,count=${_count.name}'
-          : 'count=${_count.name}';
+      execHeaders['Prefer'] =
+          oldPreferHeader != null && oldPreferHeader.isNotEmpty
+              ? '$oldPreferHeader,count=${_count.name}'
+              : 'count=${_count.name}';
     }
 
     if (method == null) {

--- a/packages/postgrest/lib/src/postgrest_query_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_query_builder.dart
@@ -94,7 +94,11 @@ class PostgrestQueryBuilder<T> extends RawPostgrestBuilder<T, T, T> {
     bool defaultToNull = true,
   }) {
     final newHeaders = {..._headers};
-    newHeaders['Prefer'] = defaultToNull ? '' : 'missing=default';
+    if (defaultToNull) {
+      newHeaders.remove('Prefer');
+    } else {
+      newHeaders['Prefer'] = 'missing=default';
+    }
 
     Uri url = _url;
     if (values is List) {
@@ -198,8 +202,7 @@ class PostgrestQueryBuilder<T> extends RawPostgrestBuilder<T, T, T> {
   ///     .select();
   /// ```
   PostgrestFilterBuilder<T> update(Map values) {
-    final newHeaders = {..._headers};
-    newHeaders['Prefer'] = '';
+    final newHeaders = {..._headers}..remove('Prefer');
 
     return PostgrestFilterBuilder(_copyWith(
       method: HttpMethod.patch,
@@ -229,8 +232,7 @@ class PostgrestQueryBuilder<T> extends RawPostgrestBuilder<T, T, T> {
   ///     .select();
   /// ```
   PostgrestFilterBuilder<T> delete() {
-    final newHeaders = {..._headers};
-    newHeaders['Prefer'] = '';
+    final newHeaders = {..._headers}..remove('Prefer');
     return PostgrestFilterBuilder(_copyWith(
       method: HttpMethod.delete,
       headers: newHeaders,

--- a/packages/postgrest/lib/src/postgrest_transform_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_transform_builder.dart
@@ -46,7 +46,7 @@ class PostgrestTransformBuilder<T> extends RawPostgrestBuilder<T, T, T> {
     final url = overrideSearchParams('select', cleanedColumns);
     final prefer = newHeaders['Prefer'];
     newHeaders['Prefer'] = [
-      if (prefer != null) prefer,
+      if (prefer != null && prefer.isNotEmpty) prefer,
       'return=representation',
     ].join(',');
     return PostgrestTransformBuilder(
@@ -267,7 +267,7 @@ class PostgrestTransformBuilder<T> extends RawPostgrestBuilder<T, T, T> {
     // Add handling=strict and max-affected headers
     final existingPrefer = newHeaders['Prefer'];
     final String preferHeader;
-    if (existingPrefer != null) {
+    if (existingPrefer != null && existingPrefer.isNotEmpty) {
       var header = existingPrefer;
       if (!header.contains('handling=strict')) {
         header += ',handling=strict';

--- a/packages/postgrest/lib/src/postgrest_transform_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_transform_builder.dart
@@ -44,9 +44,9 @@ class PostgrestTransformBuilder<T> extends RawPostgrestBuilder<T, T, T> {
     final newHeaders = {..._headers};
 
     final url = overrideSearchParams('select', cleanedColumns);
-    final prefer = newHeaders['Prefer'];
+    final prefer = _emptyPreferAsNull(newHeaders['Prefer']);
     newHeaders['Prefer'] = [
-      if (prefer != null && prefer.isNotEmpty) prefer,
+      if (prefer != null) prefer,
       'return=representation',
     ].join(',');
     return PostgrestTransformBuilder(
@@ -265,9 +265,9 @@ class PostgrestTransformBuilder<T> extends RawPostgrestBuilder<T, T, T> {
     final newHeaders = {..._headers};
 
     // Add handling=strict and max-affected headers
-    final existingPrefer = newHeaders['Prefer'];
+    final existingPrefer = _emptyPreferAsNull(newHeaders['Prefer']);
     final String preferHeader;
-    if (existingPrefer != null && existingPrefer.isNotEmpty) {
+    if (existingPrefer != null) {
       var header = existingPrefer;
       if (!header.contains('handling=strict')) {
         header += ',handling=strict';

--- a/packages/postgrest/test/prefer_header_test.dart
+++ b/packages/postgrest/test/prefer_header_test.dart
@@ -1,0 +1,152 @@
+import 'package:postgrest/postgrest.dart';
+import 'package:test/test.dart';
+
+import 'custom_http_client.dart';
+import 'test_utils.dart';
+
+/// `insert()`, `update()` and `delete()` used to seed the `Prefer` header
+/// with an empty string. Anything that later appended to `Prefer`
+/// (`select()`, `count()`, `maxAffected()`) treated that empty seed as a
+/// real value and produced a malformed header with a leading comma, e.g.
+/// `Prefer: ,return=representation`. The fix removes the `Prefer` key
+/// entirely instead of seeding it with `''`, and hardens every append site
+/// to also ignore an empty value.
+void main() {
+  late CustomHttpClient customHttpClient;
+  late PostgrestClient postgrest;
+
+  setUp(() {
+    customHttpClient = CustomHttpClient();
+    postgrest = PostgrestClient(
+      rootUrl,
+      headers: apiHeaders,
+      httpClient: customHttpClient,
+    );
+  });
+
+  String? sentPrefer() => customHttpClient.lastRequest!.headers['Prefer'];
+
+  test('insert() does not send an empty Prefer header', () async {
+    try {
+      await postgrest.from('users').insert({'username': 'foo'});
+    } catch (_) {}
+
+    expect(sentPrefer(), isNull);
+  });
+
+  test('insert(defaultToNull: false) sends missing=default', () async {
+    try {
+      await postgrest
+          .from('users')
+          .insert({'username': 'foo'}, defaultToNull: false);
+    } catch (_) {}
+
+    expect(sentPrefer(), 'missing=default');
+  });
+
+  test('update() does not send an empty Prefer header', () async {
+    try {
+      await postgrest.from('users').update({'status': 'INACTIVE'}).eq('id', 1);
+    } catch (_) {}
+
+    expect(sentPrefer(), isNull);
+  });
+
+  test('delete() does not send an empty Prefer header', () async {
+    try {
+      await postgrest.from('users').delete().eq('id', 1);
+    } catch (_) {}
+
+    expect(sentPrefer(), isNull);
+  });
+
+  test('insert().select() sends a clean Prefer header', () async {
+    try {
+      await postgrest.from('users').insert({'username': 'foo'}).select();
+    } catch (_) {}
+
+    expect(sentPrefer(), 'return=representation');
+  });
+
+  test('update().select() sends a clean Prefer header', () async {
+    try {
+      await postgrest
+          .from('users')
+          .update({'status': 'INACTIVE'})
+          .eq('id', 1)
+          .select();
+    } catch (_) {}
+
+    expect(sentPrefer(), 'return=representation');
+  });
+
+  test('delete().select() sends a clean Prefer header', () async {
+    try {
+      await postgrest.from('users').delete().eq('id', 1).select();
+    } catch (_) {}
+
+    expect(sentPrefer(), 'return=representation');
+  });
+
+  test('upsert().select() keeps its existing Prefer preferences', () async {
+    try {
+      await postgrest
+          .from('users')
+          .upsert({'id': 1, 'username': 'foo'}).select();
+    } catch (_) {}
+
+    final prefer = sentPrefer()!;
+    expect(prefer, isNot(startsWith(',')));
+    expect(prefer, contains('resolution=merge-duplicates'));
+    expect(prefer, contains('return=representation'));
+  });
+
+  test('insert().select().count() sends a clean Prefer header', () async {
+    try {
+      await postgrest
+          .from('users')
+          .insert({'username': 'foo'})
+          .select()
+          .count(CountOption.exact);
+    } catch (_) {}
+
+    final prefer = sentPrefer()!;
+    expect(prefer, isNot(startsWith(',')));
+    expect(prefer, 'return=representation,count=exact');
+  });
+
+  test('delete().count() sends a clean Prefer header', () async {
+    try {
+      await postgrest.from('users').delete().eq('id', 1).count(
+            CountOption.exact,
+          );
+    } catch (_) {}
+
+    expect(sentPrefer(), isNot(startsWith(',')));
+    expect(sentPrefer(), 'count=exact');
+  });
+
+  test('update().maxAffected() sends a clean Prefer header', () async {
+    try {
+      await postgrest
+          .from('users')
+          .update({'status': 'INACTIVE'})
+          .eq('id', 1)
+          .maxAffected(5);
+    } catch (_) {}
+
+    final prefer = sentPrefer()!;
+    expect(prefer, isNot(startsWith(',')));
+    expect(prefer, 'handling=strict,max-affected=5');
+  });
+
+  test('delete().maxAffected() sends a clean Prefer header', () async {
+    try {
+      await postgrest.from('users').delete().eq('id', 1).maxAffected(5);
+    } catch (_) {}
+
+    final prefer = sentPrefer()!;
+    expect(prefer, isNot(startsWith(',')));
+    expect(prefer, 'handling=strict,max-affected=5');
+  });
+}


### PR DESCRIPTION
## What

`insert()`, `update()` and `delete()` seed the request's `Prefer` header with an empty string (`''`). Anything that later appends to `Prefer` treats that empty seed as a real value and produces a malformed header with a leading comma. This affects three separate call sites, not just one:

- `select()`: `insert(...).select()` -> `Prefer: ,return=representation`
- `count()`: `insert(...).count()` -> `Prefer: ,count=exact`
- `maxAffected()`: `update(...).eq(...).maxAffected(5)` -> `Prefer: ,handling=strict,max-affected=5`

## Why

Related to #1504, which only patched the `select()` symptom with an `isNotEmpty` guard. That leaves the identical bug live in `count()` and `maxAffected()`, and any future call site that appends to `Prefer` would need to remember the same guard.

This PR instead fixes it at the source: `insert()`, `update()` and `delete()` no longer seed `Prefer` with `''`, they remove the key entirely (an absent key and an empty string are equivalent to PostgREST). `upsert()` was never affected since it always seeds a non-empty value.

As defense in depth, the three append sites (`select()`, the `count()` handling in `_execute()`, and `maxAffected()`) now also skip an empty `Prefer` value, in case one is ever introduced via a manual `.setHeader('Prefer', '')`.

## Tests

Added `packages/postgrest/test/prefer_header_test.dart` covering:
- `insert()`, `update()`, `delete()` send no `Prefer` header at all
- `insert(defaultToNull: false)` still sends `missing=default`
- `insert/update/delete().select()` send a clean `return=representation`
- `upsert().select()` keeps existing preferences with no leading comma
- `insert().select().count()` and `delete().count()` send a clean header
- `update/delete().maxAffected()` send a clean header

`dart format` and `dart analyze --fatal-warnings` are clean; all non-network unit tests pass.