### PR TITLE
fix(realtime): escape quotes and backslashes in `in` filter values

### DIFF
--- a/packages/realtime_client/lib/src/types.dart
+++ b/packages/realtime_client/lib/src/types.dart
@@ -334,10 +334,6 @@ class PostgresChangeFilter {
   String toString() {
     if (type == PostgresChangeFilterType.inFilter) {
       return '$column=in.(${value.map((s) {
-        // Escape `\` and `"` before quoting so a value containing a double
-        // quote (e.g. `a"b`) can't produce a malformed filter like
-        // `in.("a"b")`. Mirrors the PostgREST array quoting used by
-        // PostgrestFilterBuilder.
         final escaped = '$s'.replaceAll(r'\', r'\\').replaceAll('"', r'\"');
         return '"$escaped"';
       }).join(',')})';

--- a/packages/realtime_client/lib/src/types.dart
+++ b/packages/realtime_client/lib/src/types.dart
@@ -333,7 +333,14 @@ class PostgresChangeFilter {
   @override
   String toString() {
     if (type == PostgresChangeFilterType.inFilter) {
-      return '$column=in.(${value.map((s) => '"$s"').join(',')})';
+      return '$column=in.(${value.map((s) {
+        // Escape `\` and `"` before quoting so a value containing a double
+        // quote (e.g. `a"b`) can't produce a malformed filter like
+        // `in.("a"b")`. Mirrors the PostgREST array quoting used by
+        // PostgrestFilterBuilder.
+        final escaped = '$s'.replaceAll(r'\', r'\\').replaceAll('"', r'\"');
+        return '"$escaped"';
+      }).join(',')})';
     }
     return '$column=${type.name}.$value';
   }

--- a/packages/realtime_client/test/channel_test.dart
+++ b/packages/realtime_client/test/channel_test.dart
@@ -168,6 +168,74 @@ void main() {
     });
   });
 
+  group('join with postgres_changes filter matching', () {
+    setUp(() {
+      socket = RealtimeClient('wss://example.com/socket');
+      channel = socket.channel('topic');
+    });
+
+    test(
+        'subscribes when the server echoes back an `in` filter with escaped '
+        'quotes and backslashes', () {
+      RealtimeSubscribeStatus? status;
+      channel.onPostgresChanges(
+        event: PostgresChangeEvent.all,
+        schema: 'public',
+        table: 'todos',
+        filter: PostgresChangeFilter(
+          type: PostgresChangeFilterType.inFilter,
+          column: 'name',
+          value: [r'a"b\c'],
+        ),
+        callback: (_) {},
+      );
+
+      channel.subscribe((newStatus, _) => status = newStatus);
+
+      final sentFilter = (channel.joinPush.payload['config']['postgres_changes']
+          as List)[0] as Map;
+      expect(sentFilter['filter'], r'name=in.("a\"b\\c")');
+
+      channel.joinPush.trigger('ok', {
+        'postgres_changes': [
+          {'id': 1, ...sentFilter},
+        ],
+      });
+
+      expect(status, RealtimeSubscribeStatus.subscribed);
+    });
+
+    test(
+        'reports a channelError when the server echoes back a different '
+        'filter', () {
+      RealtimeSubscribeStatus? status;
+      channel.onPostgresChanges(
+        event: PostgresChangeEvent.all,
+        schema: 'public',
+        table: 'todos',
+        filter: PostgresChangeFilter(
+          type: PostgresChangeFilterType.inFilter,
+          column: 'name',
+          value: [r'a"b\c'],
+        ),
+        callback: (_) {},
+      );
+
+      channel.subscribe((newStatus, _) => status = newStatus);
+
+      final sentFilter = (channel.joinPush.payload['config']['postgres_changes']
+          as List)[0] as Map;
+
+      channel.joinPush.trigger('ok', {
+        'postgres_changes': [
+          {...sentFilter, 'id': 1, 'filter': 'name=in.("a"b\\c")'},
+        ],
+      });
+
+      expect(status, RealtimeSubscribeStatus.channelError);
+    });
+  });
+
   group('onError', () {
     setUp(() {
       socket = RealtimeClient('/socket');

--- a/packages/realtime_client/test/postgres_change_filter_test.dart
+++ b/packages/realtime_client/test/postgres_change_filter_test.dart
@@ -1,0 +1,38 @@
+import 'package:realtime_client/realtime_client.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('PostgresChangeFilter.toString()', () {
+    test('escapes double quotes and backslashes in `in` filter values', () {
+      final filter = PostgresChangeFilter(
+        type: PostgresChangeFilterType.inFilter,
+        column: 'name',
+        value: [r'a"b\c'],
+      );
+
+      // The `"` and `\` are backslash-escaped so the element stays a single,
+      // well-formed quoted value rather than the malformed `in.("a"b\c")`.
+      expect(filter.toString(), r'name=in.("a\"b\\c")');
+    });
+
+    test('leaves plain `in` filter values untouched', () {
+      final filter = PostgresChangeFilter(
+        type: PostgresChangeFilterType.inFilter,
+        column: 'status',
+        value: ['active', 'pending'],
+      );
+
+      expect(filter.toString(), 'status=in.("active","pending")');
+    });
+
+    test('non-`in` filters are unaffected', () {
+      final filter = PostgresChangeFilter(
+        type: PostgresChangeFilterType.eq,
+        column: 'id',
+        value: 2,
+      );
+
+      expect(filter.toString(), 'id=eq.2');
+    });
+  });
+}

--- a/packages/realtime_client/test/postgres_change_filter_test.dart
+++ b/packages/realtime_client/test/postgres_change_filter_test.dart
@@ -10,8 +10,6 @@ void main() {
         value: [r'a"b\c'],
       );
 
-      // The `"` and `\` are backslash-escaped so the element stays a single,
-      // well-formed quoted value rather than the malformed `in.("a"b\c")`.
       expect(filter.toString(), r'name=in.("a\"b\\c")');
     });
 


### PR DESCRIPTION
## What

`PostgresChangeFilter.toString()` builds the `in` filter by quoting each value, but never escapes the value first. A value containing a double quote or backslash produces a malformed filter:

```dart
PostgresChangeFilter(
  type: PostgresChangeFilterType.inFilter,
  column: 'name',
  value: ['a"b'],
).toString();
// name=in.("a"b")  <-- the inner " breaks the quoted element
```

This escapes `\` and `"` inside each element before quoting, so the value stays a single well-formed token.

## Why

The realtime `in` filter had the same missing-escaping bug that was fixed for postgrest in #1481 (`_cleanFilterArray`), but the realtime copy in `types.dart` was never updated:

```dart
return '$column=in.(${value.map((s) => '"$s"').join(',')})';
```

Any subscription filtering on a list whose values contain `"` or `\` sends a broken filter to the Realtime server. The fix mirrors the PostgREST/PostgreSQL array quoting used by `PostgrestFilterBuilder`:

```dart
final escaped = '$s'.replaceAll(r'\', r'\\').replaceAll('"', r'\"');
return '"$escaped"';
```

## Not a breaking change

Values without `"` or `\` render exactly as before (`in.("active","pending")`), and non-`in` filters are untouched. Only previously-malformed output changes.

## Tests

Added `packages/realtime_client/test/postgres_change_filter_test.dart`: asserts `['a"b\c']` renders as `name=in.("a\"b\\c")`, that plain values are unchanged, and that non-`in` filters are unaffected. The escaping test fails on the old code (`Actual: name=in.("a"b\c")`) and passes with the fix. `dart format` and `dart analyze --fatal-warnings` are clean.
