### PR TITLE
feat(realtime): add onHeartbeat stream to RealtimeClient

### DIFF
--- a/packages/realtime_client/lib/src/realtime_client.dart
+++ b/packages/realtime_client/lib/src/realtime_client.dart
@@ -58,7 +58,6 @@ enum RealtimeHeartbeatStatus {
   ok,
   error,
   timeout,
-  disconnected,
 }
 
 /// Manages a persistent WebSocket connection to the Supabase Realtime server.
@@ -388,8 +387,7 @@ class RealtimeClient {
     stateChangeCallbacks['message']!.add(callback);
   }
 
-  /// Emits a status whenever a heartbeat is sent, acknowledged, times out, or
-  /// is skipped because the socket is disconnected.
+  /// Emits a status whenever a heartbeat is sent, acknowledged, or times out.
   Stream<RealtimeHeartbeatStatus> get onHeartbeat =>
       _heartbeatController.stream;
 
@@ -628,7 +626,6 @@ class RealtimeClient {
   @internal
   Future<void> sendHeartbeat() async {
     if (!isConnected) {
-      _heartbeatController.add(RealtimeHeartbeatStatus.disconnected);
       return;
     }
 

--- a/packages/realtime_client/lib/src/realtime_client.dart
+++ b/packages/realtime_client/lib/src/realtime_client.dart
@@ -54,20 +54,10 @@ class RealtimeCloseEvent {
 
 /// The lifecycle status of a heartbeat reported to [RealtimeClient.onHeartbeat].
 enum RealtimeHeartbeatStatus {
-  /// A heartbeat message was pushed to the server.
   sent,
-
-  /// The server acknowledged the heartbeat.
   ok,
-
-  /// The server replied to the heartbeat with an error.
   error,
-
-  /// The previous heartbeat was never acknowledged, so the connection is
-  /// being torn down and re-established.
   timeout,
-
-  /// The heartbeat was skipped because the socket is not connected.
   disconnected,
 }
 

--- a/packages/realtime_client/lib/src/realtime_client.dart
+++ b/packages/realtime_client/lib/src/realtime_client.dart
@@ -52,6 +52,25 @@ class RealtimeCloseEvent {
   }
 }
 
+/// The lifecycle status of a heartbeat reported to [RealtimeClient.onHeartbeat].
+enum RealtimeHeartbeatStatus {
+  /// A heartbeat message was pushed to the server.
+  sent,
+
+  /// The server acknowledged the heartbeat.
+  ok,
+
+  /// The server replied to the heartbeat with an error.
+  error,
+
+  /// The previous heartbeat was never acknowledged, so the connection is
+  /// being torn down and re-established.
+  timeout,
+
+  /// The heartbeat was skipped because the socket is not connected.
+  disconnected,
+}
+
 /// Manages a persistent WebSocket connection to the Supabase Realtime server.
 ///
 /// [RealtimeClient] is the central hub for all real-time communication. It owns
@@ -87,26 +106,6 @@ class RealtimeCloseEvent {
 /// **Platform notes:**
 /// - Works on all Dart platforms (Flutter mobile/desktop, web, server).
 /// - On web, the underlying [WebSocketChannel] uses the browser WebSocket API.
-
-/// The lifecycle status of a heartbeat reported to [RealtimeClient.onHeartbeat].
-enum RealtimeHeartbeatStatus {
-  /// A heartbeat message was pushed to the server.
-  sent,
-
-  /// The server acknowledged the heartbeat.
-  ok,
-
-  /// The server replied to the heartbeat with an error.
-  error,
-
-  /// The previous heartbeat was never acknowledged, so the connection is
-  /// being torn down and re-established.
-  timeout,
-
-  /// The heartbeat was skipped because the socket is not connected.
-  disconnected,
-}
-
 class RealtimeClient {
   String? accessToken;
   List<RealtimeChannel> channels = [];

--- a/packages/realtime_client/lib/src/realtime_client.dart
+++ b/packages/realtime_client/lib/src/realtime_client.dart
@@ -133,8 +133,10 @@ class RealtimeClient {
     'close': [],
     'error': [],
     'message': [],
-    'heartbeat': [],
   };
+
+  final _heartbeatController =
+      StreamController<RealtimeHeartbeatStatus>.broadcast();
 
   @Deprecated("No longer used. Will be removed in the next major version.")
   int longpollerTimeout = 20000;
@@ -386,17 +388,10 @@ class RealtimeClient {
     stateChangeCallbacks['message']!.add(callback);
   }
 
-  /// Calls a function any time a heartbeat is sent, acknowledged, times out, or
+  /// Emits a status whenever a heartbeat is sent, acknowledged, times out, or
   /// is skipped because the socket is disconnected.
-  void onHeartbeat(void Function(RealtimeHeartbeatStatus status) callback) {
-    stateChangeCallbacks['heartbeat']!.add(callback);
-  }
-
-  void _triggerHeartbeat(RealtimeHeartbeatStatus status) {
-    for (final callback in stateChangeCallbacks['heartbeat']!) {
-      callback(status);
-    }
-  }
+  Stream<RealtimeHeartbeatStatus> get onHeartbeat =>
+      _heartbeatController.stream;
 
   /// Returns the current state of the socket.
   String get connectionState {
@@ -469,7 +464,7 @@ class RealtimeClient {
     if (messageRef != null && messageRef == pendingHeartbeatRef) {
       pendingHeartbeatRef = null;
       final heartbeatStatus = payload is Map ? payload['status'] : null;
-      _triggerHeartbeat(
+      _heartbeatController.add(
         heartbeatStatus == 'ok'
             ? RealtimeHeartbeatStatus.ok
             : RealtimeHeartbeatStatus.error,
@@ -633,7 +628,7 @@ class RealtimeClient {
   @internal
   Future<void> sendHeartbeat() async {
     if (!isConnected) {
-      _triggerHeartbeat(RealtimeHeartbeatStatus.disconnected);
+      _heartbeatController.add(RealtimeHeartbeatStatus.disconnected);
       return;
     }
 
@@ -644,7 +639,7 @@ class RealtimeClient {
         'transport',
         'heartbeat timeout. Attempting to re-establish conn',
       );
-      _triggerHeartbeat(RealtimeHeartbeatStatus.timeout);
+      _heartbeatController.add(RealtimeHeartbeatStatus.timeout);
       unawaited(conn?.sink.close(Constants.wsCloseNormal, 'heartbeat timeout'));
       return;
     }
@@ -655,7 +650,7 @@ class RealtimeClient {
       payload: {},
       ref: pendingHeartbeatRef!,
     ));
-    _triggerHeartbeat(RealtimeHeartbeatStatus.sent);
+    _heartbeatController.add(RealtimeHeartbeatStatus.sent);
     await setAuth(accessToken);
   }
 }

--- a/packages/realtime_client/lib/src/realtime_client.dart
+++ b/packages/realtime_client/lib/src/realtime_client.dart
@@ -87,6 +87,26 @@ class RealtimeCloseEvent {
 /// **Platform notes:**
 /// - Works on all Dart platforms (Flutter mobile/desktop, web, server).
 /// - On web, the underlying [WebSocketChannel] uses the browser WebSocket API.
+
+/// The lifecycle status of a heartbeat reported to [RealtimeClient.onHeartbeat].
+enum RealtimeHeartbeatStatus {
+  /// A heartbeat message was pushed to the server.
+  sent,
+
+  /// The server acknowledged the heartbeat.
+  ok,
+
+  /// The server replied to the heartbeat with an error.
+  error,
+
+  /// The previous heartbeat was never acknowledged, so the connection is
+  /// being torn down and re-established.
+  timeout,
+
+  /// The heartbeat was skipped because the socket is not connected.
+  disconnected,
+}
+
 class RealtimeClient {
   String? accessToken;
   List<RealtimeChannel> channels = [];
@@ -123,7 +143,8 @@ class RealtimeClient {
     'open': [],
     'close': [],
     'error': [],
-    'message': []
+    'message': [],
+    'heartbeat': [],
   };
 
   @Deprecated("No longer used. Will be removed in the next major version.")
@@ -376,6 +397,18 @@ class RealtimeClient {
     stateChangeCallbacks['message']!.add(callback);
   }
 
+  /// Calls a function any time a heartbeat is sent, acknowledged, times out, or
+  /// is skipped because the socket is disconnected.
+  void onHeartbeat(void Function(RealtimeHeartbeatStatus status) callback) {
+    stateChangeCallbacks['heartbeat']!.add(callback);
+  }
+
+  void _triggerHeartbeat(RealtimeHeartbeatStatus status) {
+    for (final callback in stateChangeCallbacks['heartbeat']!) {
+      callback(status);
+    }
+  }
+
   /// Returns the current state of the socket.
   String get connectionState {
     switch (connState) {
@@ -446,6 +479,12 @@ class RealtimeClient {
     final messageRef = message['ref'] as String?;
     if (messageRef != null && messageRef == pendingHeartbeatRef) {
       pendingHeartbeatRef = null;
+      final heartbeatStatus = payload is Map ? payload['status'] : null;
+      _triggerHeartbeat(
+        heartbeatStatus == 'ok'
+            ? RealtimeHeartbeatStatus.ok
+            : RealtimeHeartbeatStatus.error,
+      );
     }
 
     final status = payload is Map ? (payload['status'] ?? '') : '';
@@ -605,6 +644,7 @@ class RealtimeClient {
   @internal
   Future<void> sendHeartbeat() async {
     if (!isConnected) {
+      _triggerHeartbeat(RealtimeHeartbeatStatus.disconnected);
       return;
     }
 
@@ -615,6 +655,7 @@ class RealtimeClient {
         'transport',
         'heartbeat timeout. Attempting to re-establish conn',
       );
+      _triggerHeartbeat(RealtimeHeartbeatStatus.timeout);
       unawaited(conn?.sink.close(Constants.wsCloseNormal, 'heartbeat timeout'));
       return;
     }
@@ -625,6 +666,7 @@ class RealtimeClient {
       payload: {},
       ref: pendingHeartbeatRef!,
     ));
+    _triggerHeartbeat(RealtimeHeartbeatStatus.sent);
     await setAuth(accessToken);
   }
 }

--- a/packages/realtime_client/test/heartbeat_test.dart
+++ b/packages/realtime_client/test/heartbeat_test.dart
@@ -32,11 +32,11 @@ void main() {
     });
   }
 
-  test('emits disconnected when the socket is not connected', () async {
+  test('emits nothing when the socket is not connected', () async {
     await client.sendHeartbeat();
     await pumpEventQueue();
 
-    expect(statuses, [RealtimeHeartbeatStatus.disconnected]);
+    expect(statuses, isEmpty);
   });
 
   test('emits sent when a heartbeat is pushed', () async {

--- a/packages/realtime_client/test/heartbeat_test.dart
+++ b/packages/realtime_client/test/heartbeat_test.dart
@@ -1,0 +1,79 @@
+import 'dart:convert';
+
+import 'package:realtime_client/realtime_client.dart';
+import 'package:test/test.dart';
+
+void main() {
+  late RealtimeClient client;
+  late List<RealtimeHeartbeatStatus> statuses;
+
+  setUp(() {
+    client = RealtimeClient(
+      'wss://localhost:0/',
+      decode: (rawMessage) =>
+          Map<String, dynamic>.from(jsonDecode(rawMessage as String) as Map),
+    );
+    statuses = [];
+    client.onHeartbeat(statuses.add);
+  });
+
+  String heartbeatReply(String ref, String status) {
+    return jsonEncode({
+      'topic': 'phoenix',
+      'event': 'phoenix_reply',
+      'payload': {'status': status, 'response': <String, dynamic>{}},
+      'ref': ref,
+    });
+  }
+
+  test('emits disconnected when the socket is not connected', () async {
+    await client.sendHeartbeat();
+
+    expect(statuses, [RealtimeHeartbeatStatus.disconnected]);
+  });
+
+  test('emits sent when a heartbeat is pushed', () async {
+    client.connState = SocketStates.open;
+
+    await client.sendHeartbeat();
+
+    expect(statuses, [RealtimeHeartbeatStatus.sent]);
+    expect(client.pendingHeartbeatRef, isNotNull);
+  });
+
+  test('emits timeout when the previous heartbeat was not acknowledged',
+      () async {
+    client.connState = SocketStates.open;
+    client.pendingHeartbeatRef = 'stale-ref';
+
+    await client.sendHeartbeat();
+
+    expect(statuses, [RealtimeHeartbeatStatus.timeout]);
+    expect(client.pendingHeartbeatRef, isNull);
+  });
+
+  test('emits ok when the heartbeat reply succeeds', () {
+    client.pendingHeartbeatRef = 'ref-1';
+
+    client.onConnMessage(heartbeatReply('ref-1', 'ok'));
+
+    expect(statuses, [RealtimeHeartbeatStatus.ok]);
+    expect(client.pendingHeartbeatRef, isNull);
+  });
+
+  test('emits error when the heartbeat reply fails', () {
+    client.pendingHeartbeatRef = 'ref-2';
+
+    client.onConnMessage(heartbeatReply('ref-2', 'error'));
+
+    expect(statuses, [RealtimeHeartbeatStatus.error]);
+  });
+
+  test('does not emit for messages that are not the pending heartbeat', () {
+    client.pendingHeartbeatRef = 'ref-3';
+
+    client.onConnMessage(heartbeatReply('other-ref', 'ok'));
+
+    expect(statuses, isEmpty);
+  });
+}

--- a/packages/realtime_client/test/heartbeat_test.dart
+++ b/packages/realtime_client/test/heartbeat_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:realtime_client/realtime_client.dart';
@@ -6,6 +7,7 @@ import 'package:test/test.dart';
 void main() {
   late RealtimeClient client;
   late List<RealtimeHeartbeatStatus> statuses;
+  late StreamSubscription<RealtimeHeartbeatStatus> subscription;
 
   setUp(() {
     client = RealtimeClient(
@@ -14,7 +16,11 @@ void main() {
           Map<String, dynamic>.from(jsonDecode(rawMessage as String) as Map),
     );
     statuses = [];
-    client.onHeartbeat(statuses.add);
+    subscription = client.onHeartbeat.listen(statuses.add);
+  });
+
+  tearDown(() async {
+    await subscription.cancel();
   });
 
   String heartbeatReply(String ref, String status) {
@@ -28,6 +34,7 @@ void main() {
 
   test('emits disconnected when the socket is not connected', () async {
     await client.sendHeartbeat();
+    await pumpEventQueue();
 
     expect(statuses, [RealtimeHeartbeatStatus.disconnected]);
   });
@@ -36,6 +43,7 @@ void main() {
     client.connState = SocketStates.open;
 
     await client.sendHeartbeat();
+    await pumpEventQueue();
 
     expect(statuses, [RealtimeHeartbeatStatus.sent]);
     expect(client.pendingHeartbeatRef, isNotNull);
@@ -47,32 +55,37 @@ void main() {
     client.pendingHeartbeatRef = 'stale-ref';
 
     await client.sendHeartbeat();
+    await pumpEventQueue();
 
     expect(statuses, [RealtimeHeartbeatStatus.timeout]);
     expect(client.pendingHeartbeatRef, isNull);
   });
 
-  test('emits ok when the heartbeat reply succeeds', () {
+  test('emits ok when the heartbeat reply succeeds', () async {
     client.pendingHeartbeatRef = 'ref-1';
 
     client.onConnMessage(heartbeatReply('ref-1', 'ok'));
+    await pumpEventQueue();
 
     expect(statuses, [RealtimeHeartbeatStatus.ok]);
     expect(client.pendingHeartbeatRef, isNull);
   });
 
-  test('emits error when the heartbeat reply fails', () {
+  test('emits error when the heartbeat reply fails', () async {
     client.pendingHeartbeatRef = 'ref-2';
 
     client.onConnMessage(heartbeatReply('ref-2', 'error'));
+    await pumpEventQueue();
 
     expect(statuses, [RealtimeHeartbeatStatus.error]);
   });
 
-  test('does not emit for messages that are not the pending heartbeat', () {
+  test('does not emit for messages that are not the pending heartbeat',
+      () async {
     client.pendingHeartbeatRef = 'ref-3';
 
     client.onConnMessage(heartbeatReply('other-ref', 'ok'));
+    await pumpEventQueue();
 
     expect(statuses, isEmpty);
   });

--- a/packages/realtime_client/test/realtime_integration_test.dart
+++ b/packages/realtime_client/test/realtime_integration_test.dart
@@ -44,6 +44,33 @@ void main() {
         expect(client.isConnected, isTrue);
       });
 
+      test('reports heartbeat sent and ok statuses', () async {
+        final heartbeatClient = RealtimeClient(
+          realtimeUrl,
+          version: version,
+          params: {'apikey': generateRealtimeToken()},
+          heartbeatIntervalMs: 500,
+        );
+        final statuses = <RealtimeHeartbeatStatus>[];
+        final acknowledged = Completer<void>();
+        heartbeatClient.onHeartbeat((status) {
+          statuses.add(status);
+          if (status == RealtimeHeartbeatStatus.ok &&
+              !acknowledged.isCompleted) {
+            acknowledged.complete();
+          }
+        });
+
+        try {
+          await heartbeatClient.connect();
+          await acknowledged.future.timeout(const Duration(seconds: 10));
+          expect(statuses, contains(RealtimeHeartbeatStatus.sent));
+          expect(statuses, contains(RealtimeHeartbeatStatus.ok));
+        } finally {
+          await heartbeatClient.disconnect();
+        }
+      });
+
       test('subscribes to a channel', () async {
         final channel = client.channel('subscribe-${version.vsn}');
         final status = await _subscribe(channel);

--- a/packages/realtime_client/test/realtime_integration_test.dart
+++ b/packages/realtime_client/test/realtime_integration_test.dart
@@ -53,7 +53,7 @@ void main() {
         );
         final statuses = <RealtimeHeartbeatStatus>[];
         final acknowledged = Completer<void>();
-        heartbeatClient.onHeartbeat((status) {
+        final subscription = heartbeatClient.onHeartbeat.listen((status) {
           statuses.add(status);
           if (status == RealtimeHeartbeatStatus.ok &&
               !acknowledged.isCompleted) {
@@ -67,6 +67,7 @@ void main() {
           expect(statuses, contains(RealtimeHeartbeatStatus.sent));
           expect(statuses, contains(RealtimeHeartbeatStatus.ok));
         } finally {
+          await subscription.cancel();
           await heartbeatClient.disconnect();
         }
       });

--- a/packages/realtime_client/test/socket_test.dart
+++ b/packages/realtime_client/test/socket_test.dart
@@ -80,7 +80,6 @@ void main() {
         'close': [],
         'error': [],
         'message': [],
-        'heartbeat': [],
       });
       expect(socket.timeout, const Duration(milliseconds: 10000));
       expect(socket.heartbeatIntervalMs, Constants.defaultHeartbeatIntervalMs);
@@ -117,7 +116,6 @@ void main() {
         'close': [],
         'error': [],
         'message': [],
-        'heartbeat': [],
       });
       expect(socket.timeout, const Duration(milliseconds: 40000));
       expect(socket.heartbeatIntervalMs, 60000);

--- a/packages/realtime_client/test/socket_test.dart
+++ b/packages/realtime_client/test/socket_test.dart
@@ -80,6 +80,7 @@ void main() {
         'close': [],
         'error': [],
         'message': [],
+        'heartbeat': [],
       });
       expect(socket.timeout, const Duration(milliseconds: 10000));
       expect(socket.heartbeatIntervalMs, Constants.defaultHeartbeatIntervalMs);
@@ -116,6 +117,7 @@ void main() {
         'close': [],
         'error': [],
         'message': [],
+        'heartbeat': [],
       });
       expect(socket.timeout, const Duration(milliseconds: 40000));
       expect(socket.heartbeatIntervalMs, 60000);

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -310,7 +310,11 @@ features:
   realtime.client.get_channels: implemented
   realtime.client.remove_channel: implemented
   realtime.client.remove_all_channels: implemented
-  realtime.client.listen_heartbeats: not_implemented
+  realtime.client.listen_heartbeats:
+    status: implemented
+    symbols:
+      - RealtimeClient.onHeartbeat
+      - RealtimeHeartbeatStatus
   realtime.client.set_auth_token: implemented
 
   # realtime — subscriptions


### PR DESCRIPTION
## What

Adds `RealtimeClient.onHeartbeat`, a broadcast `Stream<RealtimeHeartbeatStatus>` that emits a status whenever a heartbeat is pushed (`sent`), acknowledged (`ok`/`error`), or when a prior heartbeat goes unanswered (`timeout`).

```dart
final subscription = supabase.realtime.onHeartbeat.listen((status) {
  print('heartbeat: $status');
});
```

Also adds the `RealtimeHeartbeatStatus` enum (`sent`, `ok`, `error`, `timeout`).

## Why

SDK parity: realtime-js `RealtimeClient.onHeartbeat` exposes the same lifecycle. The Dart client had the heartbeat machinery but no way to observe it.

Exposing it as a `Stream` (rather than a single callback like realtime-js) is the idiomatic Dart shape: consumers get `listen`/`where`/`firstWhere`/`timeout`, multiple subscribers and cancellation for free, and it matches how the auth client already surfaces events (`onAuthStateChange`).

## Tests

- Unit tests cover each emitted status and a case where a non-matching heartbeat reference emits nothing.
- An end-to-end test connects to a real Realtime server (both v1 and v2 protocols) and observes an actual `sent` then `ok` heartbeat cycle.

## Compliance

Marks `realtime.client.listen_heartbeats` implemented in `sdk-compliance.yaml` and registers the `RealtimeClient.onHeartbeat` and `RealtimeHeartbeatStatus` symbols.

Resolves SDK-1169