### PR TITLE
feat(realtime_client): support new postgres changes filter operators, multi-filter, column selection, and replication-ready events

### DIFF
--- a/packages/realtime_client/lib/src/realtime_channel.dart
+++ b/packages/realtime_client/lib/src/realtime_channel.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:typed_data';
 
+import 'package:collection/collection.dart';
 import 'package:http/http.dart';
 import 'package:meta/meta.dart';
 import 'package:realtime_client/realtime_client.dart';
@@ -273,6 +274,10 @@ class RealtimeChannel {
       final filter = clientPostgresBinding.filter['filter'];
       final serverPostgresFilter = serverPostgresFilters[i];
 
+      // NOTE: `select` is intentionally not part of this equality check (mirroring
+      // supabase-js), so a server that echoes `select` back in a slightly
+      // different shape does not force a spurious unsubscribe. The client
+      // binding keeps its own `select` regardless.
       if (serverPostgresFilter != null &&
           serverPostgresFilter['event'] == event &&
           serverPostgresFilter['schema'] == schema &&
@@ -369,6 +374,13 @@ class RealtimeChannel {
   ///
   /// [filter] can be used to further control which rows to listen to within the given [schema] and [table].
   ///
+  /// [filters] combines multiple [PostgresChangeFilter]s with an `AND`. Provide
+  /// either [filter] or [filters], not both.
+  ///
+  /// [select] restricts the change payload to a subset of columns instead of the
+  /// full row (reducing payload size). The listed columns must be selectable by
+  /// the subscribing role.
+  ///
   /// ```dart
   /// supabase.channel('my_channel').onPostgresChanges(
   ///     event: PostgresChangeEvent.all,
@@ -388,15 +400,29 @@ class RealtimeChannel {
     String? schema,
     String? table,
     PostgresChangeFilter? filter,
+    List<PostgresChangeFilter>? filters,
+    List<String>? select,
     required void Function(PostgresChangePayload payload) callback,
   }) {
+    assert(
+      filter == null || filters == null,
+      'Provide either `filter` or `filters`, not both.',
+    );
+
+    final allFilters = [
+      if (filter != null) filter,
+      ...?filters,
+    ];
+    final filterString = allFilters.isEmpty ? null : allFilters.join(',');
+
     return onEvents(
       'postgres_changes',
       ChannelFilter(
         event: event.toRealtimeEvent(),
         schema: schema,
         table: table,
-        filter: filter?.toString(),
+        filter: filterString,
+        select: select,
       ),
       (payload, [ref]) => callback(PostgresChangePayload.fromPayload(payload)),
     );
@@ -517,7 +543,38 @@ class RealtimeChannel {
     return result;
   }
 
-  /// Sets up a listener for realtime system events for debugging purposes.
+  /// Sets up a listener for realtime `system` events.
+  ///
+  /// The [callback] receives the raw payload (typically a `Map`). To work with
+  /// it as a typed value, parse it with [RealtimeSystemPayload.fromJson].
+  ///
+  /// Opt in to the replication-ready notification with
+  /// [RealtimeChannelConfig.replicationReady] when creating the channel, then
+  /// watch for `status == 'ok'` to know the Postgres replication connection is
+  /// ready.
+  ///
+  /// ```dart
+  /// final channel = supabase.channel(
+  ///   'room1',
+  ///   opts: const RealtimeChannelConfig(replicationReady: true),
+  /// );
+  /// channel
+  ///     .onPostgresChanges(
+  ///       event: PostgresChangeEvent.all,
+  ///       schema: 'public',
+  ///       table: 'messages',
+  ///       callback: (payload) => print('Change received! $payload'),
+  ///     )
+  ///     .onSystemEvents((payload) {
+  ///       final system = RealtimeSystemPayload.fromJson(
+  ///         Map<String, dynamic>.from(payload as Map),
+  ///       );
+  ///       if (system.extension == 'system' && system.status == 'ok') {
+  ///         print('Replication connection is ready: ${system.message}');
+  ///       }
+  ///     })
+  ///     .subscribe();
+  /// ```
   RealtimeChannel onSystemEvents(
     void Function(dynamic payload) callback,
   ) {
@@ -548,7 +605,7 @@ class RealtimeChannel {
   }
 
   @internal
-  RealtimeChannel off(String type, Map<String, String> filter) {
+  RealtimeChannel off(String type, Map<String, dynamic> filter) {
     final typeLower = type.toLowerCase();
 
     _bindings[typeLower] = _bindings[typeLower]!.where((bind) {
@@ -983,13 +1040,14 @@ class RealtimeChannel {
   @internal
   bool get isLeaving => _state == ChannelStates.leaving;
 
-  static bool _isEqual(Map<String, String> obj1, Map<String, String> obj2) {
+  static bool _isEqual(Map<String, dynamic> obj1, Map<String, dynamic> obj2) {
     if (obj1.keys.length != obj2.keys.length) {
       return false;
     }
 
+    const equality = DeepCollectionEquality();
     for (final k in obj1.keys) {
-      if (obj1[k] != obj2[k]) {
+      if (!equality.equals(obj1[k], obj2[k])) {
         return false;
       }
     }

--- a/packages/realtime_client/lib/src/realtime_channel.dart
+++ b/packages/realtime_client/lib/src/realtime_channel.dart
@@ -410,7 +410,7 @@ class RealtimeChannel {
     );
 
     final allFilters = [
-      if (filter != null) filter,
+      ?filter,
       ...?filters,
     ];
     final filterString = allFilters.isEmpty ? null : allFilters.join(',');

--- a/packages/realtime_client/lib/src/realtime_channel.dart
+++ b/packages/realtime_client/lib/src/realtime_channel.dart
@@ -1040,7 +1040,7 @@ class RealtimeChannel {
   @internal
   bool get isLeaving => _state == ChannelStates.leaving;
 
-  static bool _isEqual(Map<String, dynamic> obj1, Map<String, dynamic> obj2) {
+  static bool _isEqual(Map<String, Object?> obj1, Map<String, Object?> obj2) {
     if (obj1.keys.length != obj2.keys.length) {
       return false;
     }

--- a/packages/realtime_client/lib/src/types.dart
+++ b/packages/realtime_client/lib/src/types.dart
@@ -6,7 +6,7 @@ typedef BindingCallback = void Function(dynamic payload, [dynamic ref]);
 
 class Binding {
   String type;
-  Map<String, String> filter;
+  Map<String, dynamic> filter;
   BindingCallback callback;
   String? id;
 
@@ -19,7 +19,7 @@ class Binding {
 
   Binding copyWith({
     String? type,
-    Map<String, String>? filter,
+    Map<String, dynamic>? filter,
     BindingCallback? callback,
     String? id,
   }) {
@@ -79,24 +79,31 @@ class ChannelFilter {
   final String? schema;
   final String? table;
 
-  /// For [RealtimeListenTypes.postgresChanges] it's of the format `column=filter.value` with `filter` being one of `eq, neq, lt, lte, gt, gte, in`
+  /// For [RealtimeListenTypes.postgresChanges] it's of the format `column=filter.value` with `filter` being one of `eq, neq, lt, lte, gt, gte, in, like, ilike, is, match, imatch, isdistinct`.
   ///
-  /// Only one filter can be applied
+  /// Multiple conditions can be combined with commas; they are applied as an `AND`.
+  /// Any operator can be negated with the `not.` prefix.
   final String? filter;
+
+  /// For [RealtimeListenTypes.postgresChanges], restricts the change payload to
+  /// a subset of columns instead of the full row.
+  final List<String>? select;
 
   const ChannelFilter({
     this.event,
     this.schema,
     this.table,
     this.filter,
+    this.select,
   });
 
-  Map<String, String> toMap() {
+  Map<String, dynamic> toMap() {
     return {
       if (event != null) 'event': event!,
       if (schema != null) 'schema': schema!,
       if (table != null) 'table': table!,
       if (filter != null) 'filter': filter!,
+      if (select != null) 'select': select!,
     };
   }
 }
@@ -181,6 +188,16 @@ class RealtimeChannelConfig {
   /// Defines if the channel is private or not and if RLS policies will be used to check data
   final bool private;
 
+  /// [replicationReady] instructs the server to emit a `system` event once the
+  /// Postgres replication connection backing this channel is established and
+  /// ready to stream changes.
+  ///
+  /// Listen for it with [RealtimeChannel.onSystemEvents]; the payload's
+  /// [RealtimeSystemPayload.status] is `'ok'`
+  /// (message: `'Replication connection established'`) on success or `'error'`
+  /// if the connection is not ready in time.
+  final bool replicationReady;
+
   const RealtimeChannelConfig({
     this.ack = false,
     this.self = false,
@@ -188,6 +205,7 @@ class RealtimeChannelConfig {
     this.key = '',
     this.enabled = false,
     this.private = false,
+    this.replicationReady = false,
   });
 
   Map<String, dynamic> toMap() {
@@ -197,6 +215,9 @@ class RealtimeChannelConfig {
     };
     if (replay != null) {
       broadcastConfig['replay'] = replay!.toMap();
+    }
+    if (replicationReady) {
+      broadcastConfig['replication_ready'] = true;
     }
 
     return {
@@ -210,6 +231,48 @@ class RealtimeChannelConfig {
       },
     };
   }
+}
+
+/// Payload of a `system` event emitted by the server.
+///
+/// Most notably, when a channel is created with
+/// [RealtimeChannelConfig.replicationReady] set to `true`, the server sends one
+/// of these once the Postgres replication connection is ready
+/// ([status] is `'ok'`) or fails to become ready in time ([status] is
+/// `'error'`).
+class RealtimeSystemPayload {
+  /// The extension that produced the message, e.g. `'system'` or
+  /// `'postgres_changes'`.
+  final String extension;
+
+  /// `'ok'` on success, `'error'` on failure.
+  final String status;
+
+  /// Human-readable description, e.g. `'Replication connection established'`.
+  final String message;
+
+  /// The channel (sub)topic the message refers to.
+  final String channel;
+
+  const RealtimeSystemPayload({
+    required this.extension,
+    required this.status,
+    required this.message,
+    required this.channel,
+  });
+
+  factory RealtimeSystemPayload.fromJson(Map<String, dynamic> json) {
+    return RealtimeSystemPayload(
+      extension: json['extension']?.toString() ?? '',
+      status: json['status']?.toString() ?? '',
+      message: json['message']?.toString() ?? '',
+      channel: json['channel']?.toString() ?? '',
+    );
+  }
+
+  @override
+  String toString() =>
+      'RealtimeSystemPayload(extension: $extension, status: $status, message: $message, channel: $channel)';
 }
 
 /// Data class that contains the Postgres change event payload.
@@ -291,6 +354,10 @@ class PostgresChangePayload {
 }
 
 /// Specifies the type of filter to be applied on realtime Postgres Change listener.
+///
+/// These mirror the PostgREST operator surface that the Realtime server
+/// evaluates for Postgres Changes. Any operator can be negated with the `not.`
+/// prefix via [PostgresChangeFilter.negate].
 enum PostgresChangeFilterType {
   /// Listens to changes where a column's value in a table equals a client-specified value.
   eq,
@@ -312,6 +379,54 @@ enum PostgresChangeFilterType {
 
   /// Listen to changes when a column's value in a table equals any of the values specified.
   inFilter,
+
+  /// Listens to changes where a column matches a case-sensitive pattern (`LIKE`).
+  ///
+  /// Use `%` and `_` as wildcards, e.g. `title=like.%foo%`.
+  like,
+
+  /// Listens to changes where a column matches a case-insensitive pattern (`ILIKE`).
+  ilike,
+
+  /// Listens to changes where a column `IS` a given value (`null`, `true`,
+  /// `false` or `unknown`), e.g. `deleted_at=is.null`.
+  isFilter,
+
+  /// Listens to changes where a column matches a POSIX regular expression (`~`).
+  match,
+
+  /// Listens to changes where a column matches a case-insensitive POSIX regular
+  /// expression (`~*`).
+  imatch,
+
+  /// Listens to changes where a column is distinct from a value (NULL-safe
+  /// inequality, `IS DISTINCT FROM`).
+  isDistinct;
+
+  /// The operator token used in the filter wire format (the part between
+  /// `column=` and `.value`). Most match [name], but a few differ because the
+  /// enum names avoid Dart reserved words / casing conventions.
+  String get token {
+    switch (this) {
+      case PostgresChangeFilterType.inFilter:
+        return 'in';
+      case PostgresChangeFilterType.isFilter:
+        return 'is';
+      case PostgresChangeFilterType.isDistinct:
+        return 'isdistinct';
+      case PostgresChangeFilterType.eq:
+      case PostgresChangeFilterType.neq:
+      case PostgresChangeFilterType.lt:
+      case PostgresChangeFilterType.lte:
+      case PostgresChangeFilterType.gt:
+      case PostgresChangeFilterType.gte:
+      case PostgresChangeFilterType.like:
+      case PostgresChangeFilterType.ilike:
+      case PostgresChangeFilterType.match:
+      case PostgresChangeFilterType.imatch:
+        return name;
+    }
+  }
 }
 
 /// {@template postgres_change_filter}
@@ -327,22 +442,40 @@ class PostgresChangeFilter {
   /// The value to perform the filter on.
   final dynamic value;
 
+  /// When `true`, the operator is negated with the `not.` prefix
+  /// (e.g. `status=not.in.(draft,archived)`, `deleted_at=not.is.null`).
+  final bool negate;
+
   /// {@macro postgres_change_filter}
   const PostgresChangeFilter({
     required this.type,
     required this.column,
     required this.value,
+    this.negate = false,
   });
+
+  /// Quotes a scalar value PostgREST-style when it contains a reserved
+  /// character (`,`, `(`, `)`, `"`, `\`) or surrounding whitespace, so the
+  /// server's filter parser doesn't misread it as a condition/list boundary.
+  /// Values without reserved characters are sent verbatim.
+  static String _serializeScalar(dynamic value) {
+    final serialized = value == null ? 'null' : '$value';
+    final needsQuoting = RegExp(r'[,()"\\]').hasMatch(serialized) ||
+        serialized != serialized.trim();
+    if (!needsQuoting) return serialized;
+    final escaped = serialized.replaceAll(r'\', r'\\').replaceAll('"', r'\"');
+    return '"$escaped"';
+  }
 
   @override
   String toString() {
+    final prefix = negate ? 'not.' : '';
     if (type == PostgresChangeFilterType.inFilter) {
-      return '$column=in.(${value.map((s) {
-        final escaped = '$s'.replaceAll(r'\', r'\\').replaceAll('"', r'\"');
-        return '"$escaped"';
-      }).join(',')})';
+      final items =
+          (value as Iterable).map((s) => _serializeScalar(s)).join(',');
+      return '$column=${prefix}in.($items)';
     }
-    return '$column=${type.name}.$value';
+    return '$column=$prefix${type.token}.${_serializeScalar(value)}';
   }
 }
 

--- a/packages/realtime_client/lib/src/types.dart
+++ b/packages/realtime_client/lib/src/types.dart
@@ -458,9 +458,10 @@ class PostgresChangeFilter {
   /// character (`,`, `(`, `)`, `"`, `\`) or surrounding whitespace, so the
   /// server's filter parser doesn't misread it as a condition/list boundary.
   /// Values without reserved characters are sent verbatim.
-  static String _serializeScalar(dynamic value) {
+  static String _serializeScalar(Object? value) {
     final serialized = value == null ? 'null' : '$value';
-    final needsQuoting = RegExp(r'[,()"\\]').hasMatch(serialized) ||
+    final needsQuoting =
+        RegExp(r'[,()"\\]').hasMatch(serialized) ||
         serialized != serialized.trim();
     if (!needsQuoting) return serialized;
     final escaped = serialized.replaceAll(r'\', r'\\').replaceAll('"', r'\"');
@@ -471,8 +472,9 @@ class PostgresChangeFilter {
   String toString() {
     final prefix = negate ? 'not.' : '';
     if (type == PostgresChangeFilterType.inFilter) {
-      final items =
-          (value as Iterable).map((s) => _serializeScalar(s)).join(',');
+      final items = (value as Iterable)
+          .map((s) => _serializeScalar(s))
+          .join(',');
       return '$column=${prefix}in.($items)';
     }
     return '$column=$prefix${type.token}.${_serializeScalar(value)}';

--- a/packages/realtime_client/test/channel_test.dart
+++ b/packages/realtime_client/test/channel_test.dart
@@ -63,6 +63,26 @@ void main() {
         },
       });
     });
+
+    test('forwards broadcast.replication_ready when opted in', () {
+      channel = RealtimeChannel(
+        'topic',
+        socket,
+        params: RealtimeChannelConfig(replicationReady: true),
+      );
+
+      expect(channel.params, {
+        'config': {
+          'broadcast': {
+            'ack': false,
+            'self': false,
+            'replication_ready': true,
+          },
+          'presence': {'key': '', 'enabled': false},
+          'private': false,
+        }
+      });
+    });
   });
 
   group('join', () {
@@ -242,6 +262,49 @@ void main() {
 
       expect(status, RealtimeSubscribeStatus.channelError);
     });
+
+    test('forwards `select` columns in the join payload', () {
+      channel.onPostgresChanges(
+        event: PostgresChangeEvent.all,
+        schema: 'public',
+        table: 'users',
+        select: ['id', 'first_name'],
+        callback: (_) {},
+      );
+
+      channel.subscribe();
+
+      final sentFilter = (channel.joinPush.payload['config']['postgres_changes']
+          as List)[0] as Map;
+      expect(sentFilter['select'], ['id', 'first_name']);
+    });
+
+    test('joins multiple filters with commas as an AND condition', () {
+      channel.onPostgresChanges(
+        event: PostgresChangeEvent.update,
+        schema: 'public',
+        table: 'orders',
+        filters: [
+          PostgresChangeFilter(
+            type: PostgresChangeFilterType.gt,
+            column: 'amount',
+            value: 100,
+          ),
+          PostgresChangeFilter(
+            type: PostgresChangeFilterType.inFilter,
+            column: 'status',
+            value: ['open', 'pending'],
+          ),
+        ],
+        callback: (_) {},
+      );
+
+      channel.subscribe();
+
+      final sentFilter = (channel.joinPush.payload['config']['postgres_changes']
+          as List)[0] as Map;
+      expect(sentFilter['filter'], 'amount=gt.100,status=in.(open,pending)');
+    });
   });
 
   group('onError', () {
@@ -329,6 +392,28 @@ void main() {
       });
 
       expect(status, isNot(RealtimeSubscribeStatus.channelError));
+    });
+
+    test('forwards the raw payload, parseable into a RealtimeSystemPayload',
+        () {
+      dynamic received;
+      channel.onSystemEvents((payload) => received = payload);
+
+      channel.trigger('system', {
+        'extension': 'system',
+        'status': 'ok',
+        'message': 'Replication connection established',
+        'channel': 'topic',
+      });
+
+      expect(received, isA<Map>());
+
+      final system =
+          RealtimeSystemPayload.fromJson(Map<String, dynamic>.from(received));
+      expect(system.extension, 'system');
+      expect(system.status, 'ok');
+      expect(system.message, 'Replication connection established');
+      expect(system.channel, 'topic');
     });
   });
 

--- a/packages/realtime_client/test/channel_test.dart
+++ b/packages/realtime_client/test/channel_test.dart
@@ -80,7 +80,7 @@ void main() {
           },
           'presence': {'key': '', 'enabled': false},
           'private': false,
-        }
+        },
       });
     });
   });
@@ -274,8 +274,9 @@ void main() {
 
       channel.subscribe();
 
-      final sentFilter = (channel.joinPush.payload['config']['postgres_changes']
-          as List)[0] as Map;
+      final sentFilter =
+          (channel.joinPush.payload['config']['postgres_changes'] as List)[0]
+              as Map;
       expect(sentFilter['select'], ['id', 'first_name']);
     });
 
@@ -301,8 +302,9 @@ void main() {
 
       channel.subscribe();
 
-      final sentFilter = (channel.joinPush.payload['config']['postgres_changes']
-          as List)[0] as Map;
+      final sentFilter =
+          (channel.joinPush.payload['config']['postgres_changes'] as List)[0]
+              as Map;
       expect(sentFilter['filter'], 'amount=gt.100,status=in.(open,pending)');
     });
   });
@@ -394,27 +396,30 @@ void main() {
       expect(status, isNot(RealtimeSubscribeStatus.channelError));
     });
 
-    test('forwards the raw payload, parseable into a RealtimeSystemPayload',
-        () {
-      dynamic received;
-      channel.onSystemEvents((payload) => received = payload);
+    test(
+      'forwards the raw payload, parseable into a RealtimeSystemPayload',
+      () {
+        dynamic received;
+        channel.onSystemEvents((payload) => received = payload);
 
-      channel.trigger('system', {
-        'extension': 'system',
-        'status': 'ok',
-        'message': 'Replication connection established',
-        'channel': 'topic',
-      });
+        channel.trigger('system', {
+          'extension': 'system',
+          'status': 'ok',
+          'message': 'Replication connection established',
+          'channel': 'topic',
+        });
 
-      expect(received, isA<Map>());
+        expect(received, isA<Map>());
 
-      final system =
-          RealtimeSystemPayload.fromJson(Map<String, dynamic>.from(received));
-      expect(system.extension, 'system');
-      expect(system.status, 'ok');
-      expect(system.message, 'Replication connection established');
-      expect(system.channel, 'topic');
-    });
+        final system = RealtimeSystemPayload.fromJson(
+          Map<String, dynamic>.from(received),
+        );
+        expect(system.extension, 'system');
+        expect(system.status, 'ok');
+        expect(system.message, 'Replication connection established');
+        expect(system.channel, 'topic');
+      },
+    );
   });
 
   group('onMessage', () {

--- a/packages/realtime_client/test/postgres_change_filter_test.dart
+++ b/packages/realtime_client/test/postgres_change_filter_test.dart
@@ -13,14 +13,24 @@ void main() {
       expect(filter.toString(), r'name=in.("a\"b\\c")');
     });
 
-    test('leaves plain `in` filter values untouched', () {
+    test('leaves plain `in` filter values unquoted', () {
       final filter = PostgresChangeFilter(
         type: PostgresChangeFilterType.inFilter,
         column: 'status',
         value: ['active', 'pending'],
       );
 
-      expect(filter.toString(), 'status=in.("active","pending")');
+      expect(filter.toString(), 'status=in.(active,pending)');
+    });
+
+    test('quotes only the `in` elements that contain reserved characters', () {
+      final filter = PostgresChangeFilter(
+        type: PostgresChangeFilterType.inFilter,
+        column: 'name',
+        value: ['plain', 'a,b'],
+      );
+
+      expect(filter.toString(), 'name=in.(plain,"a,b")');
     });
 
     test('non-`in` filters are unaffected', () {
@@ -31,6 +41,79 @@ void main() {
       );
 
       expect(filter.toString(), 'id=eq.2');
+    });
+
+    test('quotes a scalar value containing a reserved character', () {
+      final filter = PostgresChangeFilter(
+        type: PostgresChangeFilterType.eq,
+        column: 'name',
+        value: 'a,b',
+      );
+
+      expect(filter.toString(), 'name=eq."a,b"');
+    });
+
+    group('new operators emit the correct wire token', () {
+      final cases = [
+        (PostgresChangeFilterType.like, 'title=like.%foo%'),
+        (PostgresChangeFilterType.ilike, 'title=ilike.%foo%'),
+        (PostgresChangeFilterType.match, 'title=match.%foo%'),
+        (PostgresChangeFilterType.imatch, 'title=imatch.%foo%'),
+        (PostgresChangeFilterType.isDistinct, 'title=isdistinct.%foo%'),
+      ];
+
+      for (final (type, expected) in cases) {
+        test('${type.name} -> $expected', () {
+          final filter = PostgresChangeFilter(
+            type: type,
+            column: 'title',
+            value: '%foo%',
+          );
+          expect(filter.toString(), expected);
+        });
+      }
+    });
+
+    test('`is` operator uses the `is` token and serializes null', () {
+      final filter = PostgresChangeFilter(
+        type: PostgresChangeFilterType.isFilter,
+        column: 'deleted_at',
+        value: null,
+      );
+
+      expect(filter.toString(), 'deleted_at=is.null');
+    });
+
+    group('negate prefixes the operator with `not.`', () {
+      test('scalar operator', () {
+        final filter = PostgresChangeFilter(
+          type: PostgresChangeFilterType.eq,
+          column: 'id',
+          value: 1,
+          negate: true,
+        );
+        expect(filter.toString(), 'id=not.eq.1');
+      });
+
+      test('`in` operator', () {
+        final filter = PostgresChangeFilter(
+          type: PostgresChangeFilterType.inFilter,
+          column: 'status',
+          value: ['draft', 'archived'],
+          negate: true,
+        );
+        expect(filter.toString(), 'status=not.in.(draft,archived)');
+      });
+
+      test('`is` operator', () {
+        final filter = PostgresChangeFilter(
+          type: PostgresChangeFilterType.isFilter,
+          column: 'deleted_at',
+          value: null,
+          negate: true,
+        );
+        expect(filter.toString(), 'deleted_at=not.is.null');
+      });
     });
   });
 }

--- a/packages/supabase/lib/src/supabase_stream_builder.dart
+++ b/packages/supabase/lib/src/supabase_stream_builder.dart
@@ -271,6 +271,20 @@ class SupabaseStreamBuilder extends Stream<SupabaseStreamEvent> {
         case PostgresChangeFilterType.inFilter:
           query = query.inFilter(_streamFilter!.column, _streamFilter!.value);
           break;
+        case PostgresChangeFilterType.like:
+        case PostgresChangeFilterType.ilike:
+        case PostgresChangeFilterType.isFilter:
+        case PostgresChangeFilterType.match:
+        case PostgresChangeFilterType.imatch:
+        case PostgresChangeFilterType.isDistinct:
+          // These operators are only reachable through the realtime
+          // `onPostgresChanges` API, not through `.stream()`'s filter builder,
+          // so they can never be set on `_streamFilter`. Guard the exhaustive
+          // switch defensively in case that ever changes.
+          throw UnsupportedError(
+            'The "${_streamFilter!.type.name}" filter is not supported by '
+            '`.stream()`. Use one of eq, neq, lt, lte, gt, gte or inFilter.',
+          );
       }
     }
     PostgrestTransformBuilder<PostgrestList>? transformQuery;

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -315,8 +315,24 @@ features:
 
   # realtime — subscriptions
   realtime.subscriptions.broadcast: implemented
-  realtime.subscriptions.postgres_changes: implemented
-  realtime.subscriptions.postgres_changes_filter: implemented
+  realtime.subscriptions.postgres_changes:
+    status: implemented
+    symbols:
+      - ChannelFilter.select
+      - RealtimeChannelConfig.replicationReady
+      - RealtimeSystemPayload
+      - RealtimeSystemPayload.RealtimeSystemPayload
+      - RealtimeSystemPayload.channel
+      - RealtimeSystemPayload.extension
+      - RealtimeSystemPayload.fromJson
+      - RealtimeSystemPayload.message
+      - RealtimeSystemPayload.status
+      - RealtimeSystemPayload.toString
+  realtime.subscriptions.postgres_changes_filter:
+    status: implemented
+    symbols:
+      - PostgresChangeFilter.negate
+      - PostgresChangeFilterType.token
   realtime.subscriptions.subscribe_presence: implemented
   realtime.subscriptions.private_channel: implemented
   realtime.subscriptions.broadcast_self: implemented


### PR DESCRIPTION
## What kind of change does this PR introduce?

Brings the realtime client to parity with the new Realtime server features:

* **New `postgres_changes` filter operators**: `like`, `ilike`, `is`, `match`, `imatch`, and `isdistinct`, exposed via `PostgresChangeFilterType`.
* **Operator negation**: `PostgresChangeFilter(negate: true)` prefixes any operator with `not.` (e.g. `status=not.in.(draft,archived)`).
* **Multiple filters**: `onPostgresChanges(filters: [...])` combines several `PostgresChangeFilter`s with an `AND`.
* **Column selection**: `onPostgresChanges(select: [...])` restricts the change payload to a subset of columns.
* **Replication-ready notification**: `RealtimeChannelConfig(replicationReady: true)` asks the server to emit a `system` event once the Postgres replication connection is ready. The new `RealtimeSystemPayload` type parses that payload.

PostgREST-style value quoting is applied to scalar and `in` filter values so reserved characters (`,()"\`) and surrounding whitespace don't break the server's filter parser.

https://linear.app/supabase/issue/SDK-1170/parityrealtime-add-postgres-changes-filter-builder-new-operators-and
https://linear.app/supabase/issue/SDK-1179/parityrealtime-add-replication-ready-broadcast-option-and-system-event
