### PR TITLE
chore(storage): drop inferrable type argument in client test

### DIFF
--- a/packages/storage_client/test/client_test.dart
+++ b/packages/storage_client/test/client_test.dart
@@ -684,7 +684,7 @@ void main() {
 
     // Valid storage keys that contain characters which are reserved in a URL
     // and therefore must be percent-encoded to address the correct object.
-    final keys = <String>[
+    final keys = [
       'folder/report?v=2 final.pdf',
       'folder/a+b,c@d=e.txt',
       'folder/amp&and;semi.txt',


### PR DESCRIPTION
## What

Removes the redundant `<String>` type argument on the key list in the storage client percent-encoding test.

## Why

DCM's `avoid-inferrable-type-arguments` rule flags `final keys = <String>[ ... ]` at `packages/storage_client/test/client_test.dart:687` because the element type is already inferred from the string literals. This is currently the only storage lint issue surfacing in PR CI runs, so removing it keeps the DCM check clean.

No behavior change; the inferred type is still `List<String>`.