### PR TITLE
chore(supabase_flutter): bump minimum supported Flutter to 3.35.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -234,7 +234,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        flutter-version: ['3.32.x', 'latest']
+        flutter-version: ['3.35.x', 'latest']
 
     defaults:
       run:
@@ -253,7 +253,7 @@ jobs:
           channel: 'stable'
           # Caching the latest stable is flaky: the cached SDK contains
           # runner-image-specific binaries that break silently when the runner
-          # image is updated. Pinned versions like 3.32.x are stable to cache.
+          # image is updated. Pinned versions like 3.35.x are stable to cache.
           cache: ${{ matrix.flutter-version != 'latest' }}
 
       - name: Show Flutter version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -234,7 +234,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        flutter-version: ['3.22.x', 'latest']
+        flutter-version: ['3.32.x', 'latest']
 
     defaults:
       run:
@@ -253,7 +253,7 @@ jobs:
           channel: 'stable'
           # Caching the latest stable is flaky: the cached SDK contains
           # runner-image-specific binaries that break silently when the runner
-          # image is updated. Pinned versions like 3.22.x are stable to cache.
+          # image is updated. Pinned versions like 3.32.x are stable to cache.
           cache: ${{ matrix.flutter-version != 'latest' }}
 
       - name: Show Flutter version

--- a/examples/passkeys/pubspec.yaml
+++ b/examples/passkeys/pubspec.yaml
@@ -6,8 +6,8 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: '>=3.4.0 <4.0.0'
-  flutter: '>=3.22.0'
+  sdk: '>=3.8.0 <4.0.0'
+  flutter: '>=3.32.0'
 
 dependencies:
   flutter:

--- a/examples/passkeys/pubspec.yaml
+++ b/examples/passkeys/pubspec.yaml
@@ -6,8 +6,8 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: '>=3.8.0 <4.0.0'
-  flutter: '>=3.32.0'
+  sdk: '>=3.9.0 <4.0.0'
+  flutter: '>=3.35.0'
 
 dependencies:
   flutter:

--- a/packages/supabase_flutter/example/lib/main.dart
+++ b/packages/supabase_flutter/example/lib/main.dart
@@ -3,7 +3,9 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 
 Future<void> main() async {
   await Supabase.initialize(
-      url: 'SUPABASE_URL', publishableKey: 'SUPABASE_PUBLISHABLE_KEY');
+    url: 'SUPABASE_URL',
+    publishableKey: 'SUPABASE_PUBLISHABLE_KEY',
+  );
   runApp(const MyApp());
 }
 
@@ -116,10 +118,12 @@ class _LoginFormState extends State<_LoginForm> {
                       password: password,
                     );
                   } catch (e) {
-                    scaffoldMessenger.showSnackBar(const SnackBar(
-                      content: Text('Login failed'),
-                      backgroundColor: Colors.red,
-                    ));
+                    scaffoldMessenger.showSnackBar(
+                      const SnackBar(
+                        content: Text('Login failed'),
+                        backgroundColor: Colors.red,
+                      ),
+                    );
                     setState(() {
                       _loading = false;
                     });
@@ -143,10 +147,12 @@ class _LoginFormState extends State<_LoginForm> {
                       password: password,
                     );
                   } catch (e) {
-                    scaffoldMessenger.showSnackBar(const SnackBar(
-                      content: Text('Signup failed'),
-                      backgroundColor: Colors.red,
-                    ));
+                    scaffoldMessenger.showSnackBar(
+                      const SnackBar(
+                        content: Text('Signup failed'),
+                        backgroundColor: Colors.red,
+                      ),
+                    );
                     setState(() {
                       _loading = false;
                     });
@@ -185,14 +191,16 @@ class _ProfileFormState extends State<_ProfileForm> {
   }
 
   Future<void> _loadProfile() async {
-    final ScaffoldMessengerState scaffoldMessenger =
-        ScaffoldMessenger.of(context);
+    final ScaffoldMessengerState scaffoldMessenger = ScaffoldMessenger.of(
+      context,
+    );
     try {
       final userId = Supabase.instance.client.auth.currentUser!.id;
       final data = (await Supabase.instance.client
           .from('profiles')
           .select()
-          .match({'id': userId}).maybeSingle());
+          .match({'id': userId})
+          .maybeSingle());
       if (data != null) {
         setState(() {
           _usernameController.text = data['username'];
@@ -200,10 +208,12 @@ class _ProfileFormState extends State<_ProfileForm> {
         });
       }
     } catch (e) {
-      scaffoldMessenger.showSnackBar(const SnackBar(
-        content: Text('Error occurred while getting profile'),
-        backgroundColor: Colors.red,
-      ));
+      scaffoldMessenger.showSnackBar(
+        const SnackBar(
+          content: Text('Error occurred while getting profile'),
+          backgroundColor: Colors.red,
+        ),
+      );
     }
     setState(() {
       _loading = false;
@@ -232,42 +242,48 @@ class _ProfileFormState extends State<_ProfileForm> {
               ),
               const SizedBox(height: 16),
               ElevatedButton(
-                  onPressed: () async {
-                    final ScaffoldMessengerState scaffoldMessenger =
-                        ScaffoldMessenger.of(context);
-                    try {
-                      setState(() {
-                        _loading = true;
-                      });
-                      final userId =
-                          Supabase.instance.client.auth.currentUser!.id;
-                      final username = _usernameController.text;
-                      final website = _websiteController.text;
-                      await Supabase.instance.client.from('profiles').upsert({
-                        'id': userId,
-                        'username': username,
-                        'website': website,
-                      });
-                      if (mounted) {
-                        scaffoldMessenger.showSnackBar(const SnackBar(
+                onPressed: () async {
+                  final ScaffoldMessengerState scaffoldMessenger =
+                      ScaffoldMessenger.of(context);
+                  try {
+                    setState(() {
+                      _loading = true;
+                    });
+                    final userId =
+                        Supabase.instance.client.auth.currentUser!.id;
+                    final username = _usernameController.text;
+                    final website = _websiteController.text;
+                    await Supabase.instance.client.from('profiles').upsert({
+                      'id': userId,
+                      'username': username,
+                      'website': website,
+                    });
+                    if (mounted) {
+                      scaffoldMessenger.showSnackBar(
+                        const SnackBar(
                           content: Text('Saved profile'),
-                        ));
-                      }
-                    } catch (e) {
-                      scaffoldMessenger.showSnackBar(const SnackBar(
+                        ),
+                      );
+                    }
+                  } catch (e) {
+                    scaffoldMessenger.showSnackBar(
+                      const SnackBar(
                         content: Text('Error saving profile'),
                         backgroundColor: Colors.red,
-                      ));
-                    }
-                    setState(() {
-                      _loading = false;
-                    });
-                  },
-                  child: const Text('Save')),
+                      ),
+                    );
+                  }
+                  setState(() {
+                    _loading = false;
+                  });
+                },
+                child: const Text('Save'),
+              ),
               const SizedBox(height: 16),
               TextButton(
-                  onPressed: () => Supabase.instance.client.auth.signOut(),
-                  child: const Text('Sign Out')),
+                onPressed: () => Supabase.instance.client.auth.signOut(),
+                child: const Text('Sign Out'),
+              ),
             ],
           );
   }

--- a/packages/supabase_flutter/example/pubspec.yaml
+++ b/packages/supabase_flutter/example/pubspec.yaml
@@ -6,7 +6,7 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: '>=3.4.0 <4.0.0'
+  sdk: '>=3.8.0 <4.0.0'
 
 dependencies:
   flutter:

--- a/packages/supabase_flutter/example/pubspec.yaml
+++ b/packages/supabase_flutter/example/pubspec.yaml
@@ -6,7 +6,7 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: '>=3.8.0 <4.0.0'
+  sdk: '>=3.9.0 <4.0.0'
 
 dependencies:
   flutter:

--- a/packages/supabase_flutter/lib/src/hot_restart_cleanup_web.dart
+++ b/packages/supabase_flutter/lib/src/hot_restart_cleanup_web.dart
@@ -17,8 +17,12 @@ external JSFunction? supabaseFlutterClientToDispose;
 /// logged.
 void markClientToDispose(SupabaseClient client) {
   void dispose() {
-    unawaited(client.realtime.disconnect(
-        code: 1000, reason: 'Closed due to Flutter Web hot-restart'));
+    unawaited(
+      client.realtime.disconnect(
+        code: 1000,
+        reason: 'Closed due to Flutter Web hot-restart',
+      ),
+    );
     unawaited(client.dispose());
   }
 

--- a/packages/supabase_flutter/lib/src/local_storage.dart
+++ b/packages/supabase_flutter/lib/src/local_storage.dart
@@ -6,7 +6,8 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 import './local_storage_stub.dart'
-    if (dart.library.js_interop) './local_storage_web.dart' as web;
+    if (dart.library.js_interop) './local_storage_web.dart'
+    as web;
 
 /// Only used for migration from Hive to SharedPreferences. Not actually in use.
 const supabasePersistSessionKey = 'SUPABASE_PERSIST_SESSION_KEY';

--- a/packages/supabase_flutter/lib/src/passkey/passkey_options_mapper.dart
+++ b/packages/supabase_flutter/lib/src/passkey/passkey_options_mapper.dart
@@ -29,8 +29,9 @@ RegisterRequestType passkeyRegisterRequestFromOptions(
 
   final authenticatorSelection = json['authenticatorSelection'];
   if (authenticatorSelection is Map) {
-    json['authenticatorSelection'] =
-        _normalizeAuthenticatorSelection(authenticatorSelection);
+    json['authenticatorSelection'] = _normalizeAuthenticatorSelection(
+      authenticatorSelection,
+    );
   }
 
   return RegisterRequestType.fromJson(json);

--- a/packages/supabase_flutter/lib/src/supabase_auth.dart
+++ b/packages/supabase_flutter/lib/src/supabase_auth.dart
@@ -105,19 +105,23 @@ class SupabaseAuth with WidgetsBindingObserver {
       final persistedSession = await _localStorage.accessToken();
       if (persistedSession != null) {
         try {
-          await Supabase.instance.client.auth
-              .setInitialSession(persistedSession);
+          await Supabase.instance.client.auth.setInitialSession(
+            persistedSession,
+          );
           shouldEmitInitialSession = false;
         } catch (error, stackTrace) {
           _log.warning(
-              'Error while setting initial session', error, stackTrace);
+            'Error while setting initial session',
+            error,
+            stackTrace,
+          );
         }
       }
     }
     if (shouldEmitInitialSession) {
       Supabase.instance.client.auth
-          // ignore: invalid_use_of_internal_member
-          .notifyAllSubscribers(AuthChangeEvent.initialSession);
+      // ignore: invalid_use_of_internal_member
+      .notifyAllSubscribers(AuthChangeEvent.initialSession);
     }
     _widgetsBindingInstance.addObserver(this);
 
@@ -177,7 +181,9 @@ class SupabaseAuth with WidgetsBindingObserver {
   }
 
   Future<void> _onAuthStateChange(
-      AuthChangeEvent event, Session? session) async {
+    AuthChangeEvent event,
+    Session? session,
+  ) async {
     try {
       if (session != null) {
         await _localStorage.persistSession(jsonEncode(session.toJson()));
@@ -186,7 +192,10 @@ class SupabaseAuth with WidgetsBindingObserver {
       }
     } catch (error, stackTrace) {
       _log.warning(
-          'Error while persisting auth state change', error, stackTrace);
+        'Error while persisting auth state change',
+        error,
+        stackTrace,
+      );
     }
   }
 

--- a/packages/supabase_flutter/pubspec.yaml
+++ b/packages/supabase_flutter/pubspec.yaml
@@ -6,8 +6,8 @@ repository: 'https://github.com/supabase/supabase-flutter/tree/main/packages/sup
 documentation: 'https://supabase.com/docs/reference/dart/introduction'
 
 environment:
-  sdk: '>=3.8.0 <4.0.0'
-  flutter: '>=3.32.0'
+  sdk: '>=3.9.0 <4.0.0'
+  flutter: '>=3.35.0'
 
 dependencies:
   app_links: '>=6.2.0 <8.0.0'

--- a/packages/supabase_flutter/pubspec.yaml
+++ b/packages/supabase_flutter/pubspec.yaml
@@ -6,8 +6,8 @@ repository: 'https://github.com/supabase/supabase-flutter/tree/main/packages/sup
 documentation: 'https://supabase.com/docs/reference/dart/introduction'
 
 environment:
-  sdk: '>=3.4.0 <4.0.0'
-  flutter: '>=3.22.0'
+  sdk: '>=3.8.0 <4.0.0'
+  flutter: '>=3.32.0'
 
 dependencies:
   app_links: '>=6.2.0 <8.0.0'

--- a/packages/supabase_flutter/test/auth_test.dart
+++ b/packages/supabase_flutter/test/auth_test.dart
@@ -63,29 +63,33 @@ void main() {
 
     group('Auth state stream error handling', () {
       test(
-          'does not propagate auth state stream errors as unhandled exceptions',
-          () async {
-        await Supabase.initialize(
-          url: supabaseUrl,
-          publishableKey: supabaseKey,
-          debug: false,
-          authOptions: FlutterAuthClientOptions(
-            localStorage: const MockEmptyLocalStorage(),
-            pkceAsyncStorage: MockAsyncStorage(),
-          ),
-        );
+        'does not propagate auth state stream errors as unhandled exceptions',
+        () async {
+          await Supabase.initialize(
+            url: supabaseUrl,
+            publishableKey: supabaseKey,
+            debug: false,
+            authOptions: FlutterAuthClientOptions(
+              localStorage: const MockEmptyLocalStorage(),
+              pkceAsyncStorage: MockAsyncStorage(),
+            ),
+          );
 
-        // Trigger an error on the auth state change stream via notifyException.
-        // This should not throw or cause an unhandled zone error.
-        final auth = Supabase.instance.client.auth;
-        // ignore: invalid_use_of_internal_member
-        auth.notifyException(Exception('test auth error'), StackTrace.current);
+          // Trigger an error on the auth state change stream via notifyException.
+          // This should not throw or cause an unhandled zone error.
+          final auth = Supabase.instance.client.auth;
+          // ignore: invalid_use_of_internal_member
+          auth.notifyException(
+            Exception('test auth error'),
+            StackTrace.current,
+          );
 
-        // Allow the stream listener to process the error.
-        await Future.delayed(Duration.zero);
+          // Allow the stream listener to process the error.
+          await Future.delayed(Duration.zero);
 
-        // If we reach here the error was not rethrown as an unhandled exception.
-      });
+          // If we reach here the error was not rethrown as an unhandled exception.
+        },
+      );
     });
 
     group('Session recovery', () {

--- a/packages/supabase_flutter/test/deep_link_test.dart
+++ b/packages/supabase_flutter/test/deep_link_test.dart
@@ -1,5 +1,4 @@
 @TestOn('!browser')
-
 /// Tests for deep link handling on non-browser platforms.
 library;
 
@@ -47,14 +46,15 @@ void main() {
     });
 
     test(
-        'Having `code` as the query parameter triggers `getSessionFromUrl` call on initialize',
-        () async {
-      // Wait for the initial app link to be handled, as this is an async
-      // process when mocking the event channel.
-      await Future.delayed(const Duration(milliseconds: 500));
-      expect(pkceHttpClient.requestCount, 1);
-      expect(pkceHttpClient.lastRequestBody['auth_code'], 'my-code-verifier');
-    });
+      'Having `code` as the query parameter triggers `getSessionFromUrl` call on initialize',
+      () async {
+        // Wait for the initial app link to be handled, as this is an async
+        // process when mocking the event channel.
+        await Future.delayed(const Duration(milliseconds: 500));
+        expect(pkceHttpClient.requestCount, 1);
+        expect(pkceHttpClient.lastRequestBody['auth_code'], 'my-code-verifier');
+      },
+    );
   });
 
   group('Deep Link with implicit token while PKCE flow is configured', () {
@@ -67,7 +67,8 @@ void main() {
       mockAppLink(
         mockMethodChannel: false,
         mockEventChannel: true,
-        initialLink: 'com.supabase://callback/#access_token=my-access-token'
+        initialLink:
+            'com.supabase://callback/#access_token=my-access-token'
             '&expires_in=3600&refresh_token=my-refresh-token'
             '&token_type=bearer&type=email_change',
       );
@@ -87,8 +88,7 @@ void main() {
           .timeout(const Duration(seconds: 5));
     });
 
-    test(
-        'Implicit token in the fragment triggers `getSessionFromUrl` and '
+    test('Implicit token in the fragment triggers `getSessionFromUrl` and '
         'updates the current user', () async {
       final state = await signedInState;
       expect(state.session?.user.email, 'new@email.com');
@@ -110,7 +110,8 @@ void main() {
       mockAppLink(
         mockMethodChannel: false,
         mockEventChannel: true,
-        initialLink: 'com.supabase://callback/?error=access_denied'
+        initialLink:
+            'com.supabase://callback/?error=access_denied'
             '&error_code=403',
       );
       await Supabase.initialize(
@@ -134,11 +135,11 @@ void main() {
       );
     });
 
-    test(
-        'Error query parameter triggers `getSessionFromUrl` and surfaces an '
+    test('Error query parameter triggers `getSessionFromUrl` and surfaces an '
         'AuthException', () async {
-      final exception =
-          await errorCompleter.future.timeout(const Duration(seconds: 5));
+      final exception = await errorCompleter.future.timeout(
+        const Duration(seconds: 5),
+      );
       expect(exception.code, 'access_denied');
       expect(exception.statusCode, '403');
     });

--- a/packages/supabase_flutter/test/dispose_test.dart
+++ b/packages/supabase_flutter/test/dispose_test.dart
@@ -11,17 +11,19 @@ void main() {
   // `Supabase` singleton keeps `_restoreSessionCancellableOperation` across
   // initialize/dispose cycles, so any earlier initialization without a custom
   // `accessToken` would assign it and mask the regression this test guards.
-  test('dispose() does not throw when initialized with a custom access token',
-      () async {
-    SharedPreferences.setMockInitialValues({});
-    mockAppLink();
+  test(
+    'dispose() does not throw when initialized with a custom access token',
+    () async {
+      SharedPreferences.setMockInitialValues({});
+      mockAppLink();
 
-    await Supabase.initialize(
-      url: '',
-      publishableKey: '',
-      accessToken: () async => 'custom-access-token',
-    );
+      await Supabase.initialize(
+        url: '',
+        publishableKey: '',
+        accessToken: () async => 'custom-access-token',
+      );
 
-    await expectLater(Supabase.instance.dispose(), completes);
-  });
+      await expectLater(Supabase.instance.dispose(), completes);
+    },
+  );
 }

--- a/packages/supabase_flutter/test/lifecycle_test.dart
+++ b/packages/supabase_flutter/test/lifecycle_test.dart
@@ -16,7 +16,7 @@ class FakeWebSocketChannel extends Fake implements WebSocketChannel {
       StreamController<dynamic>.broadcast();
 
   FakeWebSocketChannel({Completer<void>? readyCompleter})
-      : readyCompleter = readyCompleter ?? Completer<void>();
+    : readyCompleter = readyCompleter ?? Completer<void>();
 
   @override
   Future<void> get ready => readyCompleter.future;
@@ -128,8 +128,7 @@ void main() {
       }
     }
 
-    test(
-        'paused then resumed waits for disconnect '
+    test('paused then resumed waits for disconnect '
         'before reconnecting', () async {
       final realtime = Supabase.instance.client.realtime;
       final binding = TestWidgetsFlutterBinding.instance;
@@ -157,8 +156,7 @@ void main() {
       expect(realtime.conn, isNotNull);
     });
 
-    test(
-        'paused → resumed → inactive → resumed '
+    test('paused → resumed → inactive → resumed '
         'still reconnects', () async {
       final realtime = Supabase.instance.client.realtime;
       final binding = TestWidgetsFlutterBinding.instance;
@@ -191,8 +189,7 @@ void main() {
       expect(realtime.conn, isNotNull);
     });
 
-    test(
-        'rapid paused → resumed → paused → resumed '
+    test('rapid paused → resumed → paused → resumed '
         'ends up connected', () async {
       final realtime = Supabase.instance.client.realtime;
       final binding = TestWidgetsFlutterBinding.instance;
@@ -224,8 +221,7 @@ void main() {
       expect(realtime.conn, isNotNull);
     });
 
-    test(
-        'resumed then paused before connect completes '
+    test('resumed then paused before connect completes '
         'cancels reconnect', () async {
       final realtime = Supabase.instance.client.realtime;
       final binding = TestWidgetsFlutterBinding.instance;

--- a/packages/supabase_flutter/test/passkey_options_mapper_test.dart
+++ b/packages/supabase_flutter/test/passkey_options_mapper_test.dart
@@ -4,17 +4,17 @@ import 'package:supabase_flutter/src/passkey/passkey_options_mapper.dart';
 void main() {
   group('passkeyRegisterRequestFromOptions', () {
     Map<String, dynamic> baseOptions() => {
-          'challenge': 'Y2hhbGxlbmdl',
-          'rp': {'id': 'example.com', 'name': 'Example'},
-          'user': {
-            'id': 'dXNlcg==',
-            'name': 'jane@example.com',
-            'displayName': 'Jane',
-          },
-          'pubKeyCredParams': [
-            {'type': 'public-key', 'alg': -7},
-          ],
-        };
+      'challenge': 'Y2hhbGxlbmdl',
+      'rp': {'id': 'example.com', 'name': 'Example'},
+      'user': {
+        'id': 'dXNlcg==',
+        'name': 'jane@example.com',
+        'displayName': 'Jane',
+      },
+      'pubKeyCredParams': [
+        {'type': 'public-key', 'alg': -7},
+      ],
+    };
 
     test('maps the W3C fields through to the request type', () {
       final request = passkeyRegisterRequestFromOptions(baseOptions());
@@ -113,10 +113,10 @@ void main() {
 
   group('passkeyAuthenticateRequestFromOptions', () {
     Map<String, dynamic> baseOptions() => {
-          'challenge': 'Y2hhbGxlbmdl',
-          'rpId': 'example.com',
-          'userVerification': 'preferred',
-        };
+      'challenge': 'Y2hhbGxlbmdl',
+      'rpId': 'example.com',
+      'userVerification': 'preferred',
+    };
 
     test('maps the W3C fields through to the request type', () {
       final request = passkeyAuthenticateRequestFromOptions(baseOptions());

--- a/packages/supabase_flutter/test/supabase_flutter_test.dart
+++ b/packages/supabase_flutter/test/supabase_flutter_test.dart
@@ -81,8 +81,10 @@ void main() {
       // Give it a delay to wait for recoverSession to throw
       await Future.delayed(const Duration(milliseconds: 100));
 
-      await expectLater(Supabase.instance.client.auth.onAuthStateChange,
-          emitsError(isA<AuthException>()));
+      await expectLater(
+        Supabase.instance.client.auth.onAuthStateChange,
+        emitsError(isA<AuthException>()),
+      );
     });
   });
 

--- a/packages/supabase_flutter/test/utils.dart
+++ b/packages/supabase_flutter/test/utils.dart
@@ -2,14 +2,19 @@ import 'dart:convert';
 
 /// Construct session data for a given expiration date
 ({String accessToken, String sessionString}) getSessionData(
-    DateTime accessTokenExpireDateTime) {
+  DateTime accessTokenExpireDateTime,
+) {
   final accessTokenExpiresAt =
       accessTokenExpireDateTime.millisecondsSinceEpoch ~/ 1000;
-  final accessTokenMid = base64.encode(utf8.encode(json.encode({
-    'exp': accessTokenExpiresAt,
-    'sub': '1234567890',
-    'role': 'authenticated'
-  })));
+  final accessTokenMid = base64.encode(
+    utf8.encode(
+      json.encode({
+        'exp': accessTokenExpiresAt,
+        'sub': '1234567890',
+        'role': 'authenticated',
+      }),
+    ),
+  );
   final accessToken = 'any.$accessTokenMid.any';
   final sessionString =
       '{"access_token":"$accessToken","expires_in":${accessTokenExpireDateTime.difference(DateTime.now()).inSeconds},"refresh_token":"-yeS4omysFs9tpUYBws9Rg","token_type":"bearer","provider_token":null,"provider_refresh_token":null,"user":{"id":"4d2583da-8de4-49d3-9cd1-37a9a74f55bd","app_metadata":{"provider":"email","providers":["email"]},"user_metadata":{"Hello":"World"},"aud":"","email":"fake1680338105@email.com","phone":"","created_at":"2023-04-01T08:35:05.208586Z","confirmed_at":null,"email_confirmed_at":"2023-04-01T08:35:05.220096086Z","phone_confirmed_at":null,"last_sign_in_at":"2023-04-01T08:35:05.222755878Z","role":"","updated_at":"2023-04-01T08:35:05.226938Z"}}';

--- a/packages/supabase_flutter/test/widget_test.dart
+++ b/packages/supabase_flutter/test/widget_test.dart
@@ -12,8 +12,9 @@ void main() {
     mockAppLink();
   });
 
-  testWidgets('Signing out triggers AuthChangeEvent.signedOut event',
-      (tester) async {
+  testWidgets('Signing out triggers AuthChangeEvent.signedOut event', (
+    tester,
+  ) async {
     // Initialize the Supabase singleton
     await Supabase.initialize(
       url: supabaseUrl,

--- a/packages/supabase_flutter/test/widget_test_stubs.dart
+++ b/packages/supabase_flutter/test/widget_test_stubs.dart
@@ -54,8 +54,9 @@ class MockExpiredStorage extends LocalStorage {
   Future<void> initialize() async {}
   @override
   Future<String?> accessToken() async {
-    return getSessionData(DateTime.now().subtract(const Duration(hours: 1)))
-        .sessionString;
+    return getSessionData(
+      DateTime.now().subtract(const Duration(hours: 1)),
+    ).sessionString;
   }
 
   @override
@@ -72,8 +73,9 @@ class MockLocalStorage extends LocalStorage {
   Future<void> initialize() async {}
   @override
   Future<String?> accessToken() async {
-    return getSessionData(DateTime.now().add(const Duration(hours: 1)))
-        .sessionString;
+    return getSessionData(
+      DateTime.now().add(const Duration(hours: 1)),
+    ).sessionString;
   }
 
   @override
@@ -114,7 +116,9 @@ void mockAppLink({
   // ignore: invalid_null_aware_operator
   TestDefaultBinaryMessengerBinding.instance?.defaultBinaryMessenger
       .setMockMethodCallHandler(
-          channel, (call) async => mockMethodChannel ? initialLink : null);
+        channel,
+        (call) async => mockMethodChannel ? initialLink : null,
+      );
 
   // Mock event channel using method channel, to keep supporting older versions
   // of flutter_test in which setMockStreamHandler is not yet available.
@@ -122,19 +126,23 @@ void mockAppLink({
     // ignore: invalid_null_aware_operator
     TestDefaultBinaryMessengerBinding.instance?.defaultBinaryMessenger
         .setMockMethodCallHandler(
-      eventChannel,
-      // ignore: function-always-returns-null
-      (MethodCall methodCall) async {
-        // ignore: invalid_null_aware_operator
-        await TestDefaultBinaryMessengerBinding.instance?.defaultBinaryMessenger
-            .handlePlatformMessage(
-          eventChannel.name,
-          const StandardMethodCodec().encodeSuccessEnvelope(initialLink),
-          (ByteData? data) {},
+          eventChannel,
+          // ignore: function-always-returns-null
+          (MethodCall methodCall) async {
+            await TestDefaultBinaryMessengerBinding
+                .instance
+                // ignore: invalid_null_aware_operator
+                ?.defaultBinaryMessenger
+                .handlePlatformMessage(
+                  eventChannel.name,
+                  const StandardMethodCodec().encodeSuccessEnvelope(
+                    initialLink,
+                  ),
+                  (ByteData? data) {},
+                );
+            return null;
+          },
         );
-        return null;
-      },
-    );
   }
 }
 
@@ -161,7 +169,7 @@ class GetUserHttpClient extends BaseClient {
               'email': email,
               'app_metadata': {
                 'provider': 'email',
-                'providers': ['email']
+                'providers': ['email'],
               },
               'user_metadata': {},
               'created_at': '2023-04-01T09:38:59.784028Z',
@@ -236,7 +244,7 @@ class PkceHttpClient extends BaseClient {
                 'last_sign_in_at': '2023-04-01T09:38:59.904492805Z',
                 'app_metadata': {
                   'provider': 'email',
-                  'providers': ['email']
+                  'providers': ['email'],
                 },
                 'user_metadata': {},
                 'factors': [
@@ -246,8 +254,8 @@ class PkceHttpClient extends BaseClient {
                     'updated_at': '2023-04-01T09:38:59.784028Z',
                     'status': 'unverified',
                     'friendly_name': 'UnverifiedFactor',
-                    'factor_type': 'totp'
-                  }
+                    'factor_type': 'totp',
+                  },
                 ],
                 'identities': [
                   {
@@ -255,17 +263,17 @@ class PkceHttpClient extends BaseClient {
                     'user_id': '18bc7a4e-c095-4573-93dc-e0be29bada97',
                     'identity_data': {
                       'email': 'fake1@email.com',
-                      'sub': '18bc7a4e-c095-4573-93dc-e0be29bada97'
+                      'sub': '18bc7a4e-c095-4573-93dc-e0be29bada97',
                     },
                     'provider': 'email',
                     'last_sign_in_at': '2023-04-01T09:38:59.784028Z',
                     'created_at': '2023-04-01T09:38:59.784028Z',
-                    'updated_at': '2023-04-01T09:38:59.784028Z'
-                  }
+                    'updated_at': '2023-04-01T09:38:59.784028Z',
+                  },
                 ],
                 'created_at': '2023-04-01T09:38:59.784028Z',
-                'updated_at': '2023-04-01T09:38:59.908816Z'
-              }
+                'updated_at': '2023-04-01T09:38:59.908816Z',
+              },
             },
           ),
         ),


### PR DESCRIPTION
## Summary
- Raises `supabase_flutter`'s minimum supported SDK from Flutter 3.22.0/Dart 3.4.0 to Flutter 3.35.0/Dart 3.9.0.
- Updates the CI matrix (`test.yml`) to test against 3.35.x instead of 3.22.x.
- Bumps the matching `environment` constraints in the example apps (`examples/passkeys`, `packages/supabase_flutter/example`).

## Why
Needed to unblock #1521, which bumps `passkeys_platform_interface` to `^2.8.0`. That version requires a newer Dart SDK, which is unsatisfiable under the current 3.22.0 floor and was failing CI (`Flutter v3.22.x` jobs) with a version-solving error.

## Test plan
- [x] `flutter pub get` resolves cleanly
- [x] `flutter analyze` clean
- [x] `flutter test` passes (60/60)
