### PR TITLE
fix(realtime): preserve nested empty maps in Message.toJson()

### DIFF
--- a/packages/realtime_client/lib/src/message.dart
+++ b/packages/realtime_client/lib/src/message.dart
@@ -24,9 +24,9 @@ class Message {
       for (final outerKey in payload.keys) {
         final outerValue = payload[outerKey];
         if (outerValue is Map) {
+          processedPayload[outerKey] = {};
           for (final innerKey in outerValue.keys) {
             final innerValue = outerValue[innerKey];
-            processedPayload[outerKey] ??= {};
             if (innerValue is Binding) {
               processedPayload[outerKey][innerKey] = <String, dynamic>{
                 'type': innerValue.type,

--- a/packages/realtime_client/test/message_test.dart
+++ b/packages/realtime_client/test/message_test.dart
@@ -90,5 +90,34 @@ void main() {
       final json = message.toJson();
       expect(json.containsKey('ref'), isFalse);
     });
+
+    test('a nested empty map is preserved, not dropped', () {
+      final message = Message(
+        topic: 'room:lobby',
+        event: ChannelEvents.presence,
+        payload: {'event': 'track', 'payload': <String, dynamic>{}},
+      );
+      final json = message.toJson();
+      expect(json['payload'], equals({'event': 'track', 'payload': {}}));
+    });
+
+    test('nested non-empty maps still serialize correctly', () {
+      final message = Message(
+        topic: 'room:lobby',
+        event: ChannelEvents.presence,
+        payload: {
+          'event': 'track',
+          'payload': {'name': 'alice'},
+        },
+      );
+      final json = message.toJson();
+      expect(
+        json['payload'],
+        equals({
+          'event': 'track',
+          'payload': {'name': 'alice'},
+        }),
+      );
+    });
   });
 }


### PR DESCRIPTION
## What

`Message.toJson()` flattens nested maps by assigning into `processedPayload[outerKey]` from inside a loop over the inner map's keys. When the nested value is an **empty** map, that loop body never runs, so the outer key is never assigned and disappears from the serialized payload:

```dart
Message(
  topic: 'room:lobby',
  event: ChannelEvents.presence,
  payload: {'event': 'track', 'payload': <String, dynamic>{}},
).toJson();
// {topic: room:lobby, event: presence, payload: {event: track}}
//                                                 ^ the nested `payload` key is gone
```

## Why

A presence `track({})` (tracking with no metadata) and any broadcast/send whose payload contains a nested empty map are sent to the Realtime server **missing their `payload` field**. The initialization `processedPayload[outerKey] ??= {}` lived inside the inner `for` loop, so it was skipped entirely for an empty map.

Fix: initialize `processedPayload[outerKey]` to an empty map **before** the loop, so an empty map round-trips as `{}` instead of vanishing.

## Not a breaking change

Non-empty nested maps serialize exactly as before (the initialization simply moved ahead of the loop). Only the previously-dropped empty-map case changes — it's now preserved.

## Tests

Added to `packages/realtime_client/test/message_test.dart`: a nested empty map (`track({})` shape) is preserved, and a nested non-empty map still serializes correctly. The empty-map test fails on the current code (`Actual: {'event': 'track'}`) and passes with the fix. `dart format` and `dart analyze --fatal-warnings` are clean.
