### PR TITLE
feat(gotrue): add shouldSoftDelete option to admin deleteUser

### DIFF
--- a/packages/gotrue/lib/src/gotrue_admin_api.dart
+++ b/packages/gotrue/lib/src/gotrue_admin_api.dart
@@ -91,10 +91,17 @@ class GoTrueAdminApi {
   ///
   ///  [id] is the user id of the user you want to remove.
   ///
+  /// When [shouldSoftDelete] is `true` the user is soft deleted, keeping their
+  /// record and any associated data while marking the user as deleted. It
+  /// defaults to `false`, which permanently removes the user.
+  ///
   /// This function should only be called on a server. Never expose your `secret` key on the client.
-  Future<void> deleteUser(String id) async {
+  Future<void> deleteUser(String id, {bool shouldSoftDelete = false}) async {
     validateUuid(id);
-    final options = GotrueRequestOptions(headers: _headers);
+    final options = GotrueRequestOptions(
+      headers: _headers,
+      body: {'should_soft_delete': shouldSoftDelete},
+    );
     await _fetch.request(
       '$_url/admin/users/$id',
       RequestMethodType.delete,

--- a/packages/gotrue/test/admin_delete_user_test.dart
+++ b/packages/gotrue/test/admin_delete_user_test.dart
@@ -1,0 +1,48 @@
+import 'dart:convert';
+
+import 'package:gotrue/gotrue.dart';
+import 'package:http/http.dart';
+import 'package:test/test.dart';
+
+class _CapturingHttpClient extends BaseClient {
+  Request? lastRequest;
+
+  @override
+  Future<StreamedResponse> send(BaseRequest request) async {
+    lastRequest = request as Request;
+    return StreamedResponse(const Stream.empty(), 200, request: request);
+  }
+}
+
+void main() {
+  const userId = 'ef507d02-ce6a-4b3a-a8a6-6f0e14740136';
+
+  late _CapturingHttpClient httpClient;
+  late GoTrueClient client;
+
+  setUp(() {
+    httpClient = _CapturingHttpClient();
+    client = GoTrueClient(
+      url: 'http://localhost:9999',
+      httpClient: httpClient,
+    );
+  });
+
+  test('deleteUser defaults to a hard delete', () async {
+    await client.admin.deleteUser(userId);
+
+    final body = jsonDecode(httpClient.lastRequest!.body);
+    expect(body, {'should_soft_delete': false});
+  });
+
+  test('deleteUser sends should_soft_delete when soft deleting', () async {
+    await client.admin.deleteUser(userId, shouldSoftDelete: true);
+
+    final request = httpClient.lastRequest!;
+    expect(request.method, 'DELETE');
+    expect(request.url.path, endsWith('/admin/users/$userId'));
+
+    final body = jsonDecode(request.body);
+    expect(body, {'should_soft_delete': true});
+  });
+}

--- a/packages/gotrue/test/admin_test.dart
+++ b/packages/gotrue/test/admin_test.dart
@@ -114,6 +114,26 @@ void main() {
       final userLengthAfter = (await client.admin.listUsers()).length;
       expect(userLengthBefore - 1, userLengthAfter);
     });
+
+    test('deleteUser() soft deletes a user, keeping its record', () async {
+      final suffix = Random.secure().nextInt(4096);
+      final softDeleted = await client.admin.createUser(
+        AdminUserAttributes(email: 'soft-$suffix@fake.org', password: 'pw'),
+      );
+      final hardDeleted = await client.admin.createUser(
+        AdminUserAttributes(email: 'hard-$suffix@fake.org', password: 'pw'),
+      );
+
+      await client.admin
+          .deleteUser(softDeleted.user!.id, shouldSoftDelete: true);
+      await client.admin.deleteUser(hardDeleted.user!.id);
+
+      final ids = (await client.admin.listUsers()).map((user) => user.id);
+      expect(ids, contains(softDeleted.user!.id),
+          reason: 'a soft deleted user keeps its record');
+      expect(ids, isNot(contains(hardDeleted.user!.id)),
+          reason: 'a hard deleted user is removed');
+    });
   });
 
   group('validates ids', () {

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -131,9 +131,7 @@ features:
   auth.admin.create_user: implemented
   auth.admin.get_user: implemented
   auth.admin.update_user: implemented
-  auth.admin.delete_user:
-    status: partially_implemented
-    note: "No shouldSoftDelete parameter; always performs a hard delete."
+  auth.admin.delete_user: implemented
   auth.admin.list_users:
     status: partially_implemented
     note: "Returns the user list only; pagination metadata (total, nextPage, lastPage, aud) is not returned."


### PR DESCRIPTION
## What

Adds an optional `shouldSoftDelete` parameter to `GoTrueAdminApi.deleteUser`. When `true`, the client sends `{"should_soft_delete": true}` in the DELETE request body, soft deleting the user rather than permanently removing them. Defaults to `false` (hard delete), matching supabase-js.

## Why

SDK parity: supabase-js `admin.deleteUser(id, shouldSoftDelete)` supports this flag; the Dart client always performed a hard delete.

## Tests

- Mock-based unit tests assert the request method, path, and `should_soft_delete` body for both the default and soft-delete cases.
- An end-to-end test against a local stack soft-deletes one user and hard-deletes another, asserting the soft-deleted record survives in `listUsers` while the hard-deleted one is removed.

## Compliance

Marks `auth.admin.delete_user` implemented in `sdk-compliance.yaml`.

Resolves SDK-1165