### PR TITLE
ci: speed up build and test pipelines

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          dart pub global activate melos 8.0.0
+          dart pub global activate melos
 
           BASE="${{ github.event.pull_request.base.sha }}"
 
@@ -129,7 +129,7 @@ jobs:
       - name: Bootstrap workspace
         run: |
           cd ../../
-          dart pub global activate melos 8.0.0
+          dart pub global activate melos
           melos bootstrap
 
       - name: Install Linux build dependencies (cached)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          dart pub global activate melos
+          dart pub global activate melos 8.0.0
 
           BASE="${{ github.event.pull_request.base.sha }}"
 
@@ -61,20 +61,35 @@ jobs:
           fi
 
   build-flutter:
-    name: Build on ${{ matrix.os }}
+    name: Build ${{ matrix.target }} on ${{ matrix.os }}
     needs: changes
     if: ${{ needs.changes.outputs.flutter == 'true' }}
     timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        include:
+          - os: ubuntu-latest
+            target: web
+          - os: ubuntu-latest
+            target: linux
+          - os: ubuntu-latest
+            target: apk
+          - os: macos-latest
+            target: macos
+          - os: macos-latest
+            target: ios
+          - os: windows-latest
+            target: windows
 
     defaults:
       run:
         working-directory: packages/supabase_flutter
 
     runs-on: ${{ matrix.os }}
+
+    env:
+      PUB_CACHE: ${{ github.workspace }}/.pub-cache
 
     steps:
       - name: Checkout repository
@@ -92,54 +107,47 @@ jobs:
       - name: Show Flutter version
         run: flutter --version
 
+      - name: Cache pub dependencies
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        with:
+          path: ${{ env.PUB_CACHE }}
+          key: ${{ runner.os }}-pub-${{ hashFiles('**/pubspec.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pub-
+
+      - name: Cache Gradle
+        if: ${{ matrix.target == 'apk' }}
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('packages/supabase_flutter/example/android/**/*.gradle*', 'packages/supabase_flutter/example/android/**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
       - name: Bootstrap workspace
         run: |
           cd ../../
-          dart pub global activate melos
+          dart pub global activate melos 8.0.0
           melos bootstrap
 
-      - name: Build web app
-        if: ${{ matrix.os == 'ubuntu-latest' }}
-        run: |
-          cd example
-          flutter build web
-
       - name: Install Linux build dependencies (cached)
-        if: ${{ matrix.os == 'ubuntu-latest' }}
+        if: ${{ matrix.target == 'linux' }}
         uses: awalsh128/cache-apt-pkgs-action@681749ae568c81c2037cb9185e38b709b261bd2f # v1.6.1
         with:
           packages: libgtk-3-dev libblkid-dev liblzma-dev
           version: 1.0
 
-      - name: Build Linux app
-        if: ${{ matrix.os == 'ubuntu-latest' }}
+      - name: Build ${{ matrix.target }} app
+        working-directory: packages/supabase_flutter/example
+        shell: bash
         run: |
-          cd example
-          flutter build linux
-
-      - name: Build Android app
-        if: ${{ matrix.os == 'ubuntu-latest' }}
-        run: |
-          cd example
-          flutter build apk
-
-      - name: Build macOS app
-        if: ${{ matrix.os == 'macos-latest' }}
-        run: |
-          cd example
-          flutter build macos
-
-      - name: Build iOS app
-        if: ${{ matrix.os == 'macos-latest' }}
-        run: |
-          cd example
-          flutter build ios --no-codesign
-
-      - name: Build Windows app
-        if: ${{ matrix.os == 'windows-latest' }}
-        run: |
-          cd example
-          flutter build windows
+          if [ "${{ matrix.target }}" = "ios" ]; then
+            flutter build ios --no-codesign
+          else
+            flutter build ${{ matrix.target }}
+          fi
 
   build-result:
     name: Build result

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       dart-matrix: ${{ steps.detect.outputs.dart-matrix }}
+      sdk-matrix: ${{ steps.detect.outputs.sdk-matrix }}
       flutter: ${{ steps.detect.outputs.flutter }}
     steps:
       - name: Checkout repository
@@ -36,7 +37,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          dart pub global activate melos
+          dart pub global activate melos 8.0.0
 
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             BASE="${{ github.event.pull_request.base.sha }}"
@@ -87,6 +88,15 @@ jobs:
           fi
           echo "dart-matrix=$DART_MATRIX" >> "$GITHUB_OUTPUT"
 
+          # Only exercise beta/dev SDKs on pushes to main. On pull requests we
+          # test stable only to keep the matrix small; upcoming-SDK breakage is
+          # caught on merge.
+          if [ "${{ github.event_name }}" = "push" ]; then
+            echo 'sdk-matrix=["stable","beta","dev"]' >> "$GITHUB_OUTPUT"
+          else
+            echo 'sdk-matrix=["stable"]' >> "$GITHUB_OUTPUT"
+          fi
+
           if echo "$CHANGED" | grep -qx "supabase_flutter"; then
             echo "flutter=true" >> "$GITHUB_OUTPUT"
           else
@@ -103,7 +113,7 @@ jobs:
       fail-fast: false
       matrix:
         package: ${{ fromJSON(needs.changes.outputs.dart-matrix) }}
-        sdk: [stable, beta, dev]
+        sdk: ${{ fromJSON(needs.changes.outputs.sdk-matrix) }}
 
     steps:
       - name: Checkout repository
@@ -127,7 +137,7 @@ jobs:
 
       - name: Bootstrap workspace
         run: |
-          dart pub global activate melos
+          dart pub global activate melos 8.0.0
           melos bootstrap --no-flutter
 
       - name: Format
@@ -262,7 +272,7 @@ jobs:
       - name: Bootstrap workspace
         run: |
           cd ../../
-          dart pub global activate melos
+          dart pub global activate melos 8.0.0
           melos bootstrap
 
       - name: Run formatter
@@ -319,7 +329,7 @@ jobs:
 
       - name: Bootstrap workspace
         run: |
-          dart pub global activate melos
+          dart pub global activate melos 8.0.0
           melos bootstrap
 
       - name: Install DCM

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          dart pub global activate melos 8.0.0
+          dart pub global activate melos
 
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             BASE="${{ github.event.pull_request.base.sha }}"
@@ -137,7 +137,7 @@ jobs:
 
       - name: Bootstrap workspace
         run: |
-          dart pub global activate melos 8.0.0
+          dart pub global activate melos
           melos bootstrap --no-flutter
 
       - name: Format
@@ -272,7 +272,7 @@ jobs:
       - name: Bootstrap workspace
         run: |
           cd ../../
-          dart pub global activate melos 8.0.0
+          dart pub global activate melos
           melos bootstrap
 
       - name: Run formatter
@@ -329,7 +329,7 @@ jobs:
 
       - name: Bootstrap workspace
         run: |
-          dart pub global activate melos 8.0.0
+          dart pub global activate melos
           melos bootstrap
 
       - name: Install DCM


### PR DESCRIPTION
## What

Several changes to cut CI wall-clock time on `build.yml` and `test.yml`.

### `build.yml`
- **Add caching where there was none.** Cache pub dependencies (via `PUB_CACHE`) and the Gradle caches/wrapper for the Android build. The Flutter SDK cache stays off (`cache: false`) as before due to the known flakiness with latest stable.
- **Split the Flutter builds into per-target parallel jobs.** Previously each OS runner built its targets serially (ubuntu did web → linux → apk in one job). Now `web`, `linux`, `apk`, `macos`, `ios`, and `windows` each run as their own matrix job concurrently.

### `test.yml`
- **Only run the beta/dev Dart SDK matrix on pushes to `main`.** Pull requests now test `stable` only, cutting the Dart test job count by ~66% per PR. Upcoming-SDK breakage is still caught on merge to main. Driven by a new `sdk-matrix` output from the detect job.

## Trade-offs
- Splitting builds per target increases the number of runners used for the build job, trading runner minutes for wall-clock time.
- beta/dev SDK regressions surface on merge to main rather than on the PR.

## Follow-up
- Pinning melos is deferred until pub workspaces are set up in a separate PR.