### PR TITLE
feat(storage): add download option to signed and public URLs

### DIFF
--- a/packages/storage_client/lib/src/storage_file_api.dart
+++ b/packages/storage_client/lib/src/storage_file_api.dart
@@ -357,10 +357,15 @@ class StorageFileApi {
   /// example, `60` for a URL which are valid for one minute.
   ///
   /// [transform] adds image transformations parameters to the generated url.
+  ///
+  /// [download] triggers the file to be downloaded rather than opened in the
+  /// browser by setting the response's `Content-Disposition` header. Pass
+  /// `true` to keep the original file name or a [String] to override it.
   Future<String> createSignedUrl(
     String path,
     int expiresIn, {
     TransformOptions? transform,
+    Object? download,
   }) async {
     final finalPath = _getFinalPath(path);
     final options = _fetchOptions;
@@ -377,8 +382,7 @@ class StorageFileApi {
     if (signedUrlPath == null) {
       throw StorageException('No signed URL returned by API');
     }
-    final signedUrl = '$url$signedUrlPath';
-    return signedUrl;
+    return _withDownload('$url$signedUrlPath', download);
   }
 
   // TODO(v3): Remove this deprecated overload and rename createSignedUrlsResult
@@ -397,9 +401,11 @@ class StorageFileApi {
   @Deprecated('Use createSignedUrlsResult to handle missing paths correctly.')
   Future<List<SignedUrl>> createSignedUrls(
     List<String> paths,
-    int expiresIn,
-  ) async {
-    final results = await createSignedUrlsResult(paths, expiresIn);
+    int expiresIn, {
+    Object? download,
+  }) async {
+    final results =
+        await createSignedUrlsResult(paths, expiresIn, download: download);
     return results
         .whereType<SignedUrlSuccess>()
         .map((r) => SignedUrl(path: r.path, signedUrl: r.signedUrl))
@@ -418,10 +424,15 @@ class StorageFileApi {
   ///
   /// [expiresIn] is the number of seconds until the signed URLs expire. For
   /// example, `60` for URLs which are valid for one minute.
+  ///
+  /// [download] triggers the files to be downloaded rather than opened in the
+  /// browser by setting the response's `Content-Disposition` header. Pass
+  /// `true` to keep the original file name or a [String] to override it.
   Future<List<SignedUrlResult>> createSignedUrlsResult(
     List<String> paths,
-    int expiresIn,
-  ) async {
+    int expiresIn, {
+    Object? download,
+  }) async {
     final options = _fetchOptions;
     final response = await _storageFetch.post(
       '$url/object/sign/$bucketId',
@@ -435,7 +446,10 @@ class StorageFileApi {
       final signedUrlPath = e['signedURL'] as String?;
       final path = e['path'] as String? ?? '';
       if (signedUrlPath != null) {
-        return SignedUrlSuccess(path: path, signedUrl: '$url$signedUrlPath');
+        return SignedUrlSuccess(
+          path: path,
+          signedUrl: _withDownload('$url$signedUrlPath', download),
+        );
       }
       return SignedUrlFailure(
         path: path,
@@ -508,9 +522,14 @@ class StorageFileApi {
   /// For example `getPublicUrl('folder/image.png')`.
   ///
   /// [transform] adds image transformations parameters to the generated url.
+  ///
+  /// [download] triggers the file to be downloaded rather than opened in the
+  /// browser by setting the response's `Content-Disposition` header. Pass
+  /// `true` to keep the original file name or a [String] to override it.
   String getPublicUrl(
     String path, {
     TransformOptions? transform,
+    Object? download,
   }) {
     final finalPath = _getFinalPath(path);
 
@@ -522,7 +541,26 @@ class StorageFileApi {
 
     publicUrl = publicUrl.replace(queryParameters: transformationQuery);
 
-    return publicUrl.toString();
+    return _withDownload(publicUrl.toString(), download);
+  }
+
+  /// Appends a `download` query parameter to [urlString] when [download] is
+  /// set, so the response is served with a `Content-Disposition` header.
+  ///
+  /// [download] must be a [bool] or a [String]. `true` keeps the original file
+  /// name, a [String] overrides it, and `null` or `false` leaves the URL
+  /// unchanged.
+  String _withDownload(String urlString, Object? download) {
+    assert(
+      download == null || download is bool || download is String,
+      'download must be a bool or a String',
+    );
+    if (download == null || download == false) {
+      return urlString;
+    }
+    final fileName = download == true ? '' : download as String;
+    final separator = urlString.contains('?') ? '&' : '?';
+    return '$urlString${separator}download=${Uri.encodeQueryComponent(fileName)}';
   }
 
   /// Deletes files within the same bucket

--- a/packages/storage_client/lib/src/storage_file_api.dart
+++ b/packages/storage_client/lib/src/storage_file_api.dart
@@ -359,13 +359,14 @@ class StorageFileApi {
   /// [transform] adds image transformations parameters to the generated url.
   ///
   /// [download] triggers the file to be downloaded rather than opened in the
-  /// browser by setting the response's `Content-Disposition` header. Pass
-  /// `true` to keep the original file name or a [String] to override it.
+  /// browser by setting the response's `Content-Disposition` header. Use
+  /// [DownloadBehavior.withOriginalName] to keep the original file name or
+  /// [DownloadBehavior.named] to override it.
   Future<String> createSignedUrl(
     String path,
     int expiresIn, {
     TransformOptions? transform,
-    Object? download,
+    DownloadBehavior? download,
   }) async {
     final finalPath = _getFinalPath(path);
     final options = _fetchOptions;
@@ -402,7 +403,7 @@ class StorageFileApi {
   Future<List<SignedUrl>> createSignedUrls(
     List<String> paths,
     int expiresIn, {
-    Object? download,
+    DownloadBehavior? download,
   }) async {
     final results =
         await createSignedUrlsResult(paths, expiresIn, download: download);
@@ -426,12 +427,13 @@ class StorageFileApi {
   /// example, `60` for URLs which are valid for one minute.
   ///
   /// [download] triggers the files to be downloaded rather than opened in the
-  /// browser by setting the response's `Content-Disposition` header. Pass
-  /// `true` to keep the original file name or a [String] to override it.
+  /// browser by setting the response's `Content-Disposition` header. Use
+  /// [DownloadBehavior.withOriginalName] to keep the original file name or
+  /// [DownloadBehavior.named] to override it.
   Future<List<SignedUrlResult>> createSignedUrlsResult(
     List<String> paths,
     int expiresIn, {
-    Object? download,
+    DownloadBehavior? download,
   }) async {
     final options = _fetchOptions;
     final response = await _storageFetch.post(
@@ -524,12 +526,13 @@ class StorageFileApi {
   /// [transform] adds image transformations parameters to the generated url.
   ///
   /// [download] triggers the file to be downloaded rather than opened in the
-  /// browser by setting the response's `Content-Disposition` header. Pass
-  /// `true` to keep the original file name or a [String] to override it.
+  /// browser by setting the response's `Content-Disposition` header. Use
+  /// [DownloadBehavior.withOriginalName] to keep the original file name or
+  /// [DownloadBehavior.named] to override it.
   String getPublicUrl(
     String path, {
     TransformOptions? transform,
-    Object? download,
+    DownloadBehavior? download,
   }) {
     final finalPath = _getFinalPath(path);
 
@@ -546,17 +549,13 @@ class StorageFileApi {
 
   /// Appends a `download` query parameter to [urlString] when [download] is
   /// set, so the response is served with a `Content-Disposition` header.
-  String _withDownload(String urlString, Object? download) {
-    assert(
-      download == null || download is bool || download is String,
-      'download must be a bool or a String',
-    );
-    if (download == null || download == false) {
+  String _withDownload(String urlString, DownloadBehavior? download) {
+    if (download == null) {
       return urlString;
     }
-    final fileName = download == true ? '' : download as String;
     final separator = urlString.contains('?') ? '&' : '?';
-    return '$urlString${separator}download=${Uri.encodeQueryComponent(fileName)}';
+    return '$urlString${separator}download='
+        '${Uri.encodeQueryComponent(download.queryValue)}';
   }
 
   /// Deletes files within the same bucket

--- a/packages/storage_client/lib/src/storage_file_api.dart
+++ b/packages/storage_client/lib/src/storage_file_api.dart
@@ -546,10 +546,6 @@ class StorageFileApi {
 
   /// Appends a `download` query parameter to [urlString] when [download] is
   /// set, so the response is served with a `Content-Disposition` header.
-  ///
-  /// [download] must be a [bool] or a [String]. `true` keeps the original file
-  /// name, a [String] overrides it, and `null` or `false` leaves the URL
-  /// unchanged.
   String _withDownload(String urlString, Object? download) {
     assert(
       download == null || download is bool || download is String,

--- a/packages/storage_client/lib/src/types.dart
+++ b/packages/storage_client/lib/src/types.dart
@@ -1,5 +1,7 @@
 // ignore_for_file: deprecated_member_use_from_same_package
 
+import 'package:meta/meta.dart';
+
 class FetchOptions {
   final Map<String, String>? headers;
   final bool? noResolveJson;
@@ -430,6 +432,38 @@ extension ToQueryParams on TransformOptions {
       if (format != null) 'format': format!.snakeCase,
     };
   }
+}
+
+/// Controls download behavior for signed and public URLs.
+///
+/// Passing a [DownloadBehavior] triggers the file to be downloaded rather than
+/// opened in the browser by setting the response's `Content-Disposition`
+/// header.
+///
+/// ```dart
+/// storage.from('docs').getPublicUrl(
+///   'report.pdf',
+///   download: DownloadBehavior.withOriginalName,
+/// );
+/// storage.from('docs').getPublicUrl(
+///   'report.pdf',
+///   download: DownloadBehavior.named('annual-2024.pdf'),
+/// );
+/// ```
+class DownloadBehavior {
+  const DownloadBehavior._(String fileName) : _fileName = fileName;
+
+  /// Triggers a download using the file's original name.
+  static const DownloadBehavior withOriginalName = DownloadBehavior._('');
+
+  /// Triggers a download with a custom [fileName].
+  const DownloadBehavior.named(String fileName) : _fileName = fileName;
+
+  final String _fileName;
+
+  /// The value appended to the `download` query parameter.
+  @internal
+  String get queryValue => _fileName;
 }
 
 extension ToSnakeCase on Enum {

--- a/packages/storage_client/lib/src/types.dart
+++ b/packages/storage_client/lib/src/types.dart
@@ -451,19 +451,19 @@ extension ToQueryParams on TransformOptions {
 /// );
 /// ```
 class DownloadBehavior {
-  const DownloadBehavior._(String fileName) : _fileName = fileName;
+  const DownloadBehavior._(String fileName) : _queryValue = fileName;
 
   /// Triggers a download using the file's original name.
   static const DownloadBehavior withOriginalName = DownloadBehavior._('');
 
   /// Triggers a download with a custom [fileName].
-  const DownloadBehavior.named(String fileName) : _fileName = fileName;
+  const DownloadBehavior.named(String fileName) : _queryValue = fileName;
 
-  final String _fileName;
+  final String _queryValue;
 
   /// The value appended to the `download` query parameter.
   @internal
-  String get queryValue => _fileName;
+  String get queryValue => _queryValue;
 }
 
 extension ToSnakeCase on Enum {

--- a/packages/storage_client/test/basic_test.dart
+++ b/packages/storage_client/test/basic_test.dart
@@ -250,23 +250,24 @@ void main() {
     });
 
     test('getPublicUrl appends download with the original file name', () {
-      final response =
-          client.from('files').getPublicUrl('b.txt', download: true);
+      final response = client.from('files').getPublicUrl(
+            'b.txt',
+            download: DownloadBehavior.withOriginalName,
+          );
       expect(response, '$objectUrl/public/files/b.txt?download=');
     });
 
     test('getPublicUrl appends download with a custom file name', () {
-      final response =
-          client.from('files').getPublicUrl('b.txt', download: 'my file.txt');
+      final response = client.from('files').getPublicUrl('b.txt',
+          download: DownloadBehavior.named('my file.txt'));
       expect(
         response,
         '$objectUrl/public/files/b.txt?download=my+file.txt',
       );
     });
 
-    test('getPublicUrl leaves the URL unchanged when download is false', () {
-      final response =
-          client.from('files').getPublicUrl('b.txt', download: false);
+    test('getPublicUrl leaves the URL unchanged when download is null', () {
+      final response = client.from('files').getPublicUrl('b.txt');
       expect(response, '$objectUrl/public/files/b.txt');
     });
 
@@ -275,9 +276,8 @@ void main() {
         'signedURL': '/object/sign/public/b.txt?token=abc',
       };
 
-      final response = await client
-          .from('public')
-          .createSignedUrl('b.txt', 60, download: 'report.pdf');
+      final response = await client.from('public').createSignedUrl('b.txt', 60,
+          download: DownloadBehavior.named('report.pdf'));
       expect(response, endsWith('?token=abc&download=report.pdf'));
     });
 
@@ -289,9 +289,11 @@ void main() {
         },
       ];
 
-      final results = await client
-          .from('public')
-          .createSignedUrlsResult(['exists.txt'], 60, download: true);
+      final results = await client.from('public').createSignedUrlsResult(
+        ['exists.txt'],
+        60,
+        download: DownloadBehavior.withOriginalName,
+      );
 
       final success = results.single as SignedUrlSuccess;
       expect(success.signedUrl, endsWith('?token=abc&download='));

--- a/packages/storage_client/test/basic_test.dart
+++ b/packages/storage_client/test/basic_test.dart
@@ -249,6 +249,54 @@ void main() {
       expect(response, '$objectUrl/public/files/b.txt');
     });
 
+    test('getPublicUrl appends download with the original file name', () {
+      final response =
+          client.from('files').getPublicUrl('b.txt', download: true);
+      expect(response, '$objectUrl/public/files/b.txt?download=');
+    });
+
+    test('getPublicUrl appends download with a custom file name', () {
+      final response =
+          client.from('files').getPublicUrl('b.txt', download: 'my file.txt');
+      expect(
+        response,
+        '$objectUrl/public/files/b.txt?download=my+file.txt',
+      );
+    });
+
+    test('getPublicUrl leaves the URL unchanged when download is false', () {
+      final response =
+          client.from('files').getPublicUrl('b.txt', download: false);
+      expect(response, '$objectUrl/public/files/b.txt');
+    });
+
+    test('createSignedUrl appends download to the token query', () async {
+      customHttpClient.response = {
+        'signedURL': '/object/sign/public/b.txt?token=abc',
+      };
+
+      final response = await client
+          .from('public')
+          .createSignedUrl('b.txt', 60, download: 'report.pdf');
+      expect(response, endsWith('?token=abc&download=report.pdf'));
+    });
+
+    test('createSignedUrlsResult appends download to each URL', () async {
+      customHttpClient.response = [
+        {
+          'path': 'exists.txt',
+          'signedURL': '/object/sign/public/exists.txt?token=abc',
+        },
+      ];
+
+      final results = await client
+          .from('public')
+          .createSignedUrlsResult(['exists.txt'], 60, download: true);
+
+      final success = results.single as SignedUrlSuccess;
+      expect(success.signedUrl, endsWith('?token=abc&download='));
+    });
+
     test('should remove file', () async {
       customHttpClient.response = [testFileObjectJson, testFileObjectJson];
 

--- a/packages/storage_client/test/client_test.dart
+++ b/packages/storage_client/test/client_test.dart
@@ -347,6 +347,43 @@ void main() {
     });
   });
 
+  group('download option', () {
+    const downloadBucket = 'my-download-bucket';
+
+    setUp(() async {
+      await findOrCreateBucket(downloadBucket, true);
+      await storage.from(downloadBucket).upload(
+            uploadPath,
+            file,
+            fileOptions: const FileOptions(upsert: true),
+          );
+    });
+
+    test('public url download serves a Content-Disposition attachment',
+        () async {
+      final url = storage
+          .from(downloadBucket)
+          .getPublicUrl(uploadPath, download: 'renamed.jpg');
+
+      final response = await http.get(Uri.parse(url));
+      expect(response.statusCode, 200);
+      final disposition = response.headers['content-disposition'];
+      expect(disposition, contains('attachment'));
+      expect(disposition, contains('renamed.jpg'));
+    });
+
+    test('signed url download serves a Content-Disposition attachment',
+        () async {
+      final url = await storage
+          .from(downloadBucket)
+          .createSignedUrl(uploadPath, 2000, download: true);
+
+      final response = await http.get(Uri.parse(url));
+      expect(response.statusCode, 200);
+      expect(response.headers['content-disposition'], contains('attachment'));
+    });
+  });
+
   group('bucket limits', () {
     test('can upload a file within the file size limit', () async {
       final bucketName = 'with-limit-${DateTime.now()}';

--- a/packages/storage_client/test/client_test.dart
+++ b/packages/storage_client/test/client_test.dart
@@ -361,9 +361,8 @@ void main() {
 
     test('public url download serves a Content-Disposition attachment',
         () async {
-      final url = storage
-          .from(downloadBucket)
-          .getPublicUrl(uploadPath, download: 'renamed.jpg');
+      final url = storage.from(downloadBucket).getPublicUrl(uploadPath,
+          download: DownloadBehavior.named('renamed.jpg'));
 
       final response = await http.get(Uri.parse(url));
       expect(response.statusCode, 200);
@@ -374,9 +373,11 @@ void main() {
 
     test('signed url download serves a Content-Disposition attachment',
         () async {
-      final url = await storage
-          .from(downloadBucket)
-          .createSignedUrl(uploadPath, 2000, download: true);
+      final url = await storage.from(downloadBucket).createSignedUrl(
+            uploadPath,
+            2000,
+            download: DownloadBehavior.withOriginalName,
+          );
 
       final response = await http.get(Uri.parse(url));
       expect(response.statusCode, 200);

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -247,18 +247,12 @@ features:
   storage.file_buckets.copy: implemented
   storage.file_buckets.copy_cross_bucket: implemented
   storage.file_buckets.remove: implemented
-  storage.file_buckets.create_signed_url:
-    status: partially_implemented
-    note: "No download (content-disposition) option; image transform is supported."
-  storage.file_buckets.create_signed_urls:
-    status: partially_implemented
-    note: "No download (content-disposition) option."
+  storage.file_buckets.create_signed_url: implemented
+  storage.file_buckets.create_signed_urls: implemented
   storage.file_buckets.create_signed_upload_url:
     status: partially_implemented
     note: "No upsert option to allow overwriting an existing file."
-  storage.file_buckets.get_public_url:
-    status: partially_implemented
-    note: "No download (content-disposition) option; image transform is supported."
+  storage.file_buckets.get_public_url: implemented
   storage.file_buckets.url_cache_nonce: not_implemented
   storage.file_buckets.file_exists: implemented
   storage.file_buckets.file_info: implemented

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -246,7 +246,12 @@ features:
   storage.file_buckets.copy: implemented
   storage.file_buckets.copy_cross_bucket: implemented
   storage.file_buckets.remove: implemented
-  storage.file_buckets.create_signed_url: implemented
+  storage.file_buckets.create_signed_url:
+    status: implemented
+    symbols:
+      - DownloadBehavior
+      - DownloadBehavior.named
+      - DownloadBehavior.withOriginalName
   storage.file_buckets.create_signed_urls: implemented
   storage.file_buckets.create_signed_upload_url: implemented
   storage.file_buckets.get_public_url: implemented


### PR DESCRIPTION
## What

Adds an optional `download` parameter to:

- `createSignedUrl`
- `createSignedUrlsResult` (and the deprecated `createSignedUrls`)
- `getPublicUrl`

Passing `true` appends `download=` so the CDN serves the file with a `Content-Disposition: attachment` header using its original name; passing a `String` overrides the download file name. `null`/`false` leave the URL unchanged.

## Why

SDK parity: supabase-js accepts `download?: string | boolean` on these methods. The Dart client had no way to force a download.

## Tests

- Mock-based unit tests cover `getPublicUrl` (original name, custom name, disabled) and the signed-URL methods (appending `&download=` after the existing `?token=` query).
- An end-to-end test uploads to a public bucket, then fetches the signed and public URLs and asserts the real `Content-Disposition: attachment` response header.

## Compliance

Marks `create_signed_url`, `create_signed_urls`, and `get_public_url` implemented in `sdk-compliance.yaml`.

Resolves SDK-1166