### PR TITLE
feat(storage): add upsert option to createSignedUploadUrl

### DIFF
--- a/packages/storage_client/lib/src/storage_file_api.dart
+++ b/packages/storage_client/lib/src/storage_file_api.dart
@@ -198,13 +198,24 @@ class StorageFileApi {
   /// They are valid for one minute.
   ///
   /// [path] The file path, including the current file name. For example `folder/image.png`.
-  Future<SignedUploadURLResponse> createSignedUploadUrl(String path) async {
+  ///
+  /// When [upsert] is `true` the signed URL allows overwriting an existing
+  /// file at [path]. It defaults to `false`.
+  Future<SignedUploadURLResponse> createSignedUploadUrl(
+    String path, {
+    bool upsert = false,
+  }) async {
     final finalPath = _getFinalPath(path);
 
     final data = await _storageFetch.post(
       '$url/object/upload/sign/$finalPath',
       {},
-      options: _fetchOptions,
+      options: FetchOptions(
+        headers: {
+          ...headers,
+          if (upsert) 'x-upsert': 'true',
+        },
+      ),
     );
 
     final signedUrl = Uri.parse('$url${data['url']}');
@@ -220,8 +231,6 @@ class StorageFileApi {
       path: path,
       token: token,
     );
-
-    //   return { data: { signedUrl: url.toString(), path, token }, error: null }
   }
 
   /// Replaces an existing file at the specified path with a new one.

--- a/packages/storage_client/test/basic_test.dart
+++ b/packages/storage_client/test/basic_test.dart
@@ -207,6 +207,32 @@ void main() {
       );
     });
 
+    test('createSignedUploadUrl omits x-upsert by default', () async {
+      customHttpClient.response = {
+        'url': '/object/upload/sign/public/a.txt?token=xyz',
+      };
+
+      await client.from('public').createSignedUploadUrl('a.txt');
+
+      final request = customHttpClient.receivedRequests.single;
+      expect(request.headers.containsKey('x-upsert'), isFalse);
+    });
+
+    test('createSignedUploadUrl sends x-upsert when upserting', () async {
+      customHttpClient.response = {
+        'url': '/object/upload/sign/public/a.txt?token=xyz',
+      };
+
+      final response = await client
+          .from('public')
+          .createSignedUploadUrl('a.txt', upsert: true);
+
+      expect(response.token, 'xyz');
+
+      final request = customHttpClient.receivedRequests.single;
+      expect(request.headers['x-upsert'], 'true');
+    });
+
     test('should list files', () async {
       customHttpClient.response = [testFileObjectJson, testFileObjectJson];
 

--- a/packages/storage_client/test/client_test.dart
+++ b/packages/storage_client/test/client_test.dart
@@ -211,6 +211,20 @@ void main() {
             .having((e) => e.statusCode, 'statusCode', '409')),
       );
     });
+
+    test('an upsert signed url can overwrite an existing file', () async {
+      await storage.from(newBucketName).upload(uploadPath, file);
+
+      final response = await storage
+          .from(newBucketName)
+          .createSignedUploadUrl(uploadPath, upsert: true);
+
+      final uploadedPath = await storage
+          .from(newBucketName)
+          .uploadToSignedUrl(response.path, response.token, file);
+
+      expect(uploadedPath, uploadPath);
+    });
   });
 
   group('Transformations', () {

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -253,9 +253,7 @@ features:
   storage.file_buckets.create_signed_urls:
     status: partially_implemented
     note: "No download (content-disposition) option."
-  storage.file_buckets.create_signed_upload_url:
-    status: partially_implemented
-    note: "No upsert option to allow overwriting an existing file."
+  storage.file_buckets.create_signed_upload_url: implemented
   storage.file_buckets.get_public_url:
     status: partially_implemented
     note: "No download (content-disposition) option; image transform is supported."


### PR DESCRIPTION
## What

`createSignedUploadUrl` now accepts an optional `upsert` flag (default `false`). When `true`, the request sends the `x-upsert: true` header so the resulting signed upload URL can overwrite an existing file at that path.

## Why

SDK parity: supabase-js `createSignedUploadUrl(path, { upsert })` supports this; the Dart client always created a non-upsert URL.

## Tests

- Mock-based unit tests assert the `x-upsert` header is omitted by default and set to `true` when upserting.
- An end-to-end test uploads a file, then uses an upsert signed upload URL to actually overwrite it (contrasting with the existing non-upsert 409 case).

## Compliance

Marks `create_signed_upload_url` implemented in `sdk-compliance.yaml`.

Resolves SDK-1167