### PR TITLE
chore(supabase_flutter): mark auth-url helpers @internal instead of parse-ignore

### DIFF
--- a/.sdk-parse-ignore
+++ b/.sdk-parse-ignore
@@ -2,11 +2,8 @@
 #
 # The extractor over-approximates: it treats every non-underscore top-level
 # declaration under lib/** as public API. Files under lib/src are private to
-# the package by Dart convention and are not exported from the public library,
-# so internal platform shims listed here are false positives.
-
-# Internal helpers backing the conditional import that clears auth parameters
-# from the browser URL on web after a successful session exchange.
-packages/supabase_flutter/lib/src/clear_auth_url_parameters.dart
-packages/supabase_flutter/lib/src/clear_auth_url_parameters_web.dart
-packages/supabase_flutter/lib/src/clear_auth_url_parameters_stub.dart
+# the package by Dart convention and are not exported from the public library.
+#
+# Prefer annotating such declarations with `@internal` (from package:meta): the
+# extractor honours it and excludes them from the scan. Use this file only for
+# paths that cannot carry that annotation, e.g. generated sources.

--- a/packages/supabase_flutter/lib/src/clear_auth_url_parameters.dart
+++ b/packages/supabase_flutter/lib/src/clear_auth_url_parameters.dart
@@ -1,3 +1,5 @@
+import 'package:meta/meta.dart';
+
 const _authParameters = {
   'code',
   'access_token',
@@ -19,6 +21,7 @@ const _authParameters = {
 /// After a successful code exchange the auth code is single use, so leaving it
 /// in the URL means a page refresh would attempt to exchange a spent code and
 /// fail with "Code verifier could not be found in local storage.".
+@internal
 String removeAuthParametersFromUrl(String url) {
   final currentUri = Uri.parse(url);
 

--- a/packages/supabase_flutter/lib/src/clear_auth_url_parameters_stub.dart
+++ b/packages/supabase_flutter/lib/src/clear_auth_url_parameters_stub.dart
@@ -1,4 +1,7 @@
+import 'package:meta/meta.dart';
+
 /// Removes the authentication parameters from the browser URL.
 ///
 /// No-op on platforms other than web.
+@internal
 void clearAuthUrlParameters() {}

--- a/packages/supabase_flutter/lib/src/clear_auth_url_parameters_web.dart
+++ b/packages/supabase_flutter/lib/src/clear_auth_url_parameters_web.dart
@@ -1,8 +1,10 @@
+import 'package:meta/meta.dart';
 import 'package:web/web.dart';
 
 import 'clear_auth_url_parameters.dart';
 
 /// Removes the authentication parameters from the browser URL.
+@internal
 void clearAuthUrlParameters() {
   final cleanedUrl = removeAuthParametersFromUrl(window.location.href);
   window.history.replaceState(null, '', cleanedUrl);


### PR DESCRIPTION
## What

Replaces the three `.sdk-parse-ignore` entries for the clear-auth-url helpers with `@internal` annotations on the declarations, and removes those entries.

## Why

The SDK capability-matrix symbol extractor now honours `@internal` (from `package:meta`), see supabase/sdk#54. Before that, the extractor treated every non-underscore `lib/src` declaration as public API, so the internal auth-url helpers had to be excluded by path in `.sdk-parse-ignore`.

`@internal` on the declaration is a better source of truth than a hand-maintained path list: it lives next to the code, travels with refactors, and documents intent directly.

## What changed

- `removeAuthParametersFromUrl` (`clear_auth_url_parameters.dart`) marked `@internal`.
- `clearAuthUrlParameters` in both conditional-import shims (`clear_auth_url_parameters_web.dart`, `clear_auth_url_parameters_stub.dart`) marked `@internal`.
- Removed the three entries from `.sdk-parse-ignore`; its header now points to `@internal` as the preferred mechanism and reserves the file for paths that cannot carry the annotation (for example generated sources).

All three symbols are used only within `supabase_flutter`, so `@internal` produces no cross-package analyzer warnings. Verified against the updated extractor that the package no longer emits these symbols while its other 466 public symbols are unchanged.