### PR TITLE
fix(supabase_flutter): preserve hash routes and repeated query keys when clearing auth params

### DIFF
--- a/packages/supabase_flutter/lib/src/clear_auth_url_parameters.dart
+++ b/packages/supabase_flutter/lib/src/clear_auth_url_parameters.dart
@@ -22,16 +22,8 @@ const _authParameters = {
 String removeAuthParametersFromUrl(String url) {
   final currentUri = Uri.parse(url);
 
-  final query = Map<String, String>.of(currentUri.queryParameters)
+  final query = Map<String, List<String>>.of(currentUri.queryParametersAll)
     ..removeWhere((key, value) => _authParameters.contains(key));
-
-  final fragmentParameters =
-      Map<String, String>.of(Uri.splitQueryString(currentUri.fragment))
-        ..removeWhere((key, value) => _authParameters.contains(key));
-
-  final fragment = fragmentParameters.isEmpty
-      ? null
-      : Uri(queryParameters: fragmentParameters).query;
 
   final cleanedUri = Uri(
     scheme: currentUri.scheme,
@@ -40,8 +32,25 @@ String removeAuthParametersFromUrl(String url) {
     port: currentUri.hasPort ? currentUri.port : null,
     path: currentUri.path,
     queryParameters: query.isEmpty ? null : query,
-    fragment: fragment,
+    fragment: _removeAuthParametersFromFragment(currentUri.fragment),
   );
 
   return cleanedUri.toString();
+}
+
+/// Strips auth parameters from a URL [fragment].
+String? _removeAuthParametersFromFragment(String fragment) {
+  if (fragment.isEmpty) return null;
+
+  final fragmentParameters = Uri.splitQueryString(fragment);
+  final hasAuthParameter =
+      fragmentParameters.keys.any(_authParameters.contains);
+  if (!hasAuthParameter) {
+    return fragment;
+  }
+
+  final cleaned = Map<String, String>.of(fragmentParameters)
+    ..removeWhere((key, value) => _authParameters.contains(key));
+
+  return cleaned.isEmpty ? null : Uri(queryParameters: cleaned).query;
 }

--- a/packages/supabase_flutter/lib/src/clear_auth_url_parameters.dart
+++ b/packages/supabase_flutter/lib/src/clear_auth_url_parameters.dart
@@ -42,15 +42,14 @@ String removeAuthParametersFromUrl(String url) {
 String? _removeAuthParametersFromFragment(String fragment) {
   if (fragment.isEmpty) return null;
 
-  final fragmentParameters = Uri.splitQueryString(fragment);
-  final hasAuthParameter =
-      fragmentParameters.keys.any(_authParameters.contains);
-  if (!hasAuthParameter) {
+  final fragmentParameters = Uri(query: fragment).queryParametersAll;
+  final cleaned = {
+    for (final entry in fragmentParameters.entries)
+      if (!_authParameters.contains(entry.key)) entry.key: entry.value,
+  };
+  if (cleaned.length == fragmentParameters.length) {
     return fragment;
   }
-
-  final cleaned = Map<String, String>.of(fragmentParameters)
-    ..removeWhere((key, value) => _authParameters.contains(key));
 
   return cleaned.isEmpty ? null : Uri(queryParameters: cleaned).query;
 }

--- a/packages/supabase_flutter/test/clear_auth_url_parameters_test.dart
+++ b/packages/supabase_flutter/test/clear_auth_url_parameters_test.dart
@@ -52,5 +52,37 @@ void main() {
         'https://example.com/login?foo=bar',
       );
     });
+
+    test('preserves a hash-based route in the fragment', () {
+      expect(
+        removeAuthParametersFromUrl('https://example.com/#/dashboard'),
+        'https://example.com/#/dashboard',
+      );
+    });
+
+    test('preserves a hash-based route with its own query', () {
+      expect(
+        removeAuthParametersFromUrl('https://example.com/#/dashboard?foo=bar'),
+        'https://example.com/#/dashboard?foo=bar',
+      );
+    });
+
+    test('still clears auth tokens from the fragment (implicit flow)', () {
+      expect(
+        removeAuthParametersFromUrl(
+          'https://example.com/#access_token=abc&expires_in=3600',
+        ),
+        'https://example.com/',
+      );
+    });
+
+    test('preserves repeated query keys', () {
+      expect(
+        removeAuthParametersFromUrl(
+          'https://example.com/?tag=a&tag=b&code=abc123',
+        ),
+        'https://example.com/?tag=a&tag=b',
+      );
+    });
   });
 }

--- a/packages/supabase_flutter/test/clear_auth_url_parameters_test.dart
+++ b/packages/supabase_flutter/test/clear_auth_url_parameters_test.dart
@@ -84,5 +84,14 @@ void main() {
         'https://example.com/?tag=a&tag=b',
       );
     });
+
+    test('preserves repeated fragment keys alongside auth tokens', () {
+      expect(
+        removeAuthParametersFromUrl(
+          'https://example.com/#access_token=abc&ref=a&ref=b',
+        ),
+        'https://example.com/#ref=a&ref=b',
+      );
+    });
   });
 }


### PR DESCRIPTION
## What

`removeAuthParametersFromUrl` cleans the auth parameters out of a URL after a code exchange. It had two bugs that broke URLs it was supposed to leave intact:

1. **Hash-based routes were corrupted.** The fragment was parsed with `Uri.splitQueryString` and re-emitted as query parameters, so a route like `#/dashboard` became `#%2Fdashboard`. Hash-based routing is Flutter web's **default** URL strategy, so after a PKCE callback the app route was mangled.
2. **Repeated query keys were dropped.** It read `queryParameters` (last value wins), so `?tag=a&tag=b` collapsed to `?tag=b`.

Both contradict the function's own docstring ("preserving any unrelated parameters").

## Why

```dart
// (1) fragment treated as a query string, then re-encoded
Uri.splitQueryString(currentUri.fragment)   // '/dashboard' -> {'/dashboard': ''}
// (2) last-wins map loses duplicates
Map<String, String>.of(currentUri.queryParameters)  // ?tag=a&tag=b -> {tag: b}
```

Fix:
- Use `queryParametersAll` so repeated keys are preserved.
- Only rewrite the fragment when it actually contains an auth parameter (implicit flow: `#access_token=...`); otherwise preserve it verbatim so routes aren't touched.

## Not a breaking change

Auth clearing is unchanged: the PKCE `code` in the query and implicit-flow tokens in the fragment are still removed. Only previously-corrupted output changes — hash routes and duplicate query keys are now preserved.

## Tests

Extends `clear_auth_url_parameters_test.dart` (all 6 existing tests still pass):
- `#/dashboard` is preserved (was `#%2Fdashboard`).
- `?tag=a&tag=b&code=abc123` → `?tag=a&tag=b` (was `?tag=b`).
- Implicit-flow tokens in the fragment are still cleared.

The two new bug tests fail on the current code and pass with the fix. `dart format` and `dart analyze --fatal-warnings` are clean.
