### PR TITLE
feat(postgrest): add format option to explain()

### DIFF
--- a/packages/postgrest/lib/src/postgrest_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_builder.dart
@@ -246,7 +246,7 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
         } else if (response.request!.headers['Accept'] == 'text/csv') {
           body = response.body;
         } else if (_headers['Accept'] != null &&
-            _headers['Accept']!.contains('application/vnd.pgrst.plan+text')) {
+            _headers['Accept']!.contains('application/vnd.pgrst.plan')) {
           body = response.body;
         } else {
           try {

--- a/packages/postgrest/lib/src/postgrest_transform_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_transform_builder.dart
@@ -301,12 +301,17 @@ class PostgrestTransformBuilder<T> extends RawPostgrestBuilder<T, T, T> {
   /// [buffers] If `true`, include information on buffer usage.
   ///
   /// [wal] If `true`, include information on WAL record generation
+  ///
+  /// [format] The format of the returned plan. Defaults to
+  /// [ExplainFormat.text]. When [ExplainFormat.json] is used the plan is
+  /// returned as a JSON string.
   PostgrestBuilder<String, String, String> explain({
     bool analyze = false,
     bool verbose = false,
     bool settings = false,
     bool buffers = false,
     bool wal = false,
+    ExplainFormat format = ExplainFormat.text,
   }) {
     final options = [
       if (analyze) 'analyze',
@@ -320,7 +325,7 @@ class PostgrestTransformBuilder<T> extends RawPostgrestBuilder<T, T, T> {
     final forMediatype = _headers['Accept'] ?? 'application/json';
     final newHeaders = {..._headers};
     newHeaders['Accept'] =
-        'application/vnd.pgrst.plan+text; for="$forMediatype"; options=$options;';
+        'application/vnd.pgrst.plan+${format.name}; for="$forMediatype"; options=$options;';
     return _copyWithType(headers: newHeaders);
   }
 }

--- a/packages/postgrest/lib/src/types.dart
+++ b/packages/postgrest/lib/src/types.dart
@@ -96,6 +96,15 @@ enum CountOption {
   estimated,
 }
 
+/// The format of the plan returned by `PostgrestTransformBuilder.explain`.
+enum ExplainFormat {
+  /// Returns the plan as human readable text.
+  text,
+
+  /// Returns the plan as JSON.
+  json,
+}
+
 // coverage:ignore-[start]
 /// Returns count as part of the response when specified.
 @Deprecated('Not used anywhere. Will be removed in the next major version.')

--- a/packages/postgrest/lib/src/types.dart
+++ b/packages/postgrest/lib/src/types.dart
@@ -98,10 +98,7 @@ enum CountOption {
 
 /// The format of the plan returned by `PostgrestTransformBuilder.explain`.
 enum ExplainFormat {
-  /// Returns the plan as human readable text.
   text,
-
-  /// Returns the plan as JSON.
   json,
 }
 

--- a/packages/postgrest/test/explain_format_test.dart
+++ b/packages/postgrest/test/explain_format_test.dart
@@ -1,0 +1,57 @@
+import 'package:postgrest/postgrest.dart';
+import 'package:test/test.dart';
+
+import 'custom_http_client.dart';
+
+void main() {
+  late CustomHttpClient customHttpClient;
+  late PostgrestClient postgrest;
+
+  setUp(() {
+    customHttpClient = CustomHttpClient();
+    postgrest = PostgrestClient(
+      'http://localhost:3000',
+      httpClient: customHttpClient,
+    );
+  });
+
+  test('explain defaults to a text plan', () async {
+    try {
+      await postgrest.from('users').select().explain();
+    } catch (_) {}
+
+    expect(
+      customHttpClient.lastRequest!.headers['Accept'],
+      startsWith('application/vnd.pgrst.plan+text;'),
+    );
+  });
+
+  test('explain requests a json plan', () async {
+    try {
+      await postgrest
+          .from('users')
+          .select()
+          .explain(format: ExplainFormat.json);
+    } catch (_) {}
+
+    expect(
+      customHttpClient.lastRequest!.headers['Accept'],
+      startsWith('application/vnd.pgrst.plan+json;'),
+    );
+  });
+
+  test('explain forwards options alongside the format', () async {
+    try {
+      await postgrest.from('users').select().explain(
+            analyze: true,
+            verbose: true,
+            format: ExplainFormat.json,
+          );
+    } catch (_) {}
+
+    final accept = customHttpClient.lastRequest!.headers['Accept']!;
+    expect(accept, startsWith('application/vnd.pgrst.plan+json;'),
+        reason: 'format should drive the media type suffix');
+    expect(accept, contains('options=analyze|verbose'));
+  });
+}

--- a/packages/postgrest/test/transforms_test.dart
+++ b/packages/postgrest/test/transforms_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:collection/collection.dart';
 import 'package:postgrest/postgrest.dart';
 import 'package:test/test.dart';
@@ -326,6 +328,17 @@ void main() {
         );
     final regex = RegExp(r'Aggregate  \(cost=.*');
     expect(regex.hasMatch(res), isTrue);
+  });
+
+  test('explain with json format returns a parseable JSON plan', () async {
+    final res = await postgrest
+        .from('users')
+        .select()
+        .explain(format: ExplainFormat.json);
+
+    final decoded = jsonDecode(res);
+    expect(decoded, isA<List>());
+    expect((decoded as List).first, contains('Plan'));
   });
 
   test('geojson', () async {

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -219,8 +219,9 @@ features:
   database.using_modifiers.format_geojson: implemented
   database.using_modifiers.relationship_embed: implemented
   database.using_modifiers.explain:
-    status: partially_implemented
-    note: "Only the text plan is supported; there is no format: json option."
+    status: implemented
+    symbols:
+      - ExplainFormat
   database.using_modifiers.dry_run: not_implemented
   database.using_modifiers.strip_nulls: not_implemented
   database.using_modifiers.request_cancellation: not_implemented


### PR DESCRIPTION
## What

Adds an `ExplainFormat` enum (`text`, `json`) and a `format` parameter to `PostgrestTransformBuilder.explain()` (default `text`). The value is interpolated into the `Accept` media type (`application/vnd.pgrst.plan+<format>`), so a JSON plan can now be requested.

The JSON plan is returned as a raw JSON string, keeping `explain()` type-stable as `Future<String>`.

## Why

SDK parity: supabase-js `explain({ format })` supports `'text' | 'json'`; the Dart client hardcoded `+text`.

## Fix

The response parser only treated `application/vnd.pgrst.plan+text` as a raw body; the `+json` plan was JSON-decoded into a `List` and then cast to `String`, throwing at runtime. Any `application/vnd.pgrst.plan` media type is now returned as a raw body.

## Tests

- Standalone mock-based unit tests assert the `Accept` header for the default text plan, an explicit JSON plan, and that other options are still forwarded alongside the format.
- An end-to-end test runs `explain(format: json)` against Postgres and asserts the returned plan parses as a JSON list with a `Plan` key.

## Compliance

Marks `database.using_modifiers.explain` implemented in `sdk-compliance.yaml` and registers the `ExplainFormat` symbol.

Resolves SDK-1168