### PR TITLE
fix(functions): don't lose error status on a non-JSON body labeled JSON

### DIFF
--- a/packages/functions_client/lib/src/functions_client.dart
+++ b/packages/functions_client/lib/src/functions_client.dart
@@ -180,7 +180,12 @@ class FunctionsClient {
         dynamic decoded;
         try {
           decoded = await _isolate.decode(bodyText);
-        } on FormatException catch (_) {
+        } on FormatException {
+          // A body labeled JSON that doesn't parse is only tolerated on an
+          // error status, where the raw text still needs to reach the caller
+          // as the exception `details`. On a success status it's a real
+          // anomaly, so keep surfacing it instead of handing back a String.
+          if (isSuccessStatus) rethrow;
           decoded = bodyText;
         }
         data = decoded;

--- a/packages/functions_client/lib/src/functions_client.dart
+++ b/packages/functions_client/lib/src/functions_client.dart
@@ -163,7 +163,8 @@ class FunctionsClient {
             response.headers['content-type'] ??
             'text/plain')
         .split(';')[0]
-        .trim();
+        .trim()
+        .toLowerCase();
 
     final isSuccessStatus =
         200 <= response.statusCode && response.statusCode < 300;
@@ -172,9 +173,18 @@ class FunctionsClient {
 
     if (responseType == 'application/json') {
       final bodyBytes = await response.stream.toBytes();
-      data = bodyBytes.isEmpty
-          ? ""
-          : await _isolate.decode(utf8.decode(bodyBytes));
+      if (bodyBytes.isEmpty) {
+        data = "";
+      } else {
+        final bodyText = utf8.decode(bodyBytes);
+        dynamic decoded;
+        try {
+          decoded = await _isolate.decode(bodyText);
+        } on FormatException catch (_) {
+          decoded = bodyText;
+        }
+        data = decoded;
+      }
     } else if (responseType == 'application/octet-stream') {
       data = await response.stream.toBytes();
     } else if (responseType == 'text/event-stream' && isSuccessStatus) {

--- a/packages/functions_client/test/custom_http_client.dart
+++ b/packages/functions_client/test/custom_http_client.dart
@@ -71,6 +71,25 @@ class CustomHttpClient extends BaseClient {
           "Content-Type": "application/json",
         },
       );
+    } else if (request.url.path.endsWith('invalid-json-error')) {
+      return StreamedResponse(
+        Stream.value(utf8.encode('<html><body>502 Bad Gateway</body></html>')),
+        500,
+        request: request,
+        headers: {
+          "Content-Type": "application/json",
+        },
+        reasonPhrase: "Internal Server Error",
+      );
+    } else if (request.url.path.endsWith('uppercase-json')) {
+      return StreamedResponse(
+        Stream.value(utf8.encode(jsonEncode({"key": "Hello World"}))),
+        200,
+        request: request,
+        headers: {
+          "Content-Type": "application/JSON",
+        },
+      );
     }
     final Stream<List<int>> stream;
     final Map<String, String> headers;

--- a/packages/functions_client/test/custom_http_client.dart
+++ b/packages/functions_client/test/custom_http_client.dart
@@ -81,6 +81,15 @@ class CustomHttpClient extends BaseClient {
         },
         reasonPhrase: "Internal Server Error",
       );
+    } else if (request.url.path.endsWith('success-invalid-json')) {
+      return StreamedResponse(
+        Stream.value(utf8.encode('<html><body>not json</body></html>')),
+        200,
+        request: request,
+        headers: {
+          "Content-Type": "application/json",
+        },
+      );
     } else if (request.url.path.endsWith('uppercase-json')) {
       return StreamedResponse(
         Stream.value(utf8.encode(jsonEncode({"key": "Hello World"}))),

--- a/packages/functions_client/test/functions_dart_test.dart
+++ b/packages/functions_client/test/functions_dart_test.dart
@@ -39,6 +39,24 @@ void main() {
       );
     });
 
+    test('error response labeled JSON with a non-JSON body reports the status',
+        () async {
+      await expectLater(
+        () => functionsCustomHttpClient.invoke('invalid-json-error'),
+        throwsA(isA<FunctionException>()
+            .having((e) => e.status, 'status', 500)
+            .having((e) => e.details, 'details',
+                '<html><body>502 Bad Gateway</body></html>')),
+      );
+    });
+
+    test('an upper-cased application/JSON content type is parsed as JSON',
+        () async {
+      final res = await functionsCustomHttpClient.invoke('uppercase-json');
+      expect(res.data, {'key': 'Hello World'});
+      expect(res.status, 200);
+    });
+
     test('function call', () async {
       final res = await functionsCustomHttpClient.invoke('function');
       expect(

--- a/packages/functions_client/test/functions_dart_test.dart
+++ b/packages/functions_client/test/functions_dart_test.dart
@@ -50,6 +50,17 @@ void main() {
       );
     });
 
+    test('a success response labeled JSON with a non-JSON body still throws',
+        () async {
+      // On a 2xx the JSON label is a promise of structured data. A body that
+      // doesn't parse is a real anomaly, so the FormatException must surface
+      // rather than silently degrading to a raw String.
+      await expectLater(
+        () => functionsCustomHttpClient.invoke('success-invalid-json'),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
     test('an upper-cased application/JSON content type is parsed as JSON',
         () async {
       final res = await functionsCustomHttpClient.invoke('uppercase-json');


### PR DESCRIPTION
## What

`FunctionsClient.invoke()` decoded the response body as JSON whenever the `Content-Type` was `application/json`. If a response was labeled JSON but carried a non-JSON body — e.g. an upstream proxy returning an HTML error page (`500` + `<html>…502 Bad Gateway…</html>` with `Content-Type: application/json`) — `_isolate.decode` threw a `FormatException` straight out of `invoke()`. The caller never got a `FunctionException`, and the HTTP status was lost.

On an error status this now falls back to the raw text when the body isn't valid JSON, so the status is still reported. It also compares the media type case-insensitively.

## Why

Two issues in the same block:

1. The `application/json` branch decoded unconditionally, so a mislabeled non-JSON body turned a `500` into an uncaught `FormatException` instead of a `FunctionException` with `status: 500`. This is the same spirit as #1480 (drain the error body into `details` rather than letting it escape).
2. The media-type match was case-sensitive (`responseType == 'application/json'`), so `application/JSON` fell through to the raw-text branch and JSON was handed back as an undecoded `String`. Media types are case-insensitive per RFC 9110.

Fix: wrap the decode in a `try`/`on FormatException` fallback, and `.toLowerCase()` the media type. The fallback to raw text is scoped to error statuses only: on a `2xx` the `application/json` label is a promise of structured data, so a body that doesn't parse is a real anomaly and the `FormatException` is rethrown rather than silently degrading to a `String`. The narrow `FormatException` catch also preserves existing behavior (e.g. a disposed isolate still surfaces its `StateError`).

## Not a breaking change

Valid JSON responses decode exactly as before, and a malformed body on a success status still throws as it always did. Only two cases change: a mislabeled non-JSON body on an **error** status now yields a `FunctionException` (with the raw text as `details`) instead of a bare `FormatException`, and an upper-cased `application/JSON` is now parsed as JSON.

## Tests

Added to `functions_dart_test.dart`:
- `invalid-json-error` — a `500` labeled `application/json` with an HTML body now throws `FunctionException(status: 500, details: '<html>…')`. Without the fix it throws a bare `FormatException`.
- `success-invalid-json` — a `200` labeled `application/json` with an HTML body still throws `FormatException`, confirming the fallback doesn't leak into success responses.
- `uppercase-json` — `application/JSON` with a JSON body now returns the decoded map. Without the fix it returned the raw string.

Full `functions_client` suite (41 tests) passes; `dart format` and `dart analyze --fatal-warnings` are clean.
