### PR TITLE
chore: bump minimum Dart SDK to 3.9.0

### DIFF
--- a/packages/functions_client/lib/src/functions_client.dart
+++ b/packages/functions_client/lib/src/functions_client.dart
@@ -25,14 +25,15 @@ class FunctionsClient {
     http.Client? httpClient,
     YAJsonIsolate? isolate,
     String? region,
-  })  : _url = url,
-        _headers = {...Constants.defaultHeaders, ...headers},
-        _isolate = isolate ?? (YAJsonIsolate()..initialize()),
-        _hasCustomIsolate = isolate != null,
-        _httpClient = httpClient,
-        _region = region {
+  }) : _url = url,
+       _headers = {...Constants.defaultHeaders, ...headers},
+       _isolate = isolate ?? (YAJsonIsolate()..initialize()),
+       _hasCustomIsolate = isolate != null,
+       _httpClient = httpClient,
+       _region = region {
     _log.config(
-        "Initialize FunctionsClient v$version with url '$url' and region '$region'");
+      "Initialize FunctionsClient v$version with url '$url' and region '$region'",
+    );
     _log.finest("Initialize with headers: $headers");
   }
 
@@ -107,8 +108,10 @@ class FunctionsClient {
     };
 
     final uri = Uri.parse('$_url/$functionName').replace(
-        queryParameters:
-            effectiveQueryParams.isNotEmpty ? effectiveQueryParams : null);
+      queryParameters: effectiveQueryParams.isNotEmpty
+          ? effectiveQueryParams
+          : null,
+    );
 
     final finalHeaders = <String, String>{
       ..._headers,
@@ -159,12 +162,13 @@ class FunctionsClient {
     _log.finest('Request: ${request.method} ${request.url} ${request.headers}');
 
     final response = await (_httpClient?.send(request) ?? request.send());
-    final responseType = (response.headers['Content-Type'] ??
-            response.headers['content-type'] ??
-            'text/plain')
-        .split(';')[0]
-        .trim()
-        .toLowerCase();
+    final responseType =
+        (response.headers['Content-Type'] ??
+                response.headers['content-type'] ??
+                'text/plain')
+            .split(';')[0]
+            .trim()
+            .toLowerCase();
 
     final isSuccessStatus =
         200 <= response.statusCode && response.statusCode < 300;

--- a/packages/functions_client/lib/src/types.dart
+++ b/packages/functions_client/lib/src/types.dart
@@ -31,8 +31,11 @@ class FunctionException implements Exception {
   final dynamic details;
   final String? reasonPhrase;
 
-  const FunctionException(
-      {required this.status, this.details, this.reasonPhrase});
+  const FunctionException({
+    required this.status,
+    this.details,
+    this.reasonPhrase,
+  });
 
   @override
   String toString() =>

--- a/packages/functions_client/pubspec.yaml
+++ b/packages/functions_client/pubspec.yaml
@@ -6,7 +6,7 @@ repository: 'https://github.com/supabase/supabase-flutter/tree/main/packages/fun
 documentation: 'https://supabase.com/docs/reference/dart/functions-invoke'
 
 environment:
-  sdk: '>=3.4.0 <4.0.0'
+  sdk: '>=3.9.0 <4.0.0'
 
 dependencies:
   http: ^1.2.2

--- a/packages/functions_client/test/custom_http_client.dart
+++ b/packages/functions_client/test/custom_http_client.dart
@@ -39,11 +39,13 @@ class CustomHttpClient extends BaseClient {
       );
     } else if (request.url.path.endsWith('sse')) {
       return StreamedResponse(
-          Stream.fromIterable(['a', 'b', 'c'].map((e) => utf8.encode(e))), 200,
-          request: request,
-          headers: {
-            "Content-Type": "text/event-stream",
-          });
+        Stream.fromIterable(['a', 'b', 'c'].map((e) => utf8.encode(e))),
+        200,
+        request: request,
+        headers: {
+          "Content-Type": "text/event-stream",
+        },
+      );
     } else if (request.url.path.endsWith('binary')) {
       return StreamedResponse(
         Stream.value([1, 2, 3, 4, 5]),
@@ -105,13 +107,15 @@ class CustomHttpClient extends BaseClient {
 
     if (request is MultipartRequest) {
       stream = Stream.value(
-        utf8.encode(jsonEncode([
-          for (final file in request.files)
-            {
-              "name": file.field,
-              "content": await file.finalize().bytesToString()
-            }
-        ])),
+        utf8.encode(
+          jsonEncode([
+            for (final file in request.files)
+              {
+                "name": file.field,
+                "content": await file.finalize().bytesToString(),
+              },
+          ]),
+        ),
       );
       headers = {"Content-Type": "application/json"};
     } else {

--- a/packages/functions_client/test/functions_dart_test.dart
+++ b/packages/functions_client/test/functions_dart_test.dart
@@ -16,69 +16,92 @@ void main() {
   group("Custom http client", () {
     setUp(() {
       customHttpClient = CustomHttpClient();
-      functionsCustomHttpClient =
-          FunctionsClient("", {}, httpClient: customHttpClient);
+      functionsCustomHttpClient = FunctionsClient(
+        "",
+        {},
+        httpClient: customHttpClient,
+      );
     });
     test('function throws', () async {
       await expectLater(
         () => functionsCustomHttpClient.invoke('error-function'),
         throwsA(
-            isA<FunctionException>().having((e) => e.status, 'status', 420)),
+          isA<FunctionException>().having((e) => e.status, 'status', 420),
+        ),
       );
     });
 
-    test('error response with a streaming content type exposes the body',
-        () async {
-      // The error body must be drained and decoded into `details` rather than
-      // handed back as an unconsumed stream (which also leaks the connection).
-      await expectLater(
-        () => functionsCustomHttpClient.invoke('error-sse'),
-        throwsA(isA<FunctionException>()
-            .having((e) => e.status, 'status', 500)
-            .having((e) => e.details, 'details', 'error: boom')),
-      );
-    });
+    test(
+      'error response with a streaming content type exposes the body',
+      () async {
+        // The error body must be drained and decoded into `details` rather than
+        // handed back as an unconsumed stream (which also leaks the connection).
+        await expectLater(
+          () => functionsCustomHttpClient.invoke('error-sse'),
+          throwsA(
+            isA<FunctionException>()
+                .having((e) => e.status, 'status', 500)
+                .having((e) => e.details, 'details', 'error: boom'),
+          ),
+        );
+      },
+    );
 
-    test('error response labeled JSON with a non-JSON body reports the status',
-        () async {
-      await expectLater(
-        () => functionsCustomHttpClient.invoke('invalid-json-error'),
-        throwsA(isA<FunctionException>()
-            .having((e) => e.status, 'status', 500)
-            .having((e) => e.details, 'details',
-                '<html><body>502 Bad Gateway</body></html>')),
-      );
-    });
+    test(
+      'error response labeled JSON with a non-JSON body reports the status',
+      () async {
+        await expectLater(
+          () => functionsCustomHttpClient.invoke('invalid-json-error'),
+          throwsA(
+            isA<FunctionException>()
+                .having((e) => e.status, 'status', 500)
+                .having(
+                  (e) => e.details,
+                  'details',
+                  '<html><body>502 Bad Gateway</body></html>',
+                ),
+          ),
+        );
+      },
+    );
 
-    test('a success response labeled JSON with a non-JSON body still throws',
-        () async {
-      // On a 2xx the JSON label is a promise of structured data. A body that
-      // doesn't parse is a real anomaly, so the FormatException must surface
-      // rather than silently degrading to a raw String.
-      await expectLater(
-        () => functionsCustomHttpClient.invoke('success-invalid-json'),
-        throwsA(isA<FormatException>()),
-      );
-    });
+    test(
+      'a success response labeled JSON with a non-JSON body still throws',
+      () async {
+        // On a 2xx the JSON label is a promise of structured data. A body that
+        // doesn't parse is a real anomaly, so the FormatException must surface
+        // rather than silently degrading to a raw String.
+        await expectLater(
+          () => functionsCustomHttpClient.invoke('success-invalid-json'),
+          throwsA(isA<FormatException>()),
+        );
+      },
+    );
 
-    test('an upper-cased application/JSON content type is parsed as JSON',
-        () async {
-      final res = await functionsCustomHttpClient.invoke('uppercase-json');
-      expect(res.data, {'key': 'Hello World'});
-      expect(res.status, 200);
-    });
+    test(
+      'an upper-cased application/JSON content type is parsed as JSON',
+      () async {
+        final res = await functionsCustomHttpClient.invoke('uppercase-json');
+        expect(res.data, {'key': 'Hello World'});
+        expect(res.status, 200);
+      },
+    );
 
     test('function call', () async {
       final res = await functionsCustomHttpClient.invoke('function');
       expect(
-          customHttpClient.receivedRequests.last.headers["Content-Type"], null);
+        customHttpClient.receivedRequests.last.headers["Content-Type"],
+        null,
+      );
       expect(res.data, {'key': 'Hello World'});
       expect(res.status, 200);
     });
 
     test('function call with query parameters', () async {
-      final res = await functionsCustomHttpClient
-          .invoke('function', queryParameters: {'key': 'value'});
+      final res = await functionsCustomHttpClient.invoke(
+        'function',
+        queryParameters: {'key': 'value'},
+      );
 
       final request = customHttpClient.receivedRequests.last;
 
@@ -103,7 +126,7 @@ void main() {
       expect(request.url.queryParameters, {'key': 'value'});
       expect(request.headers['Content-Type'], contains('multipart/form-data'));
       expect(res.data, [
-        {'name': fileName, 'content': fileContent}
+        {'name': fileName, 'content': fileContent},
       ]);
       expect(res.status, 200);
     });
@@ -129,10 +152,11 @@ void main() {
     test('Listen to SSE event', () async {
       final res = await functionsCustomHttpClient.invoke('sse');
       expect(
-          res.data.transform(const Utf8Decoder()),
-          emitsInOrder(
-            ['a', 'b', 'c'],
-          ));
+        res.data.transform(const Utf8Decoder()),
+        emitsInOrder(
+          ['a', 'b', 'c'],
+        ),
+      );
     });
 
     group('body encoding', () {
@@ -313,17 +337,18 @@ void main() {
 
     group('Region support', () {
       test(
-          'region parameter adds x-region header and forceFunctionRegion query param',
-          () async {
-        await functionsCustomHttpClient.invoke(
-          'function',
-          region: 'us-west-1',
-        );
+        'region parameter adds x-region header and forceFunctionRegion query param',
+        () async {
+          await functionsCustomHttpClient.invoke(
+            'function',
+            region: 'us-west-1',
+          );
 
-        final req = customHttpClient.receivedRequests.last;
-        expect(req.headers['x-region'], 'us-west-1');
-        expect(req.url.queryParameters['forceFunctionRegion'], 'us-west-1');
-      });
+          final req = customHttpClient.receivedRequests.last;
+          expect(req.headers['x-region'], 'us-west-1');
+          expect(req.url.queryParameters['forceFunctionRegion'], 'us-west-1');
+        },
+      );
 
       test('region "any" does not add header or query param', () async {
         await functionsCustomHttpClient.invoke(
@@ -333,25 +358,29 @@ void main() {
 
         final req = customHttpClient.receivedRequests.last;
         expect(req.headers.containsKey('x-region'), isFalse);
-        expect(req.url.queryParameters.containsKey('forceFunctionRegion'),
-            isFalse);
-      });
-
-      test('client region is used when invoke region is not specified',
-          () async {
-        final client = FunctionsClient(
-          "",
-          {},
-          httpClient: customHttpClient,
-          region: 'eu-west-1',
+        expect(
+          req.url.queryParameters.containsKey('forceFunctionRegion'),
+          isFalse,
         );
-
-        await client.invoke('function');
-
-        final req = customHttpClient.receivedRequests.last;
-        expect(req.headers['x-region'], 'eu-west-1');
-        expect(req.url.queryParameters['forceFunctionRegion'], 'eu-west-1');
       });
+
+      test(
+        'client region is used when invoke region is not specified',
+        () async {
+          final client = FunctionsClient(
+            "",
+            {},
+            httpClient: customHttpClient,
+            region: 'eu-west-1',
+          );
+
+          await client.invoke('function');
+
+          final req = customHttpClient.receivedRequests.last;
+          expect(req.headers['x-region'], 'eu-west-1');
+          expect(req.url.queryParameters['forceFunctionRegion'], 'eu-west-1');
+        },
+      );
 
       test('invoke region overrides client region', () async {
         final client = FunctionsClient(
@@ -464,27 +493,31 @@ void main() {
       test('FunctionException contains all error details', () async {
         await expectLater(
           () => functionsCustomHttpClient.invoke('error-function'),
-          throwsA(isA<FunctionException>()
-              .having((e) => e.status, 'status', 420)
-              .having((e) => e.details, 'details', isNotNull)
-              .having((e) => e.reasonPhrase, 'reasonPhrase', isNotNull)
-              .having((e) => e.toString(), 'toString()', contains('420'))),
+          throwsA(
+            isA<FunctionException>()
+                .having((e) => e.status, 'status', 420)
+                .having((e) => e.details, 'details', isNotNull)
+                .having((e) => e.reasonPhrase, 'reasonPhrase', isNotNull)
+                .having((e) => e.toString(), 'toString()', contains('420')),
+          ),
         );
       });
     });
 
     group('Edge cases', () {
-      test('multipart request with invalid body type throws assertion',
-          () async {
-        expect(
-          () => functionsCustomHttpClient.invoke(
-            'function',
-            body: 42, // Invalid: should be Map<String, String> for multipart
-            files: [MultipartFile.fromString('file', 'content')],
-          ),
-          throwsA(isA<AssertionError>()),
-        );
-      });
+      test(
+        'multipart request with invalid body type throws assertion',
+        () async {
+          expect(
+            () => functionsCustomHttpClient.invoke(
+              'function',
+              body: 42, // Invalid: should be Map<String, String> for multipart
+              files: [MultipartFile.fromString('file', 'content')],
+            ),
+            throwsA(isA<AssertionError>()),
+          );
+        },
+      );
     });
   });
 }

--- a/packages/gotrue/lib/src/constants.dart
+++ b/packages/gotrue/lib/src/constants.dart
@@ -90,7 +90,7 @@ enum OtpType {
   magiclink,
   recovery,
   emailChange,
-  email
+  email,
 }
 
 /// Messaging channel to use (e.g. whatsapp or sms)

--- a/packages/gotrue/lib/src/fetch.dart
+++ b/packages/gotrue/lib/src/fetch.dart
@@ -142,7 +142,11 @@ class GotrueFetch {
     uri = uri.replace(queryParameters: {...uri.queryParameters, ...qs});
 
     return await _handleRequest(
-        method: method, uri: uri, options: options, headers: headers);
+      method: method,
+      uri: uri,
+      options: options,
+      headers: headers,
+    );
   }
 
   Future<dynamic> _handleRequest({

--- a/packages/gotrue/lib/src/gotrue_admin_api.dart
+++ b/packages/gotrue/lib/src/gotrue_admin_api.dart
@@ -31,8 +31,8 @@ class GoTrueAdminApi {
     this._url, {
     Map<String, String>? headers,
     Client? httpClient,
-  })  : _headers = headers ?? {},
-        _httpClient = httpClient {
+  }) : _headers = headers ?? {},
+       _httpClient = httpClient {
     mfa = GoTrueAdminMFAApi(
       url: _url,
       headers: _headers,

--- a/packages/gotrue/lib/src/gotrue_admin_mfa_api.dart
+++ b/packages/gotrue/lib/src/gotrue_admin_mfa_api.dart
@@ -12,12 +12,13 @@ class GoTrueAdminMFAApi {
     required String url,
     required Map<String, String> headers,
     required GotrueFetch fetch,
-  })  : _url = url,
-        _headers = headers,
-        _fetch = fetch;
+  }) : _url = url,
+       _headers = headers,
+       _fetch = fetch;
 
-  Future<AuthMFAAdminListFactorsResponse> listFactors(
-      {required String userId}) async {
+  Future<AuthMFAAdminListFactorsResponse> listFactors({
+    required String userId,
+  }) async {
     validateUuid(userId);
 
     final data = await _fetch.request(
@@ -29,7 +30,8 @@ class GoTrueAdminMFAApi {
     );
 
     return AuthMFAAdminListFactorsResponse(
-        factors: (data as List).map((e) => Factor.fromJson(e)).toList());
+      factors: (data as List).map((e) => Factor.fromJson(e)).toList(),
+    );
   }
 
   Future<AuthMFAAdminDeleteFactorResponse> deleteFactor({

--- a/packages/gotrue/lib/src/gotrue_admin_oauth_api.dart
+++ b/packages/gotrue/lib/src/gotrue_admin_oauth_api.dart
@@ -58,9 +58,9 @@ class GoTrueAdminOAuthApi {
     required String url,
     required Map<String, String> headers,
     required GotrueFetch fetch,
-  })  : _url = url,
-        _headers = headers,
-        _fetch = fetch;
+  }) : _url = url,
+       _headers = headers,
+       _fetch = fetch;
 
   /// Lists all OAuth clients with optional pagination.
   /// Only relevant when the OAuth 2.1 server is enabled in Supabase Auth.

--- a/packages/gotrue/lib/src/gotrue_admin_passkey_api.dart
+++ b/packages/gotrue/lib/src/gotrue_admin_passkey_api.dart
@@ -22,9 +22,9 @@ class GoTrueAdminPasskeyApi {
     required String url,
     required Map<String, String> headers,
     required GotrueFetch fetch,
-  })  : _url = url,
-        _headers = headers,
-        _fetch = fetch;
+  }) : _url = url,
+       _headers = headers,
+       _fetch = fetch;
 
   /// Returns the list of passkeys registered to the user with [userId].
   Future<List<Passkey>> listPasskeys({required String userId}) async {

--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -17,7 +17,8 @@ import 'package:meta/meta.dart';
 import 'package:retry/retry.dart';
 import 'package:rxdart/subjects.dart';
 
-import 'broadcast_stub.dart' if (dart.library.js_interop) './broadcast_web.dart'
+import 'broadcast_stub.dart'
+    if (dart.library.js_interop) './broadcast_web.dart'
     as web;
 import 'version.dart';
 
@@ -155,11 +156,11 @@ class GoTrueClient {
     Client? httpClient,
     GotrueAsyncStorage? asyncStorage,
     AuthFlowType flowType = AuthFlowType.pkce,
-  })  : _url = url ?? Constants.defaultGotrueUrl,
-        _headers = {...Constants.defaultHeaders, ...?headers},
-        _httpClient = httpClient,
-        _asyncStorage = asyncStorage,
-        _flowType = flowType {
+  }) : _url = url ?? Constants.defaultGotrueUrl,
+       _headers = {...Constants.defaultHeaders, ...?headers},
+       _httpClient = httpClient,
+       _asyncStorage = asyncStorage,
+       _flowType = flowType {
     _autoRefreshToken = autoRefreshToken ?? true;
 
     final gotrueUrl = url ?? Constants.defaultGotrueUrl;
@@ -283,11 +284,13 @@ class GoTrueClient {
         'channel': channel.name,
       };
       final fetchOptions = GotrueRequestOptions(headers: _headers, body: body);
-      response = await _fetch.request(
-        '$_url/signup',
-        RequestMethodType.post,
-        options: fetchOptions,
-      ) as Map<String, dynamic>;
+      response =
+          await _fetch.request(
+                '$_url/signup',
+                RequestMethodType.post,
+                options: fetchOptions,
+              )
+              as Map<String, dynamic>;
     } else {
       throw AuthException(
         'You must provide either an email or phone number and a password',
@@ -745,8 +748,9 @@ class GoTrueClient {
       );
     }
 
-    final codeChallenge =
-        email != null ? await _generatePKCECodeChallenge() : null;
+    final codeChallenge = email != null
+        ? await _generatePKCECodeChallenge()
+        : null;
 
     final body = {
       if (email != null) 'email': email,
@@ -1171,7 +1175,8 @@ class GoTrueClient {
       }
 
       if (!session.isExpired) {
-        final shouldEmitEvent = _currentSession == null ||
+        final shouldEmitEvent =
+            _currentSession == null ||
             _currentSession!.user.id != session.user.id;
         _saveSession(session);
 
@@ -1261,11 +1266,12 @@ class GoTrueClient {
         return;
       }
 
-      final expiresInTicks = (DateTime.fromMillisecondsSinceEpoch(
-                expiresAt * 1000,
-              ).difference(now).inMilliseconds /
-              Constants.autoRefreshTickDuration.inMilliseconds)
-          .floor();
+      final expiresInTicks =
+          (DateTime.fromMillisecondsSinceEpoch(
+                    expiresAt * 1000,
+                  ).difference(now).inMilliseconds /
+                  Constants.autoRefreshTickDuration.inMilliseconds)
+              .floor();
 
       _log.finer('Access token expires in $expiresInTicks ticks');
 
@@ -1399,8 +1405,8 @@ class GoTrueClient {
             'MFA_CHALLENGE_VERIFIED' => AuthChangeEvent.mfaChallengeVerified,
             // This case should never happen though
             _ => AuthChangeEvent.values.firstWhereOrNull(
-                (changeEvent) => changeEvent.name == rawEvent,
-              ),
+              (changeEvent) => changeEvent.name == rawEvent,
+            ),
           };
 
           if (event != null) {
@@ -1466,14 +1472,16 @@ class GoTrueClient {
     _pendingRefreshes[refreshToken] = completer;
 
     unawaited(
-      _doRefresh(refreshToken).then(
-        (response) {
-          if (!completer.isCompleted) completer.complete(response);
-        },
-        onError: (Object error, StackTrace stack) {
-          if (!completer.isCompleted) completer.completeError(error, stack);
-        },
-      ).whenComplete(() => _pendingRefreshes.remove(refreshToken)),
+      _doRefresh(refreshToken)
+          .then(
+            (response) {
+              if (!completer.isCompleted) completer.complete(response);
+            },
+            onError: (Object error, StackTrace stack) {
+              if (!completer.isCompleted) completer.completeError(error, stack);
+            },
+          )
+          .whenComplete(() => _pendingRefreshes.remove(refreshToken)),
     );
 
     return completer.future;
@@ -1515,8 +1523,10 @@ class GoTrueClient {
           error.code == 'refresh_token_already_used' &&
           existingSession != null &&
           !existingSession.isExpired) {
-        _log.fine('Refresh token already used but current session is still '
-            'valid, returning it instead of signing out');
+        _log.fine(
+          'Refresh token already used but current session is still '
+          'valid, returning it instead of signing out',
+        );
         return AuthResponse(session: existingSession);
       }
 
@@ -1664,8 +1674,8 @@ class GoTrueClient {
 
     final signingKey =
         (decoded.header.alg.startsWith('HS') || decoded.header.kid == null)
-            ? null
-            : await _fetchJwk(decoded.header.kid!, _jwks ?? JWKSet(keys: []));
+        ? null
+        : await _fetchJwk(decoded.header.kid!, _jwks ?? JWKSet(keys: []));
 
     // If symmetric algorithm, fallback to getUser()
     if (signingKey == null) {

--- a/packages/gotrue/lib/src/gotrue_mfa_api.dart
+++ b/packages/gotrue/lib/src/gotrue_mfa_api.dart
@@ -5,8 +5,8 @@ class GoTrueMFAApi {
   final GotrueFetch _fetch;
 
   const GoTrueMFAApi({required GoTrueClient client, required GotrueFetch fetch})
-      : _client = client,
-        _fetch = fetch;
+    : _client = client,
+      _fetch = fetch;
 
   /// Unenroll removes a MFA factor.
   ///
@@ -63,12 +63,14 @@ class GoTrueMFAApi {
     } else if (factorType == FactorType.phone) {
       if (phone == null) {
         throw ArgumentError(
-            'Invalid arguments, expected a phone for the phone factor type.');
+          'Invalid arguments, expected a phone for the phone factor type.',
+        );
       }
       body['phone'] = phone;
     } else {
       throw ArgumentError(
-          'Invalid arguments, unsupported factor type for enroll: ${factorType.name}.');
+        'Invalid arguments, unsupported factor type for enroll: ${factorType.name}.',
+      );
     }
 
     final data = await _fetch.request(
@@ -170,19 +172,25 @@ class GoTrueMFAApi {
     final user = _client.currentUser;
     final factors = user?.factors ?? [];
     final totp = factors
-        .where((factor) =>
-            factor.factorType == FactorType.totp &&
-            factor.status == FactorStatus.verified)
+        .where(
+          (factor) =>
+              factor.factorType == FactorType.totp &&
+              factor.status == FactorStatus.verified,
+        )
         .toList();
     final phone = factors
-        .where((factor) =>
-            factor.factorType == FactorType.phone &&
-            factor.status == FactorStatus.verified)
+        .where(
+          (factor) =>
+              factor.factorType == FactorType.phone &&
+              factor.status == FactorStatus.verified,
+        )
         .toList();
     final webauthn = factors
-        .where((factor) =>
-            factor.factorType == FactorType.webauthn &&
-            factor.status == FactorStatus.verified)
+        .where(
+          (factor) =>
+              factor.factorType == FactorType.webauthn &&
+              factor.status == FactorStatus.verified,
+        )
         .toList();
 
     return AuthMFAListFactorsResponse(
@@ -197,7 +205,7 @@ class GoTrueMFAApi {
   ///
   /// You can use this to check whether the current user needs to be shown a screen to verify their MFA factors.
   AuthMFAGetAuthenticatorAssuranceLevelResponse
-      getAuthenticatorAssuranceLevel() {
+  getAuthenticatorAssuranceLevel() {
     final session = _client.currentSession;
     if (session == null) {
       return AuthMFAGetAuthenticatorAssuranceLevelResponse(
@@ -208,13 +216,15 @@ class GoTrueMFAApi {
     }
     final payload = Jwt.parseJwt(session.accessToken);
 
-    final currentLevel = AuthenticatorAssuranceLevels.values
-        .firstWhereOrNull((level) => level.name == payload['aal']);
+    final currentLevel = AuthenticatorAssuranceLevels.values.firstWhereOrNull(
+      (level) => level.name == payload['aal'],
+    );
 
     var nextLevel = currentLevel;
 
-    if (session.user.factors
-            ?.any((factor) => factor.status == FactorStatus.verified) ??
+    if (session.user.factors?.any(
+          (factor) => factor.status == FactorStatus.verified,
+        ) ??
         false) {
       nextLevel = AuthenticatorAssuranceLevels.aal2;
     }

--- a/packages/gotrue/lib/src/gotrue_oauth_api.dart
+++ b/packages/gotrue/lib/src/gotrue_oauth_api.dart
@@ -129,8 +129,8 @@ class GoTrueOAuthApi {
   const GoTrueOAuthApi({
     required GoTrueClient client,
     required GotrueFetch fetch,
-  })  : _client = client,
-        _fetch = fetch;
+  }) : _client = client,
+       _fetch = fetch;
 
   /// Retrieves details about an OAuth authorization request.
   /// Only relevant when the OAuth 2.1 server is enabled in Supabase Auth.
@@ -170,11 +170,12 @@ class GoTrueOAuthApi {
       '${_client._url}/oauth/authorizations/$authorizationId/consent',
       RequestMethodType.post,
       options: GotrueRequestOptions(
-          headers: _client._headers,
-          jwt: session?.accessToken,
-          body: {
-            'action': 'approve',
-          }),
+        headers: _client._headers,
+        jwt: session?.accessToken,
+        body: {
+          'action': 'approve',
+        },
+      ),
     );
 
     return OAuthConsentResponse.fromJson(data);
@@ -195,11 +196,12 @@ class GoTrueOAuthApi {
       '${_client._url}/oauth/authorizations/$authorizationId/consent',
       RequestMethodType.post,
       options: GotrueRequestOptions(
-          headers: _client._headers,
-          jwt: session?.accessToken,
-          body: {
-            'action': 'deny',
-          }),
+        headers: _client._headers,
+        jwt: session?.accessToken,
+        body: {
+          'action': 'deny',
+        },
+      ),
     );
 
     return OAuthConsentResponse.fromJson(data);

--- a/packages/gotrue/lib/src/gotrue_passkey_api.dart
+++ b/packages/gotrue/lib/src/gotrue_passkey_api.dart
@@ -45,8 +45,8 @@ class GoTruePasskeyApi {
   const GoTruePasskeyApi({
     required GoTrueClient client,
     required GotrueFetch fetch,
-  })  : _client = client,
-        _fetch = fetch;
+  }) : _client = client,
+       _fetch = fetch;
 
   /// Starts the registration of a new passkey for the signed in user.
   ///

--- a/packages/gotrue/lib/src/helper.dart
+++ b/packages/gotrue/lib/src/helper.dart
@@ -11,16 +11,19 @@ String generatePKCEVerifier() {
   const verifierLength = 56;
   final random = Random.secure();
   return base64UrlEncode(
-      List.generate(verifierLength, (_) => random.nextInt(256))).split('=')[0];
+    List.generate(verifierLength, (_) => random.nextInt(256)),
+  ).split('=')[0];
 }
 
 String generatePKCEChallenge(String verifier) {
-  return base64UrlEncode(sha256.convert(ascii.encode(verifier)).bytes)
-      .split('=')[0];
+  return base64UrlEncode(
+    sha256.convert(ascii.encode(verifier)).bytes,
+  ).split('=')[0];
 }
 
-final uuidRegex =
-    RegExp(r'^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$');
+final uuidRegex = RegExp(
+  r'^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$',
+);
 
 void validateUuid(String id) {
   if (!uuidRegex.hasMatch(id)) {

--- a/packages/gotrue/lib/src/types/auth_exception.dart
+++ b/packages/gotrue/lib/src/types/auth_exception.dart
@@ -43,10 +43,10 @@ class AuthPKCEGrantCodeExchangeError extends AuthException {
 
 class AuthSessionMissingException extends AuthException {
   AuthSessionMissingException([String? message])
-      : super(
-          message ?? 'Auth session missing!',
-          statusCode: '400',
-        );
+    : super(
+        message ?? 'Auth session missing!',
+        statusCode: '400',
+      );
   @override
   String toString() =>
       'AuthSessionMissingException(message: $message, statusCode: $statusCode)';
@@ -79,11 +79,11 @@ class AuthUnknownException extends AuthException {
     required String message,
     required this.originalError,
   }) : super(
-          message,
-          statusCode: originalError is http.Response
-              ? originalError.statusCode.toString()
-              : null,
-        );
+         message,
+         statusCode: originalError is http.Response
+             ? originalError.statusCode.toString()
+             : null,
+       );
 
   @override
   String toString() =>
@@ -106,10 +106,10 @@ class AuthWeakPasswordException extends AuthException {
 
 class AuthInvalidJwtException extends AuthException {
   AuthInvalidJwtException(super.message)
-      : super(
-          statusCode: '400',
-          code: 'invalid_jwt',
-        );
+    : super(
+        statusCode: '400',
+        code: 'invalid_jwt',
+      );
 
   @override
   String toString() =>

--- a/packages/gotrue/lib/src/types/auth_response.dart
+++ b/packages/gotrue/lib/src/types/auth_response.dart
@@ -13,8 +13,8 @@ class AuthResponse {
 
   /// Instanciates an `AuthResponse` object from json response.
   AuthResponse.fromJson(Map<String, dynamic> json)
-      : session = Session.fromJson(json),
-        user = User.fromJson(json) ?? Session.fromJson(json)?.user;
+    : session = Session.fromJson(json),
+      user = User.fromJson(json) ?? Session.fromJson(json)?.user;
 }
 
 /// Response of OAuth signin
@@ -60,8 +60,8 @@ class GenerateLinkResponse {
   final User user;
 
   GenerateLinkResponse.fromJson(Map<String, dynamic> json)
-      : properties = GenerateLinkProperties.fromJson(json),
-        user = _parseUser(json);
+    : properties = GenerateLinkProperties.fromJson(json),
+      user = _parseUser(json);
 
   static User _parseUser(Map<String, dynamic> json) {
     final user = User.fromJson(json);
@@ -94,12 +94,13 @@ class GenerateLinkProperties {
   final GenerateLinkType verificationType;
 
   GenerateLinkProperties.fromJson(Map<String, dynamic> json)
-      : actionLink = json['action_link'] ?? '',
-        emailOtp = json['email_otp'] ?? '',
-        hashedToken = json['hashed_token'] ?? '',
-        redirectTo = json['redirect_to'] ?? '',
-        verificationType =
-            GenerateLinkTypeExtended.fromString(json['verification_type']);
+    : actionLink = json['action_link'] ?? '',
+      emailOtp = json['email_otp'] ?? '',
+      hashedToken = json['hashed_token'] ?? '',
+      redirectTo = json['redirect_to'] ?? '',
+      verificationType = GenerateLinkTypeExtended.fromString(
+        json['verification_type'],
+      );
 }
 
 extension ToSnakeCase on Enum {

--- a/packages/gotrue/lib/src/types/fetch_options.dart
+++ b/packages/gotrue/lib/src/types/fetch_options.dart
@@ -5,8 +5,8 @@ class FetchOptions {
   const FetchOptions(
     Map<String, String>? headers, {
     bool? noResolveJson,
-  })  : headers = headers ?? const {},
-        noResolveJson = noResolveJson ?? false;
+  }) : headers = headers ?? const {},
+       noResolveJson = noResolveJson ?? false;
 }
 
 class GotrueRequestOptions extends FetchOptions {

--- a/packages/gotrue/lib/src/types/jwt.dart
+++ b/packages/gotrue/lib/src/types/jwt.dart
@@ -167,7 +167,8 @@ class JWKSet {
   const JWKSet({required this.keys});
 
   factory JWKSet.fromJson(Map<String, dynamic> json) {
-    final keys = (json['keys'] as List<dynamic>?)
+    final keys =
+        (json['keys'] as List<dynamic>?)
             ?.map((e) => JWK.fromJson(e as Map<String, dynamic>))
             .toList() ??
         [];
@@ -217,7 +218,7 @@ class JWK {
     final kty = json['kty'] as String;
     final keyOps =
         (json['key_ops'] as List<dynamic>?)?.map((e) => e as String).toList() ??
-            [];
+        [];
     final alg = json['alg'] as String?;
     final kid = json['kid'] as String?;
 

--- a/packages/gotrue/lib/src/types/mfa.dart
+++ b/packages/gotrue/lib/src/types/mfa.dart
@@ -90,7 +90,8 @@ class PhoneEnrollment {
       return PhoneEnrollment.fromJson(value);
     }
     throw ArgumentError(
-        'Invalid phone enrollment data type: ${value.runtimeType}');
+      'Invalid phone enrollment data type: ${value.runtimeType}',
+    );
   }
 }
 

--- a/packages/gotrue/lib/src/types/passkey.dart
+++ b/packages/gotrue/lib/src/types/passkey.dart
@@ -97,7 +97,8 @@ class PasskeyRegistrationOptionsResponse {
   });
 
   factory PasskeyRegistrationOptionsResponse.fromJson(
-      Map<String, dynamic> json) {
+    Map<String, dynamic> json,
+  ) {
     return PasskeyRegistrationOptionsResponse(
       challengeId: json['challenge_id'] as String,
       options: Map.from(json['options'] as Map),
@@ -131,7 +132,8 @@ class PasskeyAuthenticationOptionsResponse {
   });
 
   factory PasskeyAuthenticationOptionsResponse.fromJson(
-      Map<String, dynamic> json) {
+    Map<String, dynamic> json,
+  ) {
     return PasskeyAuthenticationOptionsResponse(
       challengeId: json['challenge_id'] as String,
       options: Map.from(json['options'] as Map),

--- a/packages/gotrue/lib/src/types/session.dart
+++ b/packages/gotrue/lib/src/types/session.dart
@@ -89,7 +89,9 @@ class Session {
   /// The 10 second buffer is to account for latency issues.
   bool get isExpired {
     if (expiresAt == null) return false;
-    return DateTime.now().add(Constants.expiryMargin).isAfter(
+    return DateTime.now()
+        .add(Constants.expiryMargin)
+        .isAfter(
           DateTime.fromMillisecondsSinceEpoch(expiresAt! * 1000),
         );
   }

--- a/packages/gotrue/lib/src/types/user.dart
+++ b/packages/gotrue/lib/src/types/user.dart
@@ -82,7 +82,8 @@ class User {
       updatedAt: json['updated_at'],
       identities: json['identities'] != null
           ? List<UserIdentity>.from(
-              json['identities']?.map((x) => UserIdentity.fromMap(x)))
+              json['identities']?.map((x) => UserIdentity.fromMap(x)),
+            )
           : null,
       factors: json['factors'] != null
           ? List<Factor>.from(json['factors']?.map((x) => Factor.fromJson(x)))

--- a/packages/gotrue/pubspec.yaml
+++ b/packages/gotrue/pubspec.yaml
@@ -6,7 +6,7 @@ repository: "https://github.com/supabase/supabase-flutter/tree/main/packages/got
 documentation: "https://supabase.com/docs/reference/dart/auth-signup"
 
 environment:
-  sdk: ">=3.4.0 <4.0.0"
+  sdk: ">=3.9.0 <4.0.0"
 
 dependencies:
   collection: ^1.15.0

--- a/packages/gotrue/test/admin_test.dart
+++ b/packages/gotrue/test/admin_test.dart
@@ -37,70 +37,82 @@ void main() {
 
   group('User fetch', () {
     test(
-        'getUserById() should return a registered user given its user identifier',
-        () async {
-      final foundUserResponse = await client.admin.getUserById(userId1);
-      expect(foundUserResponse.user, isNotNull);
-      expect(foundUserResponse.user?.email, email1);
-    });
+      'getUserById() should return a registered user given its user identifier',
+      () async {
+        final foundUserResponse = await client.admin.getUserById(userId1);
+        expect(foundUserResponse.user, isNotNull);
+        expect(foundUserResponse.user?.email, email1);
+      },
+    );
   });
 
   group('User updates', () {
     test('modify email using updateUserById()', () async {
-      final res = await client.admin.updateUserById(userId1,
-          attributes: AdminUserAttributes(email: 'new@email.com'));
+      final res = await client.admin.updateUserById(
+        userId1,
+        attributes: AdminUserAttributes(email: 'new@email.com'),
+      );
       expect(res.user!.email, 'new@email.com');
     });
 
     test('modify userMetadata using updateUserById()', () async {
-      final res = await client.admin.updateUserById(userId1,
-          attributes:
-              AdminUserAttributes(userMetadata: {'username': 'newUserName'}));
+      final res = await client.admin.updateUserById(
+        userId1,
+        attributes: AdminUserAttributes(
+          userMetadata: {'username': 'newUserName'},
+        ),
+      );
       expect(res.user!.userMetadata!['username'], 'newUserName');
     });
   });
 
   group('User registration', () {
     test(
-        'generateLink() supports signUp with generate confirmation signup link ',
-        () async {
-      const userMetadata = {'status': 'alpha'};
+      'generateLink() supports signUp with generate confirmation signup link ',
+      () async {
+        const userMetadata = {'status': 'alpha'};
 
-      final response = await client.admin.generateLink(
-        type: GenerateLinkType.signup,
-        email: getNewEmail(),
-        password: password,
-        data: userMetadata,
-        redirectTo: 'http://localhost:9999/welcome',
-      );
+        final response = await client.admin.generateLink(
+          type: GenerateLinkType.signup,
+          email: getNewEmail(),
+          password: password,
+          data: userMetadata,
+          redirectTo: 'http://localhost:9999/welcome',
+        );
 
-      expect(response.user.id, isNotEmpty);
+        expect(response.user.id, isNotEmpty);
 
-      final actionLink = response.properties.actionLink;
+        final actionLink = response.properties.actionLink;
 
-      final actionUri = Uri.tryParse(actionLink);
-      expect(actionUri, isNotNull);
+        final actionUri = Uri.tryParse(actionLink);
+        expect(actionUri, isNotNull);
 
-      expect(actionUri!.queryParameters['token'], isNotEmpty);
-      expect(actionUri.queryParameters['type'], isNotEmpty);
-      expect(actionUri.queryParameters['redirect_to'],
-          'http://localhost:9999/welcome');
-    });
+        expect(actionUri!.queryParameters['token'], isNotEmpty);
+        expect(actionUri.queryParameters['type'], isNotEmpty);
+        expect(
+          actionUri.queryParameters['redirect_to'],
+          'http://localhost:9999/welcome',
+        );
+      },
+    );
 
-    test('inviteUserByEmail() creates a new user with an invited_at timestamp',
-        () async {
-      final newEmail = 'new${Random.secure().nextInt(4096)}@fake.org';
-      final res = await client.admin.inviteUserByEmail(newEmail);
-      expect(res.user, isNotNull);
-      expect(res.user?.email, newEmail);
-      expect(res.user?.invitedAt, isNotNull);
-    });
+    test(
+      'inviteUserByEmail() creates a new user with an invited_at timestamp',
+      () async {
+        final newEmail = 'new${Random.secure().nextInt(4096)}@fake.org';
+        final res = await client.admin.inviteUserByEmail(newEmail);
+        expect(res.user, isNotNull);
+        expect(res.user?.email, newEmail);
+        expect(res.user?.invitedAt, isNotNull);
+      },
+    );
 
     test('createUser() creates a new user', () async {
       final newEmail = 'new${Random.secure().nextInt(4096)}@fake.org';
       final userMetadata = {'name': 'supabase'};
       final res = await client.admin.createUser(
-          AdminUserAttributes(email: newEmail, userMetadata: userMetadata));
+        AdminUserAttributes(email: newEmail, userMetadata: userMetadata),
+      );
       expect(res.user, isNotNull);
       expect(res.user?.email, newEmail);
       expect(res.user?.userMetadata, userMetadata);
@@ -124,51 +136,74 @@ void main() {
         AdminUserAttributes(email: 'hard-$suffix@fake.org', password: 'pw'),
       );
 
-      await client.admin
-          .deleteUser(softDeleted.user!.id, shouldSoftDelete: true);
+      await client.admin.deleteUser(
+        softDeleted.user!.id,
+        shouldSoftDelete: true,
+      );
       await client.admin.deleteUser(hardDeleted.user!.id);
 
       final ids = (await client.admin.listUsers()).map((user) => user.id);
-      expect(ids, contains(softDeleted.user!.id),
-          reason: 'a soft deleted user keeps its record');
-      expect(ids, isNot(contains(hardDeleted.user!.id)),
-          reason: 'a hard deleted user is removed');
+      expect(
+        ids,
+        contains(softDeleted.user!.id),
+        reason: 'a soft deleted user keeps its record',
+      );
+      expect(
+        ids,
+        isNot(contains(hardDeleted.user!.id)),
+        reason: 'a hard deleted user is removed',
+      );
     });
   });
 
   group('validates ids', () {
     test('deleteUser() validates ids', () {
-      expect(() => client.admin.deleteUser('invalid-id'),
-          throwsA(isA<ArgumentError>()));
+      expect(
+        () => client.admin.deleteUser('invalid-id'),
+        throwsA(isA<ArgumentError>()),
+      );
     });
 
     test('getUserById() validates ids', () {
-      expect(() => client.admin.getUserById('invalid-id'),
-          throwsA(isA<ArgumentError>()));
+      expect(
+        () => client.admin.getUserById('invalid-id'),
+        throwsA(isA<ArgumentError>()),
+      );
     });
 
     test('updateUserById() validates ids', () {
       expect(
-          () => client.admin.updateUserById('invalid-id',
-              attributes: AdminUserAttributes(email: 'test@test.com')),
-          throwsA(isA<ArgumentError>()));
+        () => client.admin.updateUserById(
+          'invalid-id',
+          attributes: AdminUserAttributes(email: 'test@test.com'),
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
     });
 
     test('listFactors() validates ids', () {
-      expect(() => client.admin.mfa.listFactors(userId: 'invalid-id'),
-          throwsA(isA<ArgumentError>()));
+      expect(
+        () => client.admin.mfa.listFactors(userId: 'invalid-id'),
+        throwsA(isA<ArgumentError>()),
+      );
     });
 
     test('deleteFactor() validates ids', () {
       expect(
-          () => client.admin.mfa.deleteFactor(
-              userId: 'invalid-id', factorId: 'invalid-factor-id'),
-          throwsA(isA<ArgumentError>()));
+        () => client.admin.mfa.deleteFactor(
+          userId: 'invalid-id',
+          factorId: 'invalid-factor-id',
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
 
       expect(
-          () => client.admin.mfa
-              .deleteFactor(userId: userId1, factorId: 'invalid-factor-id'),
-          throwsA(isA<ArgumentError>()));
+        () => client.admin.mfa.deleteFactor(
+          userId: userId1,
+          factorId: 'invalid-factor-id',
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
     });
   });
 }

--- a/packages/gotrue/test/api_version_test.dart
+++ b/packages/gotrue/test/api_version_test.dart
@@ -7,9 +7,13 @@ void main() {
   group('ApiVersion', () {
     test('should return non null object for valid header', () {
       final String validHeader = '2024-01-01';
-      final Response response = Response('', 200, headers: {
-        Constants.apiVersionHeaderName: validHeader,
-      });
+      final Response response = Response(
+        '',
+        200,
+        headers: {
+          Constants.apiVersionHeaderName: validHeader,
+        },
+      );
       final version = ApiVersion.fromResponse(response);
       expect(version?.name, validHeader);
       expect(version?.timestamp, DateTime.parse('2024-01-01 00:00:00.000Z'));
@@ -25,9 +29,13 @@ void main() {
       ];
 
       for (final value in invalidValues) {
-        final Response response = Response('', 200, headers: {
-          Constants.apiVersionHeaderName: value,
-        });
+        final Response response = Response(
+          '',
+          200,
+          headers: {
+            Constants.apiVersionHeaderName: value,
+          },
+        );
         final version = ApiVersion.fromResponse(response);
         expect(version, isNull);
       }

--- a/packages/gotrue/test/client_test.dart
+++ b/packages/gotrue/test/client_test.dart
@@ -28,7 +28,8 @@ void main() {
     setUp(() async {
       final res = await http.post(
         Uri.parse(
-            'http://127.0.0.1:54421/rest/v1/rpc/reset_and_init_auth_data'),
+          'http://127.0.0.1:54421/rest/v1/rpc/reset_and_init_auth_data',
+        ),
         headers: {
           'x-forwarded-for': '127.0.0.1',
           'apikey': getServiceRoleToken(env),
@@ -105,8 +106,13 @@ void main() {
       () async {
         await expectLater(
           () => client.signUp(email: newEmail, password: '123'),
-          throwsA(isA<AuthWeakPasswordException>()
-              .having((e) => e.code, 'code', ErrorCode.weakPassword.code)),
+          throwsA(
+            isA<AuthWeakPasswordException>().having(
+              (e) => e.code,
+              'code',
+              ErrorCode.weakPassword.code,
+            ),
+          ),
         );
       },
     );
@@ -135,10 +141,12 @@ void main() {
       );
       await expectLater(
         () => client.getSessionFromUrl(urlWithoutAccessToken),
-        throwsA(isA<AuthException>()
-            .having((e) => e.message, 'message', errorMessage)
-            .having((e) => e.statusCode, 'statusCode', '401')
-            .having((e) => e.code, 'code', 'unauthorized_client')),
+        throwsA(
+          isA<AuthException>()
+              .having((e) => e.message, 'message', errorMessage)
+              .having((e) => e.statusCode, 'statusCode', '401')
+              .having((e) => e.code, 'code', 'unauthorized_client'),
+        ),
       );
     });
 
@@ -337,7 +345,8 @@ void main() {
         // Header: {"alg":"HS256","typ":"JWT"}
         // Payload: {"sub":"user","exp":1}  (epoch second 1 = Jan 1, 1970)
         // Signature: 3 zero bytes as valid base64url ("AAAA")
-        const expiredAccessToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9'
+        const expiredAccessToken =
+            'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9'
             '.eyJzdWIiOiJ1c2VyIiwiZXhwIjoxfQ'
             '.AAAA';
 
@@ -434,8 +443,13 @@ void main() {
       await client.signInWithPassword(email: email1, password: password);
       await expectLater(
         () => client.updateUser(UserAttributes(password: password)),
-        throwsA(isA<AuthException>()
-            .having((e) => e.code, 'code', ErrorCode.samePassword.code)),
+        throwsA(
+          isA<AuthException>().having(
+            (e) => e.code,
+            'code',
+            ErrorCode.samePassword.code,
+          ),
+        ),
       );
     });
 
@@ -467,8 +481,9 @@ void main() {
           email: email1,
           password: 'wrong_$password',
         ),
-        throwsA(isA<AuthException>()
-            .having((e) => e.message, 'message', isNotNull)),
+        throwsA(
+          isA<AuthException>().having((e) => e.message, 'message', isNotNull),
+        ),
       );
     });
 
@@ -682,8 +697,13 @@ void main() {
       );
       await expectLater(
         () => client.getSessionFromUrl(urlWithoutAccessToken),
-        throwsA(isA<AuthException>()
-            .having((e) => e.message, 'message', errorMessage)),
+        throwsA(
+          isA<AuthException>().having(
+            (e) => e.message,
+            'message',
+            errorMessage,
+          ),
+        ),
       );
     });
 
@@ -701,7 +721,7 @@ void main() {
             'email': 'new@email.com',
             'app_metadata': {
               'provider': 'email',
-              'providers': ['email']
+              'providers': ['email'],
             },
             'user_metadata': {},
             'created_at': '2023-04-01T09:38:59.784028Z',
@@ -717,7 +737,8 @@ void main() {
 
         final emittedEvent = pkceClient.onAuthStateChange
             .firstWhere(
-                (state) => state.event != AuthChangeEvent.initialSession)
+              (state) => state.event != AuthChangeEvent.initialSession,
+            )
             .then((state) => state.event);
 
         final response = await pkceClient.getSessionFromUrl(url);
@@ -754,8 +775,7 @@ void main() {
     // the server respond with `refresh_token_already_used`, signing the user
     // out. `recoverSession` must instead detect the already valid in-memory
     // session and return it.
-    test('does not reuse a stale refresh token after another refresh',
-        () async {
+    test('does not reuse a stale refresh token after another refresh', () async {
       final expiredSessionString = getSessionData(
         DateTime.now().subtract(const Duration(hours: 1)),
       ).sessionString;

--- a/packages/gotrue/test/custom_http_client.dart
+++ b/packages/gotrue/test/custom_http_client.dart
@@ -34,7 +34,7 @@ class NoEmailConfirmationHttpClient extends BaseClient {
               'confirmation_sent_at': now,
               'app_metadata': {
                 'provider': 'email',
-                'providers': ['email']
+                'providers': ['email'],
               },
               'user_metadata': {},
               'identities': [
@@ -43,13 +43,13 @@ class NoEmailConfirmationHttpClient extends BaseClient {
                   'user_id': 'ef507d02-ce6a-4b3a-a8a6-6f0e14740136',
                   'identity_data': {
                     'email': 'fake1@email.com',
-                    'sub': 'ef507d02-ce6a-4b3a-a8a6-6f0e14740136'
+                    'sub': 'ef507d02-ce6a-4b3a-a8a6-6f0e14740136',
                   },
                   'provider': 'email',
                   'last_sign_in_at': now,
                   'created_at': now,
-                  'updated_at': now
-                }
+                  'updated_at': now,
+                },
               ],
               'created_at': now,
               'updated_at': now,
@@ -107,7 +107,7 @@ class RetryTestHttpClient extends BaseClient {
                 'last_sign_in_at': '2023-04-01T09:38:59.904492805Z',
                 'app_metadata': {
                   'provider': 'email',
-                  'providers': ['email']
+                  'providers': ['email'],
                 },
                 'user_metadata': {},
                 'factors': [
@@ -117,8 +117,8 @@ class RetryTestHttpClient extends BaseClient {
                     'updated_at': '2023-04-01T09:38:59.784028Z',
                     'status': 'unverified',
                     'friendly_name': 'UnverifiedFactor',
-                    'factor_type': 'totp'
-                  }
+                    'factor_type': 'totp',
+                  },
                 ],
                 'identities': [
                   {
@@ -126,17 +126,17 @@ class RetryTestHttpClient extends BaseClient {
                     'user_id': '18bc7a4e-c095-4573-93dc-e0be29bada97',
                     'identity_data': {
                       'email': 'fake1@email.com',
-                      'sub': '18bc7a4e-c095-4573-93dc-e0be29bada97'
+                      'sub': '18bc7a4e-c095-4573-93dc-e0be29bada97',
                     },
                     'provider': 'email',
                     'last_sign_in_at': '2023-04-01T09:38:59.784028Z',
                     'created_at': '2023-04-01T09:38:59.784028Z',
-                    'updated_at': '2023-04-01T09:38:59.784028Z'
-                  }
+                    'updated_at': '2023-04-01T09:38:59.784028Z',
+                  },
                 ],
                 'created_at': '2023-04-01T09:38:59.784028Z',
-                'updated_at': '2023-04-01T09:38:59.908816Z'
-              }
+                'updated_at': '2023-04-01T09:38:59.908816Z',
+              },
             },
           ),
         ),
@@ -216,13 +216,13 @@ class SingleUseRefreshTokenHttpClient extends BaseClient {
                 'last_sign_in_at': '2023-04-01T09:38:59.904492805Z',
                 'app_metadata': {
                   'provider': 'email',
-                  'providers': ['email']
+                  'providers': ['email'],
                 },
                 'user_metadata': {},
                 'identities': <dynamic>[],
                 'created_at': '2023-04-01T09:38:59.784028Z',
-                'updated_at': '2023-04-01T09:38:59.908816Z'
-              }
+                'updated_at': '2023-04-01T09:38:59.908816Z',
+              },
             },
           ),
         ),

--- a/packages/gotrue/test/custom_oauth_provider_test.dart
+++ b/packages/gotrue/test/custom_oauth_provider_test.dart
@@ -78,7 +78,8 @@ void main() {
       expect(
         OAuthProvider.values,
         hasLength(declaredCount),
-        reason: 'A static const OAuthProvider field is missing from '
+        reason:
+            'A static const OAuthProvider field is missing from '
             'OAuthProvider.values. Add it to the values list in types.dart.',
       );
     });

--- a/packages/gotrue/test/fetch_test.dart
+++ b/packages/gotrue/test/fetch_test.dart
@@ -21,35 +21,39 @@ void main() {
       await _testFetchRequest(client);
     });
 
-    test('without API version and weak password error code with payload',
-        () async {
-      final client = MockedHttpClient(
-        {
-          'code': 400,
-          'msg': 'error_message',
-          'error_code': 'weak_password',
-          'weak_password': {
-            'reasons': ['characters'],
+    test(
+      'without API version and weak password error code with payload',
+      () async {
+        final client = MockedHttpClient(
+          {
+            'code': 400,
+            'msg': 'error_message',
+            'error_code': 'weak_password',
+            'weak_password': {
+              'reasons': ['characters'],
+            },
           },
-        },
-        statusCode: 400,
-      );
-      await _testFetchRequest(client);
-    });
+          statusCode: 400,
+        );
+        await _testFetchRequest(client);
+      },
+    );
 
-    test('without API version, no error code and weak_password payload',
-        () async {
-      final client = MockedHttpClient(
-        {
-          'msg': 'error_message',
-          'weak_password': {
-            'reasons': ['characters'],
+    test(
+      'without API version, no error code and weak_password payload',
+      () async {
+        final client = MockedHttpClient(
+          {
+            'msg': 'error_message',
+            'weak_password': {
+              'reasons': ['characters'],
+            },
           },
-        },
-        statusCode: 400,
-      );
-      await _testFetchRequest(client);
-    });
+          statusCode: 400,
+        );
+        await _testFetchRequest(client);
+      },
+    );
 
     test('with API version 2024-01-01 and error code', () async {
       final client = MockedHttpClient(
@@ -74,8 +78,10 @@ Future<void> _testFetchRequest(Client client) async {
   final GotrueFetch fetch = GotrueFetch(client);
   await expectLater(
     () => fetch.request(_mockUrl, RequestMethodType.get),
-    throwsA(isA<AuthException>()
-        .having((e) => e.code, 'code', 'weak_password')
-        .having((e) => e.message, 'message', 'error_message')),
+    throwsA(
+      isA<AuthException>()
+          .having((e) => e.code, 'code', 'weak_password')
+          .having((e) => e.message, 'message', 'error_message'),
+    ),
   );
 }

--- a/packages/gotrue/test/get_claims_test.dart
+++ b/packages/gotrue/test/get_claims_test.dart
@@ -18,13 +18,15 @@ void main() {
 
     setUp(() async {
       final res = await http.post(
-          Uri.parse(
-              'http://127.0.0.1:54421/rest/v1/rpc/reset_and_init_auth_data'),
-          headers: {
-            'x-forwarded-for': '127.0.0.1',
-            'apikey': getServiceRoleToken(env),
-            'Authorization': 'Bearer ${getServiceRoleToken(env)}',
-          });
+        Uri.parse(
+          'http://127.0.0.1:54421/rest/v1/rpc/reset_and_init_auth_data',
+        ),
+        headers: {
+          'x-forwarded-for': '127.0.0.1',
+          'apikey': getServiceRoleToken(env),
+          'Authorization': 'Bearer ${getServiceRoleToken(env)}',
+        },
+      );
       if (res.body.isNotEmpty) throw res.body;
 
       newEmail = getNewEmail();
@@ -227,35 +229,37 @@ void main() {
       );
     });
 
-    test('getClaims() with RS256 JWT on first call should not crash (SDK-627)',
-        () async {
-      // This test reproduces the bug reported in SDK-627
-      // A JWT with RS256 algorithm and kid in header
-      // Header: {"alg":"RS256","typ":"JWT","kid":"test-key-id"}
-      // Payload: {"sub":"1234567890","aud":"authenticated","exp":9999999999,"iat":1516239022,"email":"test@example.com","role":"authenticated"}
-      // Signature: dummy base64url encoded signature (not cryptographically valid, but structurally valid)
-      const rs256Jwt =
-          'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6InRlc3Qta2V5LWlkIn0.eyJzdWIiOiIxMjM0NTY3ODkwIiwiYXVkIjoiYXV0aGVudGljYXRlZCIsImV4cCI6OTk5OTk5OTk5OSwiaWF0IjoxNTE2MjM5MDIyLCJlbWFpbCI6InRlc3RAZXhhbXBsZS5jb20iLCJyb2xlIjoiYXV0aGVudGljYXRlZCJ9.SW52YWxpZFNpZ25hdHVyZURhdGFIZXJlVGhhdElzTm90UmVhbEJ1dFZhbGlkQmFzZTY0VXJs';
+    test(
+      'getClaims() with RS256 JWT on first call should not crash (SDK-627)',
+      () async {
+        // This test reproduces the bug reported in SDK-627
+        // A JWT with RS256 algorithm and kid in header
+        // Header: {"alg":"RS256","typ":"JWT","kid":"test-key-id"}
+        // Payload: {"sub":"1234567890","aud":"authenticated","exp":9999999999,"iat":1516239022,"email":"test@example.com","role":"authenticated"}
+        // Signature: dummy base64url encoded signature (not cryptographically valid, but structurally valid)
+        const rs256Jwt =
+            'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6InRlc3Qta2V5LWlkIn0.eyJzdWIiOiIxMjM0NTY3ODkwIiwiYXVkIjoiYXV0aGVudGljYXRlZCIsImV4cCI6OTk5OTk5OTk5OSwiaWF0IjoxNTE2MjM5MDIyLCJlbWFpbCI6InRlc3RAZXhhbXBsZS5jb20iLCJyb2xlIjoiYXV0aGVudGljYXRlZCJ9.SW52YWxpZFNpZ25hdHVyZURhdGFIZXJlVGhhdElzTm90UmVhbEJ1dFZhbGlkQmFzZTY0VXJs';
 
-      // Before the fix, this would crash with:
-      // "Null check operator used on a null value"
-      // because _jwks is null on first call and the code does _jwks!
-      //
-      // After the fix, this should attempt to fetch JWKS from the server
-      // and fail gracefully (either with network error or invalid signature)
-      // but NOT crash with null error
-      try {
-        await client.getClaims(rs256Jwt);
-        // If we get here, the server responded successfully (unlikely in test env)
-      } catch (e) {
-        // The important part is that it should NOT crash with null error
-        // It may fail with network error, invalid signature, etc.
-        // but the error message should not contain null-related errors
-        expect(e.toString(), isNot(contains('Unexpected null value')));
-        expect(e.toString(), isNot(contains('Null check operator')));
-      }
-      // Test passes if we get here without null error
-    });
+        // Before the fix, this would crash with:
+        // "Null check operator used on a null value"
+        // because _jwks is null on first call and the code does _jwks!
+        //
+        // After the fix, this should attempt to fetch JWKS from the server
+        // and fail gracefully (either with network error or invalid signature)
+        // but NOT crash with null error
+        try {
+          await client.getClaims(rs256Jwt);
+          // If we get here, the server responded successfully (unlikely in test env)
+        } catch (e) {
+          // The important part is that it should NOT crash with null error
+          // It may fail with network error, invalid signature, etc.
+          // but the error message should not contain null-related errors
+          expect(e.toString(), isNot(contains('Unexpected null value')));
+          expect(e.toString(), isNot(contains('Null check operator')));
+        }
+        // Test passes if we get here without null error
+      },
+    );
   });
 
   group('JWT helper functions', () {

--- a/packages/gotrue/test/header_isolation_test.dart
+++ b/packages/gotrue/test/header_isolation_test.dart
@@ -13,18 +13,22 @@ class _RecordingHttpClient extends BaseClient {
   Future<StreamedResponse> send(BaseRequest request) async {
     requestHeaders.add(Map.of(request.headers));
     return StreamedResponse(
-      Stream.value(utf8.encode(jsonEncode({
-        'id': '18bc7a4e-c095-4573-93dc-e0be29bada97',
-        'aud': 'authenticated',
-        'role': 'authenticated',
-        'email': 'fake1@email.com',
-        'app_metadata': {
-          'provider': 'email',
-          'providers': ['email'],
-        },
-        'user_metadata': <String, dynamic>{},
-        'created_at': '2023-04-01T09:38:59.784028Z',
-      }))),
+      Stream.value(
+        utf8.encode(
+          jsonEncode({
+            'id': '18bc7a4e-c095-4573-93dc-e0be29bada97',
+            'aud': 'authenticated',
+            'role': 'authenticated',
+            'email': 'fake1@email.com',
+            'app_metadata': {
+              'provider': 'email',
+              'providers': ['email'],
+            },
+            'user_metadata': <String, dynamic>{},
+            'created_at': '2023-04-01T09:38:59.784028Z',
+          }),
+        ),
+      ),
       200,
       request: request,
     );

--- a/packages/gotrue/test/mfa_enroll_test.dart
+++ b/packages/gotrue/test/mfa_enroll_test.dart
@@ -17,15 +17,19 @@ class _RecordingHttpClient extends BaseClient {
         : <String, dynamic>{};
     requestBodies.add(body);
     return StreamedResponse(
-      Stream.value(utf8.encode(jsonEncode({
-        'id': '3f1e2d4c-1111-2222-3333-444455556666',
-        'type': 'totp',
-        'totp': {
-          'qr_code': 'svg',
-          'secret': 'ABC123',
-          'uri': 'otpauth://totp/Example?secret=ABC123',
-        },
-      }))),
+      Stream.value(
+        utf8.encode(
+          jsonEncode({
+            'id': '3f1e2d4c-1111-2222-3333-444455556666',
+            'type': 'totp',
+            'totp': {
+              'qr_code': 'svg',
+              'secret': 'ABC123',
+              'uri': 'otpauth://totp/Example?secret=ABC123',
+            },
+          }),
+        ),
+      ),
       200,
       request: request,
     );
@@ -68,13 +72,15 @@ void main() {
       );
     });
 
-    test('a webauthn factor is rejected instead of reaching the network',
-        () async {
-      expect(
-        () => client.mfa.enroll(factorType: FactorType.webauthn),
-        throwsArgumentError,
-      );
-      expect(http.requestBodies, isEmpty);
-    });
+    test(
+      'a webauthn factor is rejected instead of reaching the network',
+      () async {
+        expect(
+          () => client.mfa.enroll(factorType: FactorType.webauthn),
+          throwsArgumentError,
+        );
+        expect(http.requestBodies, isEmpty);
+      },
+    );
   });
 }

--- a/packages/gotrue/test/mocks/otp_mock_client.dart
+++ b/packages/gotrue/test/mocks/otp_mock_client.dart
@@ -72,7 +72,8 @@ class OtpMockClient extends BaseClient {
     // Default response for unhandled requests
     return StreamedResponse(
       Stream.value(
-          utf8.encode(jsonEncode({'error': 'Unhandled mock request'}))),
+        utf8.encode(jsonEncode({'error': 'Unhandled mock request'})),
+      ),
       501,
       request: request,
     );
@@ -82,10 +83,14 @@ class OtpMockClient extends BaseClient {
     // Check if it's a phone OTP request
     if (requestBody?['phone'] != null) {
       return StreamedResponse(
-        Stream.value(utf8.encode(jsonEncode({
-          'message': 'OTP sent to phone',
-          'message_id': 'mock-message-id-phone',
-        }))),
+        Stream.value(
+          utf8.encode(
+            jsonEncode({
+              'message': 'OTP sent to phone',
+              'message_id': 'mock-message-id-phone',
+            }),
+          ),
+        ),
         200,
         request: null,
       );
@@ -94,10 +99,14 @@ class OtpMockClient extends BaseClient {
     // Check if it's an email OTP request
     if (requestBody?['email'] != null) {
       return StreamedResponse(
-        Stream.value(utf8.encode(jsonEncode({
-          'message': 'OTP sent to email',
-          'message_id': 'mock-message-id-email',
-        }))),
+        Stream.value(
+          utf8.encode(
+            jsonEncode({
+              'message': 'OTP sent to email',
+              'message_id': 'mock-message-id-email',
+            }),
+          ),
+        ),
         200,
         request: null,
       );
@@ -105,10 +114,14 @@ class OtpMockClient extends BaseClient {
 
     // Invalid OTP request
     return StreamedResponse(
-      Stream.value(utf8.encode(jsonEncode({
-        'error': 'Invalid OTP request',
-        'message': 'Email or phone number required',
-      }))),
+      Stream.value(
+        utf8.encode(
+          jsonEncode({
+            'error': 'Invalid OTP request',
+            'message': 'Email or phone number required',
+          }),
+        ),
+      ),
       400,
       request: null,
     );
@@ -119,44 +132,50 @@ class OtpMockClient extends BaseClient {
 
     // OTP token verification response
     return StreamedResponse(
-      Stream.value(utf8.encode(jsonEncode({
-        'access_token': accessToken,
-        'token_type': 'bearer',
-        'expires_in': 3600,
-        'refresh_token': refreshToken,
-        'user': {
-          'id': userId,
-          'aud': 'authenticated',
-          'role': 'authenticated',
-          'email': requestBody?['email'] ?? email,
-          'phone': requestBody?['phone'] ?? phoneNumber,
-          'phone_confirmed_at': now,
-          'confirmed_at': now,
-          'last_sign_in_at': now,
-          'created_at': now,
-          'updated_at': now,
-          'app_metadata': {
-            'provider': requestBody?['email'] != null ? 'email' : 'phone',
-            'providers': [requestBody?['email'] != null ? 'email' : 'phone'],
-          },
-          'user_metadata': {},
-          'identities': [
-            {
+      Stream.value(
+        utf8.encode(
+          jsonEncode({
+            'access_token': accessToken,
+            'token_type': 'bearer',
+            'expires_in': 3600,
+            'refresh_token': refreshToken,
+            'user': {
               'id': userId,
-              'user_id': userId,
-              'identity_data': {
-                'sub': userId,
-                'email': requestBody?['email'] ?? email,
-                'phone': requestBody?['phone'] ?? phoneNumber,
-              },
-              'provider': requestBody?['email'] != null ? 'email' : 'phone',
+              'aud': 'authenticated',
+              'role': 'authenticated',
+              'email': requestBody?['email'] ?? email,
+              'phone': requestBody?['phone'] ?? phoneNumber,
+              'phone_confirmed_at': now,
+              'confirmed_at': now,
               'last_sign_in_at': now,
               'created_at': now,
               'updated_at': now,
-            }
-          ],
-        }
-      }))),
+              'app_metadata': {
+                'provider': requestBody?['email'] != null ? 'email' : 'phone',
+                'providers': [
+                  requestBody?['email'] != null ? 'email' : 'phone',
+                ],
+              },
+              'user_metadata': {},
+              'identities': [
+                {
+                  'id': userId,
+                  'user_id': userId,
+                  'identity_data': {
+                    'sub': userId,
+                    'email': requestBody?['email'] ?? email,
+                    'phone': requestBody?['phone'] ?? phoneNumber,
+                  },
+                  'provider': requestBody?['email'] != null ? 'email' : 'phone',
+                  'last_sign_in_at': now,
+                  'created_at': now,
+                  'updated_at': now,
+                },
+              ],
+            },
+          }),
+        ),
+      ),
       200,
       request: null,
     );
@@ -166,90 +185,99 @@ class OtpMockClient extends BaseClient {
     final now = DateTime.now().toIso8601String();
 
     return StreamedResponse(
-      Stream.value(utf8.encode(jsonEncode({
-        'access_token': accessToken,
-        'token_type': 'bearer',
-        'expires_in': 3600,
-        'refresh_token': refreshToken,
-        'user': {
-          'id': userId,
-          'aud': 'authenticated',
-          'role': 'authenticated',
-          'email': null,
-          'phone': requestBody?['phone'] ?? phoneNumber,
-          'phone_confirmed_at': now,
-          'confirmed_at': now,
-          'last_sign_in_at': now,
-          'created_at': now,
-          'updated_at': now,
-          'app_metadata': {
-            'provider': 'phone',
-            'providers': ['phone'],
-          },
-          'user_metadata': requestBody?['data'] ?? {},
-          'identities': [
-            {
+      Stream.value(
+        utf8.encode(
+          jsonEncode({
+            'access_token': accessToken,
+            'token_type': 'bearer',
+            'expires_in': 3600,
+            'refresh_token': refreshToken,
+            'user': {
               'id': userId,
-              'user_id': userId,
-              'identity_data': {
-                'sub': userId,
-                'phone': requestBody?['phone'] ?? phoneNumber,
-              },
-              'provider': 'phone',
+              'aud': 'authenticated',
+              'role': 'authenticated',
+              'email': null,
+              'phone': requestBody?['phone'] ?? phoneNumber,
+              'phone_confirmed_at': now,
+              'confirmed_at': now,
               'last_sign_in_at': now,
               'created_at': now,
               'updated_at': now,
-            }
-          ],
-        }
-      }))),
+              'app_metadata': {
+                'provider': 'phone',
+                'providers': ['phone'],
+              },
+              'user_metadata': requestBody?['data'] ?? {},
+              'identities': [
+                {
+                  'id': userId,
+                  'user_id': userId,
+                  'identity_data': {
+                    'sub': userId,
+                    'phone': requestBody?['phone'] ?? phoneNumber,
+                  },
+                  'provider': 'phone',
+                  'last_sign_in_at': now,
+                  'created_at': now,
+                  'updated_at': now,
+                },
+              ],
+            },
+          }),
+        ),
+      ),
       200,
       request: null,
     );
   }
 
   StreamedResponse _handlePhoneSignInWithPassword(
-      Map<String, dynamic>? requestBody) {
+    Map<String, dynamic>? requestBody,
+  ) {
     final now = DateTime.now().toIso8601String();
 
     return StreamedResponse(
-      Stream.value(utf8.encode(jsonEncode({
-        'access_token': accessToken,
-        'token_type': 'bearer',
-        'expires_in': 3600,
-        'refresh_token': refreshToken,
-        'user': {
-          'id': userId,
-          'aud': 'authenticated',
-          'role': 'authenticated',
-          'email': null,
-          'phone': requestBody?['phone'] ?? phoneNumber,
-          'phone_confirmed_at': now,
-          'confirmed_at': now,
-          'last_sign_in_at': now,
-          'created_at': now,
-          'updated_at': now,
-          'app_metadata': {
-            'provider': 'phone',
-            'providers': ['phone'],
-          },
-          'user_metadata': {},
-          'identities': [
-            {
+      Stream.value(
+        utf8.encode(
+          jsonEncode({
+            'access_token': accessToken,
+            'token_type': 'bearer',
+            'expires_in': 3600,
+            'refresh_token': refreshToken,
+            'user': {
               'id': userId,
-              'user_id': userId,
-              'identity_data': {
-                'sub': userId,
-                'phone': requestBody?['phone'] ?? phoneNumber,
-              },
-              'provider': 'phone',
+              'aud': 'authenticated',
+              'role': 'authenticated',
+              'email': null,
+              'phone': requestBody?['phone'] ?? phoneNumber,
+              'phone_confirmed_at': now,
+              'confirmed_at': now,
               'last_sign_in_at': now,
               'created_at': now,
               'updated_at': now,
-            }
-          ],
-        }
-      }))),
+              'app_metadata': {
+                'provider': 'phone',
+                'providers': ['phone'],
+              },
+              'user_metadata': {},
+              'identities': [
+                {
+                  'id': userId,
+                  'user_id': userId,
+                  'identity_data': {
+                    'sub': userId,
+                    'phone': requestBody?['phone'] ?? phoneNumber,
+                  },
+                  'provider': 'phone',
+                  'last_sign_in_at': now,
+                  'created_at': now,
+                  'updated_at': now,
+                },
+              ],
+            },
+          }),
+        ),
+      ),
       200,
       request: null,
     );
@@ -257,9 +285,13 @@ class OtpMockClient extends BaseClient {
 
   StreamedResponse _handleReauthenticate() {
     return StreamedResponse(
-      Stream.value(utf8.encode(jsonEncode({
-        'message': 'Reauthentication succeeded',
-      }))),
+      Stream.value(
+        utf8.encode(
+          jsonEncode({
+            'message': 'Reauthentication succeeded',
+          }),
+        ),
+      ),
       200,
       request: null,
     );
@@ -268,10 +300,14 @@ class OtpMockClient extends BaseClient {
   StreamedResponse _handleResend(Map<String, dynamic>? requestBody) {
     lastResendBody = requestBody;
     return StreamedResponse(
-      Stream.value(utf8.encode(jsonEncode({
-        'message': 'OTP resent',
-        'message_id': 'mock-message-id-resend',
-      }))),
+      Stream.value(
+        utf8.encode(
+          jsonEncode({
+            'message': 'OTP resent',
+            'message_id': 'mock-message-id-resend',
+          }),
+        ),
+      ),
       200,
       request: null,
     );
@@ -302,30 +338,34 @@ class ChannelMockClient extends BaseClient {
       final now = DateTime.now().toIso8601String();
 
       return StreamedResponse(
-        Stream.value(utf8.encode(jsonEncode({
-          'access_token': 'mock-access-token',
-          'token_type': 'bearer',
-          'expires_in': 3600,
-          'refresh_token': 'mock-refresh-token',
-          'user': {
-            'id': 'mock-user-id',
-            'aud': 'authenticated',
-            'role': 'authenticated',
-            'email': 'test@example.com',
-            'phone': '+11234567890',
-            'phone_confirmed_at': now,
-            'confirmed_at': now,
-            'last_sign_in_at': now,
-            'created_at': now,
-            'updated_at': now,
-            'app_metadata': {
-              'provider': 'phone',
-              'providers': ['phone'],
-            },
-            'user_metadata': {},
-            'identities': [],
-          }
-        }))),
+        Stream.value(
+          utf8.encode(
+            jsonEncode({
+              'access_token': 'mock-access-token',
+              'token_type': 'bearer',
+              'expires_in': 3600,
+              'refresh_token': 'mock-refresh-token',
+              'user': {
+                'id': 'mock-user-id',
+                'aud': 'authenticated',
+                'role': 'authenticated',
+                'email': 'test@example.com',
+                'phone': '+11234567890',
+                'phone_confirmed_at': now,
+                'confirmed_at': now,
+                'last_sign_in_at': now,
+                'created_at': now,
+                'updated_at': now,
+                'app_metadata': {
+                  'provider': 'phone',
+                  'providers': ['phone'],
+                },
+                'user_metadata': {},
+                'identities': [],
+              },
+            }),
+          ),
+        ),
         200,
         request: request,
       );
@@ -333,10 +373,14 @@ class ChannelMockClient extends BaseClient {
 
     // Default response for other requests
     return StreamedResponse(
-      Stream.value(utf8.encode(jsonEncode({
-        'message': 'OTP sent',
-        'message_id': 'mock-message-id',
-      }))),
+      Stream.value(
+        utf8.encode(
+          jsonEncode({
+            'message': 'OTP sent',
+            'message_id': 'mock-message-id',
+          }),
+        ),
+      ),
       200,
       request: request,
     );
@@ -387,10 +431,14 @@ class ConditionalErrorClient extends BaseClient {
     if (url.contains('/verify') && method == 'POST') {
       // Simulate expired OTP
       return StreamedResponse(
-        Stream.value(utf8.encode(jsonEncode({
-          'error': 'expired_token',
-          'message': 'The OTP has expired',
-        }))),
+        Stream.value(
+          utf8.encode(
+            jsonEncode({
+              'error': 'expired_token',
+              'message': 'The OTP has expired',
+            }),
+          ),
+        ),
         401,
         request: request,
       );
@@ -399,10 +447,14 @@ class ConditionalErrorClient extends BaseClient {
     if (url.contains('/token') && method == 'POST') {
       // Simulate wrong password
       return StreamedResponse(
-        Stream.value(utf8.encode(jsonEncode({
-          'error': 'invalid_grant',
-          'message': 'Invalid login credentials',
-        }))),
+        Stream.value(
+          utf8.encode(
+            jsonEncode({
+              'error': 'invalid_grant',
+              'message': 'Invalid login credentials',
+            }),
+          ),
+        ),
         401,
         request: request,
       );
@@ -419,10 +471,14 @@ class ConditionalErrorClient extends BaseClient {
       if (body?['phone'] != null) {
         // Simulate phone number already exists
         return StreamedResponse(
-          Stream.value(utf8.encode(jsonEncode({
-            'error': 'phone_taken',
-            'message': 'Phone number is already registered',
-          }))),
+          Stream.value(
+            utf8.encode(
+              jsonEncode({
+                'error': 'phone_taken',
+                'message': 'Phone number is already registered',
+              }),
+            ),
+          ),
           400,
           request: request,
         );
@@ -431,10 +487,14 @@ class ConditionalErrorClient extends BaseClient {
 
     // Simulate unknown error for other requests
     return StreamedResponse(
-      Stream.value(utf8.encode(jsonEncode({
-        'error': 'internal_error',
-        'message': 'An unknown error occurred',
-      }))),
+      Stream.value(
+        utf8.encode(
+          jsonEncode({
+            'error': 'internal_error',
+            'message': 'An unknown error occurred',
+          }),
+        ),
+      ),
       500,
       request: request,
     );
@@ -460,11 +520,16 @@ class NullSessionClient extends BaseClient {
   @override
   Future<StreamedResponse> send(BaseRequest request) async {
     return StreamedResponse(
-      Stream.value(utf8.encode(jsonEncode({
-        'msg': 'Confirmation link accepted. Please proceed to confirm link '
-            'sent to the other email',
-        'code': 200,
-      }))),
+      Stream.value(
+        utf8.encode(
+          jsonEncode({
+            'msg':
+                'Confirmation link accepted. Please proceed to confirm link '
+                'sent to the other email',
+            'code': 200,
+          }),
+        ),
+      ),
       200,
       request: request,
     );

--- a/packages/gotrue/test/mocks/passkey_mock_client.dart
+++ b/packages/gotrue/test/mocks/passkey_mock_client.dart
@@ -92,7 +92,8 @@ class PasskeyMockClient extends BaseClient {
 
     return StreamedResponse(
       Stream.value(
-          utf8.encode(jsonEncode({'error': 'Unhandled mock request'}))),
+        utf8.encode(jsonEncode({'error': 'Unhandled mock request'})),
+      ),
       501,
       request: request,
     );
@@ -219,10 +220,14 @@ class PasskeyDisabledMockClient extends BaseClient {
   @override
   Future<StreamedResponse> send(BaseRequest request) async {
     return StreamedResponse(
-      Stream.value(utf8.encode(jsonEncode({
-        'code': 'passkey_disabled',
-        'msg': 'Passkey authentication is disabled',
-      }))),
+      Stream.value(
+        utf8.encode(
+          jsonEncode({
+            'code': 'passkey_disabled',
+            'msg': 'Passkey authentication is disabled',
+          }),
+        ),
+      ),
       404,
       headers: {'x-supabase-api-version': '2024-01-01'},
       request: request,

--- a/packages/gotrue/test/otp_mock_test.dart
+++ b/packages/gotrue/test/otp_mock_test.dart
@@ -34,15 +34,19 @@ void main() {
     test('signInWithOtp() with phone number', () async {
       await client.signInWithOtp(phone: testPhone);
       // This test passes if no exceptions are thrown
-      expect(client.currentSession,
-          isNull); // No session should be set yet as OTP is not verified
+      expect(
+        client.currentSession,
+        isNull,
+      ); // No session should be set yet as OTP is not verified
     });
 
     test('signInWithOtp() with email', () async {
       await client.signInWithOtp(email: testEmail);
       // This test passes if no exceptions are thrown
-      expect(client.currentSession,
-          isNull); // No session should be set yet as OTP is not verified
+      expect(
+        client.currentSession,
+        isNull,
+      ); // No session should be set yet as OTP is not verified
     });
 
     test('signInWithOtp() with phone number and custom data', () async {
@@ -52,15 +56,22 @@ void main() {
         data: {'name': 'Test User'},
       );
       // This test passes if no exceptions are thrown
-      expect(client.currentSession,
-          isNull); // No session should be set yet as OTP is not verified
+      expect(
+        client.currentSession,
+        isNull,
+      ); // No session should be set yet as OTP is not verified
     });
 
     test('signInWithOtp() without email or phone should throw', () async {
       await expectLater(
         () => client.signInWithOtp(),
-        throwsA(isA<AuthException>().having((e) => e.message, 'message',
-            contains('You must provide either an email, phone number'))),
+        throwsA(
+          isA<AuthException>().having(
+            (e) => e.message,
+            'message',
+            contains('You must provide either an email, phone number'),
+          ),
+        ),
       );
     });
 
@@ -144,22 +155,27 @@ void main() {
     });
 
     test(
-        'verifyOTP() with recovery type and tokenHash should reject email/phone',
-        () async {
-      // Recovery type with tokenHash should not accept email/phone
-      await expectLater(
-        () => client.verifyOTP(
-          email: testEmail,
-          tokenHash: 'mock-token-hash',
-          type: OtpType.recovery,
-        ),
-        throwsA(isA<AssertionError>().having(
-            (e) => e.toString(),
-            'toString()',
-            contains(
-                'For recovery type with tokenHash, only tokenHash and type should be provided'))),
-      );
-    });
+      'verifyOTP() with recovery type and tokenHash should reject email/phone',
+      () async {
+        // Recovery type with tokenHash should not accept email/phone
+        await expectLater(
+          () => client.verifyOTP(
+            email: testEmail,
+            tokenHash: 'mock-token-hash',
+            type: OtpType.recovery,
+          ),
+          throwsA(
+            isA<AssertionError>().having(
+              (e) => e.toString(),
+              'toString()',
+              contains(
+                'For recovery type with tokenHash, only tokenHash and type should be provided',
+              ),
+            ),
+          ),
+        );
+      },
+    );
 
     test('verifyOTP() without token should throw', () async {
       await expectLater(
@@ -369,29 +385,40 @@ void main() {
           token: '123456',
           type: OtpType.sms,
         ),
-        throwsA(isA<AuthException>().having((e) => e.message, 'message',
-            'The OTP provided is invalid or has expired')),
+        throwsA(
+          isA<AuthException>().having(
+            (e) => e.message,
+            'message',
+            'The OTP provided is invalid or has expired',
+          ),
+        ),
       );
     });
 
     test(
-        'signInWithPassword() with phone and wrong password throws AuthException',
-        () async {
-      final client = GoTrueClient(
-        url: 'https://example.com',
-        httpClient: ConditionalErrorClient(),
-        asyncStorage: TestAsyncStorage(),
-      );
+      'signInWithPassword() with phone and wrong password throws AuthException',
+      () async {
+        final client = GoTrueClient(
+          url: 'https://example.com',
+          httpClient: ConditionalErrorClient(),
+          asyncStorage: TestAsyncStorage(),
+        );
 
-      await expectLater(
-        () => client.signInWithPassword(
-          phone: testPhone,
-          password: 'wrong-password',
-        ),
-        throwsA(isA<AuthException>()
-            .having((e) => e.message, 'message', 'Invalid login credentials')),
-      );
-    });
+        await expectLater(
+          () => client.signInWithPassword(
+            phone: testPhone,
+            password: 'wrong-password',
+          ),
+          throwsA(
+            isA<AuthException>().having(
+              (e) => e.message,
+              'message',
+              'Invalid login credentials',
+            ),
+          ),
+        );
+      },
+    );
 
     test('signUp() with existing phone number throws AuthException', () async {
       final client = GoTrueClient(
@@ -405,8 +432,13 @@ void main() {
           phone: testPhone,
           password: testPassword,
         ),
-        throwsA(isA<AuthException>().having(
-            (e) => e.message, 'message', 'Phone number is already registered')),
+        throwsA(
+          isA<AuthException>().having(
+            (e) => e.message,
+            'message',
+            'Phone number is already registered',
+          ),
+        ),
       );
     });
 
@@ -421,22 +453,24 @@ void main() {
       await client.signInWithOtp(phone: testPhone);
     });
 
-    test('verifyOTP() with neither email nor phone throws assertion error',
-        () async {
-      final client = GoTrueClient(
-        url: 'https://example.com',
-        httpClient: EmptyResponseClient(),
-        asyncStorage: TestAsyncStorage(),
-      );
+    test(
+      'verifyOTP() with neither email nor phone throws assertion error',
+      () async {
+        final client = GoTrueClient(
+          url: 'https://example.com',
+          httpClient: EmptyResponseClient(),
+          asyncStorage: TestAsyncStorage(),
+        );
 
-      await expectLater(
-        () => client.verifyOTP(
-          token: '123456',
-          type: OtpType.sms,
-        ),
-        throwsA(isA<AssertionError>()),
-      );
-    });
+        await expectLater(
+          () => client.verifyOTP(
+            token: '123456',
+            type: OtpType.sms,
+          ),
+          throwsA(isA<AssertionError>()),
+        );
+      },
+    );
 
     test('verifyOTP() with expired token throws AuthException', () async {
       final client = GoTrueClient(
@@ -451,8 +485,13 @@ void main() {
           token: '123456',
           type: OtpType.sms,
         ),
-        throwsA(isA<AuthException>()
-            .having((e) => e.message, 'message', 'The OTP has expired')),
+        throwsA(
+          isA<AuthException>().having(
+            (e) => e.message,
+            'message',
+            'The OTP has expired',
+          ),
+        ),
       );
     });
 
@@ -486,20 +525,27 @@ void main() {
       );
     });
 
-    test('signInWithPassword() without email or phone throws exception',
-        () async {
-      final client = GoTrueClient(
-        url: 'https://example.com',
-        httpClient: EmptyResponseClient(),
-        asyncStorage: TestAsyncStorage(),
-      );
+    test(
+      'signInWithPassword() without email or phone throws exception',
+      () async {
+        final client = GoTrueClient(
+          url: 'https://example.com',
+          httpClient: EmptyResponseClient(),
+          asyncStorage: TestAsyncStorage(),
+        );
 
-      await expectLater(
-        () => client.signInWithPassword(password: testPassword),
-        throwsA(isA<AuthException>().having((e) => e.message, 'message',
-            contains('You must provide either an'))),
-      );
-    });
+        await expectLater(
+          () => client.signInWithPassword(password: testPassword),
+          throwsA(
+            isA<AuthException>().having(
+              (e) => e.message,
+              'message',
+              contains('You must provide either an'),
+            ),
+          ),
+        );
+      },
+    );
 
     test('empty response on server error', () async {
       final client = GoTrueClient(
@@ -510,13 +556,13 @@ void main() {
 
       await expectLater(
         () => client.signInWithOtp(phone: testPhone),
-        throwsA(isA<AuthException>()
-            .having((e) => e.statusCode, 'statusCode', '500')),
+        throwsA(
+          isA<AuthException>().having((e) => e.statusCode, 'statusCode', '500'),
+        ),
       );
     });
 
-    test('response with null session returns the intermediate response',
-        () async {
+    test('response with null session returns the intermediate response', () async {
       final client = GoTrueClient(
         url: 'https://example.com',
         httpClient: NullSessionClient(),
@@ -664,18 +710,21 @@ void main() {
       expect(mockClient.lastRequestBody?['type'], 'email_change');
     });
 
-    test('verifyOTP() sends the captcha token under the captcha_token key',
-        () async {
-      await client.verifyOTP(
-        phone: testPhone,
-        token: '123456',
-        type: OtpType.sms,
-        captchaToken: 'captcha-token-123',
-      );
+    test(
+      'verifyOTP() sends the captcha token under the captcha_token key',
+      () async {
+        await client.verifyOTP(
+          phone: testPhone,
+          token: '123456',
+          type: OtpType.sms,
+          captchaToken: 'captcha-token-123',
+        );
 
-      final security = mockClient.lastRequestBody?['gotrue_meta_security']
-          as Map<String, dynamic>?;
-      expect(security?['captcha_token'], 'captcha-token-123');
-    });
+        final security =
+            mockClient.lastRequestBody?['gotrue_meta_security']
+                as Map<String, dynamic>?;
+        expect(security?['captcha_token'], 'captcha-token-123');
+      },
+    );
   });
 }

--- a/packages/gotrue/test/passkey_test.dart
+++ b/packages/gotrue/test/passkey_test.dart
@@ -61,15 +61,17 @@ void main() {
       );
     });
 
-    test('startAuthentication without captcha token sends null token',
-        () async {
-      await client.passkey.startAuthentication();
+    test(
+      'startAuthentication without captcha token sends null token',
+      () async {
+        await client.passkey.startAuthentication();
 
-      expect(
-        mockClient.lastRequestBody?['gotrue_meta_security'],
-        {'captcha_token': null},
-      );
-    });
+        expect(
+          mockClient.lastRequestBody?['gotrue_meta_security'],
+          {'captcha_token': null},
+        );
+      },
+    );
 
     test('verifyAuthentication signs the user in', () async {
       final events = <AuthChangeEvent>[];
@@ -259,22 +261,25 @@ void main() {
         );
       });
 
-      test('listPasskeys throws FormatException when response is not a list',
-          () async {
-        final malformedClient = GoTrueClient(
-          url: 'http://localhost:9999',
-          httpClient: EmptyResponseClient(),
-          autoRefreshToken: false,
-          asyncStorage: TestAsyncStorage(),
-        );
-        addTearDown(malformedClient.dispose);
+      test(
+        'listPasskeys throws FormatException when response is not a list',
+        () async {
+          final malformedClient = GoTrueClient(
+            url: 'http://localhost:9999',
+            httpClient: EmptyResponseClient(),
+            autoRefreshToken: false,
+            asyncStorage: TestAsyncStorage(),
+          );
+          addTearDown(malformedClient.dispose);
 
-        expect(
-          malformedClient.admin.passkey
-              .listPasskeys(userId: PasskeyMockClient.userId),
-          throwsFormatException,
-        );
-      });
+          expect(
+            malformedClient.admin.passkey.listPasskeys(
+              userId: PasskeyMockClient.userId,
+            ),
+            throwsFormatException,
+          );
+        },
+      );
     });
 
     test('throws AuthApiException when passkeys are disabled', () async {
@@ -288,9 +293,11 @@ void main() {
 
       await expectLater(
         () => disabledClient.passkey.startAuthentication(),
-        throwsA(isA<AuthApiException>()
-            .having((e) => e.code, 'code', 'passkey_disabled')
-            .having((e) => e.statusCode, 'statusCode', '404')),
+        throwsA(
+          isA<AuthApiException>()
+              .having((e) => e.code, 'code', 'passkey_disabled')
+              .having((e) => e.statusCode, 'statusCode', '404'),
+        ),
       );
     });
   });

--- a/packages/gotrue/test/provider_test.dart
+++ b/packages/gotrue/test/provider_test.dart
@@ -28,8 +28,9 @@ void main() {
   });
   group('Provider sign in', () {
     test('signIn() with Provider', () async {
-      final res =
-          await client.getOAuthSignInUrl(provider: OAuthProvider.google);
+      final res = await client.getOAuthSignInUrl(
+        provider: OAuthProvider.google,
+      );
       final url = res.url;
       final provider = res.provider;
       expect(url, startsWith('$gotrueUrl/authorize?provider=google'));
@@ -47,7 +48,8 @@ void main() {
       expect(
         url,
         startsWith(
-            '$gotrueUrl/authorize?provider=github&scopes=repo&redirect_to=redirectToURL'),
+          '$gotrueUrl/authorize?provider=github&scopes=repo&redirect_to=redirectToURL',
+        ),
       );
       expect(provider, OAuthProvider.github);
     });
@@ -56,13 +58,15 @@ void main() {
   group('getSessionFromUrl()', () {
     setUp(() async {
       final res = await http.post(
-          Uri.parse(
-              'http://127.0.0.1:54421/rest/v1/rpc/reset_and_init_auth_data'),
-          headers: {
-            'x-forwarded-for': '127.0.0.1',
-            'apikey': getServiceRoleToken(env),
-            'Authorization': 'Bearer ${getServiceRoleToken(env)}',
-          });
+        Uri.parse(
+          'http://127.0.0.1:54421/rest/v1/rpc/reset_and_init_auth_data',
+        ),
+        headers: {
+          'x-forwarded-for': '127.0.0.1',
+          'apikey': getServiceRoleToken(env),
+          'Authorization': 'Bearer ${getServiceRoleToken(env)}',
+        },
+      );
       if (res.body.isNotEmpty) throw res.body;
 
       await client.signInWithPassword(email: email1, password: password);
@@ -115,8 +119,13 @@ void main() {
               'http://my-callback-url.com?page=welcome&foo=bar#access_token=$accessToken';
           await client.getSessionFromUrl(Uri.parse(url));
         },
-        throwsA(isA<AuthException>()
-            .having((e) => e.message, 'message', 'No expires_in detected.')),
+        throwsA(
+          isA<AuthException>().having(
+            (e) => e.message,
+            'message',
+            'No expires_in detected.',
+          ),
+        ),
       );
     });
 
@@ -128,8 +137,9 @@ void main() {
               'http://my-callback-url.com?page=welcome&foo=bar#error_description=$errorDesc';
           await client.getSessionFromUrl(Uri.parse(url));
         },
-        throwsA(isA<AuthException>()
-            .having((e) => e.message, 'message', errorDesc)),
+        throwsA(
+          isA<AuthException>().having((e) => e.message, 'message', errorDesc),
+        ),
       );
     });
 
@@ -140,11 +150,16 @@ void main() {
               'http://my-callback-url.com?error=access_denied&error_code=403';
           await client.getSessionFromUrl(Uri.parse(url));
         },
-        throwsA(isA<AuthException>()
-            .having((e) => e.code, 'code', 'access_denied')
-            .having((e) => e.statusCode, 'statusCode', '403')
-            .having((e) => e.message, 'message',
-                'Error in URL with unspecified error_description')),
+        throwsA(
+          isA<AuthException>()
+              .having((e) => e.code, 'code', 'access_denied')
+              .having((e) => e.statusCode, 'statusCode', '403')
+              .having(
+                (e) => e.message,
+                'message',
+                'Error in URL with unspecified error_description',
+              ),
+        ),
       );
     });
   });

--- a/packages/gotrue/test/refresh_token_race_test.dart
+++ b/packages/gotrue/test/refresh_token_race_test.dart
@@ -48,7 +48,8 @@ class RefreshTokenTrackingHttpClient extends BaseClient {
     }
 
     requestLog.add(
-        'Request #$requestNumber: refresh_token=${refreshToken ?? "unknown"}');
+      'Request #$requestNumber: refresh_token=${refreshToken ?? "unknown"}',
+    );
 
     // Simulate network latency if configured
     if (responseDelay != null) {
@@ -113,7 +114,7 @@ class RefreshTokenTrackingHttpClient extends BaseClient {
               'email_confirmed_at': DateTime.now().toIso8601String(),
               'app_metadata': {
                 'provider': 'email',
-                'providers': ['email']
+                'providers': ['email'],
               },
               'user_metadata': {},
               'identities': [],
@@ -155,8 +156,11 @@ class InvalidRefreshTokenHttpClient extends BaseClient {
 String createExpiredSessionForUser1() {
   final expireDateTime = DateTime.now().subtract(Duration(hours: 1));
   final expiresAt = expireDateTime.millisecondsSinceEpoch ~/ 1000;
-  final accessTokenMid = base64.encode(utf8.encode(json
-      .encode({'exp': expiresAt, 'sub': userId1, 'role': 'authenticated'})));
+  final accessTokenMid = base64.encode(
+    utf8.encode(
+      json.encode({'exp': expiresAt, 'sub': userId1, 'role': 'authenticated'}),
+    ),
+  );
   final accessToken = 'any.$accessTokenMid.any';
   return '{"access_token":"$accessToken","expires_in":-3600,"refresh_token":"-yeS4omysFs9tpUYBws9Rg","token_type":"bearer","provider_token":null,"provider_refresh_token":null,"user":{"id":"$userId1","app_metadata":{"provider":"email","providers":["email"]},"user_metadata":{},"aud":"","email":"test@example.com","phone":"","created_at":"2023-04-01T08:35:05.208586Z","confirmed_at":null,"email_confirmed_at":"2023-04-01T08:35:05.220096086Z","phone_confirmed_at":null,"last_sign_in_at":"2023-04-01T08:35:05.222755878Z","role":"","updated_at":"2023-04-01T08:35:05.226938Z"}}';
 }
@@ -165,308 +169,337 @@ void main() {
   const gotrueUrl = 'http://localhost:9999';
 
   group('Refresh token race condition fix tests', () {
-    test('concurrent recoverSession calls are bundled (protected by completer)',
-        () async {
-      final httpClient = RefreshTokenTrackingHttpClient();
-      final client = GoTrueClient(
-        url: gotrueUrl,
-        asyncStorage: TestAsyncStorage(),
-        httpClient: httpClient,
-      );
+    test(
+      'concurrent recoverSession calls are bundled (protected by completer)',
+      () async {
+        final httpClient = RefreshTokenTrackingHttpClient();
+        final client = GoTrueClient(
+          url: gotrueUrl,
+          asyncStorage: TestAsyncStorage(),
+          httpClient: httpClient,
+        );
 
-      // Create an expired session for the same user
-      final expiredSession = createExpiredSessionForUser1();
+        // Create an expired session for the same user
+        final expiredSession = createExpiredSessionForUser1();
 
-      // Call recoverSession concurrently - these SHOULD be bundled
-      final results = await Future.wait([
-        client.recoverSession(expiredSession),
-        client.recoverSession(expiredSession),
-      ]);
+        // Call recoverSession concurrently - these SHOULD be bundled
+        final results = await Future.wait([
+          client.recoverSession(expiredSession),
+          client.recoverSession(expiredSession),
+        ]);
 
-      // Both should succeed with same token (bundled into one request)
-      expect(results[0].session?.accessToken, isNotNull);
-      expect(results[0].session?.accessToken, results[1].session?.accessToken);
+        // Both should succeed with same token (bundled into one request)
+        expect(results[0].session?.accessToken, isNotNull);
+        expect(
+          results[0].session?.accessToken,
+          results[1].session?.accessToken,
+        );
 
-      // Only ONE HTTP request should have been made (bundling works)
-      expect(httpClient.requestCount, 1,
-          reason: 'Concurrent calls should be bundled into one request');
-    });
+        // Only ONE HTTP request should have been made (bundling works)
+        expect(
+          httpClient.requestCount,
+          1,
+          reason: 'Concurrent calls should be bundled into one request',
+        );
+      },
+    );
 
     test(
-        'FIXED: sequential recoverSession calls with same user return current session',
-        () async {
-      final httpClient = RefreshTokenTrackingHttpClient();
-      final client = GoTrueClient(
-        url: gotrueUrl,
-        asyncStorage: TestAsyncStorage(),
-        httpClient: httpClient,
-      );
+      'FIXED: sequential recoverSession calls with same user return current session',
+      () async {
+        final httpClient = RefreshTokenTrackingHttpClient();
+        final client = GoTrueClient(
+          url: gotrueUrl,
+          asyncStorage: TestAsyncStorage(),
+          httpClient: httpClient,
+        );
 
-      // Create an expired session for the test user
-      final expiredSession = createExpiredSessionForUser1();
+        // Create an expired session for the test user
+        final expiredSession = createExpiredSessionForUser1();
 
-      // First call succeeds and refreshes
-      final result1 = await client.recoverSession(expiredSession);
-      expect(result1.session?.accessToken, isNotNull);
-      expect(httpClient.requestCount, 1);
+        // First call succeeds and refreshes
+        final result1 = await client.recoverSession(expiredSession);
+        expect(result1.session?.accessToken, isNotNull);
+        expect(httpClient.requestCount, 1);
 
-      final newRefreshToken = client.currentSession?.refreshToken;
-      expect(newRefreshToken, isNot('-yeS4omysFs9tpUYBws9Rg'));
+        final newRefreshToken = client.currentSession?.refreshToken;
+        expect(newRefreshToken, isNot('-yeS4omysFs9tpUYBws9Rg'));
 
-      // Second call with the SAME stale session (same user ID)
-      // FIXED: Should return current valid session without making new request
-      final result2 = await client.recoverSession(expiredSession);
+        // Second call with the SAME stale session (same user ID)
+        // FIXED: Should return current valid session without making new request
+        final result2 = await client.recoverSession(expiredSession);
 
-      // Should succeed (not throw)
-      expect(result2.session, isNotNull);
-      // Should return the CURRENT valid session
-      expect(result2.session?.refreshToken, newRefreshToken);
-      // Should NOT have made another HTTP request (early return in recoverSession)
-      expect(httpClient.requestCount, 1,
+        // Should succeed (not throw)
+        expect(result2.session, isNotNull);
+        // Should return the CURRENT valid session
+        expect(result2.session?.refreshToken, newRefreshToken);
+        // Should NOT have made another HTTP request (early return in recoverSession)
+        expect(
+          httpClient.requestCount,
+          1,
           reason:
-              'Should not make request if session already refreshed for same user');
-    });
-
-    test('FIXED: recoverSession races with autoRefreshTokenTick safely',
-        () async {
-      final holdFirstRequest = Completer<void>();
-      final httpClient = RefreshTokenTrackingHttpClient(
-        holdFirstRequest: holdFirstRequest,
-      );
-
-      final client = GoTrueClient(
-        url: gotrueUrl,
-        asyncStorage: TestAsyncStorage(),
-        httpClient: httpClient,
-        autoRefreshToken: true,
-      );
-
-      // Create an expired session for the test user
-      final expiredSession = createExpiredSessionForUser1();
-
-      // Simulate the race: start recoverSession (will be held)
-      final recoverFuture = client.recoverSession(expiredSession);
-
-      // Give time for the request to start
-      await Future.delayed(Duration(milliseconds: 10));
-
-      // Now start auto-refresh tick (simulates didChangeAppLifecycleState(resumed))
-      client.startAutoRefresh();
-
-      // Release the held request
-      holdFirstRequest.complete();
-
-      // Wait for recovery to complete
-      final result = await recoverFuture;
-      expect(result.session?.accessToken, isNotNull);
-
-      // Stop auto-refresh to clean up
-      client.stopAutoRefresh();
-
-      // With proper bundling, only ONE request should be made
-      expect(httpClient.requestCount, lessThanOrEqualTo(2));
-    });
-
-    test('FIXED: setInitialSession followed by concurrent refresh attempts',
-        () async {
-      final httpClient = RefreshTokenTrackingHttpClient(
-        responseDelay: Duration(milliseconds: 50),
-      );
-
-      final client = GoTrueClient(
-        url: gotrueUrl,
-        asyncStorage: TestAsyncStorage(),
-        httpClient: httpClient,
-        autoRefreshToken: true,
-      );
-
-      // Create an expired session for the test user
-      final expiredSession = createExpiredSessionForUser1();
-
-      // 1. setInitialSession loads the expired session (but doesn't refresh)
-      await client.setInitialSession(expiredSession);
-      expect(client.currentSession?.isExpired, isTrue);
-
-      // 2. Start auto-refresh (simulates didChangeAppLifecycleState(resumed))
-      client.startAutoRefresh();
-
-      // 3. Also call recoverSession (simulates lazy recovery call)
-      final recoverFuture = client.recoverSession(expiredSession);
-
-      // Wait a bit for both to potentially race
-      await Future.delayed(Duration(milliseconds: 100));
-
-      // FIXED: Should succeed without throwing
-      final result = await recoverFuture;
-      expect(result.session, isNotNull);
-
-      client.stopAutoRefresh();
-
-      // Should only make 1 or 2 requests (not more due to races)
-      expect(httpClient.requestCount, lessThanOrEqualTo(2));
-    });
+              'Should not make request if session already refreshed for same user',
+        );
+      },
+    );
 
     test(
-        'FIXED: "refresh_token_already_used" error is handled gracefully when session is valid',
-        () async {
-      final httpClient = RefreshTokenTrackingHttpClient();
+      'FIXED: recoverSession races with autoRefreshTokenTick safely',
+      () async {
+        final holdFirstRequest = Completer<void>();
+        final httpClient = RefreshTokenTrackingHttpClient(
+          holdFirstRequest: holdFirstRequest,
+        );
 
-      final client = GoTrueClient(
-        url: gotrueUrl,
-        asyncStorage: TestAsyncStorage(),
-        httpClient: httpClient,
-        autoRefreshToken: true,
-      );
+        final client = GoTrueClient(
+          url: gotrueUrl,
+          asyncStorage: TestAsyncStorage(),
+          httpClient: httpClient,
+          autoRefreshToken: true,
+        );
 
-      // Create expired session for the test user
-      final expiredSession = createExpiredSessionForUser1();
+        // Create an expired session for the test user
+        final expiredSession = createExpiredSessionForUser1();
 
-      // 1. Set initial session (doesn't refresh)
-      await client.setInitialSession(expiredSession);
-      expect(client.currentSession?.isExpired, isTrue);
-      expect(httpClient.requestCount, 0);
+        // Simulate the race: start recoverSession (will be held)
+        final recoverFuture = client.recoverSession(expiredSession);
 
-      // 2. First refresh succeeds
-      await client.refreshSession();
-      expect(httpClient.requestCount, 1);
+        // Give time for the request to start
+        await Future.delayed(Duration(milliseconds: 10));
 
-      // 3. Verify the session now has a NEW refresh token
-      final newToken = client.currentSession?.refreshToken;
-      expect(newToken, isNot('-yeS4omysFs9tpUYBws9Rg'));
-      expect(client.currentSession?.isExpired, isFalse);
+        // Now start auto-refresh tick (simulates didChangeAppLifecycleState(resumed))
+        client.startAutoRefresh();
 
-      // 4. Manually mark the current token as "already used" on the server
-      // This simulates a race condition where another request (e.g., auto-refresh)
-      // already consumed the token before our next refresh attempt
-      httpClient.markTokenAsUsed(newToken!);
+        // Release the held request
+        holdFirstRequest.complete();
 
-      // 5. Attempt refresh - this will get "already_used" error from server
-      // The error handler should detect we have a valid session and return it
-      final response = await client.refreshSession();
-      expect(response.session, isNotNull);
+        // Wait for recovery to complete
+        final result = await recoverFuture;
+        expect(result.session?.accessToken, isNotNull);
 
-      // Session should still be valid (the error handler returned current session)
-      expect(client.currentSession, isNotNull);
-      expect(client.currentSession?.isExpired, isFalse);
-    });
+        // Stop auto-refresh to clean up
+        client.stopAutoRefresh();
 
-    test('FIXED: signedOut event is NOT emitted when session is still valid',
-        () async {
-      final httpClient = RefreshTokenTrackingHttpClient();
-      final client = GoTrueClient(
-        url: gotrueUrl,
-        asyncStorage: TestAsyncStorage(),
-        httpClient: httpClient,
-      );
-
-      // Create and recover an expired session (first refresh succeeds)
-      final expiredSession = createExpiredSessionForUser1();
-      await client.recoverSession(expiredSession);
-
-      // Capture the valid session after refresh
-      final validSession = client.currentSession;
-      expect(validSession, isNotNull);
-      expect(validSession!.isExpired, isFalse);
-
-      // Listen for auth state changes AFTER first successful refresh
-      final authEvents = <AuthChangeEvent>[];
-      final subscription = client.onAuthStateChange.listen(
-        (state) {
-          authEvents.add(state.event);
-        },
-        onError: (_) {}, // Ignore stream errors
-      );
-
-      // Second call with stale token (same user) - should return current session
-      final result2 = await client.recoverSession(expiredSession);
-
-      // Should succeed
-      expect(result2.session, isNotNull);
-
-      // Wait for any events
-      await Future.delayed(Duration(milliseconds: 50));
-
-      // FIXED: signedOut should NOT be emitted since session is valid
-      expect(authEvents, isNot(contains(AuthChangeEvent.signedOut)),
-          reason: 'Should not sign out user when session is still valid');
-
-      // Session should still be valid
-      expect(client.currentSession?.accessToken, validSession.accessToken);
-
-      await subscription.cancel();
-    });
+        // With proper bundling, only ONE request should be made
+        expect(httpClient.requestCount, lessThanOrEqualTo(2));
+      },
+    );
 
     test(
-        'FIXED: concurrent recoverSession and autoRefreshTick both succeed with same result',
-        () async {
-      final httpClient = RefreshTokenTrackingHttpClient(
-        responseDelay: Duration(milliseconds: 50),
-      );
+      'FIXED: setInitialSession followed by concurrent refresh attempts',
+      () async {
+        final httpClient = RefreshTokenTrackingHttpClient(
+          responseDelay: Duration(milliseconds: 50),
+        );
 
-      final client = GoTrueClient(
-        url: gotrueUrl,
-        asyncStorage: TestAsyncStorage(),
-        httpClient: httpClient,
-        autoRefreshToken: true,
-      );
+        final client = GoTrueClient(
+          url: gotrueUrl,
+          asyncStorage: TestAsyncStorage(),
+          httpClient: httpClient,
+          autoRefreshToken: true,
+        );
 
-      // Set up expired session for the test user
-      final expiredSession = createExpiredSessionForUser1();
-      await client.setInitialSession(expiredSession);
+        // Create an expired session for the test user
+        final expiredSession = createExpiredSessionForUser1();
 
-      // Start auto-refresh (triggers _autoRefreshTokenTick immediately)
-      client.startAutoRefresh();
+        // 1. setInitialSession loads the expired session (but doesn't refresh)
+        await client.setInitialSession(expiredSession);
+        expect(client.currentSession?.isExpired, isTrue);
 
-      // Simultaneously call recoverSession
-      final recoverFuture = client.recoverSession(expiredSession);
+        // 2. Start auto-refresh (simulates didChangeAppLifecycleState(resumed))
+        client.startAutoRefresh();
 
-      // Wait a bit for both to potentially start
-      await Future.delayed(Duration(milliseconds: 10));
+        // 3. Also call recoverSession (simulates lazy recovery call)
+        final recoverFuture = client.recoverSession(expiredSession);
 
-      // FIXED: Both should succeed
-      final result = await recoverFuture;
-      expect(result.session, isNotNull);
+        // Wait a bit for both to potentially race
+        await Future.delayed(Duration(milliseconds: 100));
 
-      client.stopAutoRefresh();
+        // FIXED: Should succeed without throwing
+        final result = await recoverFuture;
+        expect(result.session, isNotNull);
 
-      // Should only make ONE or TWO HTTP requests (properly handled)
-      expect(httpClient.requestCount, lessThanOrEqualTo(2),
-          reason: 'Refresh attempts should be handled without errors');
+        client.stopAutoRefresh();
 
-      // Session should be valid
-      expect(client.currentSession?.isExpired, isFalse);
-    });
+        // Should only make 1 or 2 requests (not more due to races)
+        expect(httpClient.requestCount, lessThanOrEqualTo(2));
+      },
+    );
 
     test(
-        'FIXED: recoverSession returns current session for same user when already valid',
-        () async {
-      final httpClient = RefreshTokenTrackingHttpClient();
-      final client = GoTrueClient(
-        url: gotrueUrl,
-        asyncStorage: TestAsyncStorage(),
-        httpClient: httpClient,
-      );
+      'FIXED: "refresh_token_already_used" error is handled gracefully when session is valid',
+      () async {
+        final httpClient = RefreshTokenTrackingHttpClient();
 
-      // Set up and refresh session
-      final expiredSession = createExpiredSessionForUser1();
-      await client.recoverSession(expiredSession);
-      expect(httpClient.requestCount, 1);
+        final client = GoTrueClient(
+          url: gotrueUrl,
+          asyncStorage: TestAsyncStorage(),
+          httpClient: httpClient,
+          autoRefreshToken: true,
+        );
 
-      final currentToken = client.currentSession?.refreshToken;
+        // Create expired session for the test user
+        final expiredSession = createExpiredSessionForUser1();
 
-      // Second call with stale session (same user)
-      // FIXED: Should return current session without new request
-      final result2 = await client.recoverSession(expiredSession);
+        // 1. Set initial session (doesn't refresh)
+        await client.setInitialSession(expiredSession);
+        expect(client.currentSession?.isExpired, isTrue);
+        expect(httpClient.requestCount, 0);
 
-      expect(result2.session, isNotNull);
-      expect(result2.session?.refreshToken, currentToken);
-      expect(httpClient.requestCount, 1,
+        // 2. First refresh succeeds
+        await client.refreshSession();
+        expect(httpClient.requestCount, 1);
+
+        // 3. Verify the session now has a NEW refresh token
+        final newToken = client.currentSession?.refreshToken;
+        expect(newToken, isNot('-yeS4omysFs9tpUYBws9Rg'));
+        expect(client.currentSession?.isExpired, isFalse);
+
+        // 4. Manually mark the current token as "already used" on the server
+        // This simulates a race condition where another request (e.g., auto-refresh)
+        // already consumed the token before our next refresh attempt
+        httpClient.markTokenAsUsed(newToken!);
+
+        // 5. Attempt refresh - this will get "already_used" error from server
+        // The error handler should detect we have a valid session and return it
+        final response = await client.refreshSession();
+        expect(response.session, isNotNull);
+
+        // Session should still be valid (the error handler returned current session)
+        expect(client.currentSession, isNotNull);
+        expect(client.currentSession?.isExpired, isFalse);
+      },
+    );
+
+    test(
+      'FIXED: signedOut event is NOT emitted when session is still valid',
+      () async {
+        final httpClient = RefreshTokenTrackingHttpClient();
+        final client = GoTrueClient(
+          url: gotrueUrl,
+          asyncStorage: TestAsyncStorage(),
+          httpClient: httpClient,
+        );
+
+        // Create and recover an expired session (first refresh succeeds)
+        final expiredSession = createExpiredSessionForUser1();
+        await client.recoverSession(expiredSession);
+
+        // Capture the valid session after refresh
+        final validSession = client.currentSession;
+        expect(validSession, isNotNull);
+        expect(validSession!.isExpired, isFalse);
+
+        // Listen for auth state changes AFTER first successful refresh
+        final authEvents = <AuthChangeEvent>[];
+        final subscription = client.onAuthStateChange.listen(
+          (state) {
+            authEvents.add(state.event);
+          },
+          onError: (_) {}, // Ignore stream errors
+        );
+
+        // Second call with stale token (same user) - should return current session
+        final result2 = await client.recoverSession(expiredSession);
+
+        // Should succeed
+        expect(result2.session, isNotNull);
+
+        // Wait for any events
+        await Future.delayed(Duration(milliseconds: 50));
+
+        // FIXED: signedOut should NOT be emitted since session is valid
+        expect(
+          authEvents,
+          isNot(contains(AuthChangeEvent.signedOut)),
+          reason: 'Should not sign out user when session is still valid',
+        );
+
+        // Session should still be valid
+        expect(client.currentSession?.accessToken, validSession.accessToken);
+
+        await subscription.cancel();
+      },
+    );
+
+    test(
+      'FIXED: concurrent recoverSession and autoRefreshTick both succeed with same result',
+      () async {
+        final httpClient = RefreshTokenTrackingHttpClient(
+          responseDelay: Duration(milliseconds: 50),
+        );
+
+        final client = GoTrueClient(
+          url: gotrueUrl,
+          asyncStorage: TestAsyncStorage(),
+          httpClient: httpClient,
+          autoRefreshToken: true,
+        );
+
+        // Set up expired session for the test user
+        final expiredSession = createExpiredSessionForUser1();
+        await client.setInitialSession(expiredSession);
+
+        // Start auto-refresh (triggers _autoRefreshTokenTick immediately)
+        client.startAutoRefresh();
+
+        // Simultaneously call recoverSession
+        final recoverFuture = client.recoverSession(expiredSession);
+
+        // Wait a bit for both to potentially start
+        await Future.delayed(Duration(milliseconds: 10));
+
+        // FIXED: Both should succeed
+        final result = await recoverFuture;
+        expect(result.session, isNotNull);
+
+        client.stopAutoRefresh();
+
+        // Should only make ONE or TWO HTTP requests (properly handled)
+        expect(
+          httpClient.requestCount,
+          lessThanOrEqualTo(2),
+          reason: 'Refresh attempts should be handled without errors',
+        );
+
+        // Session should be valid
+        expect(client.currentSession?.isExpired, isFalse);
+      },
+    );
+
+    test(
+      'FIXED: recoverSession returns current session for same user when already valid',
+      () async {
+        final httpClient = RefreshTokenTrackingHttpClient();
+        final client = GoTrueClient(
+          url: gotrueUrl,
+          asyncStorage: TestAsyncStorage(),
+          httpClient: httpClient,
+        );
+
+        // Set up and refresh session
+        final expiredSession = createExpiredSessionForUser1();
+        await client.recoverSession(expiredSession);
+        expect(httpClient.requestCount, 1);
+
+        final currentToken = client.currentSession?.refreshToken;
+
+        // Second call with stale session (same user)
+        // FIXED: Should return current session without new request
+        final result2 = await client.recoverSession(expiredSession);
+
+        expect(result2.session, isNotNull);
+        expect(result2.session?.refreshToken, currentToken);
+        expect(
+          httpClient.requestCount,
+          1,
           reason:
-              'Should not attempt refresh when current session is valid for same user');
-    });
+              'Should not attempt refresh when current session is valid for same user',
+        );
+      },
+    );
 
-    test(
-        'signedOut event carries the sign-out reason on an invalid refresh '
+    test('signedOut event carries the sign-out reason on an invalid refresh '
         'token', () async {
       final client = GoTrueClient(
         url: gotrueUrl,
@@ -492,18 +525,23 @@ void main() {
 
       await pumpEventQueue();
 
-      expect(signedOutState, isNotNull,
-          reason: 'An invalid refresh token should sign the user out');
-      expect(signedOutState!.signOutReason, SignOutReason.sessionExpired,
-          reason: 'The signedOut event should report why the session ended');
+      expect(
+        signedOutState,
+        isNotNull,
+        reason: 'An invalid refresh token should sign the user out',
+      );
+      expect(
+        signedOutState!.signOutReason,
+        SignOutReason.sessionExpired,
+        reason: 'The signedOut event should report why the session ended',
+      );
       expect(signedOutState!.session, isNull);
       expect(client.currentSession, isNull);
 
       await subscription.cancel();
     });
 
-    test(
-        'signedOut event reports a userInitiated reason on an explicit '
+    test('signedOut event reports a userInitiated reason on an explicit '
         'signOut', () async {
       final httpClient = RefreshTokenTrackingHttpClient();
       final client = GoTrueClient(
@@ -529,42 +567,46 @@ void main() {
       await pumpEventQueue();
 
       expect(signedOutState, isNotNull);
-      expect(signedOutState!.signOutReason, SignOutReason.userInitiated,
-          reason: 'An explicit signOut should report a userInitiated reason');
+      expect(
+        signedOutState!.signOutReason,
+        SignOutReason.userInitiated,
+        reason: 'An explicit signOut should report a userInitiated reason',
+      );
 
       await subscription.cancel();
     });
 
-    test('recoverSession stays in the stack trace when the refresh fails',
-        () async {
-      final httpClient = RefreshTokenTrackingHttpClient();
-      // Force the refresh to fail by pre-consuming the persisted refresh token.
-      httpClient.markTokenAsUsed('-yeS4omysFs9tpUYBws9Rg');
-      final client = GoTrueClient(
-        url: gotrueUrl,
-        asyncStorage: TestAsyncStorage(),
-        httpClient: httpClient,
-      );
+    test(
+      'recoverSession stays in the stack trace when the refresh fails',
+      () async {
+        final httpClient = RefreshTokenTrackingHttpClient();
+        // Force the refresh to fail by pre-consuming the persisted refresh token.
+        httpClient.markTokenAsUsed('-yeS4omysFs9tpUYBws9Rg');
+        final client = GoTrueClient(
+          url: gotrueUrl,
+          asyncStorage: TestAsyncStorage(),
+          httpClient: httpClient,
+        );
 
-      Object? caught;
-      StackTrace? trace;
-      try {
-        await client.recoverSession(createExpiredSessionForUser1());
-      } catch (error, stackTrace) {
-        caught = error;
-        trace = stackTrace;
-      }
+        Object? caught;
+        StackTrace? trace;
+        try {
+          await client.recoverSession(createExpiredSessionForUser1());
+        } catch (error, stackTrace) {
+          caught = error;
+          trace = stackTrace;
+        }
 
-      expect(caught, isA<AuthException>());
-      expect(trace, isNotNull);
-      // The refresh runs fire-and-forget internally, so `recoverSession` only
-      // appears in the asynchronous stack trace because it rethrows with the
-      // current stack.
-      expect(trace!.toString(), contains('recoverSession'));
-    });
+        expect(caught, isA<AuthException>());
+        expect(trace, isNotNull);
+        // The refresh runs fire-and-forget internally, so `recoverSession` only
+        // appears in the asynchronous stack trace because it rethrows with the
+        // current stack.
+        expect(trace!.toString(), contains('recoverSession'));
+      },
+    );
 
-    test('recoverSession emits a single error for an expired session',
-        () async {
+    test('recoverSession emits a single error for an expired session', () async {
       final client = GoTrueClient(
         url: gotrueUrl,
         asyncStorage: TestAsyncStorage(),

--- a/packages/gotrue/test/src/broadcast_web_test.dart
+++ b/packages/gotrue/test/src/broadcast_web_test.dart
@@ -1,5 +1,4 @@
 @TestOn('browser')
-
 /// Tests for the web BroadcastChannel implementation.
 library;
 
@@ -35,7 +34,7 @@ void main() {
       // Send message from channel1
       final testMessage = {
         'event': 'test-event',
-        'data': {'foo': 'bar'}
+        'data': {'foo': 'bar'},
       };
       channel1.postMessage(testMessage);
 

--- a/packages/gotrue/test/src/constants_test.dart
+++ b/packages/gotrue/test/src/constants_test.dart
@@ -13,8 +13,10 @@ void main() {
 
     test('has correct default headers', () {
       expect(Constants.defaultHeaders, isA<Map<String, String>>());
-      expect(Constants.defaultHeaders['X-Client-Info'],
-          equals('gotrue-dart/$version'));
+      expect(
+        Constants.defaultHeaders['X-Client-Info'],
+        equals('gotrue-dart/$version'),
+      );
     });
 
     test('has correct default storage key', () {
@@ -26,8 +28,10 @@ void main() {
     });
 
     test('has correct auto refresh tick duration', () {
-      expect(Constants.autoRefreshTickDuration,
-          equals(const Duration(seconds: 10)));
+      expect(
+        Constants.autoRefreshTickDuration,
+        equals(const Duration(seconds: 10)),
+      );
     });
 
     test('has correct auto refresh tick threshold', () {
@@ -59,29 +63,37 @@ void main() {
       expect(AuthChangeEvent.values.length, equals(8));
       expect(AuthChangeEvent.values, contains(AuthChangeEvent.initialSession));
       expect(
-          AuthChangeEvent.values, contains(AuthChangeEvent.passwordRecovery));
+        AuthChangeEvent.values,
+        contains(AuthChangeEvent.passwordRecovery),
+      );
       expect(AuthChangeEvent.values, contains(AuthChangeEvent.signedIn));
       expect(AuthChangeEvent.values, contains(AuthChangeEvent.signedOut));
       expect(AuthChangeEvent.values, contains(AuthChangeEvent.tokenRefreshed));
       expect(AuthChangeEvent.values, contains(AuthChangeEvent.userUpdated));
       // ignore: deprecated_member_use
       expect(AuthChangeEvent.values, contains(AuthChangeEvent.userDeleted));
-      expect(AuthChangeEvent.values,
-          contains(AuthChangeEvent.mfaChallengeVerified));
+      expect(
+        AuthChangeEvent.values,
+        contains(AuthChangeEvent.mfaChallengeVerified),
+      );
     });
 
     test('has correct JS names', () {
       expect(AuthChangeEvent.initialSession.jsName, equals('INITIAL_SESSION'));
       expect(
-          AuthChangeEvent.passwordRecovery.jsName, equals('PASSWORD_RECOVERY'));
+        AuthChangeEvent.passwordRecovery.jsName,
+        equals('PASSWORD_RECOVERY'),
+      );
       expect(AuthChangeEvent.signedIn.jsName, equals('SIGNED_IN'));
       expect(AuthChangeEvent.signedOut.jsName, equals('SIGNED_OUT'));
       expect(AuthChangeEvent.tokenRefreshed.jsName, equals('TOKEN_REFRESHED'));
       expect(AuthChangeEvent.userUpdated.jsName, equals('USER_UPDATED'));
       // ignore: deprecated_member_use
       expect(AuthChangeEvent.userDeleted.jsName, equals(''));
-      expect(AuthChangeEvent.mfaChallengeVerified.jsName,
-          equals('MFA_CHALLENGE_VERIFIED'));
+      expect(
+        AuthChangeEvent.mfaChallengeVerified.jsName,
+        equals('MFA_CHALLENGE_VERIFIED'),
+      );
     });
 
     test('userDeleted is deprecated', () {
@@ -91,23 +103,39 @@ void main() {
 
     group('AuthChangeEventExtended', () {
       test('fromString returns correct event for valid names', () {
-        expect(AuthChangeEventExtended.fromString('initialSession'),
-            equals(AuthChangeEvent.initialSession));
-        expect(AuthChangeEventExtended.fromString('passwordRecovery'),
-            equals(AuthChangeEvent.passwordRecovery));
-        expect(AuthChangeEventExtended.fromString('signedIn'),
-            equals(AuthChangeEvent.signedIn));
-        expect(AuthChangeEventExtended.fromString('signedOut'),
-            equals(AuthChangeEvent.signedOut));
-        expect(AuthChangeEventExtended.fromString('tokenRefreshed'),
-            equals(AuthChangeEvent.tokenRefreshed));
-        expect(AuthChangeEventExtended.fromString('userUpdated'),
-            equals(AuthChangeEvent.userUpdated));
+        expect(
+          AuthChangeEventExtended.fromString('initialSession'),
+          equals(AuthChangeEvent.initialSession),
+        );
+        expect(
+          AuthChangeEventExtended.fromString('passwordRecovery'),
+          equals(AuthChangeEvent.passwordRecovery),
+        );
+        expect(
+          AuthChangeEventExtended.fromString('signedIn'),
+          equals(AuthChangeEvent.signedIn),
+        );
+        expect(
+          AuthChangeEventExtended.fromString('signedOut'),
+          equals(AuthChangeEvent.signedOut),
+        );
+        expect(
+          AuthChangeEventExtended.fromString('tokenRefreshed'),
+          equals(AuthChangeEvent.tokenRefreshed),
+        );
+        expect(
+          AuthChangeEventExtended.fromString('userUpdated'),
+          equals(AuthChangeEvent.userUpdated),
+        );
         // ignore: deprecated_member_use
-        expect(AuthChangeEventExtended.fromString('userDeleted'),
-            equals(AuthChangeEvent.userDeleted));
-        expect(AuthChangeEventExtended.fromString('mfaChallengeVerified'),
-            equals(AuthChangeEvent.mfaChallengeVerified));
+        expect(
+          AuthChangeEventExtended.fromString('userDeleted'),
+          equals(AuthChangeEvent.userDeleted),
+        );
+        expect(
+          AuthChangeEventExtended.fromString('mfaChallengeVerified'),
+          equals(AuthChangeEvent.mfaChallengeVerified),
+        );
       });
 
       test('fromString returns null for invalid names', () {
@@ -123,8 +151,10 @@ void main() {
 
       test('fromString uses enum name, not jsName', () {
         expect(AuthChangeEventExtended.fromString('SIGNED_IN'), isNull);
-        expect(AuthChangeEventExtended.fromString('signedIn'),
-            equals(AuthChangeEvent.signedIn));
+        expect(
+          AuthChangeEventExtended.fromString('signedIn'),
+          equals(AuthChangeEvent.signedIn),
+        );
       });
     });
   });
@@ -136,43 +166,69 @@ void main() {
       expect(GenerateLinkType.values, contains(GenerateLinkType.invite));
       expect(GenerateLinkType.values, contains(GenerateLinkType.magiclink));
       expect(GenerateLinkType.values, contains(GenerateLinkType.recovery));
-      expect(GenerateLinkType.values,
-          contains(GenerateLinkType.emailChangeCurrent));
       expect(
-          GenerateLinkType.values, contains(GenerateLinkType.emailChangeNew));
+        GenerateLinkType.values,
+        contains(GenerateLinkType.emailChangeCurrent),
+      );
+      expect(
+        GenerateLinkType.values,
+        contains(GenerateLinkType.emailChangeNew),
+      );
       expect(GenerateLinkType.values, contains(GenerateLinkType.unknown));
     });
 
     group('GenerateLinkTypeExtended', () {
       test('fromString returns correct type for valid snake_case names', () {
-        expect(GenerateLinkTypeExtended.fromString('signup'),
-            equals(GenerateLinkType.signup));
-        expect(GenerateLinkTypeExtended.fromString('invite'),
-            equals(GenerateLinkType.invite));
-        expect(GenerateLinkTypeExtended.fromString('magiclink'),
-            equals(GenerateLinkType.magiclink));
-        expect(GenerateLinkTypeExtended.fromString('recovery'),
-            equals(GenerateLinkType.recovery));
-        expect(GenerateLinkTypeExtended.fromString('email_change_current'),
-            equals(GenerateLinkType.emailChangeCurrent));
-        expect(GenerateLinkTypeExtended.fromString('email_change_new'),
-            equals(GenerateLinkType.emailChangeNew));
+        expect(
+          GenerateLinkTypeExtended.fromString('signup'),
+          equals(GenerateLinkType.signup),
+        );
+        expect(
+          GenerateLinkTypeExtended.fromString('invite'),
+          equals(GenerateLinkType.invite),
+        );
+        expect(
+          GenerateLinkTypeExtended.fromString('magiclink'),
+          equals(GenerateLinkType.magiclink),
+        );
+        expect(
+          GenerateLinkTypeExtended.fromString('recovery'),
+          equals(GenerateLinkType.recovery),
+        );
+        expect(
+          GenerateLinkTypeExtended.fromString('email_change_current'),
+          equals(GenerateLinkType.emailChangeCurrent),
+        );
+        expect(
+          GenerateLinkTypeExtended.fromString('email_change_new'),
+          equals(GenerateLinkType.emailChangeNew),
+        );
       });
 
       test('fromString returns unknown for invalid names', () {
-        expect(GenerateLinkTypeExtended.fromString('invalid'),
-            equals(GenerateLinkType.unknown));
-        expect(GenerateLinkTypeExtended.fromString('emailChangeCurrent'),
-            equals(GenerateLinkType.unknown));
-        expect(GenerateLinkTypeExtended.fromString('SIGNUP'),
-            equals(GenerateLinkType.unknown));
-        expect(GenerateLinkTypeExtended.fromString(''),
-            equals(GenerateLinkType.unknown));
+        expect(
+          GenerateLinkTypeExtended.fromString('invalid'),
+          equals(GenerateLinkType.unknown),
+        );
+        expect(
+          GenerateLinkTypeExtended.fromString('emailChangeCurrent'),
+          equals(GenerateLinkType.unknown),
+        );
+        expect(
+          GenerateLinkTypeExtended.fromString('SIGNUP'),
+          equals(GenerateLinkType.unknown),
+        );
+        expect(
+          GenerateLinkTypeExtended.fromString(''),
+          equals(GenerateLinkType.unknown),
+        );
       });
 
       test('fromString returns unknown for null input', () {
-        expect(GenerateLinkTypeExtended.fromString(null),
-            equals(GenerateLinkType.unknown));
+        expect(
+          GenerateLinkTypeExtended.fromString(null),
+          equals(GenerateLinkType.unknown),
+        );
       });
 
       test('all enum values have corresponding snake_case representation', () {
@@ -238,10 +294,14 @@ void main() {
       expect(GenerateLinkType.invite.snakeCase, equals('invite'));
       expect(GenerateLinkType.magiclink.snakeCase, equals('magiclink'));
       expect(GenerateLinkType.recovery.snakeCase, equals('recovery'));
-      expect(GenerateLinkType.emailChangeCurrent.snakeCase,
-          equals('email_change_current'));
-      expect(GenerateLinkType.emailChangeNew.snakeCase,
-          equals('email_change_new'));
+      expect(
+        GenerateLinkType.emailChangeCurrent.snakeCase,
+        equals('email_change_current'),
+      );
+      expect(
+        GenerateLinkType.emailChangeNew.snakeCase,
+        equals('email_change_new'),
+      );
       expect(GenerateLinkType.unknown.snakeCase, equals('unknown'));
     });
   });

--- a/packages/gotrue/test/src/gotrue_admin_mfa_api_test.dart
+++ b/packages/gotrue/test/src/gotrue_admin_mfa_api_test.dart
@@ -17,13 +17,13 @@ void main() {
 
   setUp(() async {
     final res = await http.post(
-        Uri.parse(
-            'http://127.0.0.1:54421/rest/v1/rpc/reset_and_init_auth_data'),
-        headers: {
-          'x-forwarded-for': '127.0.0.1',
-          'apikey': serviceRoleToken,
-          'Authorization': 'Bearer $serviceRoleToken',
-        });
+      Uri.parse('http://127.0.0.1:54421/rest/v1/rpc/reset_and_init_auth_data'),
+      headers: {
+        'x-forwarded-for': '127.0.0.1',
+        'apikey': serviceRoleToken,
+        'Authorization': 'Bearer $serviceRoleToken',
+      },
+    );
     if (res.body.isNotEmpty) throw res.body;
 
     client = GoTrueClient(
@@ -31,7 +31,7 @@ void main() {
       headers: {
         'Authorization': 'Bearer $serviceRoleToken',
         'apikey': serviceRoleToken,
-        'x-forwarded-for': '127.0.0.1'
+        'x-forwarded-for': '127.0.0.1',
       },
     );
   });
@@ -40,10 +40,14 @@ void main() {
     final res = await client.admin.mfa.listFactors(userId: userId2);
     expect(res.factors.length, 1);
     final factor = res.factors.first;
-    expect(factor.createdAt.difference(DateTime.now()) < Duration(seconds: 2),
-        true);
-    expect(factor.updatedAt.difference(DateTime.now()) < Duration(seconds: 2),
-        true);
+    expect(
+      factor.createdAt.difference(DateTime.now()) < Duration(seconds: 2),
+      true,
+    );
+    expect(
+      factor.updatedAt.difference(DateTime.now()) < Duration(seconds: 2),
+      true,
+    );
     expect(factor.id, factorId2);
   });
 

--- a/packages/gotrue/test/src/gotrue_admin_oauth_api_test.dart
+++ b/packages/gotrue/test/src/gotrue_admin_oauth_api_test.dart
@@ -17,13 +17,13 @@ void main() {
 
   setUp(() async {
     final res = await http.post(
-        Uri.parse(
-            'http://127.0.0.1:54421/rest/v1/rpc/reset_and_init_auth_data'),
-        headers: {
-          'x-forwarded-for': '127.0.0.1',
-          'apikey': serviceRoleToken,
-          'Authorization': 'Bearer $serviceRoleToken',
-        });
+      Uri.parse('http://127.0.0.1:54421/rest/v1/rpc/reset_and_init_auth_data'),
+      headers: {
+        'x-forwarded-for': '127.0.0.1',
+        'apikey': serviceRoleToken,
+        'Authorization': 'Bearer $serviceRoleToken',
+      },
+    );
     if (res.body.isNotEmpty) throw res.body;
 
     client = GoTrueClient(
@@ -31,7 +31,7 @@ void main() {
       headers: {
         'Authorization': 'Bearer $serviceRoleToken',
         'apikey': serviceRoleToken,
-        'x-forwarded-for': '127.0.0.1'
+        'x-forwarded-for': '127.0.0.1',
       },
     );
   });
@@ -94,8 +94,10 @@ void main() {
       final updateParams = UpdateOAuthClientParams(
         clientName: 'Updated OAuth Client Name',
       );
-      final updateRes =
-          await client.admin.oauth.updateClient(clientId, updateParams);
+      final updateRes = await client.admin.oauth.updateClient(
+        clientId,
+        updateParams,
+      );
       expect(updateRes.client, isNotNull);
       expect(updateRes.client?.clientId, clientId);
       expect(updateRes.client?.clientName, 'Updated OAuth Client Name');
@@ -139,24 +141,32 @@ void main() {
 
   group('validates ids', () {
     test('getClient() validates ids', () {
-      expect(() => client.admin.oauth.getClient('invalid-id'),
-          throwsA(isA<ArgumentError>()));
+      expect(
+        () => client.admin.oauth.getClient('invalid-id'),
+        throwsA(isA<ArgumentError>()),
+      );
     });
 
     test('deleteClient() validates ids', () {
-      expect(() => client.admin.oauth.deleteClient('invalid-id'),
-          throwsA(isA<ArgumentError>()));
+      expect(
+        () => client.admin.oauth.deleteClient('invalid-id'),
+        throwsA(isA<ArgumentError>()),
+      );
     });
 
     test('regenerateClientSecret() validates ids', () {
-      expect(() => client.admin.oauth.regenerateClientSecret('invalid-id'),
-          throwsA(isA<ArgumentError>()));
+      expect(
+        () => client.admin.oauth.regenerateClientSecret('invalid-id'),
+        throwsA(isA<ArgumentError>()),
+      );
     });
 
     test('updateClient() validates ids', () {
       final params = UpdateOAuthClientParams(clientName: 'Updated Name');
-      expect(() => client.admin.oauth.updateClient('invalid-id', params),
-          throwsA(isA<ArgumentError>()));
+      expect(
+        () => client.admin.oauth.updateClient('invalid-id', params),
+        throwsA(isA<ArgumentError>()),
+      );
     });
   });
 }

--- a/packages/gotrue/test/src/gotrue_mfa_api_test.dart
+++ b/packages/gotrue/test/src/gotrue_mfa_api_test.dart
@@ -17,18 +17,18 @@ String _accessToken(Map<String, dynamic> claims) {
 }
 
 Map<String, dynamic> _session(String accessToken) => {
-      'access_token': accessToken,
-      'token_type': 'bearer',
-      'refresh_token': 'refresh-token',
-      'expires_in': 3600,
-      'user': {
-        'id': 'user-id',
-        'aud': 'authenticated',
-        'app_metadata': <String, dynamic>{},
-        'user_metadata': <String, dynamic>{},
-        'created_at': '2023-04-01T09:38:59.784028Z',
-      },
-    };
+  'access_token': accessToken,
+  'token_type': 'bearer',
+  'refresh_token': 'refresh-token',
+  'expires_in': 3600,
+  'user': {
+    'id': 'user-id',
+    'aud': 'authenticated',
+    'app_metadata': <String, dynamic>{},
+    'user_metadata': <String, dynamic>{},
+    'created_at': '2023-04-01T09:38:59.784028Z',
+  },
+};
 
 void main() {
   group('against a running GoTrue instance', () {
@@ -43,13 +43,15 @@ void main() {
     late GoTrueClient client;
     setUp(() async {
       final res = await http.post(
-          Uri.parse(
-              'http://127.0.0.1:54421/rest/v1/rpc/reset_and_init_auth_data'),
-          headers: {
-            'x-forwarded-for': '127.0.0.1',
-            'apikey': getServiceRoleToken(env),
-            'Authorization': 'Bearer ${getServiceRoleToken(env)}',
-          });
+        Uri.parse(
+          'http://127.0.0.1:54421/rest/v1/rpc/reset_and_init_auth_data',
+        ),
+        headers: {
+          'x-forwarded-for': '127.0.0.1',
+          'apikey': getServiceRoleToken(env),
+          'Authorization': 'Bearer ${getServiceRoleToken(env)}',
+        },
+      );
       if (res.body.isNotEmpty) throw res.body;
 
       client = GoTrueClient(
@@ -57,7 +59,7 @@ void main() {
         headers: {
           'Authorization': 'Bearer $anonToken',
           'apikey': anonToken,
-          'x-forwarded-for': '127.0.0.1'
+          'x-forwarded-for': '127.0.0.1',
         },
       );
     });
@@ -65,8 +67,10 @@ void main() {
     test('enroll totp', () async {
       await client.signInWithPassword(password: password, email: email1);
 
-      final res = await client.mfa
-          .enroll(issuer: 'MyFriend', friendlyName: 'MyFriendName');
+      final res = await client.mfa.enroll(
+        issuer: 'MyFriend',
+        friendlyName: 'MyFriendName',
+      );
       final uri = Uri.parse(res.totp!.uri);
 
       expect(res.type, FactorType.totp);
@@ -115,7 +119,10 @@ void main() {
       final challengeRes = await client.mfa.challenge(factorId: factorId1);
 
       final res = await client.mfa.verify(
-          factorId: factorId1, challengeId: challengeRes.id, code: getTOTP());
+        factorId: factorId1,
+        challengeId: challengeRes.id,
+        code: getTOTP(),
+      );
 
       expect(client.currentSession?.accessToken, res.accessToken);
       expect(client.currentUser, res.user);
@@ -128,9 +135,13 @@ void main() {
 
       expect(client.currentUser!.factors!.length, 1);
       expect(
-          client.currentUser!.factors!.first.status, FactorStatus.unverified);
-      final res = await client.mfa
-          .challengeAndVerify(factorId: factorId1, code: getTOTP());
+        client.currentUser!.factors!.first.status,
+        FactorStatus.unverified,
+      );
+      final res = await client.mfa.challengeAndVerify(
+        factorId: factorId1,
+        code: getTOTP(),
+      );
       expect(client.currentUser, res.user);
       expect(client.currentUser!.factors!.length, 1);
       expect(client.currentUser!.factors!.first.id, factorId1);
@@ -157,13 +168,15 @@ void main() {
       expect(res.all.first.id, factorId2);
       expect(res.all.first.status, FactorStatus.verified);
       expect(
-          res.all.first.createdAt.difference(DateTime.now()) <
-              Duration(seconds: 2),
-          true);
+        res.all.first.createdAt.difference(DateTime.now()) <
+            Duration(seconds: 2),
+        true,
+      );
       expect(
-          res.all.first.updatedAt.difference(DateTime.now()) <
-              Duration(seconds: 2),
-          true);
+        res.all.first.updatedAt.difference(DateTime.now()) <
+            Duration(seconds: 2),
+        true,
+      );
     });
 
     test('list factors with phone enrollment', () async {
@@ -216,16 +229,18 @@ void main() {
       final res = client.mfa.getAuthenticatorAssuranceLevel();
       expect(res.currentLevel, AuthenticatorAssuranceLevels.aal2);
       expect(res.nextLevel, AuthenticatorAssuranceLevels.aal2);
-      final passwordEntry = res.currentAuthenticationMethods
-          .firstWhereOrNull((element) => element.method == AMRMethod.password);
-      final totpEntry = res.currentAuthenticationMethods
-          .firstWhereOrNull((element) => element.method == AMRMethod.totp);
+      final passwordEntry = res.currentAuthenticationMethods.firstWhereOrNull(
+        (element) => element.method == AMRMethod.password,
+      );
+      final totpEntry = res.currentAuthenticationMethods.firstWhereOrNull(
+        (element) => element.method == AMRMethod.totp,
+      );
       expect(passwordEntry, isNotNull);
       expect(totpEntry, isNotNull);
       expect(
-          totpEntry!.timestamp.difference(DateTime.now()) <
-              Duration(seconds: 2),
-          true);
+        totpEntry!.timestamp.difference(DateTime.now()) < Duration(seconds: 2),
+        true,
+      );
     });
 
     test('Session object can be properly json serielized', () async {
@@ -238,29 +253,33 @@ void main() {
     });
   });
 
-  test('getAuthenticatorAssuranceLevel does not throw when amr is absent',
-      () async {
-    final expirationTimestamp =
-        DateTime.now().add(const Duration(hours: 1)).millisecondsSinceEpoch ~/
-            1000;
-    // An access token that carries `aal` but no `amr` claim.
-    final accessToken =
-        _accessToken({'exp': expirationTimestamp, 'aal': 'aal1'});
+  test(
+    'getAuthenticatorAssuranceLevel does not throw when amr is absent',
+    () async {
+      final expirationTimestamp =
+          DateTime.now().add(const Duration(hours: 1)).millisecondsSinceEpoch ~/
+          1000;
+      // An access token that carries `aal` but no `amr` claim.
+      final accessToken = _accessToken({
+        'exp': expirationTimestamp,
+        'aal': 'aal1',
+      });
 
-    final localClient = GoTrueClient(
-      url: 'http://localhost',
-      autoRefreshToken: false,
-      flowType: AuthFlowType.implicit,
-    );
-    addTearDown(localClient.dispose);
+      final localClient = GoTrueClient(
+        url: 'http://localhost',
+        autoRefreshToken: false,
+        flowType: AuthFlowType.implicit,
+      );
+      addTearDown(localClient.dispose);
 
-    await localClient.recoverSession(jsonEncode(_session(accessToken)));
+      await localClient.recoverSession(jsonEncode(_session(accessToken)));
 
-    final result = localClient.mfa.getAuthenticatorAssuranceLevel();
+      final result = localClient.mfa.getAuthenticatorAssuranceLevel();
 
-    expect(result.currentLevel, AuthenticatorAssuranceLevels.aal1);
-    expect(result.currentAuthenticationMethods, isEmpty);
-  });
+      expect(result.currentLevel, AuthenticatorAssuranceLevels.aal1);
+      expect(result.currentAuthenticationMethods, isEmpty);
+    },
+  );
 }
 
 String getTOTP() {

--- a/packages/gotrue/test/src/gotrue_oauth_api_test.dart
+++ b/packages/gotrue/test/src/gotrue_oauth_api_test.dart
@@ -23,9 +23,9 @@ void main() {
         },
         'user': {
           'id': '1bee2038-51fe-4f93-8fbb-442df18657ff',
-          'email': 'translator.user@mail.com'
+          'email': 'translator.user@mail.com',
         },
-        'scope': 'email'
+        'scope': 'email',
       };
 
       final actual = OAuthAuthorizationDetailsResponse.fromJson(json);
@@ -56,7 +56,7 @@ void main() {
           'id': '7263e727-435b-4d38-a5ff-a14c954b8680',
           'name': 'OAuth test client',
         },
-        'scope': 'email'
+        'scope': 'email',
       };
 
       expect(
@@ -205,20 +205,22 @@ class GotrueOauthApiFixture {
     return Uri.parse(location).queryParameters['authorization_id']!;
   }
 
-  Future<AuthResponse> sutLogsIn(
-      {required String email, required String password}) {
+  Future<AuthResponse> sutLogsIn({
+    required String email,
+    required String password,
+  }) {
     return _client.signInWithPassword(password: password, email: email);
   }
 
   Future<void> _reset() async {
     final res = await http.post(
-        Uri.parse(
-            'http://127.0.0.1:54421/rest/v1/rpc/reset_and_init_auth_data'),
-        headers: {
-          'x-forwarded-for': '127.0.0.1',
-          'apikey': _serviceRoleToken,
-          'Authorization': 'Bearer $_serviceRoleToken',
-        });
+      Uri.parse('http://127.0.0.1:54421/rest/v1/rpc/reset_and_init_auth_data'),
+      headers: {
+        'x-forwarded-for': '127.0.0.1',
+        'apikey': _serviceRoleToken,
+        'Authorization': 'Bearer $_serviceRoleToken',
+      },
+    );
     if (res.body.isNotEmpty) throw res.body;
   }
 

--- a/packages/gotrue/test/src/helper_test.dart
+++ b/packages/gotrue/test/src/helper_test.dart
@@ -7,9 +7,11 @@ void main() {
       test('generates verifier with correct character set', () {
         final codeVerifier = generatePKCEVerifier();
         final regex = RegExp(r'^[A-Za-z0-9_-]*$');
-        expect(regex.hasMatch(codeVerifier), isTrue,
-            reason:
-                'Code verifier "$codeVerifier" contains invalid characters');
+        expect(
+          regex.hasMatch(codeVerifier),
+          isTrue,
+          reason: 'Code verifier "$codeVerifier" contains invalid characters',
+        );
       });
 
       test('generates verifier with correct length', () {
@@ -45,9 +47,11 @@ void main() {
         final codeVerifier = generatePKCEVerifier();
         final codeChallenge = generatePKCEChallenge(codeVerifier);
         final regex = RegExp(r'^[A-Za-z0-9_-]*$');
-        expect(regex.hasMatch(codeChallenge), isTrue,
-            reason:
-                'Code challenge "$codeChallenge" contains invalid characters');
+        expect(
+          regex.hasMatch(codeChallenge),
+          isTrue,
+          reason: 'Code challenge "$codeChallenge" contains invalid characters',
+        );
       });
 
       test('generates same challenge for same verifier', () {
@@ -84,8 +88,9 @@ void main() {
       });
 
       test('handles special characters in verifier', () {
-        final codeChallenge =
-            generatePKCEChallenge('test-verifier_with.special~chars');
+        final codeChallenge = generatePKCEChallenge(
+          'test-verifier_with.special~chars',
+        );
         expect(codeChallenge, isNotEmpty);
         final regex = RegExp(r'^[A-Za-z0-9_-]*$');
         expect(regex.hasMatch(codeChallenge), isTrue);
@@ -120,73 +125,115 @@ void main() {
   group('UUID validation', () {
     group('validateUuid', () {
       test('accepts valid UUID v4', () {
-        expect(() => validateUuid('550e8400-e29b-41d4-a716-446655440000'),
-            returnsNormally);
-        expect(() => validateUuid('6ba7b810-9dad-11d1-80b4-00c04fd430c8'),
-            returnsNormally);
-        expect(() => validateUuid('6ba7b811-9dad-11d1-80b4-00c04fd430c8'),
-            returnsNormally);
+        expect(
+          () => validateUuid('550e8400-e29b-41d4-a716-446655440000'),
+          returnsNormally,
+        );
+        expect(
+          () => validateUuid('6ba7b810-9dad-11d1-80b4-00c04fd430c8'),
+          returnsNormally,
+        );
+        expect(
+          () => validateUuid('6ba7b811-9dad-11d1-80b4-00c04fd430c8'),
+          returnsNormally,
+        );
       });
 
       test('accepts valid UUID with lowercase only', () {
-        expect(() => validateUuid('550e8400-e29b-41d4-a716-446655440000'),
-            returnsNormally);
+        expect(
+          () => validateUuid('550e8400-e29b-41d4-a716-446655440000'),
+          returnsNormally,
+        );
       });
 
       test('rejects UUID with uppercase characters', () {
-        expect(() => validateUuid('550E8400-E29B-41D4-A716-446655440000'),
-            throwsArgumentError);
+        expect(
+          () => validateUuid('550E8400-E29B-41D4-A716-446655440000'),
+          throwsArgumentError,
+        );
       });
 
       test('accepts nil UUID', () {
-        expect(() => validateUuid('00000000-0000-0000-0000-000000000000'),
-            returnsNormally);
+        expect(
+          () => validateUuid('00000000-0000-0000-0000-000000000000'),
+          returnsNormally,
+        );
       });
 
       test('rejects invalid UUID formats', () {
         expect(() => validateUuid('invalid-uuid'), throwsArgumentError);
         expect(
-            () => validateUuid('550e8400-e29b-41d4-a716'), throwsArgumentError);
-        expect(() => validateUuid('550e8400-e29b-41d4-a716-446655440000-extra'),
-            throwsArgumentError);
-        expect(() => validateUuid('550e8400e29b41d4a716446655440000'),
-            throwsArgumentError);
+          () => validateUuid('550e8400-e29b-41d4-a716'),
+          throwsArgumentError,
+        );
+        expect(
+          () => validateUuid('550e8400-e29b-41d4-a716-446655440000-extra'),
+          throwsArgumentError,
+        );
+        expect(
+          () => validateUuid('550e8400e29b41d4a716446655440000'),
+          throwsArgumentError,
+        );
       });
 
       test('rejects UUID with wrong character count', () {
-        expect(() => validateUuid('550e8400-e29b-41d4-a716-44665544000'),
-            throwsArgumentError);
-        expect(() => validateUuid('550e8400-e29b-41d4-a716-4466554400000'),
-            throwsArgumentError);
+        expect(
+          () => validateUuid('550e8400-e29b-41d4-a716-44665544000'),
+          throwsArgumentError,
+        );
+        expect(
+          () => validateUuid('550e8400-e29b-41d4-a716-4466554400000'),
+          throwsArgumentError,
+        );
       });
 
       test('rejects UUID with invalid characters', () {
-        expect(() => validateUuid('550e8400-e29b-41d4-a716-44665544000g'),
-            throwsArgumentError);
-        expect(() => validateUuid('550e8400-e29b-41d4-a716-44665544000G'),
-            throwsArgumentError);
-        expect(() => validateUuid('550e8400-e29b-41d4-a716-44665544000!'),
-            throwsArgumentError);
+        expect(
+          () => validateUuid('550e8400-e29b-41d4-a716-44665544000g'),
+          throwsArgumentError,
+        );
+        expect(
+          () => validateUuid('550e8400-e29b-41d4-a716-44665544000G'),
+          throwsArgumentError,
+        );
+        expect(
+          () => validateUuid('550e8400-e29b-41d4-a716-44665544000!'),
+          throwsArgumentError,
+        );
       });
 
       test('rejects UUID with missing hyphens', () {
-        expect(() => validateUuid('550e8400e29b-41d4-a716-446655440000'),
-            throwsArgumentError);
-        expect(() => validateUuid('550e8400-e29b41d4-a716-446655440000'),
-            throwsArgumentError);
-        expect(() => validateUuid('550e8400-e29b-41d4a716-446655440000'),
-            throwsArgumentError);
-        expect(() => validateUuid('550e8400-e29b-41d4-a716446655440000'),
-            throwsArgumentError);
+        expect(
+          () => validateUuid('550e8400e29b-41d4-a716-446655440000'),
+          throwsArgumentError,
+        );
+        expect(
+          () => validateUuid('550e8400-e29b41d4-a716-446655440000'),
+          throwsArgumentError,
+        );
+        expect(
+          () => validateUuid('550e8400-e29b-41d4a716-446655440000'),
+          throwsArgumentError,
+        );
+        expect(
+          () => validateUuid('550e8400-e29b-41d4-a716446655440000'),
+          throwsArgumentError,
+        );
       });
 
       test('rejects UUID with extra hyphens', () {
-        expect(() => validateUuid('550e-8400-e29b-41d4-a716-446655440000'),
-            throwsArgumentError);
-        expect(() => validateUuid('550e8400--e29b-41d4-a716-446655440000'),
-            throwsArgumentError);
-        expect(() => validateUuid('550e8400-e29b-41d4-a716-446655440000-'),
-            throwsArgumentError);
+        expect(
+          () => validateUuid('550e-8400-e29b-41d4-a716-446655440000'),
+          throwsArgumentError,
+        );
+        expect(
+          () => validateUuid('550e8400--e29b-41d4-a716-446655440000'),
+          throwsArgumentError,
+        );
+        expect(
+          () => validateUuid('550e8400-e29b-41d4-a716-446655440000-'),
+          throwsArgumentError,
+        );
       });
 
       test('rejects empty string', () {
@@ -201,11 +248,19 @@ void main() {
       test('provides helpful error message', () {
         expect(
           () => validateUuid('invalid-id'),
-          throwsA(isA<ArgumentError>()
-              .having((e) => e.toString(), 'toString()',
-                  contains('Invalid id: invalid-id'))
-              .having((e) => e.toString(), 'toString()',
-                  contains('must be a valid UUID'))),
+          throwsA(
+            isA<ArgumentError>()
+                .having(
+                  (e) => e.toString(),
+                  'toString()',
+                  contains('Invalid id: invalid-id'),
+                )
+                .having(
+                  (e) => e.toString(),
+                  'toString()',
+                  contains('must be a valid UUID'),
+                ),
+          ),
         );
       });
 
@@ -213,8 +268,13 @@ void main() {
         const invalidId = 'test-invalid-uuid-123';
         expect(
           () => validateUuid(invalidId),
-          throwsA(isA<ArgumentError>()
-              .having((e) => e.toString(), 'toString()', contains(invalidId))),
+          throwsA(
+            isA<ArgumentError>().having(
+              (e) => e.toString(),
+              'toString()',
+              contains(invalidId),
+            ),
+          ),
         );
       });
     });
@@ -222,37 +282,51 @@ void main() {
     group('uuidRegex', () {
       test('matches valid UUIDs', () {
         expect(
-            uuidRegex.hasMatch('550e8400-e29b-41d4-a716-446655440000'), isTrue);
+          uuidRegex.hasMatch('550e8400-e29b-41d4-a716-446655440000'),
+          isTrue,
+        );
         expect(
-            uuidRegex.hasMatch('6ba7b810-9dad-11d1-80b4-00c04fd430c8'), isTrue);
+          uuidRegex.hasMatch('6ba7b810-9dad-11d1-80b4-00c04fd430c8'),
+          isTrue,
+        );
         expect(
-            uuidRegex.hasMatch('00000000-0000-0000-0000-000000000000'), isTrue);
+          uuidRegex.hasMatch('00000000-0000-0000-0000-000000000000'),
+          isTrue,
+        );
       });
 
       test('does not match invalid UUIDs', () {
         expect(uuidRegex.hasMatch('invalid-uuid'), isFalse);
         expect(uuidRegex.hasMatch('550e8400-e29b-41d4-a716'), isFalse);
         expect(uuidRegex.hasMatch('550e8400e29b41d4a716446655440000'), isFalse);
-        expect(uuidRegex.hasMatch('550e8400-e29b-41d4-a716-44665544000g'),
-            isFalse);
+        expect(
+          uuidRegex.hasMatch('550e8400-e29b-41d4-a716-44665544000g'),
+          isFalse,
+        );
       });
 
       test('only matches lowercase hexadecimal characters', () {
         // Note: The uuidRegex specifically checks for lowercase hex characters
         // while validateUuid accepts both cases
-        expect(uuidRegex.hasMatch('550E8400-E29B-41D4-A716-446655440000'),
-            isFalse);
         expect(
-            uuidRegex.hasMatch('550e8400-e29b-41d4-a716-446655440000'), isTrue);
+          uuidRegex.hasMatch('550E8400-E29B-41D4-A716-446655440000'),
+          isFalse,
+        );
+        expect(
+          uuidRegex.hasMatch('550e8400-e29b-41d4-a716-446655440000'),
+          isTrue,
+        );
       });
 
       test('matches exact pattern without partial matches', () {
         expect(
-            uuidRegex.hasMatch('prefix-550e8400-e29b-41d4-a716-446655440000'),
-            isFalse);
+          uuidRegex.hasMatch('prefix-550e8400-e29b-41d4-a716-446655440000'),
+          isFalse,
+        );
         expect(
-            uuidRegex.hasMatch('550e8400-e29b-41d4-a716-446655440000-suffix'),
-            isFalse);
+          uuidRegex.hasMatch('550e8400-e29b-41d4-a716-446655440000-suffix'),
+          isFalse,
+        );
       });
     });
   });

--- a/packages/gotrue/test/src/set_session_test.dart
+++ b/packages/gotrue/test/src/set_session_test.dart
@@ -9,18 +9,18 @@ import '../utils.dart';
 
 // Minimal user payload accepted by User.fromJson.
 Map<String, dynamic> get _mockUserJson => {
-      'id': 'mock-user-id',
-      'aud': 'authenticated',
-      'role': 'authenticated',
-      'email': 'mock@example.com',
-      'app_metadata': {
-        'provider': 'email',
-        'providers': ['email'],
-      },
-      'user_metadata': {},
-      'created_at': '2024-01-01T00:00:00.000Z',
-      'updated_at': '2024-01-01T00:00:00.000Z',
-    };
+  'id': 'mock-user-id',
+  'aud': 'authenticated',
+  'role': 'authenticated',
+  'email': 'mock@example.com',
+  'app_metadata': {
+    'provider': 'email',
+    'providers': ['email'],
+  },
+  'user_metadata': {},
+  'created_at': '2024-01-01T00:00:00.000Z',
+  'updated_at': '2024-01-01T00:00:00.000Z',
+};
 
 /// Mock HTTP client for setSession tests.
 ///
@@ -96,8 +96,7 @@ void main() {
   });
 
   group('setSession — validation edge cases', () {
-    test(
-        'empty refresh token with a non-null access token throws before '
+    test('empty refresh token with a non-null access token throws before '
         'inspecting the access token', () async {
       final exp = DateTime.now().millisecondsSinceEpoch ~/ 1000 + 3600;
       final at = _makeRawJwt({
@@ -114,8 +113,7 @@ void main() {
       expect(mockClient.userCallCount, 0);
     });
 
-    test(
-        'access token with exp within the 30-second expiry margin is treated '
+    test('access token with exp within the 30-second expiry margin is treated '
         'as expired and falls back to the refresh-token path', () async {
       final timeNow = DateTime.now().millisecondsSinceEpoch ~/ 1000;
       // exp is 20 s in the future, inside the 30 s Constants.expiryMargin.
@@ -136,8 +134,7 @@ void main() {
       expect(mockClient.userCallCount, 0); // /user was NOT called
     });
 
-    test(
-        'access token with no exp claim is treated as expired and falls back '
+    test('access token with no exp claim is treated as expired and falls back '
         'to the refresh-token path', () async {
       // JWT without an exp claim: decodeJwt succeeds but exp == null.
       final at = _makeRawJwt({'role': 'authenticated', 'sub': 'mock-user-id'});

--- a/packages/gotrue/test/src/token_refresh_race_test.dart
+++ b/packages/gotrue/test/src/token_refresh_race_test.dart
@@ -12,18 +12,18 @@ import '../utils.dart';
 // ---------------------------------------------------------------------------
 
 Map<String, dynamic> get _mockUserJson => {
-      'id': 'mock-user-id',
-      'aud': 'authenticated',
-      'role': 'authenticated',
-      'email': 'mock@example.com',
-      'app_metadata': {
-        'provider': 'email',
-        'providers': ['email'],
-      },
-      'user_metadata': {},
-      'created_at': '2024-01-01T00:00:00.000Z',
-      'updated_at': '2024-01-01T00:00:00.000Z',
-    };
+  'id': 'mock-user-id',
+  'aud': 'authenticated',
+  'role': 'authenticated',
+  'email': 'mock@example.com',
+  'app_metadata': {
+    'provider': 'email',
+    'providers': ['email'],
+  },
+  'user_metadata': {},
+  'created_at': '2024-01-01T00:00:00.000Z',
+  'updated_at': '2024-01-01T00:00:00.000Z',
+};
 
 String _makeRawJwt(Map<String, dynamic> payload) {
   final header = base64Url.encode(
@@ -85,18 +85,26 @@ class _DelayedTokenMockClient extends BaseClient {
 
       if (tokenStatusOverride != null) {
         return StreamedResponse(
-          Stream.value(utf8.encode(jsonEncode({
-            'error': 'invalid_grant',
-            'error_description': 'Token has been revoked',
-          }))),
+          Stream.value(
+            utf8.encode(
+              jsonEncode({
+                'error': 'invalid_grant',
+                'error_description': 'Token has been revoked',
+              }),
+            ),
+          ),
           tokenStatusOverride!,
         );
       }
 
       return StreamedResponse(
-        Stream.value(utf8.encode(_tokenResponseJson(
-          refreshToken: responseRefreshToken,
-        ))),
+        Stream.value(
+          utf8.encode(
+            _tokenResponseJson(
+              refreshToken: responseRefreshToken,
+            ),
+          ),
+        ),
         200,
       );
     }
@@ -211,8 +219,7 @@ void main() {
       expect(mockClient.tokenRequestCount, 1);
     });
 
-    test(
-        'concurrent refresh with different tokens '
+    test('concurrent refresh with different tokens '
         'both execute (version guard ensures correctness)', () async {
       final future1 = client.setSession('token-A');
       final future2 = client.setSession('token-B');
@@ -223,8 +230,7 @@ void main() {
       expect(mockClient.tokenRequestCount, 2);
     });
 
-    test(
-        'A-B-A pattern: repeated token request deduplicates '
+    test('A-B-A pattern: repeated token request deduplicates '
         'even when another token is in-flight', () async {
       mockClient.tokenGate = Completer<void>();
 
@@ -262,16 +268,17 @@ void main() {
 
       await expectLater(
         refreshFuture,
-        throwsA(isA<AuthException>().having(
-          (e) => e.message,
-          'message',
-          'Disposed',
-        )),
+        throwsA(
+          isA<AuthException>().having(
+            (e) => e.message,
+            'message',
+            'Disposed',
+          ),
+        ),
       );
     });
 
-    test(
-        'refresh failure does not sign out '
+    test('refresh failure does not sign out '
         'if session changed during refresh', () async {
       mockClient.tokenGate = Completer<void>();
       mockClient.tokenStatusOverride = 400; // non-retryable error
@@ -300,28 +307,30 @@ void main() {
       expect(client.currentSession?.refreshToken, 'new-refresh-token');
     });
 
-    test('signOut event is emitted when refresh fails and session is unchanged',
-        () async {
-      final events = <AuthChangeEvent>[];
-      client.onAuthStateChange.listen((state) {
-        events.add(state.event);
-      });
+    test(
+      'signOut event is emitted when refresh fails and session is unchanged',
+      () async {
+        final events = <AuthChangeEvent>[];
+        client.onAuthStateChange.listen((state) {
+          events.add(state.event);
+        });
 
-      // Set an initial session.
-      final freshAt = _freshAccessToken();
-      await client.setSession('initial-token', accessToken: freshAt);
-      events.clear();
+        // Set an initial session.
+        final freshAt = _freshAccessToken();
+        await client.setSession('initial-token', accessToken: freshAt);
+        events.clear();
 
-      // Now make a refresh that will fail with a non-retryable error.
-      mockClient.tokenStatusOverride = 400;
+        // Now make a refresh that will fail with a non-retryable error.
+        mockClient.tokenStatusOverride = 400;
 
-      try {
-        await client.refreshSession('initial-token');
-      } catch (_) {}
+        try {
+          await client.refreshSession('initial-token');
+        } catch (_) {}
 
-      // Without any concurrent session changes, the failure should sign out.
-      expect(client.currentSession, isNull);
-      expect(events, contains(AuthChangeEvent.signedOut));
-    });
+        // Without any concurrent session changes, the failure should sign out.
+        expect(client.currentSession, isNull);
+        expect(events, contains(AuthChangeEvent.signedOut));
+      },
+    );
   });
 }

--- a/packages/gotrue/test/src/types/auth_exception_test.dart
+++ b/packages/gotrue/test/src/types/auth_exception_test.dart
@@ -100,8 +100,10 @@ void main() {
       });
 
       test('returns false for exceptions with different codes', () {
-        const exception1 =
-            AuthException('Test error', code: 'validation_failed');
+        const exception1 = AuthException(
+          'Test error',
+          code: 'validation_failed',
+        );
         const exception2 = AuthException('Test error', code: 'bad_json');
 
         expect(exception1, isNot(equals(exception2)));
@@ -109,8 +111,11 @@ void main() {
 
       test('handles null values correctly in equality', () {
         const exception1 = AuthException('Test error');
-        const exception2 =
-            AuthException('Test error', statusCode: null, code: null);
+        const exception2 = AuthException(
+          'Test error',
+          statusCode: null,
+          code: null,
+        );
 
         expect(exception1, equals(exception2));
       });
@@ -346,8 +351,10 @@ void main() {
       expect(exception.message, equals('Password is too weak'));
       expect(exception.statusCode, equals('422'));
       expect(exception.code, equals(ErrorCode.weakPassword.code));
-      expect(exception.reasons,
-          equals(['too_short', 'no_uppercase', 'no_numbers']));
+      expect(
+        exception.reasons,
+        equals(['too_short', 'no_uppercase', 'no_numbers']),
+      );
     });
 
     test('automatically sets code to weak_password', () {
@@ -422,7 +429,9 @@ void main() {
         AuthRetryableFetchException(),
         AuthApiException('api error'),
         AuthUnknownException(
-            message: 'unknown error', originalError: 'original'),
+          message: 'unknown error',
+          originalError: 'original',
+        ),
         AuthWeakPasswordException(
           message: 'weak password',
           statusCode: '422',

--- a/packages/gotrue/test/src/types/session_test.dart
+++ b/packages/gotrue/test/src/types/session_test.dart
@@ -103,8 +103,10 @@ void main() {
         expect(session.refreshToken, equals('test-refresh-token'));
         expect(session.tokenType, equals('bearer'));
         expect(session.providerToken, equals('test-provider-token'));
-        expect(session.providerRefreshToken,
-            equals('test-provider-refresh-token'));
+        expect(
+          session.providerRefreshToken,
+          equals('test-provider-refresh-token'),
+        );
         expect(session.user.id, equals('123'));
       });
     });
@@ -134,8 +136,10 @@ void main() {
         expect(json['refresh_token'], equals('test-refresh-token'));
         expect(json['token_type'], equals('bearer'));
         expect(json['provider_token'], equals('test-provider-token'));
-        expect(json['provider_refresh_token'],
-            equals('test-provider-refresh-token'));
+        expect(
+          json['provider_refresh_token'],
+          equals('test-provider-refresh-token'),
+        );
         expect(json['user'], equals(mockUser.toJson()));
         expect(json['expires_at'], isNotNull);
       });
@@ -361,7 +365,9 @@ void main() {
         expect(copy.tokenType, equals(original.tokenType));
         expect(copy.providerToken, equals(original.providerToken));
         expect(
-            copy.providerRefreshToken, equals(original.providerRefreshToken));
+          copy.providerRefreshToken,
+          equals(original.providerRefreshToken),
+        );
         expect(copy.user, equals(original.user));
       });
     });
@@ -518,8 +524,10 @@ void main() {
         expect(restored.refreshToken, equals(original.refreshToken));
         expect(restored.tokenType, equals(original.tokenType));
         expect(restored.providerToken, equals(original.providerToken));
-        expect(restored.providerRefreshToken,
-            equals(original.providerRefreshToken));
+        expect(
+          restored.providerRefreshToken,
+          equals(original.providerRefreshToken),
+        );
         expect(restored.user, equals(original.user));
       });
     });

--- a/packages/gotrue/test/src/types/user_attributes_test.dart
+++ b/packages/gotrue/test/src/types/user_attributes_test.dart
@@ -71,7 +71,7 @@ void main() {
     setUp(() {
       userMetadata = {'first_name': 'John', 'last_name': 'Doe'};
       appMetadata = {
-        'roles': ['admin']
+        'roles': ['admin'],
       };
       emailConfirm = true;
       phoneConfirm = true;

--- a/packages/gotrue/test/src/types/user_test.dart
+++ b/packages/gotrue/test/src/types/user_test.dart
@@ -83,9 +83,13 @@ void main() {
         expect(user, isNotNull);
         expect(user!.id, equals('123'));
         expect(
-            user.appMetadata, equals(<String, dynamic>{'provider': 'email'}));
+          user.appMetadata,
+          equals(<String, dynamic>{'provider': 'email'}),
+        );
         expect(
-            user.userMetadata, equals(<String, dynamic>{'name': 'John Doe'}));
+          user.userMetadata,
+          equals(<String, dynamic>{'name': 'John Doe'}),
+        );
         expect(user.aud, equals('authenticated'));
         expect(user.confirmationSentAt, equals('2023-01-01T00:00:00Z'));
         expect(user.recoverySentAt, equals('2023-01-01T01:00:00Z'));
@@ -180,7 +184,7 @@ void main() {
               'provider': 'email',
               'created_at': '2023-01-01T00:00:00Z',
               'last_sign_in_at': '2023-01-01T00:00:00Z',
-            }
+            },
           ],
         };
 
@@ -208,7 +212,7 @@ void main() {
               'status': 'verified',
               'created_at': '2023-01-01T00:00:00Z',
               'updated_at': '2023-01-01T00:00:00Z',
-            }
+            },
           ],
         };
 
@@ -441,10 +445,10 @@ void main() {
         const user1 = User(
           id: '123',
           appMetadata: {
-            'nested': <String, dynamic>{'key': 'value'}
+            'nested': <String, dynamic>{'key': 'value'},
           },
           userMetadata: <String, dynamic>{
-            'list': [1, 2, 3]
+            'list': [1, 2, 3],
           },
           aud: 'authenticated',
           createdAt: '2023-01-01T00:00:00Z',
@@ -453,10 +457,10 @@ void main() {
         const user2 = User(
           id: '123',
           appMetadata: {
-            'nested': <String, dynamic>{'key': 'value'}
+            'nested': <String, dynamic>{'key': 'value'},
           },
           userMetadata: <String, dynamic>{
-            'list': [1, 2, 3]
+            'list': [1, 2, 3],
           },
           aud: 'authenticated',
           createdAt: '2023-01-01T00:00:00Z',
@@ -503,11 +507,11 @@ void main() {
           appMetadata: {
             'provider': 'oauth',
             'providers': ['google', 'facebook'],
-            'nested': <String, dynamic>{'deep': 'value'}
+            'nested': <String, dynamic>{'deep': 'value'},
           },
           userMetadata: <String, dynamic>{
             'profile': <String, dynamic>{'name': 'John', 'age': 30},
-            'preferences': ['dark_mode', 'notifications']
+            'preferences': ['dark_mode', 'notifications'],
           },
           aud: 'authenticated',
           createdAt: '2023-01-01T00:00:00Z',
@@ -539,8 +543,10 @@ void main() {
 
         expect(identity.id, equals('identity-1'));
         expect(identity.userId, equals('123'));
-        expect(identity.identityData,
-            equals(<String, dynamic>{'email': 'test@example.com'}));
+        expect(
+          identity.identityData,
+          equals(<String, dynamic>{'email': 'test@example.com'}),
+        );
         expect(identity.identityId, equals('identity-1'));
         expect(identity.provider, equals('email'));
         expect(identity.createdAt, equals('2023-01-01T00:00:00Z'));
@@ -613,8 +619,10 @@ void main() {
 
         expect(json['id'], equals('identity-1'));
         expect(json['user_id'], equals('123'));
-        expect(json['identity_data'],
-            equals(<String, dynamic>{'email': 'test@example.com'}));
+        expect(
+          json['identity_data'],
+          equals(<String, dynamic>{'email': 'test@example.com'}),
+        );
         expect(json['identity_id'], equals('identity-1'));
         expect(json['provider'], equals('email'));
         expect(json['created_at'], equals('2023-01-01T00:00:00Z'));
@@ -642,8 +650,10 @@ void main() {
 
         expect(copy.id, equals(original.id));
         expect(copy.userId, equals(original.userId));
-        expect(copy.identityData,
-            equals(<String, dynamic>{'email': 'new@example.com'}));
+        expect(
+          copy.identityData,
+          equals(<String, dynamic>{'email': 'new@example.com'}),
+        );
         expect(copy.identityId, equals(original.identityId));
         expect(copy.provider, equals(original.provider));
         expect(copy.createdAt, equals(original.createdAt));
@@ -750,7 +760,7 @@ void main() {
           id: 'identity-1',
           userId: '123',
           identityData: <String, dynamic>{
-            'nested': <String, dynamic>{'key': 'value'}
+            'nested': <String, dynamic>{'key': 'value'},
           },
           identityId: 'identity-1',
           provider: 'email',
@@ -762,7 +772,7 @@ void main() {
           id: 'identity-1',
           userId: '123',
           identityData: <String, dynamic>{
-            'nested': <String, dynamic>{'key': 'value'}
+            'nested': <String, dynamic>{'key': 'value'},
           },
           identityId: 'identity-1',
           provider: 'email',
@@ -795,7 +805,7 @@ void main() {
           userId: '123',
           identityData: <String, dynamic>{
             'email': 'test@example.com',
-            'verified': true
+            'verified': true,
           },
           identityId: 'identity-1',
           provider: 'email',

--- a/packages/gotrue/test/utils.dart
+++ b/packages/gotrue/test/utils.dart
@@ -27,14 +27,14 @@ const factorId2 = '2d3aa138-da96-4aea-8217-af07daa6b82d';
 final password = 'secret';
 
 String getNewEmail() {
-  final timestamp =
-      (DateTime.now().microsecondsSinceEpoch / (1000 * 1000)).round();
+  final timestamp = (DateTime.now().microsecondsSinceEpoch / (1000 * 1000))
+      .round();
   return 'fake$timestamp@email.com';
 }
 
 String getNewPhone() {
-  final timestamp =
-      (DateTime.now().microsecondsSinceEpoch / (1000 * 1000)).round();
+  final timestamp = (DateTime.now().microsecondsSinceEpoch / (1000 * 1000))
+      .round();
   return '$timestamp';
 }
 
@@ -57,10 +57,18 @@ const sessionDataUserId = '4d2583da-8de4-49d3-9cd1-37a9a74f55bd';
 
 /// Construct session data for a given expiration date
 ({String accessToken, String sessionString}) getSessionData(
-    DateTime expireDateTime) {
+  DateTime expireDateTime,
+) {
   final expiresAt = expireDateTime.millisecondsSinceEpoch ~/ 1000;
-  final accessTokenMid = base64.encode(utf8.encode(json.encode(
-      {'exp': expiresAt, 'sub': '1234567890', 'role': 'authenticated'})));
+  final accessTokenMid = base64.encode(
+    utf8.encode(
+      json.encode({
+        'exp': expiresAt,
+        'sub': '1234567890',
+        'role': 'authenticated',
+      }),
+    ),
+  );
   final accessToken = 'any.$accessTokenMid.any';
   final sessionString =
       '{"access_token":"$accessToken","expires_in":${expireDateTime.difference(DateTime.now()).inSeconds},"refresh_token":"-yeS4omysFs9tpUYBws9Rg","token_type":"bearer","provider_token":null,"provider_refresh_token":null,"user":{"id":"$sessionDataUserId","app_metadata":{"provider":"email","providers":["email"]},"user_metadata":{"Hello":"World"},"aud":"","email":"fake1680338105@email.com","phone":"","created_at":"2023-04-01T08:35:05.208586Z","confirmed_at":null,"email_confirmed_at":"2023-04-01T08:35:05.220096086Z","phone_confirmed_at":null,"last_sign_in_at":"2023-04-01T08:35:05.222755878Z","role":"","updated_at":"2023-04-01T08:35:05.226938Z"}}';

--- a/packages/postgrest/lib/src/postgrest.dart
+++ b/packages/postgrest/lib/src/postgrest.dart
@@ -40,11 +40,11 @@ class PostgrestClient {
     YAJsonIsolate? isolate,
     this.retryEnabled = true,
     @visibleForTesting Duration Function(int attempt)? retryDelay,
-  })  : _schema = schema,
-        headers = {...defaultHeaders, ...?headers},
-        _isolate = isolate ?? (YAJsonIsolate()..initialize()),
-        _hasCustomIsolate = isolate != null,
-        _retryDelay = retryDelay {
+  }) : _schema = schema,
+       headers = {...defaultHeaders, ...?headers},
+       _isolate = isolate ?? (YAJsonIsolate()..initialize()),
+       _hasCustomIsolate = isolate != null,
+       _retryDelay = retryDelay {
     _log.config('Initialize PostgrestClient with url: $url, schema: $_schema');
     _log.finest('Initialize with headers: $headers');
   }

--- a/packages/postgrest/lib/src/postgrest_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_builder.dart
@@ -73,18 +73,18 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
     PostgrestConverter<S, R>? converter,
     bool retryEnabled = true,
     @visibleForTesting Duration Function(int attempt)? retryDelay,
-  })  : _maybeSingle = maybeSingle,
-        _method = method,
-        _converter = converter,
-        _schema = schema,
-        _url = url,
-        _headers = headers,
-        _httpClient = httpClient,
-        _isolate = isolate,
-        _count = count,
-        _body = body,
-        _retryEnabled = retryEnabled,
-        _retryDelay = retryDelay ?? _defaultRetryDelay;
+  }) : _maybeSingle = maybeSingle,
+       _method = method,
+       _converter = converter,
+       _schema = schema,
+       _url = url,
+       _headers = headers,
+       _httpClient = httpClient,
+       _isolate = isolate,
+       _count = count,
+       _body = body,
+       _retryEnabled = retryEnabled,
+       _retryDelay = retryDelay ?? _defaultRetryDelay;
 
   PostgrestBuilder<T, S, R> _copyWith({
     Uri? url,
@@ -169,22 +169,22 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
       send = () => (_httpClient?.get ?? http.get)(_url, headers: execHeaders);
     } else if (method == HttpMethod.post) {
       send = () => (_httpClient?.post ?? http.post)(
-            _url,
-            headers: execHeaders,
-            body: bodyStr,
-          );
+        _url,
+        headers: execHeaders,
+        body: bodyStr,
+      );
     } else if (method == HttpMethod.put) {
       send = () => (_httpClient?.put ?? http.put)(
-            _url,
-            headers: execHeaders,
-            body: bodyStr,
-          );
+        _url,
+        headers: execHeaders,
+        body: bodyStr,
+      );
     } else if (method == HttpMethod.patch) {
       send = () => (_httpClient?.patch ?? http.patch)(
-            _url,
-            headers: execHeaders,
-            body: bodyStr,
-          );
+        _url,
+        headers: execHeaders,
+        body: bodyStr,
+      );
     } else if (method == HttpMethod.delete) {
       send = () =>
           (_httpClient?.delete ?? http.delete)(_url, headers: execHeaders);
@@ -298,16 +298,15 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
             : int.parse(contentRange.split('/').last);
       }
 
-      body as dynamic;
       final S converted;
 
       if (R == PostgrestList) {
-        body = PostgrestList.from(body);
+        body = PostgrestList.from(body as Iterable);
       } else if (R == PostgrestMap) {
-        body = PostgrestMap.from(body);
+        body = PostgrestMap.from(body as Map);
       } else if (R == _Nullable<PostgrestMap>) {
         if (body != null) {
-          body = PostgrestMap.from(body);
+          body = PostgrestMap.from(body as Map);
         }
       } else if (R == int) {
         if (count != null) body = count;
@@ -322,9 +321,10 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
 
       if (_count != null && method != HttpMethod.head) {
         return PostgrestResponse<S>(
-          data: converted,
-          count: count!,
-        ) as T;
+              data: converted,
+              count: count!,
+            )
+            as T;
       }
       return converted as T;
     }
@@ -393,8 +393,9 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
   ///
   /// [url] may be used to update based on a different url than the current one
   Uri appendSearchParams(String key, String value, [Uri? url]) {
-    final searchParams =
-        Map<String, dynamic>.of((url ?? _url).queryParametersAll);
+    final searchParams = Map<String, dynamic>.of(
+      (url ?? _url).queryParametersAll,
+    );
     searchParams[key] = [...?searchParams[key], value];
     return (url ?? _url).replace(queryParameters: searchParams);
   }
@@ -403,8 +404,9 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
   ///
   /// [url] may be used to update based on a different url than the current one
   Uri overrideSearchParams(String key, String value, [Uri? url]) {
-    final searchParams =
-        Map<String, dynamic>.of((url ?? _url).queryParametersAll);
+    final searchParams = Map<String, dynamic>.of(
+      (url ?? _url).queryParametersAll,
+    );
     searchParams[key] = value;
     return (url ?? _url).replace(queryParameters: searchParams);
   }
@@ -417,10 +419,12 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
     // Escape `\` and `"` inside each element before quoting, otherwise a value
     // containing a double quote (e.g. `a"b`) produces a malformed PostgREST
     // filter like `in.("a"b")`. This matches PostgREST/PostgreSQL array quoting.
-    return filter.map((s) {
-      final escaped = '$s'.replaceAll(r'\', r'\\').replaceAll('"', r'\"');
-      return '"$escaped"';
-    }).join(',');
+    return filter
+        .map((s) {
+          final escaped = '$s'.replaceAll(r'\', r'\\').replaceAll('"', r'\"');
+          return '"$escaped"';
+        })
+        .join(',');
   }
 
   @override
@@ -429,12 +433,14 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
 
     unawaited(
       then((value) {
-        controller.add(value);
-      }).catchError((Object error, StackTrace stack) {
-        controller.addError(error, stack);
-      }).whenComplete(() {
-        unawaited(controller.close());
-      }),
+            controller.add(value);
+          })
+          .catchError((Object error, StackTrace stack) {
+            controller.addError(error, stack);
+          })
+          .whenComplete(() {
+            unawaited(controller.close());
+          }),
     );
 
     return controller.stream;
@@ -453,12 +459,14 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
     if (onError != null &&
         onError is! Function(Object, StackTrace) &&
         onError is! Function(Object)) {
-      return Future.error(ArgumentError.value(
-        onError,
-        "onError",
-        "Error handler must accept one Object or one Object and a StackTrace "
-            "as arguments, and return a value of the returned future's type",
-      ));
+      return Future.error(
+        ArgumentError.value(
+          onError,
+          "onError",
+          "Error handler must accept one Object or one Object and a StackTrace "
+              "as arguments, and return a value of the returned future's type",
+        ),
+      );
     }
 
     // then() is called synchronously by Dart's async state machine, so user
@@ -469,45 +477,49 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
         StackTrace.fromString('$stack\n<async call site>\n$callerTrace');
 
     if (onError == null) {
-      return _execute().then(onValue,
-          onError: (Object error, StackTrace stack) {
-        Error.throwWithStackTrace(error, enrichStack(stack));
-      });
+      return _execute().then(
+        onValue,
+        onError: (Object error, StackTrace stack) {
+          Error.throwWithStackTrace(error, enrichStack(stack));
+        },
+      );
     }
 
-    return _execute().then(onValue,
-        onError: (Object error, StackTrace stack) async {
-      final enrichedStack = enrichStack(stack);
-      final FutureOr<U> result;
-      if (onError is Function(Object, StackTrace)) {
-        result = onError(error, enrichedStack);
-      } else if (onError is Function(Object)) {
-        try {
-          result = onError(error);
-        } catch (rethrown) {
-          if (identical(rethrown, error)) {
-            Error.throwWithStackTrace(rethrown, enrichedStack);
+    return _execute().then(
+      onValue,
+      onError: (Object error, StackTrace stack) async {
+        final enrichedStack = enrichStack(stack);
+        final FutureOr<U> result;
+        if (onError is Function(Object, StackTrace)) {
+          result = onError(error, enrichedStack);
+        } else if (onError is Function(Object)) {
+          try {
+            result = onError(error);
+          } catch (rethrown) {
+            if (identical(rethrown, error)) {
+              Error.throwWithStackTrace(rethrown, enrichedStack);
+            }
+            rethrow;
           }
-          rethrow;
+        } else {
+          throw ArgumentError.value(
+            onError,
+            "onError",
+            "Error handler must accept one Object or one Object and a StackTrace "
+                "as arguments, and return a value of the returned future's type",
+          );
         }
-      } else {
-        throw ArgumentError.value(
-          onError,
-          "onError",
-          "Error handler must accept one Object or one Object and a StackTrace "
-              "as arguments, and return a value of the returned future's type",
-        );
-      }
-      try {
-        return await result;
-      } on TypeError {
-        throw ArgumentError(
-          "The error handler of Future.then must return a value of the "
-              "returned future's type",
-          "onError",
-        );
-      }
-    });
+        try {
+          return await result;
+        } on TypeError {
+          throw ArgumentError(
+            "The error handler of Future.then must return a value of the "
+                "returned future's type",
+            "onError",
+          );
+        }
+      },
+    );
   }
 
   @override

--- a/packages/postgrest/lib/src/postgrest_filter_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_filter_builder.dart
@@ -157,7 +157,8 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   /// ```
   PostgrestFilterBuilder likeAllOf(String column, List<String> patterns) {
     return copyWithUrl(
-        appendSearchParams(column, 'like(all).{${patterns.join(',')}}'));
+      appendSearchParams(column, 'like(all).{${patterns.join(',')}}'),
+    );
   }
 
   /// Match only rows where [column] matches any of [patterns] case-sensitively.
@@ -170,7 +171,8 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   /// ```
   PostgrestFilterBuilder likeAnyOf(String column, List<String> patterns) {
     return copyWithUrl(
-        appendSearchParams(column, 'like(any).{${patterns.join(',')}}'));
+      appendSearchParams(column, 'like(any).{${patterns.join(',')}}'),
+    );
   }
 
   /// Finds all rows whose value in the stated [column] matches the supplied [pattern] (case insensitive).
@@ -195,7 +197,8 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   /// ```
   PostgrestFilterBuilder ilikeAllOf(String column, List<String> patterns) {
     return copyWithUrl(
-        appendSearchParams(column, 'ilike(all).{${patterns.join(',')}}'));
+      appendSearchParams(column, 'ilike(all).{${patterns.join(',')}}'),
+    );
   }
 
   /// Match only rows where [column] matches any of [patterns] case-insensitively.
@@ -208,7 +211,8 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   /// ```
   PostgrestFilterBuilder ilikeAnyOf(String column, List<String> patterns) {
     return copyWithUrl(
-        appendSearchParams(column, 'ilike(any).{${patterns.join(',')}}'));
+      appendSearchParams(column, 'ilike(any).{${patterns.join(',')}}'),
+    );
   }
 
   /// A check for exact equality (null, true, false)
@@ -234,7 +238,8 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   /// ```
   PostgrestFilterBuilder<T> inFilter(String column, List values) {
     return copyWithUrl(
-        appendSearchParams(column, 'in.(${_cleanFilterArray(values)})'));
+      appendSearchParams(column, 'in.(${_cleanFilterArray(values)})'),
+    );
   }
 
   /// Finds all rows whose json, array, or range value on the stated [column] contains the values specified in [value].
@@ -411,6 +416,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   PostgrestFilterBuilder<T> textSearch(
     String column,
     String query, {
+
     /// The text search configuration to use.
     String? config,
 
@@ -427,7 +433,8 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
     }
     final configPart = config == null ? '' : '($config)';
     return copyWithUrl(
-        appendSearchParams(column, '${typePart}fts$configPart.$query'));
+      appendSearchParams(column, '${typePart}fts$configPart.$query'),
+    );
   }
 
   /// Finds all rows whose [column] satisfies the filter.
@@ -439,7 +446,10 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   ///     .filter('username', 'eq', 'supabot');
   /// ```
   PostgrestFilterBuilder<T> filter(
-      String column, String operator, Object? value) {
+    String column,
+    String operator,
+    Object? value,
+  ) {
     final Uri url;
     if (value is List) {
       if (operator == "in") {

--- a/packages/postgrest/lib/src/postgrest_query_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_query_builder.dart
@@ -22,17 +22,17 @@ class PostgrestQueryBuilder<T> extends RawPostgrestBuilder<T, T, T> {
     bool retryEnabled = true,
     Duration Function(int attempt)? retryDelay,
   }) : super(
-          PostgrestBuilder(
-            url: url,
-            method: method,
-            headers: headers ?? {},
-            schema: schema,
-            httpClient: httpClient,
-            isolate: isolate,
-            retryEnabled: retryEnabled,
-            retryDelay: retryDelay,
-          ),
-        );
+         PostgrestBuilder(
+           url: url,
+           method: method,
+           headers: headers ?? {},
+           schema: schema,
+           httpClient: httpClient,
+           isolate: isolate,
+           retryEnabled: retryEnabled,
+           retryDelay: retryDelay,
+         ),
+       );
 
   /// Perform a SELECT query on the table or view.
   ///
@@ -59,10 +59,12 @@ class PostgrestQueryBuilder<T> extends RawPostgrestBuilder<T, T, T> {
     }).join();
 
     final url = overrideSearchParams('select', cleanedColumns);
-    return PostgrestFilterBuilder(_copyWithType(
-      url: url,
-      method: HttpMethod.get,
-    ));
+    return PostgrestFilterBuilder(
+      _copyWithType(
+        url: url,
+        method: HttpMethod.get,
+      ),
+    );
   }
 
   /// Perform an INSERT into the table or view.
@@ -105,12 +107,14 @@ class PostgrestQueryBuilder<T> extends RawPostgrestBuilder<T, T, T> {
       url = _setColumnsSearchParam(values);
     }
 
-    return PostgrestFilterBuilder(_copyWith(
-      method: HttpMethod.post,
-      headers: newHeaders,
-      body: values,
-      url: url,
-    ));
+    return PostgrestFilterBuilder(
+      _copyWith(
+        method: HttpMethod.post,
+        headers: newHeaders,
+        body: values,
+        url: url,
+      ),
+    );
   }
 
   /// Perform an UPSERT on the table or view.
@@ -173,12 +177,14 @@ class PostgrestQueryBuilder<T> extends RawPostgrestBuilder<T, T, T> {
       );
     }
 
-    return PostgrestFilterBuilder(_copyWith(
-      method: HttpMethod.post,
-      headers: newHeaders,
-      body: values,
-      url: url,
-    ));
+    return PostgrestFilterBuilder(
+      _copyWith(
+        method: HttpMethod.post,
+        headers: newHeaders,
+        body: values,
+        url: url,
+      ),
+    );
   }
 
   /// Perform an UPDATE on the table or view.
@@ -204,11 +210,13 @@ class PostgrestQueryBuilder<T> extends RawPostgrestBuilder<T, T, T> {
   PostgrestFilterBuilder<T> update(Map values) {
     final newHeaders = {..._headers}..remove('Prefer');
 
-    return PostgrestFilterBuilder(_copyWith(
-      method: HttpMethod.patch,
-      headers: newHeaders,
-      body: values,
-    ));
+    return PostgrestFilterBuilder(
+      _copyWith(
+        method: HttpMethod.patch,
+        headers: newHeaders,
+        body: values,
+      ),
+    );
   }
 
   /// Perform a DELETE on the table or view.
@@ -233,16 +241,20 @@ class PostgrestQueryBuilder<T> extends RawPostgrestBuilder<T, T, T> {
   /// ```
   PostgrestFilterBuilder<T> delete() {
     final newHeaders = {..._headers}..remove('Prefer');
-    return PostgrestFilterBuilder(_copyWith(
-      method: HttpMethod.delete,
-      headers: newHeaders,
-    ));
+    return PostgrestFilterBuilder(
+      _copyWith(
+        method: HttpMethod.delete,
+        headers: newHeaders,
+      ),
+    );
   }
 
   Uri _setColumnsSearchParam(List values) {
     final newValues = PostgrestList.from(values);
     final columns = newValues.fold<List<String>>(
-        [], (value, element) => value..addAll(element.keys));
+      [],
+      (value, element) => value..addAll(element.keys),
+    );
     if (newValues.isNotEmpty) {
       final uniqueColumns = {...columns}.map((e) => '"$e"').join(',');
       return appendSearchParams("columns", uniqueColumns);
@@ -255,10 +267,12 @@ class PostgrestQueryBuilder<T> extends RawPostgrestBuilder<T, T, T> {
   /// int count = await supabase.from('users').count();
   /// ```
   PostgrestFilterBuilder<int> count([CountOption option = CountOption.exact]) {
-    return PostgrestFilterBuilder(_copyWithType(
-      method: HttpMethod.head,
-      count: option,
-    ));
+    return PostgrestFilterBuilder(
+      _copyWithType(
+        method: HttpMethod.head,
+        count: option,
+      ),
+    );
   }
 
   @override

--- a/packages/postgrest/lib/src/postgrest_rpc_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_rpc_builder.dart
@@ -10,16 +10,16 @@ class PostgrestRpcBuilder extends RawPostgrestBuilder {
     bool retryEnabled = true,
     Duration Function(int attempt)? retryDelay,
   }) : super(
-          PostgrestBuilder(
-            url: Uri.parse(url),
-            headers: headers ?? {},
-            schema: schema,
-            httpClient: httpClient,
-            isolate: isolate,
-            retryEnabled: retryEnabled,
-            retryDelay: retryDelay,
-          ),
-        );
+         PostgrestBuilder(
+           url: Uri.parse(url),
+           headers: headers ?? {},
+           schema: schema,
+           httpClient: httpClient,
+           isolate: isolate,
+           retryEnabled: retryEnabled,
+           retryDelay: retryDelay,
+         ),
+       );
 
   /// {@macro postgrest_rpc}
   PostgrestFilterBuilder<T> rpc<T>([
@@ -32,14 +32,20 @@ class PostgrestRpcBuilder extends RawPostgrestBuilder {
       method = HttpMethod.get;
       if (params is Map) {
         for (final entry in params.entries) {
-          assert(entry.key is String,
-              "RPC params map keys must be of type String");
+          assert(
+            entry.key is String,
+            "RPC params map keys must be of type String",
+          );
 
           final MapEntry(:key, :value) = entry;
-          final formattedValue =
-              value is List ? '{${_cleanFilterArray(value)}}' : value;
-          newUrl =
-              appendSearchParams(key.toString(), '$formattedValue', newUrl);
+          final formattedValue = value is List
+              ? '{${_cleanFilterArray(value)}}'
+              : value;
+          newUrl = appendSearchParams(
+            key.toString(),
+            '$formattedValue',
+            newUrl,
+          );
         }
       } else {
         throw ArgumentError.value(params, 'params', 'argument must be a Map');
@@ -48,10 +54,12 @@ class PostgrestRpcBuilder extends RawPostgrestBuilder {
       method = HttpMethod.post;
     }
 
-    return PostgrestFilterBuilder(_copyWithType(
-      method: method,
-      url: newUrl,
-      body: params,
-    ));
+    return PostgrestFilterBuilder(
+      _copyWithType(
+        method: method,
+        url: newUrl,
+        body: params,
+      ),
+    );
   }
 }

--- a/packages/postgrest/lib/src/postgrest_transform_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_transform_builder.dart
@@ -83,7 +83,8 @@ class PostgrestTransformBuilder<T> extends RawPostgrestBuilder<T, T, T> {
   }) {
     final key = referencedTable == null ? 'order' : '$referencedTable.order';
     final existingOrder = _url.queryParameters[key];
-    final value = '${existingOrder == null ? '' : '$existingOrder,'}'
+    final value =
+        '${existingOrder == null ? '' : '$existingOrder,'}'
         '$column.${ascending ? 'asc' : 'desc'}.${nullsFirst ? 'nullsfirst' : 'nullslast'}';
     final url = overrideSearchParams(key, value);
     return PostgrestTransformBuilder(copyWithUrl(url));
@@ -127,12 +128,17 @@ class PostgrestTransformBuilder<T> extends RawPostgrestBuilder<T, T, T> {
   ///     .select('messages(*)')
   ///     .range(1, 1, referencedTable: 'messages');
   /// ```
-  PostgrestTransformBuilder<T> range(int from, int to,
-      {String? referencedTable}) {
-    final keyOffset =
-        referencedTable == null ? 'offset' : '$referencedTable.offset';
-    final keyLimit =
-        referencedTable == null ? 'limit' : '$referencedTable.limit';
+  PostgrestTransformBuilder<T> range(
+    int from,
+    int to, {
+    String? referencedTable,
+  }) {
+    final keyOffset = referencedTable == null
+        ? 'offset'
+        : '$referencedTable.offset';
+    final keyLimit = referencedTable == null
+        ? 'limit'
+        : '$referencedTable.limit';
 
     var url = overrideSearchParams(keyOffset, '$from');
     url = overrideSearchParams(keyLimit, '${to - from + 1}', url);
@@ -215,8 +221,9 @@ class PostgrestTransformBuilder<T> extends RawPostgrestBuilder<T, T, T> {
   /// final users = res.data;
   /// int count = res.count;
   /// ```
-  ResponsePostgrestBuilder<PostgrestResponse<T>, T, T> count(
-      [CountOption count = CountOption.exact]) {
+  ResponsePostgrestBuilder<PostgrestResponse<T>, T, T> count([
+    CountOption count = CountOption.exact,
+  ]) {
     return ResponsePostgrestBuilder(
       _copyWithType(count: count),
     );
@@ -242,8 +249,12 @@ class PostgrestTransformBuilder<T> extends RawPostgrestBuilder<T, T, T> {
   ///
   /// https://supabase.com/docs/guides/database/extensions/postgis
   ///
-  ResponsePostgrestBuilder<Map<String, dynamic>, Map<String, dynamic>,
-      Map<String, dynamic>> geojson() {
+  ResponsePostgrestBuilder<
+    Map<String, dynamic>,
+    Map<String, dynamic>,
+    Map<String, dynamic>
+  >
+  geojson() {
     final newHeaders = {..._headers};
     newHeaders['Accept'] = 'application/geo+json;';
     return ResponsePostgrestBuilder(_copyWithType(headers: newHeaders));

--- a/packages/postgrest/lib/src/raw_postgrest_builder.dart
+++ b/packages/postgrest/lib/src/raw_postgrest_builder.dart
@@ -3,20 +3,20 @@ part of 'postgrest_builder.dart';
 /// Needed as a wrapper around [PostgrestBuilder] to allow for the different return type of [withConverter] than in [ResponsePostgrestBuilder.withConverter].
 class RawPostgrestBuilder<T, S, R> extends PostgrestBuilder<T, S, R> {
   RawPostgrestBuilder(PostgrestBuilder<T, S, R> builder)
-      : super(
-          url: builder._url,
-          method: builder._method,
-          headers: builder._headers,
-          schema: builder._schema,
-          body: builder._body,
-          httpClient: builder._httpClient,
-          count: builder._count,
-          isolate: builder._isolate,
-          maybeSingle: builder._maybeSingle,
-          converter: builder._converter,
-          retryEnabled: builder._retryEnabled,
-          retryDelay: builder._retryDelay,
-        );
+    : super(
+        url: builder._url,
+        method: builder._method,
+        headers: builder._headers,
+        schema: builder._schema,
+        body: builder._body,
+        httpClient: builder._httpClient,
+        count: builder._count,
+        isolate: builder._isolate,
+        maybeSingle: builder._maybeSingle,
+        converter: builder._converter,
+        retryEnabled: builder._retryEnabled,
+        retryDelay: builder._retryDelay,
+      );
 
   /// Very similar to [_copyWith], but allows changing the generics, therefore [_converter] is omitted
   RawPostgrestBuilder<O, P, Q> _copyWithType<O, P, Q>({
@@ -31,19 +31,21 @@ class RawPostgrestBuilder<T, S, R> extends PostgrestBuilder<T, S, R> {
     CountOption? count,
     bool? maybeSingle,
   }) {
-    return RawPostgrestBuilder(PostgrestBuilder(
-      url: url ?? _url,
-      headers: headers ?? _headers,
-      schema: schema ?? _schema,
-      method: method ?? _method,
-      body: body ?? _body,
-      httpClient: httpClient ?? _httpClient,
-      isolate: isolate ?? _isolate,
-      count: count ?? _count,
-      maybeSingle: maybeSingle ?? _maybeSingle,
-      retryEnabled: _retryEnabled,
-      retryDelay: _retryDelay,
-    ));
+    return RawPostgrestBuilder(
+      PostgrestBuilder(
+        url: url ?? _url,
+        headers: headers ?? _headers,
+        schema: schema ?? _schema,
+        method: method ?? _method,
+        body: body ?? _body,
+        httpClient: httpClient ?? _httpClient,
+        isolate: isolate ?? _isolate,
+        count: count ?? _count,
+        maybeSingle: maybeSingle ?? _maybeSingle,
+        retryEnabled: _retryEnabled,
+        retryDelay: _retryDelay,
+      ),
+    );
   }
 
   @override
@@ -64,7 +66,8 @@ class RawPostgrestBuilder<T, S, R> extends PostgrestBuilder<T, S, R> {
   ///     );
   /// ```
   PostgrestBuilder<U, U, R> withConverter<U>(
-      PostgrestConverter<U, R> converter) {
+    PostgrestConverter<U, R> converter,
+  ) {
     return PostgrestBuilder(
       url: _url,
       headers: _headers,

--- a/packages/postgrest/lib/src/response_postgrest_builder.dart
+++ b/packages/postgrest/lib/src/response_postgrest_builder.dart
@@ -3,20 +3,20 @@ part of 'postgrest_builder.dart';
 /// Needed as a wrapper around [PostgrestBuilder] to allow for the different return type of [withConverter] than in [RawPostgrestBuilder.withConverter].
 class ResponsePostgrestBuilder<T, S, R> extends PostgrestBuilder<T, S, R> {
   ResponsePostgrestBuilder(PostgrestBuilder<T, S, R> builder)
-      : super(
-          url: builder._url,
-          method: builder._method,
-          headers: builder._headers,
-          schema: builder._schema,
-          body: builder._body,
-          httpClient: builder._httpClient,
-          count: builder._count,
-          isolate: builder._isolate,
-          maybeSingle: builder._maybeSingle,
-          converter: builder._converter,
-          retryEnabled: builder._retryEnabled,
-          retryDelay: builder._retryDelay,
-        );
+    : super(
+        url: builder._url,
+        method: builder._method,
+        headers: builder._headers,
+        schema: builder._schema,
+        body: builder._body,
+        httpClient: builder._httpClient,
+        count: builder._count,
+        isolate: builder._isolate,
+        maybeSingle: builder._maybeSingle,
+        converter: builder._converter,
+        retryEnabled: builder._retryEnabled,
+        retryDelay: builder._retryDelay,
+      );
 
   @override
   ResponsePostgrestBuilder<T, S, R> setHeader(String key, String value) {
@@ -39,7 +39,8 @@ class ResponsePostgrestBuilder<T, S, R> extends PostgrestBuilder<T, S, R> {
   /// int count = res.count;
   /// ```
   PostgrestBuilder<PostgrestResponse<U>, U, R> withConverter<U>(
-      PostgrestConverter<U, R> converter) {
+    PostgrestConverter<U, R> converter,
+  ) {
     return PostgrestBuilder(
       url: _url,
       headers: _headers,

--- a/packages/postgrest/lib/src/types.dart
+++ b/packages/postgrest/lib/src/types.dart
@@ -74,9 +74,9 @@ class PostgrestResponse<T> {
   }
 
   Map<String, dynamic> toJson() => {
-        'data': data,
-        'count': count,
-      };
+    'data': data,
+    'count': count,
+  };
 
   @override
   String toString() {

--- a/packages/postgrest/pubspec.yaml
+++ b/packages/postgrest/pubspec.yaml
@@ -6,7 +6,7 @@ repository: 'https://github.com/supabase/supabase-flutter/tree/main/packages/pos
 documentation: 'https://supabase.com/docs/reference/dart/select'
 
 environment:
-  sdk: '>=3.4.0 <4.0.0'
+  sdk: '>=3.9.0 <4.0.0'
 
 dependencies:
   http: ^1.2.2

--- a/packages/postgrest/test/basic_test.dart
+++ b/packages/postgrest/test/basic_test.dart
@@ -36,17 +36,22 @@ void main() {
     });
 
     test('stored procedure', () async {
-      final res = await postgrest.rpc<String>('get_status', params: {
-        'name_param': 'supabot',
-      });
+      final res = await postgrest.rpc<String>(
+        'get_status',
+        params: {
+          'name_param': 'supabot',
+        },
+      );
       expect(res, 'ONLINE');
     });
 
     test('select on stored procedure', () async {
-      final res = await postgrest.rpc(
-        'get_username_and_status',
-        params: {'name_param': 'supabot'},
-      ).select('status');
+      final res = await postgrest
+          .rpc(
+            'get_username_and_status',
+            params: {'name_param': 'supabot'},
+          )
+          .select('status');
       expect(
         res.first['status'],
         'ONLINE',
@@ -68,7 +73,7 @@ void main() {
         'get_array_element',
         params: {
           'arr': [37, 420, 64],
-          'index': 2
+          'index': 2,
         },
       );
       expect(res, 420);
@@ -79,7 +84,7 @@ void main() {
         'get_array_element',
         params: {
           'arr': [37, 420, 64],
-          'index': 2
+          'index': 2,
         },
         get: true,
       );
@@ -123,8 +128,10 @@ void main() {
 
       // Other following requests should not have the header
       await client.rpc('empty-succ').select().head();
-      expect(httpClient.lastRequest!.headers,
-          isNot(containsPair("myKey", "myValue")));
+      expect(
+        httpClient.lastRequest!.headers,
+        isNot(containsPair("myKey", "myValue")),
+      );
     });
 
     test('set header on query builder', () async {
@@ -140,21 +147,28 @@ void main() {
 
       // Other following requests should not have the header
       await client.from('empty-succ').select().head();
-      expect(httpClient.lastRequest!.headers,
-          isNot(containsPair("myKey", "myValue")));
+      expect(
+        httpClient.lastRequest!.headers,
+        isNot(containsPair("myKey", "myValue")),
+      );
     });
 
     test('switch schema', () async {
-      final client =
-          PostgrestClient(rootUrl, schema: 'personal', headers: apiHeaders);
+      final client = PostgrestClient(
+        rootUrl,
+        schema: 'personal',
+        headers: apiHeaders,
+      );
       final res = await client.from('users').select();
       expect(res.length, 5);
     });
 
     test('query non-public schema dynamically', () async {
       final client = PostgrestClient(rootUrl, headers: apiHeaders);
-      final personalData =
-          await client.schema('personal').from('users').select();
+      final personalData = await client
+          .schema('personal')
+          .from('users')
+          .select();
       expect(personalData.length, 5);
 
       // confirm that the client defaults to its initialized schema by default.
@@ -179,7 +193,7 @@ void main() {
         'id': 3,
         'message': 'foo',
         'username': 'supabot',
-        'channel_id': 2
+        'channel_id': 2,
       }).select();
       final headersAfter = {...postgrest.headers};
 
@@ -191,11 +205,14 @@ void main() {
     });
 
     test('ignoreDuplicates upsert', () async {
-      final res = await postgrest.from('users').upsert(
-        {'username': 'dragarcia'},
-        onConflict: 'username',
-        ignoreDuplicates: true,
-      ).select();
+      final res = await postgrest
+          .from('users')
+          .upsert(
+            {'username': 'dragarcia'},
+            onConflict: 'username',
+            ignoreDuplicates: true,
+          )
+          .select();
       expect(res, isEmpty);
     });
 
@@ -233,7 +250,7 @@ void main() {
     test('bulk insert', () async {
       final res = await postgrest.from('messages').insert([
         {'id': 4, 'message': 'foo', 'username': 'supabot', 'channel_id': 2},
-        {'id': 5, 'message': 'foo', 'username': 'supabot', 'channel_id': 1}
+        {'id': 5, 'message': 'foo', 'username': 'supabot', 'channel_id': 1},
       ]).select();
       expect(res.length, 2);
     });
@@ -303,8 +320,8 @@ void main() {
           'message': 'Supabase Launch Week is on fire',
           'username': 'supabot',
           'channel_id': 1,
-          'inserted_at': '2021-06-20T04:28:21.598+00:00'
-        }
+          'inserted_at': '2021-06-20T04:28:21.598+00:00',
+        },
       ]);
 
       final resMsg = await postgrest
@@ -353,15 +370,18 @@ void main() {
     });
 
     test('select with count: planned', () async {
-      final res =
-          await postgrest.from('users').select('*').count(CountOption.planned);
+      final res = await postgrest
+          .from('users')
+          .select('*')
+          .count(CountOption.planned);
       final int count = res.count;
       expect(count, greaterThanOrEqualTo(0));
     });
 
     test('select with head:true, count: estimated', () async {
-      final int res =
-          await postgrest.from('users').count(CountOption.estimated);
+      final int res = await postgrest
+          .from('users')
+          .count(CountOption.estimated);
       expect(res, isA<int>());
     });
 
@@ -371,10 +391,12 @@ void main() {
     });
 
     test('stored procedure with count: exact', () async {
-      final res = await postgrest.rpc<String>(
-        'get_status',
-        params: {'name_param': 'supabot'},
-      ).count(CountOption.exact);
+      final res = await postgrest
+          .rpc<String>(
+            'get_status',
+            params: {'name_param': 'supabot'},
+          )
+          .count(CountOption.exact);
       expect(res.count, greaterThanOrEqualTo(0));
     });
 
@@ -427,7 +449,7 @@ void main() {
 
     test('insert from uppercase table name', () async {
       final res = await postgrest.from('TestTable').insert([
-        {'slug': 'new slug'}
+        {'slug': 'new slug'},
       ]).select();
       expect(
         (res.first)['slug'],
@@ -487,15 +509,17 @@ void main() {
         throwsA(isA<PostgrestException>().having((e) => e.code, 'code', '420')),
       );
     });
-    test('select() builds a valid Prefer header without a preceding Prefer',
-        () async {
-      await postgrestCustomHttpClient.rpc('empty-succ').select().head();
+    test(
+      'select() builds a valid Prefer header without a preceding Prefer',
+      () async {
+        await postgrestCustomHttpClient.rpc('empty-succ').select().head();
 
-      expect(
-        customHttpClient.lastRequest!.headers['Prefer'],
-        'return=representation',
-      );
-    });
+        expect(
+          customHttpClient.lastRequest!.headers['Prefer'],
+          'return=representation',
+        );
+      },
+    );
     test('basic select table with converter', () async {
       await expectLater(
         () => postgrestCustomHttpClient
@@ -507,8 +531,10 @@ void main() {
     });
     test('basic stored procedure call', () async {
       await expectLater(
-        () => postgrestCustomHttpClient
-            .rpc<String>('get_status', params: {'name_param': 'supabot'}),
+        () => postgrestCustomHttpClient.rpc<String>(
+          'get_status',
+          params: {'name_param': 'supabot'},
+        ),
         throwsA(isA<PostgrestException>().having((e) => e.code, 'code', '420')),
       );
       expect(customHttpClient.lastRequest?.method, "POST");
@@ -531,7 +557,9 @@ void main() {
       await expectLater(
         () => postgrestCustomHttpClient.from('non-json-succ').select(),
         throwsA(
-          isA<PostgrestException>().having((e) => e.code, 'code', '200').having(
+          isA<PostgrestException>()
+              .having((e) => e.code, 'code', '200')
+              .having(
                 (e) => e.message,
                 'message',
                 '<html><body>502 Bad Gateway</body></html>',

--- a/packages/postgrest/test/explain_format_test.dart
+++ b/packages/postgrest/test/explain_format_test.dart
@@ -42,7 +42,10 @@ void main() {
 
   test('explain forwards options alongside the format', () async {
     try {
-      await postgrest.from('users').select().explain(
+      await postgrest
+          .from('users')
+          .select()
+          .explain(
             analyze: true,
             verbose: true,
             format: ExplainFormat.json,
@@ -50,8 +53,11 @@ void main() {
     } catch (_) {}
 
     final accept = customHttpClient.lastRequest!.headers['Accept']!;
-    expect(accept, startsWith('application/vnd.pgrst.plan+json;'),
-        reason: 'format should drive the media type suffix');
+    expect(
+      accept,
+      startsWith('application/vnd.pgrst.plan+json;'),
+      reason: 'format should drive the media type suffix',
+    );
     expect(accept, contains('options=analyze|verbose'));
   });
 }

--- a/packages/postgrest/test/filter_test.dart
+++ b/packages/postgrest/test/filter_test.dart
@@ -33,10 +33,11 @@ void main() {
   });
 
   test('not with in filter', () async {
-    final res = await postgrest
-        .from('users')
-        .select('username')
-        .not('username', 'in', ['supabot', 'kiwicopple']);
+    final res = await postgrest.from('users').select('username').not(
+      'username',
+      'in',
+      ['supabot', 'kiwicopple'],
+    );
     expect(res, isNotEmpty);
 
     for (final item in res) {
@@ -54,15 +55,18 @@ void main() {
   });
 
   test('not with List of values', () async {
-    final res = await postgrest
-        .from('users')
-        .select('status')
-        .not('interests', 'cs', ['baseball', 'basketball']);
+    final res = await postgrest.from('users').select('status').not(
+      'interests',
+      'cs',
+      ['baseball', 'basketball'],
+    );
     expect(res, isNotEmpty);
     for (final item in res) {
       expect(
-        ((item['interests'] ?? []) as List)
-            .contains(['baseball', 'basketball']),
+        ((item['interests'] ?? []) as List).contains([
+          'baseball',
+          'basketball',
+        ]),
         isFalse,
       );
     }
@@ -97,10 +101,10 @@ void main() {
     });
 
     test('eq list', () async {
-      final res = await postgrest
-          .from('users')
-          .select('username')
-          .eq('interests', ["basketball", "baseball"]);
+      final res = await postgrest.from('users').select('username').eq(
+        'interests',
+        ["basketball", "baseball"],
+      );
       expect(res, isNotEmpty);
 
       for (final item in res) {
@@ -123,10 +127,10 @@ void main() {
     });
 
     test('neq list', () async {
-      final res = await postgrest
-          .from('users')
-          .select('username')
-          .neq('interests', ["football"]);
+      final res = await postgrest.from('users').select('username').neq(
+        'interests',
+        ["football"],
+      );
       expect(res, isNotEmpty);
 
       final onlyNames = res.map((row) => row["username"]).toList();
@@ -199,8 +203,9 @@ void main() {
     expect(res, isNotEmpty);
     for (final item in res) {
       expect(
-          item['username'].contains('supa') || item['username'].contains('wai'),
-          isTrue);
+        item['username'].contains('supa') || item['username'].contains('wai'),
+        isTrue,
+      );
     }
   });
 
@@ -236,15 +241,18 @@ void main() {
     expect(res, isNotEmpty);
     for (final item in res) {
       expect(
-          item['username'].toLowerCase().contains('supa') ||
-              item['username'].toLowerCase().contains('wai'),
-          isTrue);
+        item['username'].toLowerCase().contains('supa') ||
+            item['username'].toLowerCase().contains('wai'),
+        isTrue,
+      );
     }
   });
 
   test('is', () async {
-    final res =
-        await postgrest.from('users').select('data').isFilter('data', null);
+    final res = await postgrest
+        .from('users')
+        .select('data')
+        .isFilter('data', null);
     expect(res, isNotEmpty);
     for (final item in res) {
       expect(item['data'], null);
@@ -252,10 +260,10 @@ void main() {
   });
 
   test('in', () async {
-    final res = await postgrest
-        .from('users')
-        .select('status')
-        .inFilter('status', ['ONLINE', 'OFFLINE']);
+    final res = await postgrest.from('users').select('status').inFilter(
+      'status',
+      ['ONLINE', 'OFFLINE'],
+    );
     expect(res, isNotEmpty);
     for (final item in res) {
       expect(
@@ -290,10 +298,10 @@ void main() {
     });
 
     test('contains list', () async {
-      final res = await postgrest
-          .from('users')
-          .select('username')
-          .contains('interests', ["basketball", "baseball"]);
+      final res = await postgrest.from('users').select('username').contains(
+        'interests',
+        ["basketball", "baseball"],
+      );
       expect(res, isNotEmpty);
       expect(
         (res[0])['username'],
@@ -312,10 +320,10 @@ void main() {
     });
 
     test('containedBy list', () async {
-      final res = await postgrest
-          .from('users')
-          .select('username')
-          .containedBy('interests', ["basketball", "baseball", "xxxx"]);
+      final res = await postgrest.from('users').select('username').containedBy(
+        'interests',
+        ["basketball", "baseball", "xxxx"],
+      );
       expect(res, isNotEmpty);
       expect(res[0]['username'], 'supabot');
     });
@@ -384,10 +392,10 @@ void main() {
     });
 
     test('overlaps list', () async {
-      final res = await postgrest
-          .from('users')
-          .select('username')
-          .overlaps('interests', ["basketball", "baseball"]);
+      final res = await postgrest.from('users').select('username').overlaps(
+        'interests',
+        ["basketball", "baseball"],
+      );
       expect(
         (res[0])['username'],
         'supabot',
@@ -404,7 +412,10 @@ void main() {
   });
 
   test('textSearch with plainto_tsquery', () async {
-    final res = await postgrest.from('users').select('username').textSearch(
+    final res = await postgrest
+        .from('users')
+        .select('username')
+        .textSearch(
           'catchphrase',
           "'fat' & 'cat'",
           config: 'english',
@@ -414,7 +425,10 @@ void main() {
   });
 
   test('textSearch with phraseto_tsquery', () async {
-    final res = await postgrest.from('users').select('username').textSearch(
+    final res = await postgrest
+        .from('users')
+        .select('username')
+        .textSearch(
           'catchphrase',
           'cat',
           config: 'english',
@@ -424,7 +438,10 @@ void main() {
   });
 
   test('textSearch with websearch_to_tsquery', () async {
-    final res = await postgrest.from('users').select('username').textSearch(
+    final res = await postgrest
+        .from('users')
+        .select('username')
+        .textSearch(
           'catchphrase',
           "'fat' & 'cat'",
           config: 'english',
@@ -455,10 +472,11 @@ void main() {
     });
 
     test('filter in with List of values', () async {
-      final res = await postgrest
-          .from('users')
-          .select()
-          .filter('username', 'in', ['supabot', 'kiwicopple']);
+      final res = await postgrest.from('users').select().filter(
+        'username',
+        'in',
+        ['supabot', 'kiwicopple'],
+      );
       expect(res.length, 2);
       for (final item in res) {
         expect(
@@ -470,10 +488,10 @@ void main() {
   });
 
   test('match', () async {
-    final res = await postgrest
-        .from('users')
-        .select()
-        .match({'username': 'supabot', 'status': 'ONLINE'});
+    final res = await postgrest.from('users').select().match({
+      'username': 'supabot',
+      'status': 'ONLINE',
+    });
     expect(res[0]['username'], 'supabot');
   });
 
@@ -495,8 +513,10 @@ void main() {
         .imatchRegex('username', '^SUPA.*');
     expect(res, isNotEmpty);
     for (final item in res) {
-      expect((item['username'] as String).toLowerCase().startsWith('supa'),
-          isTrue);
+      expect(
+        (item['username'] as String).toLowerCase().startsWith('supa'),
+        isTrue,
+      );
     }
   });
 
@@ -511,8 +531,9 @@ void main() {
     }
   });
   test('filter on rpc', () async {
-    final List res = await postgrest.rpc('get_username_and_status',
-        params: {'name_param': 'supabot'}).neq('status', 'ONLINE');
+    final List res = await postgrest
+        .rpc('get_username_and_status', params: {'name_param': 'supabot'})
+        .neq('status', 'ONLINE');
     expect(res, isEmpty);
   });
 

--- a/packages/postgrest/test/maybe_single_test.dart
+++ b/packages/postgrest/test/maybe_single_test.dart
@@ -10,12 +10,16 @@ class ZeroRowsHttpClient extends BaseClient {
   @override
   Future<StreamedResponse> send(BaseRequest request) async {
     return StreamedResponse(
-      Stream.value(utf8.encode(jsonEncode({
-        'code': 'PGRST116',
-        'details': 'Results contain 0 rows',
-        'hint': null,
-        'message': 'JSON object requested, multiple (or no) rows returned',
-      }))),
+      Stream.value(
+        utf8.encode(
+          jsonEncode({
+            'code': 'PGRST116',
+            'details': 'Results contain 0 rows',
+            'hint': null,
+            'message': 'JSON object requested, multiple (or no) rows returned',
+          }),
+        ),
+      ),
       406,
       request: request,
     );
@@ -23,21 +27,23 @@ class ZeroRowsHttpClient extends BaseClient {
 }
 
 void main() {
-  test('maybeSingle().count() returns null data and count 0 when no rows match',
-      () async {
-    final postgrest = PostgrestClient(
-      'https://example.com',
-      httpClient: ZeroRowsHttpClient(),
-    );
+  test(
+    'maybeSingle().count() returns null data and count 0 when no rows match',
+    () async {
+      final postgrest = PostgrestClient(
+        'https://example.com',
+        httpClient: ZeroRowsHttpClient(),
+      );
 
-    final response = await postgrest
-        .from('users')
-        .update({'name': 'x'})
-        .select()
-        .maybeSingle()
-        .count();
+      final response = await postgrest
+          .from('users')
+          .update({'name': 'x'})
+          .select()
+          .maybeSingle()
+          .count();
 
-    expect(response.data, isNull);
-    expect(response.count, 0);
-  });
+      expect(response.data, isNull);
+      expect(response.count, 0);
+    },
+  );
 }

--- a/packages/postgrest/test/prefer_header_test.dart
+++ b/packages/postgrest/test/prefer_header_test.dart
@@ -36,9 +36,9 @@ void main() {
 
   test('insert(defaultToNull: false) sends missing=default', () async {
     try {
-      await postgrest
-          .from('users')
-          .insert({'username': 'foo'}, defaultToNull: false);
+      await postgrest.from('users').insert({
+        'username': 'foo',
+      }, defaultToNull: false);
     } catch (_) {}
 
     expect(sentPrefer(), 'missing=default');
@@ -90,9 +90,10 @@ void main() {
 
   test('upsert().select() keeps its existing Prefer preferences', () async {
     try {
-      await postgrest
-          .from('users')
-          .upsert({'id': 1, 'username': 'foo'}).select();
+      await postgrest.from('users').upsert({
+        'id': 1,
+        'username': 'foo',
+      }).select();
     } catch (_) {}
 
     final prefer = sentPrefer()!;
@@ -117,7 +118,11 @@ void main() {
 
   test('delete().count() sends a clean Prefer header', () async {
     try {
-      await postgrest.from('users').delete().eq('id', 1).count(
+      await postgrest
+          .from('users')
+          .delete()
+          .eq('id', 1)
+          .count(
             CountOption.exact,
           );
     } catch (_) {}

--- a/packages/postgrest/test/retry_test.dart
+++ b/packages/postgrest/test/retry_test.dart
@@ -7,20 +7,27 @@ import 'package:test/test.dart';
 
 typedef _ResponseFactory = Future<StreamedResponse> Function(BaseRequest);
 
-_ResponseFactory _ok() => (req) => Future.value(StreamedResponse(
-      Stream.value(Uint8List.fromList('[]'.codeUnits)),
-      200,
-      request: req,
-      headers: {'content-type': 'application/json'},
-    ));
+_ResponseFactory _ok() =>
+    (req) => Future.value(
+      StreamedResponse(
+        Stream.value(Uint8List.fromList('[]'.codeUnits)),
+        200,
+        request: req,
+        headers: {'content-type': 'application/json'},
+      ),
+    );
 
-_ResponseFactory _status(int code) => (req) => Future.value(StreamedResponse(
-      Stream.value(
-          Uint8List.fromList('{"message":"err","code":"$code"}'.codeUnits)),
-      code,
-      request: req,
-      headers: {'content-type': 'application/json'},
-    ));
+_ResponseFactory _status(int code) =>
+    (req) => Future.value(
+      StreamedResponse(
+        Stream.value(
+          Uint8List.fromList('{"message":"err","code":"$code"}'.codeUnits),
+        ),
+        code,
+        request: req,
+        headers: {'content-type': 'application/json'},
+      ),
+    );
 
 _ResponseFactory _networkError() =>
     (_) => throw const SocketException('Connection refused');
@@ -39,7 +46,8 @@ class _MockRetryClient extends BaseClient {
     requests.add(request);
     if (index >= _responses.length) {
       throw StateError(
-          'Unexpected call #${index + 1}, only ${_responses.length} configured');
+        'Unexpected call #${index + 1}, only ${_responses.length} configured',
+      );
     }
     return _responses[index](request);
   }
@@ -59,32 +67,36 @@ PostgrestClient _buildClient(
 
 void main() {
   group('retry logic', () {
-    test('GET retries on 520 then succeeds, X-Retry-Count increments',
-        () async {
-      final mock = _MockRetryClient([_status(520), _status(520), _ok()]);
-      final client = _buildClient(mock);
+    test(
+      'GET retries on 520 then succeeds, X-Retry-Count increments',
+      () async {
+        final mock = _MockRetryClient([_status(520), _status(520), _ok()]);
+        final client = _buildClient(mock);
 
-      final result = await client.from('users').select();
+        final result = await client.from('users').select();
 
-      expect(result, isEmpty);
-      expect(mock.callCount, 3);
-      // Initial attempt: no header
-      expect(mock.requests[0].headers['x-retry-count'], isNull);
-      // First retry: X-Retry-Count: 1
-      expect(mock.requests[1].headers['x-retry-count'], '1');
-      // Second retry: X-Retry-Count: 2
-      expect(mock.requests[2].headers['x-retry-count'], '2');
-    });
+        expect(result, isEmpty);
+        expect(mock.callCount, 3);
+        // Initial attempt: no header
+        expect(mock.requests[0].headers['x-retry-count'], isNull);
+        // First retry: X-Retry-Count: 1
+        expect(mock.requests[1].headers['x-retry-count'], '1');
+        // Second retry: X-Retry-Count: 2
+        expect(mock.requests[2].headers['x-retry-count'], '2');
+      },
+    );
 
     test('HEAD retries on 520 then succeeds', () async {
       final mock = _MockRetryClient([
         _status(520),
-        (req) => Future.value(StreamedResponse(
-              Stream.empty(),
-              200,
-              request: req,
-              headers: {'content-range': '*/4'},
-            )),
+        (req) => Future.value(
+          StreamedResponse(
+            Stream.empty(),
+            200,
+            request: req,
+            headers: {'content-range': '*/4'},
+          ),
+        ),
       ]);
       final client = _buildClient(mock);
 
@@ -152,8 +164,12 @@ void main() {
     });
 
     test('exhausts all 3 retries (4 total calls) then throws on 520', () async {
-      final mock = _MockRetryClient(
-          [_status(520), _status(520), _status(520), _status(520)]);
+      final mock = _MockRetryClient([
+        _status(520),
+        _status(520),
+        _status(520),
+        _status(520),
+      ]);
       final client = _buildClient(mock);
 
       await expectLater(
@@ -174,44 +190,50 @@ void main() {
       expect(mock.callCount, 1);
     });
 
-    test('PostgrestClient(retryEnabled: false) disables retry globally',
-        () async {
-      final mock = _MockRetryClient([_status(520)]);
-      final client = _buildClient(mock, retryEnabled: false);
+    test(
+      'PostgrestClient(retryEnabled: false) disables retry globally',
+      () async {
+        final mock = _MockRetryClient([_status(520)]);
+        final client = _buildClient(mock, retryEnabled: false);
 
-      await expectLater(
-        () => client.from('users').select(),
-        throwsA(isA<PostgrestException>()),
-      );
-      expect(mock.callCount, 1);
-    });
+        await expectLater(
+          () => client.from('users').select(),
+          throwsA(isA<PostgrestException>()),
+        );
+        expect(mock.callCount, 1);
+      },
+    );
 
-    test('.retry(enabled: true) re-enables retry when client-level is false',
-        () async {
-      final mock = _MockRetryClient([_status(520), _ok()]);
-      final client = _buildClient(mock, retryEnabled: false);
+    test(
+      '.retry(enabled: true) re-enables retry when client-level is false',
+      () async {
+        final mock = _MockRetryClient([_status(520), _ok()]);
+        final client = _buildClient(mock, retryEnabled: false);
 
-      final result = await client.from('users').select().retry(enabled: true);
+        final result = await client.from('users').select().retry(enabled: true);
 
-      expect(result, isEmpty);
-      expect(mock.callCount, 2);
-    });
+        expect(result, isEmpty);
+        expect(mock.callCount, 2);
+      },
+    );
 
-    test('GET exhausts retries on repeated network errors then rethrows',
-        () async {
-      final mock = _MockRetryClient([
-        _networkError(),
-        _networkError(),
-        _networkError(),
-        _networkError(),
-      ]);
-      final client = _buildClient(mock);
+    test(
+      'GET exhausts retries on repeated network errors then rethrows',
+      () async {
+        final mock = _MockRetryClient([
+          _networkError(),
+          _networkError(),
+          _networkError(),
+          _networkError(),
+        ]);
+        final client = _buildClient(mock);
 
-      await expectLater(
-        () => client.from('users').select(),
-        throwsA(isA<SocketException>()),
-      );
-      expect(mock.callCount, 4);
-    });
+        await expectLater(
+          () => client.from('users').select(),
+          throwsA(isA<SocketException>()),
+        );
+        expect(mock.callCount, 4);
+      },
+    );
   });
 }

--- a/packages/postgrest/test/stack_trace_test.dart
+++ b/packages/postgrest/test/stack_trace_test.dart
@@ -6,13 +6,16 @@ import 'package:postgrest/postgrest.dart';
 import 'package:test/test.dart';
 
 _ResponseFactory _errorStatus(int code) =>
-    (req) => Future.value(StreamedResponse(
-          Stream.value(
-              Uint8List.fromList('{"message":"err","code":"$code"}'.codeUnits)),
-          code,
-          request: req,
-          headers: {'content-type': 'application/json'},
-        ));
+    (req) => Future.value(
+      StreamedResponse(
+        Stream.value(
+          Uint8List.fromList('{"message":"err","code":"$code"}'.codeUnits),
+        ),
+        code,
+        request: req,
+        headers: {'content-type': 'application/json'},
+      ),
+    );
 
 typedef _ResponseFactory = Future<StreamedResponse> Function(BaseRequest);
 
@@ -61,13 +64,16 @@ void main() {
       StackTrace? capturedTrace;
 
       Future<void> anotherCallerFunction() async {
-        await client.from('users').select().then(
-          (_) {},
-          onError: (Object error, StackTrace trace) {
-            capturedTrace = trace;
-            throw error;
-          },
-        );
+        await client
+            .from('users')
+            .select()
+            .then(
+              (_) {},
+              onError: (Object error, StackTrace trace) {
+                capturedTrace = trace;
+                throw error;
+              },
+            );
       }
 
       await expectLater(
@@ -82,42 +88,48 @@ void main() {
       );
     });
 
-    test('includes caller frame when using single-arg onError that re-throws',
-        () async {
-      final client = _buildClient(_MockClient(_errorStatus(400)));
+    test(
+      'includes caller frame when using single-arg onError that re-throws',
+      () async {
+        final client = _buildClient(_MockClient(_errorStatus(400)));
 
-      StackTrace? capturedTrace;
+        StackTrace? capturedTrace;
 
-      Future<void> singleArgCallerFunction() async {
-        try {
-          await client.from('users').select().then(
-                (_) {},
-                onError: (Object error) => throw error,
-              );
-        } catch (_, trace) {
-          capturedTrace = trace;
-          rethrow;
+        Future<void> singleArgCallerFunction() async {
+          try {
+            await client
+                .from('users')
+                .select()
+                .then(
+                  (_) {},
+                  onError: (Object error) => throw error,
+                );
+          } catch (_, trace) {
+            capturedTrace = trace;
+            rethrow;
+          }
         }
-      }
 
-      await expectLater(
-        singleArgCallerFunction(),
-        throwsA(isA<PostgrestException>()),
-      );
+        await expectLater(
+          singleArgCallerFunction(),
+          throwsA(isA<PostgrestException>()),
+        );
 
-      expect(
-        capturedTrace?.toString(),
-        contains('singleArgCallerFunction'),
-        reason:
-            'Outer catch should include the caller frame even with a single-arg onError',
-      );
-    });
+        expect(
+          capturedTrace?.toString(),
+          contains('singleArgCallerFunction'),
+          reason:
+              'Outer catch should include the caller frame even with a single-arg onError',
+        );
+      },
+    );
 
     test('includes caller frame for non-PostgrestException errors', () async {
       final client = PostgrestClient(
         'http://localhost:3000',
-        httpClient:
-            _MockClient((_) async => throw const SocketException('refused')),
+        httpClient: _MockClient(
+          (_) async => throw const SocketException('refused'),
+        ),
         retryEnabled: false,
       );
 
@@ -145,37 +157,39 @@ void main() {
       );
     });
 
-    test('includes caller frame when error passes through whenComplete',
-        () async {
-      final client = _buildClient(_MockClient(_errorStatus(400)));
+    test(
+      'includes caller frame when error passes through whenComplete',
+      () async {
+        final client = _buildClient(_MockClient(_errorStatus(400)));
 
-      StackTrace? capturedTrace;
-      var actionCalled = false;
+        StackTrace? capturedTrace;
+        var actionCalled = false;
 
-      Future<void> whenCompleteFunction() async {
-        try {
-          await client
-              .from('users')
-              .select()
-              .whenComplete(() => actionCalled = true);
-        } catch (_, trace) {
-          capturedTrace = trace;
-          rethrow;
+        Future<void> whenCompleteFunction() async {
+          try {
+            await client
+                .from('users')
+                .select()
+                .whenComplete(() => actionCalled = true);
+          } catch (_, trace) {
+            capturedTrace = trace;
+            rethrow;
+          }
         }
-      }
 
-      await expectLater(
-        whenCompleteFunction(),
-        throwsA(isA<PostgrestException>()),
-      );
+        await expectLater(
+          whenCompleteFunction(),
+          throwsA(isA<PostgrestException>()),
+        );
 
-      expect(actionCalled, isTrue);
-      expect(
-        capturedTrace?.toString(),
-        contains('whenCompleteFunction'),
-        reason:
-            'Stack trace should include the caller frame after whenComplete',
-      );
-    });
+        expect(actionCalled, isTrue);
+        expect(
+          capturedTrace?.toString(),
+          contains('whenCompleteFunction'),
+          reason:
+              'Stack trace should include the caller frame after whenComplete',
+        );
+      },
+    );
   });
 }

--- a/packages/postgrest/test/transforms_test.dart
+++ b/packages/postgrest/test/transforms_test.dart
@@ -241,23 +241,29 @@ void main() {
       );
     });
 
-    test('range() overrides a preceding limit() instead of duplicating it',
-        () async {
-      try {
-        await postgrestCustomHttpClient.from('t').select().limit(5).range(0, 9);
-      } catch (_) {
-        // Expected to fail with custom client, we just want to check the url
-      }
+    test(
+      'range() overrides a preceding limit() instead of duplicating it',
+      () async {
+        try {
+          await postgrestCustomHttpClient
+              .from('t')
+              .select()
+              .limit(5)
+              .range(0, 9);
+        } catch (_) {
+          // Expected to fail with custom client, we just want to check the url
+        }
 
-      expect(
-        customHttpClient.lastRequest!.url.queryParametersAll['limit'],
-        ['10'],
-      );
-      expect(
-        customHttpClient.lastRequest!.url.queryParametersAll['offset'],
-        ['0'],
-      );
-    });
+        expect(
+          customHttpClient.lastRequest!.url.queryParametersAll['limit'],
+          ['10'],
+        );
+        expect(
+          customHttpClient.lastRequest!.url.queryParametersAll['offset'],
+          ['0'],
+        );
+      },
+    );
 
     test('a later range() replaces the earlier one', () async {
       try {
@@ -297,27 +303,35 @@ void main() {
       );
     });
 
-    test('referencedTable range overrides a preceding limit and range',
-        () async {
-      try {
-        await postgrestCustomHttpClient
-            .from('t')
-            .select('messages(*)')
-            .limit(5, referencedTable: 'messages')
-            .range(0, 9, referencedTable: 'messages');
-      } catch (_) {
-        // Expected to fail with custom client, we just want to check the url
-      }
+    test(
+      'referencedTable range overrides a preceding limit and range',
+      () async {
+        try {
+          await postgrestCustomHttpClient
+              .from('t')
+              .select('messages(*)')
+              .limit(5, referencedTable: 'messages')
+              .range(0, 9, referencedTable: 'messages');
+        } catch (_) {
+          // Expected to fail with custom client, we just want to check the url
+        }
 
-      expect(
-        customHttpClient.lastRequest!.url.queryParametersAll['messages.limit'],
-        ['10'],
-      );
-      expect(
-        customHttpClient.lastRequest!.url.queryParametersAll['messages.offset'],
-        ['0'],
-      );
-    });
+        expect(
+          customHttpClient
+              .lastRequest!
+              .url
+              .queryParametersAll['messages.limit'],
+          ['10'],
+        );
+        expect(
+          customHttpClient
+              .lastRequest!
+              .url
+              .queryParametersAll['messages.offset'],
+          ['0'],
+        );
+      },
+    );
   });
 
   test('single', () async {
@@ -395,29 +409,32 @@ void main() {
     });
 
     test(
-        'maybeSingle followed by another transformer preserves the maybeSingle status',
-        () async {
-      await expectLater(
-        () => postgrest.from('channels').select().maybeSingle().limit(2),
-        throwsA(
-          isA<PostgrestException>().having((e) => e.code, 'code', '406'),
-        ),
-      );
-    });
+      'maybeSingle followed by another transformer preserves the maybeSingle status',
+      () async {
+        await expectLater(
+          () => postgrest.from('channels').select().maybeSingle().limit(2),
+          throwsA(
+            isA<PostgrestException>().having((e) => e.code, 'code', '406'),
+          ),
+        );
+      },
+    );
 
-    test('maybeSingle with converter throws if more than 1 rows were returned',
-        () async {
-      await expectLater(
-        () => postgrest
-            .from('channels')
-            .select()
-            .maybeSingle()
-            .withConverter((data) => data?.entries.length),
-        throwsA(
-          isA<PostgrestException>().having((e) => e.code, 'code', '406'),
-        ),
-      );
-    });
+    test(
+      'maybeSingle with converter throws if more than 1 rows were returned',
+      () async {
+        await expectLater(
+          () => postgrest
+              .from('channels')
+              .select()
+              .maybeSingle()
+              .withConverter((data) => data?.entries.length),
+          throwsA(
+            isA<PostgrestException>().having((e) => e.code, 'code', '406'),
+          ),
+        );
+      },
+    );
   });
 
   test('explain', () async {
@@ -427,7 +444,10 @@ void main() {
   });
 
   test('explain with options', () async {
-    final res = await postgrest.from('users').select().explain(
+    final res = await postgrest
+        .from('users')
+        .select()
+        .explain(
           analyze: true,
           verbose: true,
         );
@@ -477,10 +497,14 @@ void main() {
 
       expect(customHttpClient.lastRequest, isNotNull);
       expect(customHttpClient.lastRequest!.headers['Prefer'], isNotNull);
-      expect(customHttpClient.lastRequest!.headers['Prefer'],
-          contains('handling=strict'));
-      expect(customHttpClient.lastRequest!.headers['Prefer'],
-          contains('max-affected=5'));
+      expect(
+        customHttpClient.lastRequest!.headers['Prefer'],
+        contains('handling=strict'),
+      );
+      expect(
+        customHttpClient.lastRequest!.headers['Prefer'],
+        contains('max-affected=5'),
+      );
     });
 
     test('maxAffected sets correct headers for delete', () async {
@@ -496,10 +520,14 @@ void main() {
 
       expect(customHttpClient.lastRequest, isNotNull);
       expect(customHttpClient.lastRequest!.headers['Prefer'], isNotNull);
-      expect(customHttpClient.lastRequest!.headers['Prefer'],
-          contains('handling=strict'));
-      expect(customHttpClient.lastRequest!.headers['Prefer'],
-          contains('max-affected=10'));
+      expect(
+        customHttpClient.lastRequest!.headers['Prefer'],
+        contains('handling=strict'),
+      );
+      expect(
+        customHttpClient.lastRequest!.headers['Prefer'],
+        contains('max-affected=10'),
+      );
     });
 
     test('maxAffected preserves existing Prefer headers', () async {
@@ -522,20 +550,25 @@ void main() {
     });
 
     test(
-        'maxAffected works with select operations (sets headers but likely ineffective)',
-        () async {
-      try {
-        await postgrestCustomHttpClient.from('users').select().maxAffected(2);
-      } catch (_) {
-        // Expected to fail with custom client, we just want to check headers
-      }
+      'maxAffected works with select operations (sets headers but likely ineffective)',
+      () async {
+        try {
+          await postgrestCustomHttpClient.from('users').select().maxAffected(2);
+        } catch (_) {
+          // Expected to fail with custom client, we just want to check headers
+        }
 
-      expect(customHttpClient.lastRequest, isNotNull);
-      expect(customHttpClient.lastRequest!.headers['Prefer'], isNotNull);
-      expect(customHttpClient.lastRequest!.headers['Prefer'],
-          contains('handling=strict'));
-      expect(customHttpClient.lastRequest!.headers['Prefer'],
-          contains('max-affected=2'));
-    });
+        expect(customHttpClient.lastRequest, isNotNull);
+        expect(customHttpClient.lastRequest!.headers['Prefer'], isNotNull);
+        expect(
+          customHttpClient.lastRequest!.headers['Prefer'],
+          contains('handling=strict'),
+        );
+        expect(
+          customHttpClient.lastRequest!.headers['Prefer'],
+          contains('max-affected=2'),
+        );
+      },
+    );
   });
 }

--- a/packages/postgrest/test/upsert_test.dart
+++ b/packages/postgrest/test/upsert_test.dart
@@ -32,25 +32,27 @@ void main() {
           'external_id': 'ext_001',
           'source_system': 'system_a',
           'data': {'name': 'Test Item 1', 'value': 100},
-          'status': 'active'
+          'status': 'active',
         },
         {
           'external_id': 'ext_002',
           'source_system': 'system_a',
           'data': {'name': 'Test Item 2', 'value': 200},
-          'status': 'active'
+          'status': 'active',
         },
         {
           'external_id': 'ext_003',
           'source_system': 'system_b',
           'data': {'name': 'Test Item 3', 'value': 300},
-          'status': 'active'
-        }
+          'status': 'active',
+        },
       ];
 
       // Step 1: INSERT 3 rows (without onConflict)
-      final insertResult =
-          await postgrest.from('imported_data').insert(testData).select();
+      final insertResult = await postgrest
+          .from('imported_data')
+          .insert(testData)
+          .select();
 
       expect(insertResult.length, 3);
       expect(insertResult[0]['external_id'], 'ext_001');
@@ -63,8 +65,8 @@ void main() {
           'external_id': 'ext_001',
           'source_system': 'system_a',
           'data': {'name': 'Updated Item 1', 'value': 150},
-          'status': 'updated'
-        }
+          'status': 'updated',
+        },
       ];
 
       await expectLater(
@@ -80,8 +82,8 @@ void main() {
           'external_id': 'ext_001',
           'source_system': 'system_a',
           'data': {'name': 'Successfully Updated Item 1', 'value': 175},
-          'status': 'updated_via_upsert'
-        }
+          'status': 'updated_via_upsert',
+        },
       ];
 
       final upsertResult = await postgrest
@@ -116,59 +118,61 @@ void main() {
       expect(allRows.length, 3);
     });
 
-    test('upsert with List values and onConflict - multiple rows update',
-        () async {
-      // Clean up the imported_data table before starting the test
-      await postgrest.from('imported_data').delete().neq('id', 0);
+    test(
+      'upsert with List values and onConflict - multiple rows update',
+      () async {
+        // Clean up the imported_data table before starting the test
+        await postgrest.from('imported_data').delete().neq('id', 0);
 
-      // Test the fix with multiple rows in a single upsert operation
-      final initialData = [
-        {
-          'external_id': 'batch_001',
-          'source_system': 'batch_system',
-          'data': {'batch': 1, 'initial': true},
-          'status': 'initial'
-        },
-        {
-          'external_id': 'batch_002',
-          'source_system': 'batch_system',
-          'data': {'batch': 1, 'initial': true},
-          'status': 'initial'
-        }
-      ];
+        // Test the fix with multiple rows in a single upsert operation
+        final initialData = [
+          {
+            'external_id': 'batch_001',
+            'source_system': 'batch_system',
+            'data': {'batch': 1, 'initial': true},
+            'status': 'initial',
+          },
+          {
+            'external_id': 'batch_002',
+            'source_system': 'batch_system',
+            'data': {'batch': 1, 'initial': true},
+            'status': 'initial',
+          },
+        ];
 
-      // Insert initial data
-      await postgrest.from('imported_data').insert(initialData).select();
+        // Insert initial data
+        await postgrest.from('imported_data').insert(initialData).select();
 
-      // Update both rows in a single upsert operation
-      final updateData = [
-        {
-          'external_id': 'batch_001',
-          'source_system': 'batch_system',
-          'data': {'batch': 1, 'updated': true},
-          'status': 'batch_updated'
-        },
-        {
-          'external_id': 'batch_002',
-          'source_system': 'batch_system',
-          'data': {'batch': 1, 'updated': true},
-          'status': 'batch_updated'
-        }
-      ];
+        // Update both rows in a single upsert operation
+        final updateData = [
+          {
+            'external_id': 'batch_001',
+            'source_system': 'batch_system',
+            'data': {'batch': 1, 'updated': true},
+            'status': 'batch_updated',
+          },
+          {
+            'external_id': 'batch_002',
+            'source_system': 'batch_system',
+            'data': {'batch': 1, 'updated': true},
+            'status': 'batch_updated',
+          },
+        ];
 
-      final batchUpsertResult = await postgrest
-          .from('imported_data')
-          .upsert(
-            updateData,
-            onConflict: 'external_id,source_system',
-          )
-          .select();
+        final batchUpsertResult = await postgrest
+            .from('imported_data')
+            .upsert(
+              updateData,
+              onConflict: 'external_id,source_system',
+            )
+            .select();
 
-      expect(batchUpsertResult.length, 2);
-      expect(batchUpsertResult[0]['status'], 'batch_updated');
-      expect(batchUpsertResult[1]['status'], 'batch_updated');
-      expect(batchUpsertResult[0]['data']['updated'], isTrue);
-      expect(batchUpsertResult[1]['data']['updated'], isTrue);
-    });
+        expect(batchUpsertResult.length, 2);
+        expect(batchUpsertResult[0]['status'], 'batch_updated');
+        expect(batchUpsertResult[1]['status'], 'batch_updated');
+        expect(batchUpsertResult[0]['data']['updated'], isTrue);
+        expect(batchUpsertResult[1]['data']['updated'], isTrue);
+      },
+    );
   });
 }

--- a/packages/realtime_client/example/main.dart
+++ b/packages/realtime_client/example/main.dart
@@ -2,12 +2,14 @@ import 'package:realtime_client/realtime_client.dart';
 
 /// Example to use with Supabase Realtime https://supabase.io/
 Future<void> main() async {
-  final socket = RealtimeClient('ws://SUPABASE_API_ENDPOINT/realtime/v1',
-      params: {'apikey': 'SUPABSE_API_KEY'},
-      // ignore: avoid_print
-      logger: (kind, msg, data) {
-    print('$kind $msg $data');
-  });
+  final socket = RealtimeClient(
+    'ws://SUPABASE_API_ENDPOINT/realtime/v1',
+    params: {'apikey': 'SUPABSE_API_KEY'},
+    // ignore: avoid_print
+    logger: (kind, msg, data) {
+      print('$kind $msg $data');
+    },
+  );
 
   final channel = socket.channel('realtime:public');
   channel.onPostgresChanges(
@@ -20,17 +22,19 @@ Future<void> main() async {
     callback: (payload) {},
   );
   channel.onPostgresChanges(
-      event: PostgresChangeEvent.delete,
-      schema: 'public',
-      callback: (payload) {
-        print('channel delete payload: ${payload.toString()}');
-      });
+    event: PostgresChangeEvent.delete,
+    schema: 'public',
+    callback: (payload) {
+      print('channel delete payload: ${payload.toString()}');
+    },
+  );
   channel.onPostgresChanges(
-      event: PostgresChangeEvent.insert,
-      schema: 'public',
-      callback: (payload) {
-        print('channel insert payload: ${payload.toString()}');
-      });
+    event: PostgresChangeEvent.insert,
+    schema: 'public',
+    callback: (payload) {
+      print('channel insert payload: ${payload.toString()}');
+    },
+  );
 
   socket.onMessage((message) => print('MESSAGE $message'));
 

--- a/packages/realtime_client/lib/src/message.dart
+++ b/packages/realtime_client/lib/src/message.dart
@@ -45,8 +45,9 @@ class Message {
     }
     return {
       'topic': topic,
-      'event':
-          event != ChannelEvents.heartbeat ? event.eventName() : 'heartbeat',
+      'event': event != ChannelEvents.heartbeat
+          ? event.eventName()
+          : 'heartbeat',
       'payload': processedPayload,
       if (ref != null) 'ref': ref,
       if (joinRef != null) 'join_ref': joinRef,

--- a/packages/realtime_client/lib/src/realtime_channel.dart
+++ b/packages/realtime_client/lib/src/realtime_channel.dart
@@ -40,10 +40,12 @@ class RealtimeChannel {
     this.topic,
     this.socket, {
     RealtimeChannelConfig params = const RealtimeChannelConfig(),
-  })  : _timeout = socket.timeout,
-        params = params.toMap(),
-        subTopic = topic.replaceFirst(
-            RegExp(r"^realtime:", caseSensitive: false), "") {
+  }) : _timeout = socket.timeout,
+       params = params.toMap(),
+       subTopic = topic.replaceFirst(
+         RegExp(r"^realtime:", caseSensitive: false),
+         "",
+       ) {
     broadcastEndpointURL = '${httpEndpointURL(socket.endPoint)}/api/broadcast';
     _private = params.private;
 
@@ -53,8 +55,10 @@ class RealtimeChannel {
       this.params,
       _timeout,
     );
-    _rejoinTimer =
-        RetryTimer(() => rejoinUntilConnected(), socket.reconnectAfterMs);
+    _rejoinTimer = RetryTimer(
+      () => rejoinUntilConnected(),
+      socket.reconnectAfterMs,
+    );
     joinPush.receive('ok', (_) {
       _state = ChannelStates.joined;
       _rejoinTimer.reset();
@@ -89,8 +93,10 @@ class RealtimeChannel {
       _rejoinTimer.scheduleTimeout();
     });
 
-    onEvents(ChannelEvents.reply.eventName(), ChannelFilter(), (payload,
-        [ref]) {
+    onEvents(ChannelEvents.reply.eventName(), ChannelFilter(), (
+      payload, [
+      ref,
+    ]) {
       trigger(replyEventName(ref), payload);
     });
 
@@ -168,8 +174,10 @@ class RealtimeChannel {
         if (callback != null) {
           callback(
             RealtimeSubscribeStatus.channelError,
-            Exception(payload['message']?.toString() ??
-                'postgres_changes subscription failed'),
+            Exception(
+              payload['message']?.toString() ??
+                  'postgres_changes subscription failed',
+            ),
           );
         }
       }
@@ -197,24 +205,30 @@ class RealtimeChannel {
 
     joinPush
         .receive(
-      'ok',
-      (response) =>
-          unawaited(_handleJoinOk(response as Map<String, dynamic>, callback)),
-    )
-        .receive('error', (error) {
-      if (callback != null) {
-        callback(
-          RealtimeSubscribeStatus.channelError,
-          Exception(
-            jsonEncode((error as Map<String, dynamic>).isNotEmpty
-                ? (error).values.join(', ')
-                : 'error'),
+          'ok',
+          (response) => unawaited(
+            _handleJoinOk(response as Map<String, dynamic>, callback),
           ),
-        );
-      }
-    }).receive('timeout', (_) {
-      if (callback != null) callback(RealtimeSubscribeStatus.timedOut, null);
-    });
+        )
+        .receive('error', (error) {
+          if (callback != null) {
+            callback(
+              RealtimeSubscribeStatus.channelError,
+              Exception(
+                jsonEncode(
+                  (error as Map<String, dynamic>).isNotEmpty
+                      ? (error).values.join(', ')
+                      : 'error',
+                ),
+              ),
+            );
+          }
+        })
+        .receive('timeout', (_) {
+          if (callback != null) {
+            callback(RealtimeSubscribeStatus.timedOut, null);
+          }
+        });
     return this;
   }
 
@@ -264,16 +278,19 @@ class RealtimeChannel {
           serverPostgresFilter['schema'] == schema &&
           serverPostgresFilter['table'] == table &&
           serverPostgresFilter['filter'] == filter) {
-        newPostgresBindings.add(clientPostgresBinding.copyWith(
-          id: serverPostgresFilter['id']?.toString(),
-        ));
+        newPostgresBindings.add(
+          clientPostgresBinding.copyWith(
+            id: serverPostgresFilter['id']?.toString(),
+          ),
+        );
       } else {
         unawaited(unsubscribe());
         if (callback != null) {
           callback(
             RealtimeSubscribeStatus.channelError,
             Exception(
-                'mismatch between server and client bindings for postgres changes'),
+              'mismatch between server and client bindings for postgres changes',
+            ),
           );
         }
         return;
@@ -289,13 +306,17 @@ class RealtimeChannel {
 
   List<SinglePresenceState> presenceState() {
     return presence.state.entries
-        .map((entry) =>
-            SinglePresenceState(key: entry.key, presences: entry.value))
+        .map(
+          (entry) =>
+              SinglePresenceState(key: entry.key, presences: entry.value),
+        )
         .toList();
   }
 
-  Future<ChannelResponse> track(Map<String, dynamic> payload,
-      [Map<String, dynamic> opts = const {}]) {
+  Future<ChannelResponse> track(
+    Map<String, dynamic> payload, [
+    Map<String, dynamic> opts = const {},
+  ]) {
     return send(
       type: RealtimeListenTypes.presence,
       payload: {
@@ -320,14 +341,20 @@ class RealtimeChannel {
 
   /// Registers a callback that will be executed when the channel closes.
   void _onClose(Function callback) {
-    onEvents(ChannelEvents.close.eventName(), ChannelFilter(),
-        (reason, [ref]) => callback());
+    onEvents(
+      ChannelEvents.close.eventName(),
+      ChannelFilter(),
+      (reason, [ref]) => callback(),
+    );
   }
 
   /// Registers a callback that will be executed when the channel encounteres an error.
   void _onError(Function callback) {
-    onEvents(ChannelEvents.error.eventName(), ChannelFilter(),
-        (reason, [ref]) => callback(reason));
+    onEvents(
+      ChannelEvents.error.eventName(),
+      ChannelFilter(),
+      (reason, [ref]) => callback(reason),
+    );
   }
 
   /// Sets up a listener on your Supabase database.
@@ -417,8 +444,11 @@ class RealtimeChannel {
         event: PresenceEvent.sync.name,
       ),
       (payload, [ref]) {
-        callback(RealtimePresenceSyncPayload.fromJson(
-            Map<String, dynamic>.from(payload)));
+        callback(
+          RealtimePresenceSyncPayload.fromJson(
+            Map<String, dynamic>.from(payload),
+          ),
+        );
       },
     );
     _handlePresenceUpdate();
@@ -445,8 +475,11 @@ class RealtimeChannel {
         event: PresenceEvent.join.name,
       ),
       (payload, [ref]) {
-        callback(RealtimePresenceJoinPayload.fromJson(
-            Map<String, dynamic>.from(payload)));
+        callback(
+          RealtimePresenceJoinPayload.fromJson(
+            Map<String, dynamic>.from(payload),
+          ),
+        );
       },
     );
     _handlePresenceUpdate();
@@ -473,8 +506,11 @@ class RealtimeChannel {
         event: PresenceEvent.leave.name,
       ),
       (payload, [ref]) {
-        callback(RealtimePresenceLeavePayload.fromJson(
-            Map<String, dynamic>.from(payload)));
+        callback(
+          RealtimePresenceLeavePayload.fromJson(
+            Map<String, dynamic>.from(payload),
+          ),
+        );
       },
     );
     _handlePresenceUpdate();
@@ -494,7 +530,10 @@ class RealtimeChannel {
 
   @internal
   RealtimeChannel onEvents(
-      String type, ChannelFilter filter, BindingCallback callback) {
+    String type,
+    ChannelFilter filter,
+    BindingCallback callback,
+  ) {
     final typeLower = type.toLowerCase();
 
     final binding = Binding(typeLower, filter.toMap(), callback);
@@ -588,8 +627,9 @@ class RealtimeChannel {
 
     final headers = {
       ..._broadcastHeaders,
-      'Content-Type':
-          isBinary ? 'application/octet-stream' : 'application/json',
+      'Content-Type': isBinary
+          ? 'application/octet-stream'
+          : 'application/json',
     };
 
     final url = Uri.parse(
@@ -601,12 +641,15 @@ class RealtimeChannel {
 
     final body = isBinary ? _asBytes(payload) : json.encode(payload);
 
-    final response = await (socket.httpClient?.post ?? post)(url,
-            headers: headers, body: body)
-        .timeout(
-      timeout ?? _timeout,
-      onTimeout: () => throw TimeoutException('Request timeout'),
-    );
+    final response =
+        await (socket.httpClient?.post ?? post)(
+          url,
+          headers: headers,
+          body: body,
+        ).timeout(
+          timeout ?? _timeout,
+          onTimeout: () => throw TimeoutException('Request timeout'),
+        );
 
     if (response.statusCode == 202) {
       return;
@@ -623,9 +666,9 @@ class RealtimeChannel {
     String errorMessage = response.reasonPhrase ?? 'Unknown error';
     try {
       final errorBody = json.decode(response.body) as Map<String, dynamic>;
-      errorMessage = (errorBody['error'] ??
-          errorBody['message'] ??
-          errorMessage) as String;
+      errorMessage =
+          (errorBody['error'] ?? errorBody['message'] ?? errorMessage)
+              as String;
     } catch (_) {
       // If JSON parsing fails, use the default error message
     }
@@ -737,12 +780,12 @@ class RealtimeChannel {
   }
 
   Map<String, String> get _broadcastHeaders => {
-        'Content-Type': 'application/json',
-        if (socket.params['apikey'] != null) 'apikey': socket.params['apikey']!,
-        ...socket.headers,
-        if (socket.accessToken != null)
-          'Authorization': 'Bearer ${socket.accessToken}',
-      };
+    'Content-Type': 'application/json',
+    if (socket.params['apikey'] != null) 'apikey': socket.params['apikey']!,
+    ...socket.headers,
+    if (socket.accessToken != null)
+      'Authorization': 'Bearer ${socket.accessToken}',
+  };
 
   Map<String, dynamic> _broadcastBody(
     String? event,
@@ -755,8 +798,8 @@ class RealtimeChannel {
           'event': event,
           'payload': payload,
           'private': _private,
-        }
-      ]
+        },
+      ],
     };
   }
 
@@ -788,22 +831,25 @@ class RealtimeChannel {
 
     final leavePush = Push(this, ChannelEvents.leave, {}, timeout ?? _timeout);
 
-    leavePush.receive('ok', (_) {
-      onClose();
-      if (!completer.isCompleted) {
-        completer.complete('ok');
-      }
-    }).receive('timeout', (_) {
-      if (!completer.isCompleted) {
-        onClose();
-      }
-      completer.complete('timed out');
-    }).receive('error', (_) {
-      onClose();
-      if (!completer.isCompleted) {
-        completer.complete('error');
-      }
-    });
+    leavePush
+        .receive('ok', (_) {
+          onClose();
+          if (!completer.isCompleted) {
+            completer.complete('ok');
+          }
+        })
+        .receive('timeout', (_) {
+          if (!completer.isCompleted) {
+            onClose();
+          }
+          completer.complete('timed out');
+        })
+        .receive('error', (_) {
+          onClose();
+          if (!completer.isCompleted) {
+            completer.complete('error');
+          }
+        });
 
     leavePush.send();
 

--- a/packages/realtime_client/lib/src/realtime_client.dart
+++ b/packages/realtime_client/lib/src/realtime_client.dart
@@ -14,10 +14,11 @@ import 'package:realtime_client/src/serializer.dart';
 import 'package:realtime_client/src/websocket/websocket.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
 
-typedef WebSocketTransport = WebSocketChannel Function(
-  String url,
-  Map<String, String> headers,
-);
+typedef WebSocketTransport =
+    WebSocketChannel Function(
+      String url,
+      Map<String, String> headers,
+    );
 
 /// Serializes an outgoing message into the `String` or binary frame written to
 /// the WebSocket.
@@ -187,27 +188,31 @@ class RealtimeClient {
     this.httpClient,
     this.customAccessToken,
     this.version = RealtimeProtocolVersion.v2,
-  })  : endPoint = Uri.parse('$endPoint/${Transports.websocket}')
-            .replace(
-              queryParameters:
-                  logLevel == null ? null : {'log_level': logLevel.name},
-            )
-            .toString(),
-        headers = {
-          ...Constants.defaultHeaders,
-          ...?headers,
-        },
-        transport = transport ?? createWebSocketClient,
-        encode = encode ??
-            (version == RealtimeProtocolVersion.v1
-                ? _encodeLegacy
-                : _serializer.encode),
-        decode = decode ??
-            (version == RealtimeProtocolVersion.v1
-                ? _decodeLegacy
-                : _serializer.decode) {
+  }) : endPoint = Uri.parse('$endPoint/${Transports.websocket}')
+           .replace(
+             queryParameters: logLevel == null
+                 ? null
+                 : {'log_level': logLevel.name},
+           )
+           .toString(),
+       headers = {
+         ...Constants.defaultHeaders,
+         ...?headers,
+       },
+       transport = transport ?? createWebSocketClient,
+       encode =
+           encode ??
+           (version == RealtimeProtocolVersion.v1
+               ? _encodeLegacy
+               : _serializer.encode),
+       decode =
+           decode ??
+           (version == RealtimeProtocolVersion.v1
+               ? _decodeLegacy
+               : _serializer.decode) {
     _log.config(
-        'Initialize RealtimeClient with endpoint: $endPoint, timeout: $timeout, heartbeatIntervalMs: $heartbeatIntervalMs, logLevel: ${logLevel?.name}');
+      'Initialize RealtimeClient with endpoint: $endPoint, timeout: $timeout, heartbeatIntervalMs: $heartbeatIntervalMs, logLevel: ${logLevel?.name}',
+    );
     _log.finest('Initialize with headers: $headers, params: $params');
     final customJWT = this.headers['Authorization']?.split(' ').last;
     accessToken = customJWT ?? params['apikey'];
@@ -297,8 +302,10 @@ class RealtimeClient {
       if (shouldCloseSink) {
         // Don't set the state to `disconnecting` if the connection is already closed.
         connState = SocketStates.disconnecting;
-        log('transport', 'disconnecting', {'code': code, 'reason': reason},
-            Level.FINE);
+        log('transport', 'disconnecting', {
+          'code': code,
+          'reason': reason,
+        }, Level.FINE);
       }
 
       // Connection cannot be closed while it's still connecting. Wait for connection to
@@ -345,8 +352,9 @@ class RealtimeClient {
   }
 
   Future<List<String>> removeAllChannels() async {
-    final values =
-        await Future.wait(channels.map((channel) => channel.unsubscribe()));
+    final values = await Future.wait(
+      channels.map((channel) => channel.unsubscribe()),
+    );
     unawaited(disconnect());
     return values;
   }
@@ -354,11 +362,12 @@ class RealtimeClient {
   /// Logs the message. Override `this.logger` for specialized logging.
   ///
   /// [level] must be [Level.FINEST] for senitive data
-  void log(
-      [String? kind,
-      String? message,
-      dynamic data,
-      Level level = Level.FINEST]) {
+  void log([
+    String? kind,
+    String? message,
+    dynamic data,
+    Level level = Level.FINEST,
+  ]) {
     _log.log(level, '$kind: $message', data);
     logger?.call(kind, message, data);
   }
@@ -435,8 +444,11 @@ class RealtimeClient {
       conn?.sink.add(encode(message.toJson()));
     }
 
-    log('push', '${message.topic} ${message.event.name} (${message.ref})',
-        message.payload);
+    log(
+      'push',
+      '${message.topic} ${message.event.name} (${message.ref})',
+      message.payload,
+    );
 
     if (isConnected) {
       callback();
@@ -476,7 +488,9 @@ class RealtimeClient {
       payload,
     );
 
-    channels.where((channel) => channel.isMember(topic)).forEach(
+    channels
+        .where((channel) => channel.isMember(topic))
+        .forEach(
           (channel) => channel.trigger(
             event,
             payload,
@@ -606,10 +620,12 @@ class RealtimeClient {
     }
 
     var endpoint = Uri.parse(url);
-    endpoint = endpoint.replace(queryParameters: {
-      ...endpoint.queryParameters,
-      ...queryParameters,
-    });
+    endpoint = endpoint.replace(
+      queryParameters: {
+        ...endpoint.queryParameters,
+        ...queryParameters,
+      },
+    );
 
     return endpoint.toString();
   }
@@ -641,12 +657,14 @@ class RealtimeClient {
       return;
     }
     pendingHeartbeatRef = makeRef();
-    push(Message(
-      topic: 'phoenix',
-      event: ChannelEvents.heartbeat,
-      payload: {},
-      ref: pendingHeartbeatRef!,
-    ));
+    push(
+      Message(
+        topic: 'phoenix',
+        event: ChannelEvents.heartbeat,
+        payload: {},
+        ref: pendingHeartbeatRef!,
+      ),
+    );
     _heartbeatController.add(RealtimeHeartbeatStatus.sent);
     await setAuth(accessToken);
   }

--- a/packages/realtime_client/lib/src/realtime_presence.dart
+++ b/packages/realtime_client/lib/src/realtime_presence.dart
@@ -38,11 +38,11 @@ class Presence {
 
 typedef PresenceChooser<T> = T Function(String key, dynamic presence);
 
-typedef PresenceOnJoinCallback = void Function(
-    String? key, dynamic currentPresences, dynamic newPresences);
+typedef PresenceOnJoinCallback =
+    void Function(String? key, dynamic currentPresences, dynamic newPresences);
 
-typedef PresenceOnLeaveCallback = void Function(
-    String? key, dynamic currentPresences, dynamic newPresences);
+typedef PresenceOnLeaveCallback =
+    void Function(String? key, dynamic currentPresences, dynamic newPresences);
 
 class PresenceOpts {
   final PresenceEvents events;
@@ -64,7 +64,7 @@ class RealtimePresence {
   Map<String, dynamic> caller = {
     'onJoin': (_, __, ___) {},
     'onLeave': (_, __, ___) {},
-    'onSync': () {}
+    'onSync': () {},
   };
 
   final RealtimeChannel channel;
@@ -75,7 +75,8 @@ class RealtimePresence {
   ///
   /// `opts` - The options, for example `PresenceOpts(events: PresenceEvents(state: 'state', diff: 'diff'))`
   RealtimePresence(this.channel, [PresenceOpts? opts]) {
-    final events = opts?.events ??
+    final events =
+        opts?.events ??
         PresenceEvents(state: 'presence_state', diff: 'presence_diff');
 
     channel.onEvents(events.state, ChannelFilter(), (newState, [_]) {
@@ -179,13 +180,17 @@ class RealtimePresence {
       final currentPresences = state[key];
 
       if (currentPresences != null) {
-        final newPresenceRefs =
-            (newPresences as List).map((m) => m.presenceRef as String).toList();
-        final curPresenceRefs =
-            currentPresences.map((m) => m.presenceRef).toList();
-        final joinedPresences = newPresences
-            .where((m) => !curPresenceRefs.contains(m.presenceRef))
-            .toList() as List<Presence>;
+        final newPresenceRefs = (newPresences as List)
+            .map((m) => m.presenceRef as String)
+            .toList();
+        final curPresenceRefs = currentPresences
+            .map((m) => m.presenceRef)
+            .toList();
+        final joinedPresences =
+            newPresences
+                    .where((m) => !curPresenceRefs.contains(m.presenceRef))
+                    .toList()
+                as List<Presence>;
         final leftPresences = currentPresences
             .where((m) => !newPresenceRefs.contains(m.presenceRef))
             .toList();
@@ -231,8 +236,9 @@ class RealtimePresence {
       }).toList();
 
       if (currentPresences.isNotEmpty) {
-        final joinedPresenceRefs =
-            state[key]!.map((m) => m.presenceRef).toList();
+        final joinedPresenceRefs = state[key]!
+            .map((m) => m.presenceRef)
+            .toList();
         final curPresences = currentPresences
             .where((m) => !joinedPresenceRefs.contains(m.presenceRef))
             .toList();
@@ -253,8 +259,9 @@ class RealtimePresence {
           .toList();
 
       currentPresences = currentPresences
-          .where((presence) =>
-              !presenceRefsToRemove.contains(presence.presenceRef))
+          .where(
+            (presence) => !presenceRefsToRemove.contains(presence.presenceRef),
+          )
           .toList();
 
       state[key] = currentPresences;
@@ -309,8 +316,9 @@ class RealtimePresence {
       final presences = state[key]!;
 
       if (presences is Map) {
-        newStateMap[key] =
-            (presences['metas'] as List).map<Presence>((presence) {
+        newStateMap[key] = (presences['metas'] as List).map<Presence>((
+          presence,
+        ) {
           presence['presence_ref'] = presence['phx_ref'] as String;
 
           presence.remove('phx_ref');
@@ -327,9 +335,16 @@ class RealtimePresence {
   }
 
   static Map<String, List<Presence>> _cloneDeep(
-      Map<String, List<Presence>> obj) {
-    return Map.fromEntries(obj.entries.map((entry) => MapEntry(entry.key,
-        entry.value.map((presence) => presence.deepClone()).toList())));
+    Map<String, List<Presence>> obj,
+  ) {
+    return Map.fromEntries(
+      obj.entries.map(
+        (entry) => MapEntry(
+          entry.key,
+          entry.value.map((presence) => presence.deepClone()).toList(),
+        ),
+      ),
+    );
   }
 
   void onJoin(PresenceOnJoinCallback callback) {

--- a/packages/realtime_client/lib/src/serializer.dart
+++ b/packages/realtime_client/lib/src/serializer.dart
@@ -36,7 +36,7 @@ class Serializer {
   final List<String> allowedMetadataKeys;
 
   const Serializer({List<String>? allowedMetadataKeys})
-      : allowedMetadataKeys = allowedMetadataKeys ?? const [];
+    : allowedMetadataKeys = allowedMetadataKeys ?? const [];
 
   /// Encodes a message map into the string or binary representation that is
   /// written to the WebSocket.
@@ -107,7 +107,8 @@ class Serializer {
     _checkLength('userEvent', userEvent.length);
     _checkLength('metadata', metadata.length);
 
-    final metaLength = userBroadcastPushMetaLength +
+    final metaLength =
+        userBroadcastPushMetaLength +
         joinRef.length +
         ref.length +
         topic.length +
@@ -151,15 +152,18 @@ class Serializer {
     final payloadEncoding = view.getUint8(4);
 
     var offset = headerLength + userBroadcastMetaLength;
-    final topic =
-        utf8.decode(Uint8List.sublistView(buffer, offset, offset + topicSize));
+    final topic = utf8.decode(
+      Uint8List.sublistView(buffer, offset, offset + topicSize),
+    );
     offset += topicSize;
-    final userEvent = utf8
-        .decode(Uint8List.sublistView(buffer, offset, offset + userEventSize));
+    final userEvent = utf8.decode(
+      Uint8List.sublistView(buffer, offset, offset + userEventSize),
+    );
     offset += userEventSize;
     final metadata = metadataSize > 0
         ? utf8.decode(
-            Uint8List.sublistView(buffer, offset, offset + metadataSize))
+            Uint8List.sublistView(buffer, offset, offset + metadataSize),
+          )
         : '';
     offset += metadataSize;
 

--- a/packages/realtime_client/lib/src/transformers.dart
+++ b/packages/realtime_client/lib/src/transformers.dart
@@ -166,7 +166,7 @@ dynamic convertCell(String type, dynamic value) {
     case PostgresTypes.text:
     case PostgresTypes.time: // To allow users to cast it based on Timezone
     case PostgresTypes
-          .timestamptz: // To allow users to cast it based on Timezone
+        .timestamptz: // To allow users to cast it based on Timezone
     case PostgresTypes.timetz: // To allow users to cast it based on Timezone
     case PostgresTypes.tsrange:
     case PostgresTypes.tstzrange:
@@ -304,7 +304,8 @@ Map<String, dynamic> getEnrichedPayload(Map<String, dynamic> payload) {
 }
 
 Map<String, Map<String, dynamic>> getPayloadRecords(
-    Map<String, dynamic> payload) {
+  Map<String, dynamic> payload,
+) {
   // ignore: avoid-inferrable-type-arguments
   final records = <String, Map<String, dynamic>>{
     'new': {},

--- a/packages/realtime_client/lib/src/types.dart
+++ b/packages/realtime_client/lib/src/types.dart
@@ -64,7 +64,8 @@ extension PostgresChangeEventMethods on PostgresChangeEvent {
         return PostgresChangeEvent.delete;
     }
     throw ArgumentError(
-        'Only "INSERT", "UPDATE", or "DELETE" can be can be passed to `fromString()` method.');
+      'Only "INSERT", "UPDATE", or "DELETE" can be can be passed to `fromString()` method.',
+    );
   }
 }
 
@@ -104,9 +105,10 @@ enum ChannelResponse {
   ok,
   timedOut,
   @Deprecated(
-      'Client side rate limiting has been removed, and this enum value will never be returned.')
+    'Client side rate limiting has been removed, and this enum value will never be returned.',
+  )
   rateLimited,
-  error
+  error,
 }
 
 enum RealtimeListenTypes { postgresChanges, broadcast, presence, system }
@@ -121,7 +123,8 @@ extension PresenceEventExtended on PresenceEvent {
       }
     }
     throw ArgumentError(
-        'Only "sync", "join", or "leave" can be can be passed to `fromString()` method.');
+      'Only "sync", "join", or "leave" can be can be passed to `fromString()` method.',
+    );
   }
 }
 
@@ -204,7 +207,7 @@ class RealtimeChannelConfig {
           'enabled': enabled,
         },
         'private': private,
-      }
+      },
     };
   }
 }
@@ -247,8 +250,9 @@ class PostgresChangePayload {
       schema: payload['schema'] as String,
       table: payload['table'] as String,
       commitTimestamp: commitTimestamp,
-      eventType:
-          PostgresChangeEventMethods.fromString(payload['eventType'] as String),
+      eventType: PostgresChangeEventMethods.fromString(
+        payload['eventType'] as String,
+      ),
       newRecord: newData is Map ? Map.from(newData) : {},
       oldRecord: oldData is Map ? Map.from(oldData) : {},
       errors: payload['errors'],
@@ -307,7 +311,7 @@ enum PostgresChangeFilterType {
   gte,
 
   /// Listen to changes when a column's value in a table equals any of the values specified.
-  inFilter;
+  inFilter,
 }
 
 /// {@template postgres_change_filter}
@@ -352,7 +356,7 @@ abstract class RealtimePresencePayload {
   });
 
   RealtimePresencePayload.fromJson(Map<String, dynamic> json)
-      : event = PresenceEventExtended.fromString(json['event']);
+    : event = PresenceEventExtended.fromString(json['event']);
 
   @override
   String toString() => 'PresencePayload(event: ${event.name})';

--- a/packages/realtime_client/pubspec.yaml
+++ b/packages/realtime_client/pubspec.yaml
@@ -6,7 +6,7 @@ repository: 'https://github.com/supabase/supabase-flutter/tree/main/packages/rea
 documentation: 'https://supabase.com/docs/reference/dart/subscribe'
 
 environment:
-  sdk: '>=3.4.0 <4.0.0'
+  sdk: '>=3.9.0 <4.0.0'
 
 dependencies:
   collection: ^1.15.0

--- a/packages/realtime_client/test/channel_test.dart
+++ b/packages/realtime_client/test/channel_test.dart
@@ -25,8 +25,11 @@ void main() {
   group('constructor', () {
     setUp(() {
       socket = RealtimeClient('', timeout: const Duration(milliseconds: 1234));
-      channel =
-          RealtimeChannel('topic', socket, params: RealtimeChannelConfig());
+      channel = RealtimeChannel(
+        'topic',
+        socket,
+        params: RealtimeChannelConfig(),
+      );
     });
 
     test('sets defaults', () {
@@ -37,7 +40,7 @@ void main() {
           'broadcast': {'ack': false, 'self': false},
           'presence': {'key': '', 'enabled': false},
           'private': false,
-        }
+        },
       });
       expect(channel.socket, socket);
     });
@@ -107,8 +110,7 @@ void main() {
     // that specific message so it does not escape as an unhandled async
     // error (which Sentry/Crashlytics surface as a fatal). See
     // https://github.com/supabase/supabase-flutter/issues/1363.
-    test(
-        "swallows FormatException with 'InvalidJWTToken' from setAuth and "
+    test("swallows FormatException with 'InvalidJWTToken' from setAuth and "
         "still emits 'subscribed' status", () async {
       final throwingSocket = _SetAuthThrowingSocket(
         '/socket',
@@ -132,13 +134,13 @@ void main() {
       expect(
         status,
         RealtimeSubscribeStatus.subscribed,
-        reason: "If the catch is missing the 'ok' callback aborts at setAuth "
+        reason:
+            "If the catch is missing the 'ok' callback aborts at setAuth "
             "and the subscribed status is never emitted.",
       );
     });
 
-    test(
-        "non-InvalidJWTToken FormatExceptions from setAuth still abort the "
+    test("non-InvalidJWTToken FormatExceptions from setAuth still abort the "
         "rejoin handler", () async {
       final throwingSocket = _SetAuthThrowingSocket(
         '/socket',
@@ -151,18 +153,24 @@ void main() {
       RealtimeSubscribeStatus? status;
       // Use runZonedGuarded so the rethrown async error does not pollute
       // the test runner zone.
-      await runZonedGuarded(() async {
-        localChannel.subscribe((s, _) => status = s);
-        localChannel.joinPush.trigger('ok', {});
-        await Future<void>.value();
-        await Future<void>.value();
-      }, (_, __) {/* expected: rethrown FormatException */});
+      await runZonedGuarded(
+        () async {
+          localChannel.subscribe((s, _) => status = s);
+          localChannel.joinPush.trigger('ok', {});
+          await Future<void>.value();
+          await Future<void>.value();
+        },
+        (_, __) {
+          /* expected: rethrown FormatException */
+        },
+      );
 
       expect(throwingSocket.setAuthCalls, 1);
       expect(
         status,
         isNull,
-        reason: 'A non-InvalidJWTToken FormatException should propagate out of '
+        reason:
+            'A non-InvalidJWTToken FormatException should propagate out of '
             'the callback before subscribed is emitted.',
       );
     });
@@ -174,8 +182,7 @@ void main() {
       channel = socket.channel('topic');
     });
 
-    test(
-        'subscribes when the server echoes back an `in` filter with escaped '
+    test('subscribes when the server echoes back an `in` filter with escaped '
         'quotes and backslashes', () {
       RealtimeSubscribeStatus? status;
       channel.onPostgresChanges(
@@ -192,8 +199,9 @@ void main() {
 
       channel.subscribe((newStatus, _) => status = newStatus);
 
-      final sentFilter = (channel.joinPush.payload['config']['postgres_changes']
-          as List)[0] as Map;
+      final sentFilter =
+          (channel.joinPush.payload['config']['postgres_changes'] as List)[0]
+              as Map;
       expect(sentFilter['filter'], r'name=in.("a\"b\\c")');
 
       channel.joinPush.trigger('ok', {
@@ -205,8 +213,7 @@ void main() {
       expect(status, RealtimeSubscribeStatus.subscribed);
     });
 
-    test(
-        'reports a channelError when the server echoes back a different '
+    test('reports a channelError when the server echoes back a different '
         'filter', () {
       RealtimeSubscribeStatus? status;
       channel.onPostgresChanges(
@@ -223,8 +230,9 @@ void main() {
 
       channel.subscribe((newStatus, _) => status = newStatus);
 
-      final sentFilter = (channel.joinPush.payload['config']['postgres_changes']
-          as List)[0] as Map;
+      final sentFilter =
+          (channel.joinPush.payload['config']['postgres_changes'] as List)[0]
+              as Map;
 
       channel.joinPush.trigger('ok', {
         'postgres_changes': [
@@ -274,27 +282,29 @@ void main() {
       channel = socket.channel('topic');
     });
 
-    test('forwards a system error to the subscribe callback as channelError',
-        () {
-      RealtimeSubscribeStatus? status;
-      Object? error;
-      channel.subscribe((newStatus, newError) {
-        status = newStatus;
-        error = newError;
-      });
+    test(
+      'forwards a system error to the subscribe callback as channelError',
+      () {
+        RealtimeSubscribeStatus? status;
+        Object? error;
+        channel.subscribe((newStatus, newError) {
+          status = newStatus;
+          error = newError;
+        });
 
-      channel.trigger('system', {
-        'status': 'error',
-        'message': 'Unable to subscribe to changes with given parameters',
-      });
+        channel.trigger('system', {
+          'status': 'error',
+          'message': 'Unable to subscribe to changes with given parameters',
+        });
 
-      expect(status, RealtimeSubscribeStatus.channelError);
-      expect(error, isA<Exception>());
-      expect(
-        error?.toString(),
-        contains('Unable to subscribe to changes with given parameters'),
-      );
-    });
+        expect(status, RealtimeSubscribeStatus.channelError);
+        expect(error, isA<Exception>());
+        expect(
+          error?.toString(),
+          contains('Unable to subscribe to changes with given parameters'),
+        );
+      },
+    );
 
     test('falls back to a default message when the system error has none', () {
       Object? error;
@@ -304,7 +314,9 @@ void main() {
 
       expect(error, isA<Exception>());
       expect(
-          error?.toString(), contains('postgres_changes subscription failed'));
+        error?.toString(),
+        contains('postgres_changes subscription failed'),
+      );
     });
 
     test('does not surface a system ok event as an error', () {
@@ -341,8 +353,11 @@ void main() {
 
     test('sets up callback for event', () {
       var callbackCalled = 0;
-      channel.onEvents('event', ChannelFilter(),
-          (dynamic payload, [dynamic ref]) => callbackCalled++);
+      channel.onEvents(
+        'event',
+        ChannelFilter(),
+        (dynamic payload, [dynamic ref]) => callbackCalled++,
+      );
 
       channel.trigger('event', {});
       expect(callbackCalled, 1);
@@ -369,8 +384,11 @@ void main() {
 
     test('"*" bind all events', () {
       var callbackCalled = 0;
-      channel.onEvents('realtime', ChannelFilter(event: '*'),
-          (dynamic payload, [dynamic ref]) => callbackCalled++);
+      channel.onEvents(
+        'realtime',
+        ChannelFilter(event: '*'),
+        (dynamic payload, [dynamic ref]) => callbackCalled++,
+      );
 
       channel.trigger('realtime', {'event': 'INSERT'});
       channel.trigger('realtime', {'event': 'UPDATE'});
@@ -391,12 +409,21 @@ void main() {
       var callbackEventCalled2 = 0;
       var callbackOtherCalled = 0;
 
-      channel.onEvents('event', ChannelFilter(),
-          (dynamic payload, [dynamic ref]) => callBackEventCalled1++);
-      channel.onEvents('event', ChannelFilter(),
-          (dynamic payload, [dynamic ref]) => callbackEventCalled2++);
-      channel.onEvents('other', ChannelFilter(),
-          (dynamic payload, [dynamic ref]) => callbackOtherCalled++);
+      channel.onEvents(
+        'event',
+        ChannelFilter(),
+        (dynamic payload, [dynamic ref]) => callBackEventCalled1++,
+      );
+      channel.onEvents(
+        'event',
+        ChannelFilter(),
+        (dynamic payload, [dynamic ref]) => callbackEventCalled2++,
+      );
+      channel.onEvents(
+        'other',
+        ChannelFilter(),
+        (dynamic payload, [dynamic ref]) => callbackOtherCalled++,
+      );
 
       channel.off('event', {});
 
@@ -408,8 +435,7 @@ void main() {
       expect(callbackOtherCalled, 1);
     });
 
-    test(
-        'maintains type safety after off() - '
+    test('maintains type safety after off() - '
         'reproduces web hot restart issue', () {
       // This test reproduces the issue where .where().toList() returns
       // List<dynamic> on Flutter web during hot restart, causing a
@@ -417,12 +443,21 @@ void main() {
       // Map<String, List<Binding>>
 
       // Add multiple bindings
-      channel.onEvents('postgres_changes', ChannelFilter(),
-          (dynamic payload, [dynamic ref]) {});
-      channel.onEvents('postgres_changes', ChannelFilter(),
-          (dynamic payload, [dynamic ref]) {});
       channel.onEvents(
-          'broadcast', ChannelFilter(), (dynamic payload, [dynamic ref]) {});
+        'postgres_changes',
+        ChannelFilter(),
+        (dynamic payload, [dynamic ref]) {},
+      );
+      channel.onEvents(
+        'postgres_changes',
+        ChannelFilter(),
+        (dynamic payload, [dynamic ref]) {},
+      );
+      channel.onEvents(
+        'broadcast',
+        ChannelFilter(),
+        (dynamic payload, [dynamic ref]) {},
+      );
 
       // Call off() which internally uses .where().toList()
       // Without explicit type cast, this would fail on web with:
@@ -435,13 +470,19 @@ void main() {
 
       // Verify the bindings map still has proper type after off()
       // This would throw a type error if off() returned List<dynamic>
-      channel.onEvents('postgres_changes', ChannelFilter(),
-          (dynamic payload, [dynamic ref]) {});
+      channel.onEvents(
+        'postgres_changes',
+        ChannelFilter(),
+        (dynamic payload, [dynamic ref]) {},
+      );
 
       // Verify functionality still works
       var broadcastCalled = 0;
-      channel.onEvents('broadcast', ChannelFilter(),
-          (dynamic payload, [dynamic ref]) => broadcastCalled++);
+      channel.onEvents(
+        'broadcast',
+        ChannelFilter(),
+        (dynamic payload, [dynamic ref]) => broadcastCalled++,
+      );
       channel.trigger('broadcast', {}, defaultRef);
       expect(broadcastCalled, 1);
     });
@@ -507,8 +548,10 @@ void main() {
     });
 
     test('sets endpoint', () {
-      expect(channel.broadcastEndpointURL,
-          'http://${mockServer.address.host}:${mockServer.port}/realtime/v1/api/broadcast');
+      expect(
+        channel.broadcastEndpointURL,
+        'http://${mockServer.address.host}:${mockServer.port}/realtime/v1/api/broadcast',
+      );
       expect(channel.subTopic, 'myTopic');
     });
 
@@ -522,20 +565,23 @@ void main() {
 
       // Accept the websocket the client opens on subscribe, then reply to the
       // channel join so it transitions to subscribed.
-      final serverSocket =
-          await mockServer.first.then(WebSocketTransformer.upgrade);
+      final serverSocket = await mockServer.first.then(
+        WebSocketTransformer.upgrade,
+      );
       final broadcast = Completer<List<dynamic>>();
       serverSocket.listen((frame) {
         final message = jsonDecode(frame as String) as List;
         switch (message[3]) {
           case 'phx_join':
-            serverSocket.add(jsonEncode([
-              message[0],
-              message[1],
-              message[2],
-              'phx_reply',
-              {'status': 'ok', 'response': <String, dynamic>{}},
-            ]));
+            serverSocket.add(
+              jsonEncode([
+                message[0],
+                message[1],
+                message[2],
+                'phx_reply',
+                {'status': 'ok', 'response': <String, dynamic>{}},
+              ]),
+            );
           case 'broadcast':
             broadcast.complete(message);
         }
@@ -557,68 +603,70 @@ void main() {
     });
 
     test(
-        'send message via http request to Broadcast endpoint when not subscribed to channel',
-        () async {
-      final requestFuture = mockServer.first;
-      final sendFuture = channel.send(
-        type: RealtimeListenTypes.broadcast,
-        payload: {'myKey': 'myValue'},
-      );
+      'send message via http request to Broadcast endpoint when not subscribed to channel',
+      () async {
+        final requestFuture = mockServer.first;
+        final sendFuture = channel.send(
+          type: RealtimeListenTypes.broadcast,
+          payload: {'myKey': 'myValue'},
+        );
 
-      final request = await requestFuture;
-      expect(request.uri.toString(), '/realtime/v1/api/broadcast');
-      expect(request.headers.value('apikey'), 'supabaseKey');
+        final request = await requestFuture;
+        expect(request.uri.toString(), '/realtime/v1/api/broadcast');
+        expect(request.headers.value('apikey'), 'supabaseKey');
 
-      final body = json.decode(await utf8.decodeStream(request));
-      final message = body['messages'].first;
-      expect(message['payload'], containsPair('myKey', 'myValue'));
-      expect(message, containsPair('topic', 'myTopic'));
-      expect(message['private'], isTrue);
+        final body = json.decode(await utf8.decodeStream(request));
+        final message = body['messages'].first;
+        expect(message['payload'], containsPair('myKey', 'myValue'));
+        expect(message, containsPair('topic', 'myTopic'));
+        expect(message['private'], isTrue);
 
-      await request.response.close();
+        await request.response.close();
 
-      expect(await sendFuture, ChannelResponse.ok);
-    });
+        expect(await sendFuture, ChannelResponse.ok);
+      },
+    );
   });
 
   group('presence', () {
     setUp(() {
       socket = RealtimeClient('', timeout: const Duration(milliseconds: 1234));
-      channel =
-          RealtimeChannel('topic', socket, params: RealtimeChannelConfig());
+      channel = RealtimeChannel(
+        'topic',
+        socket,
+        params: RealtimeChannelConfig(),
+      );
     });
 
     test('description', () async {
       bool syncCalled = false, joinCalled = false, leaveCalled = false;
-      channel.onPresenceSync((payload) {
-        syncCalled = true;
-      }).onPresenceJoin((payload) {
-        joinCalled = true;
-      }).onPresenceLeave((payload) {
-        leaveCalled = true;
-      }).subscribe();
+      channel
+          .onPresenceSync((payload) {
+            syncCalled = true;
+          })
+          .onPresenceJoin((payload) {
+            joinCalled = true;
+          })
+          .onPresenceLeave((payload) {
+            leaveCalled = true;
+          })
+          .subscribe();
 
       channel.trigger('presence', {'event': 'sync'}, '1');
       expect(syncCalled, isTrue);
-      channel.trigger(
-          'presence',
-          {
-            'event': 'join',
-            'key': 'joinKey',
-            'newPresences': <Presence>[],
-            'currentPresences': <Presence>[],
-          },
-          '2');
+      channel.trigger('presence', {
+        'event': 'join',
+        'key': 'joinKey',
+        'newPresences': <Presence>[],
+        'currentPresences': <Presence>[],
+      }, '2');
       expect(joinCalled, isTrue);
-      channel.trigger(
-          'presence',
-          {
-            'event': 'leave',
-            'key': 'leaveKey',
-            'leftPresences': <Presence>[],
-            'currentPresences': <Presence>[],
-          },
-          '3');
+      channel.trigger('presence', {
+        'event': 'leave',
+        'key': 'leaveKey',
+        'leftPresences': <Presence>[],
+        'currentPresences': <Presence>[],
+      }, '3');
       expect(leaveCalled, isTrue);
     });
   });
@@ -629,19 +677,20 @@ void main() {
     });
 
     test(
-        'should enable presence when config.presence.enabled is true even without bindings',
-        () {
-      channel = RealtimeChannel(
-        'topic',
-        socket,
-        params: const RealtimeChannelConfig(enabled: true),
-      );
+      'should enable presence when config.presence.enabled is true even without bindings',
+      () {
+        channel = RealtimeChannel(
+          'topic',
+          socket,
+          params: const RealtimeChannelConfig(enabled: true),
+        );
 
-      channel.subscribe();
+        channel.subscribe();
 
-      final joinPayload = channel.joinPush.payload;
-      expect(joinPayload['config']['presence']['enabled'], isTrue);
-    });
+        final joinPayload = channel.joinPush.payload;
+        expect(joinPayload['config']['presence']['enabled'], isTrue);
+      },
+    );
 
     test('should enable presence when presence listeners exist', () {
       channel = RealtimeChannel(
@@ -658,35 +707,37 @@ void main() {
     });
 
     test(
-        'should enable presence when both bindings exist and config.presence.enabled is true',
-        () {
-      channel = RealtimeChannel(
-        'topic',
-        socket,
-        params: const RealtimeChannelConfig(enabled: true),
-      );
+      'should enable presence when both bindings exist and config.presence.enabled is true',
+      () {
+        channel = RealtimeChannel(
+          'topic',
+          socket,
+          params: const RealtimeChannelConfig(enabled: true),
+        );
 
-      channel.onPresenceSync((payload) {});
-      channel.subscribe();
+        channel.onPresenceSync((payload) {});
+        channel.subscribe();
 
-      final joinPayload = channel.joinPush.payload;
-      expect(joinPayload['config']['presence']['enabled'], isTrue);
-    });
+        final joinPayload = channel.joinPush.payload;
+        expect(joinPayload['config']['presence']['enabled'], isTrue);
+      },
+    );
 
     test(
-        'should not enable presence when neither bindings exist nor config.presence.enabled is true',
-        () {
-      channel = RealtimeChannel(
-        'topic',
-        socket,
-        params: const RealtimeChannelConfig(),
-      );
+      'should not enable presence when neither bindings exist nor config.presence.enabled is true',
+      () {
+        channel = RealtimeChannel(
+          'topic',
+          socket,
+          params: const RealtimeChannelConfig(),
+        );
 
-      channel.subscribe();
+        channel.subscribe();
 
-      final joinPayload = channel.joinPush.payload;
-      expect(joinPayload['config']['presence']['enabled'], isFalse);
-    });
+        final joinPayload = channel.joinPush.payload;
+        expect(joinPayload['config']['presence']['enabled'], isFalse);
+      },
+    );
 
     test('should enable presence when join listener exists', () {
       channel = RealtimeChannel(
@@ -723,102 +774,108 @@ void main() {
     });
 
     test(
-        'should resubscribe when presence callback added to subscribed channel without initial presence',
-        () {
-      channel = RealtimeChannel(
-        'topic',
-        socket,
-        params: const RealtimeChannelConfig(),
-      );
+      'should resubscribe when presence callback added to subscribed channel without initial presence',
+      () {
+        channel = RealtimeChannel(
+          'topic',
+          socket,
+          params: const RealtimeChannelConfig(),
+        );
 
-      channel.subscribe();
-      channel.joinPush.trigger('ok', {});
-      expect(channel.params['config']['presence']['enabled'], isFalse);
+        channel.subscribe();
+        channel.joinPush.trigger('ok', {});
+        expect(channel.params['config']['presence']['enabled'], isFalse);
 
-      channel.onPresenceSync((payload) {});
+        channel.onPresenceSync((payload) {});
 
-      expect(channel.params['config']['presence']['enabled'], isTrue);
-    });
-
-    test(
-        'should not resubscribe when presence callback added to channel with existing presence',
-        () {
-      channel = RealtimeChannel(
-        'topic',
-        socket,
-        params: const RealtimeChannelConfig(enabled: true),
-      );
-
-      channel.subscribe();
-      channel.joinPush.trigger('ok', {});
-      final initialPayload = Map.from(channel.params);
-
-      channel.onPresenceSync((payload) {});
-
-      expect(channel.params['config']['presence']['enabled'], isTrue);
-      expect(channel.params, equals(initialPayload));
-    });
-
-    test('should only resubscribe once when multiple presence callbacks added',
-        () {
-      channel = RealtimeChannel(
-        'topic',
-        socket,
-        params: const RealtimeChannelConfig(),
-      );
-
-      channel.subscribe();
-      channel.joinPush.trigger('ok', {});
-      expect(channel.params['config']['presence']['enabled'], isFalse);
-
-      channel.onPresenceSync((payload) {});
-      expect(channel.params['config']['presence']['enabled'], isTrue);
-
-      final payloadAfterFirst = Map.from(channel.params);
-
-      channel.onPresenceJoin((payload) {});
-      channel.onPresenceLeave((payload) {});
-
-      expect(channel.params, equals(payloadAfterFirst));
-    });
+        expect(channel.params['config']['presence']['enabled'], isTrue);
+      },
+    );
 
     test(
-        'should not resubscribe when presence callback added to unsubscribed channel',
-        () {
-      channel = RealtimeChannel(
-        'topic',
-        socket,
-        params: const RealtimeChannelConfig(),
-      );
+      'should not resubscribe when presence callback added to channel with existing presence',
+      () {
+        channel = RealtimeChannel(
+          'topic',
+          socket,
+          params: const RealtimeChannelConfig(enabled: true),
+        );
 
-      expect(channel.joinedOnce, isFalse);
+        channel.subscribe();
+        channel.joinPush.trigger('ok', {});
+        final initialPayload = Map.from(channel.params);
 
-      channel.onPresenceSync((payload) {});
+        channel.onPresenceSync((payload) {});
 
-      expect(channel.params['config']['presence']['enabled'], isFalse);
-    });
+        expect(channel.params['config']['presence']['enabled'], isTrue);
+        expect(channel.params, equals(initialPayload));
+      },
+    );
 
     test(
-        'should receive presence events after resubscription triggered by adding callback',
-        () {
-      channel = RealtimeChannel(
-        'topic',
-        socket,
-        params: const RealtimeChannelConfig(),
-      );
+      'should only resubscribe once when multiple presence callbacks added',
+      () {
+        channel = RealtimeChannel(
+          'topic',
+          socket,
+          params: const RealtimeChannelConfig(),
+        );
 
-      channel.subscribe();
-      channel.joinPush.trigger('ok', {});
+        channel.subscribe();
+        channel.joinPush.trigger('ok', {});
+        expect(channel.params['config']['presence']['enabled'], isFalse);
 
-      bool syncCalled = false;
-      channel.onPresenceSync((payload) {
-        syncCalled = true;
-      });
+        channel.onPresenceSync((payload) {});
+        expect(channel.params['config']['presence']['enabled'], isTrue);
 
-      channel.trigger('presence', {'event': 'sync'}, '1');
+        final payloadAfterFirst = Map.from(channel.params);
 
-      expect(syncCalled, isTrue);
-    });
+        channel.onPresenceJoin((payload) {});
+        channel.onPresenceLeave((payload) {});
+
+        expect(channel.params, equals(payloadAfterFirst));
+      },
+    );
+
+    test(
+      'should not resubscribe when presence callback added to unsubscribed channel',
+      () {
+        channel = RealtimeChannel(
+          'topic',
+          socket,
+          params: const RealtimeChannelConfig(),
+        );
+
+        expect(channel.joinedOnce, isFalse);
+
+        channel.onPresenceSync((payload) {});
+
+        expect(channel.params['config']['presence']['enabled'], isFalse);
+      },
+    );
+
+    test(
+      'should receive presence events after resubscription triggered by adding callback',
+      () {
+        channel = RealtimeChannel(
+          'topic',
+          socket,
+          params: const RealtimeChannelConfig(),
+        );
+
+        channel.subscribe();
+        channel.joinPush.trigger('ok', {});
+
+        bool syncCalled = false;
+        channel.onPresenceSync((payload) {
+          syncCalled = true;
+        });
+
+        channel.trigger('presence', {'event': 'sync'}, '1');
+
+        expect(syncCalled, isTrue);
+      },
+    );
 
     test('should handle presence join callback resubscription', () {
       channel = RealtimeChannel(
@@ -864,34 +921,40 @@ void main() {
       await mockServer.close();
     });
 
-    test('sends message via http endpoint with correct headers and payload',
-        () async {
-      socket = RealtimeClient(
-        'ws://${mockServer.address.host}:${mockServer.port}/realtime/v1',
-        headers: {'apikey': 'supabaseKey'},
-        params: {'apikey': 'supabaseKey'},
-      );
-      channel =
-          socket.channel('myTopic', const RealtimeChannelConfig(private: true));
+    test(
+      'sends message via http endpoint with correct headers and payload',
+      () async {
+        socket = RealtimeClient(
+          'ws://${mockServer.address.host}:${mockServer.port}/realtime/v1',
+          headers: {'apikey': 'supabaseKey'},
+          params: {'apikey': 'supabaseKey'},
+        );
+        channel = socket.channel(
+          'myTopic',
+          const RealtimeChannelConfig(private: true),
+        );
 
-      final requestFuture = mockServer.first;
-      final sendFuture =
-          channel.httpSend(event: 'test', payload: {'myKey': 'myValue'});
+        final requestFuture = mockServer.first;
+        final sendFuture = channel.httpSend(
+          event: 'test',
+          payload: {'myKey': 'myValue'},
+        );
 
-      final req = await requestFuture;
-      expect(req.uri.path, '/realtime/v1/api/broadcast/myTopic/events/test');
-      expect(req.uri.queryParameters['private'], 'true');
-      expect(req.headers.value('apikey'), 'supabaseKey');
-      expect(req.headers.contentType?.mimeType, 'application/json');
+        final req = await requestFuture;
+        expect(req.uri.path, '/realtime/v1/api/broadcast/myTopic/events/test');
+        expect(req.uri.queryParameters['private'], 'true');
+        expect(req.headers.value('apikey'), 'supabaseKey');
+        expect(req.headers.contentType?.mimeType, 'application/json');
 
-      final body = json.decode(await utf8.decodeStream(req));
-      expect(body, {'myKey': 'myValue'});
+        final body = json.decode(await utf8.decodeStream(req));
+        expect(body, {'myKey': 'myValue'});
 
-      req.response.statusCode = 202;
-      await req.response.close();
+        req.response.statusCode = 202;
+        await req.response.close();
 
-      await sendFuture;
-    });
+        await sendFuture;
+      },
+    );
 
     test('omits private query parameter for public channels', () async {
       socket = RealtimeClient(
@@ -902,8 +965,10 @@ void main() {
       channel = socket.channel('myTopic');
 
       final requestFuture = mockServer.first;
-      final sendFuture =
-          channel.httpSend(event: 'test', payload: {'myKey': 'myValue'});
+      final sendFuture = channel.httpSend(
+        event: 'test',
+        payload: {'myKey': 'myValue'},
+      );
 
       final req = await requestFuture;
       expect(req.uri.path, '/realtime/v1/api/broadcast/myTopic/events/test');
@@ -924,8 +989,10 @@ void main() {
       channel = socket.channel('room:42');
 
       final requestFuture = mockServer.first;
-      final sendFuture =
-          channel.httpSend(event: 'user/joined', payload: {'id': 1});
+      final sendFuture = channel.httpSend(
+        event: 'user/joined',
+        payload: {'id': 1},
+      );
 
       final req = await requestFuture;
       expect(
@@ -955,8 +1022,10 @@ void main() {
       expect(req.uri.path, '/realtime/v1/api/broadcast/myTopic/events/bin');
       expect(req.headers.contentType?.mimeType, 'application/octet-stream');
 
-      final received = await req
-          .fold<List<int>>(<int>[], (acc, chunk) => acc..addAll(chunk));
+      final received = await req.fold<List<int>>(
+        <int>[],
+        (acc, chunk) => acc..addAll(chunk),
+      );
       expect(received, equals(bytes));
 
       req.response.statusCode = 202;
@@ -980,8 +1049,10 @@ void main() {
       final req = await requestFuture;
       expect(req.headers.contentType?.mimeType, 'application/octet-stream');
 
-      final received = await req
-          .fold<List<int>>(<int>[], (acc, chunk) => acc..addAll(chunk));
+      final received = await req.fold<List<int>>(
+        <int>[],
+        (acc, chunk) => acc..addAll(chunk),
+      );
       expect(received, equals(bytes));
 
       req.response.statusCode = 202;
@@ -1000,8 +1071,10 @@ void main() {
       channel = socket.channel('topic');
 
       final requestFuture = mockServer.first;
-      final sendFuture =
-          channel.httpSend(event: 'test', payload: {'data': 'test'});
+      final sendFuture = channel.httpSend(
+        event: 'test',
+        payload: {'data': 'test'},
+      );
 
       final req = await requestFuture;
       expect(req.headers.value('Authorization'), 'Bearer token123');
@@ -1021,8 +1094,10 @@ void main() {
       channel = socket.channel('topic');
 
       final requestFuture = mockServer.first;
-      final sendFuture =
-          channel.httpSend(event: 'test', payload: {'data': 'test'});
+      final sendFuture = channel.httpSend(
+        event: 'test',
+        payload: {'data': 'test'},
+      );
 
       final req = await requestFuture;
       req.response.statusCode = 500;
@@ -1031,8 +1106,11 @@ void main() {
 
       await expectLater(
         sendFuture,
-        throwsA(predicate(
-            (Object error) => error.toString().contains('Server error'))),
+        throwsA(
+          predicate(
+            (Object error) => error.toString().contains('Server error'),
+          ),
+        ),
       );
     });
 
@@ -1044,11 +1122,13 @@ void main() {
       channel = socket.channel('topic');
 
       // Don't await the server - let it hang to trigger timeout
-      unawaited(mockServer.first.then((req) async {
-        await Future.delayed(const Duration(seconds: 1));
-        req.response.statusCode = 202;
-        await req.response.close();
-      }));
+      unawaited(
+        mockServer.first.then((req) async {
+          await Future.delayed(const Duration(seconds: 1));
+          req.response.statusCode = 202;
+          await req.response.close();
+        }),
+      );
 
       await expectLater(
         channel.httpSend(

--- a/packages/realtime_client/test/heartbeat_test.dart
+++ b/packages/realtime_client/test/heartbeat_test.dart
@@ -49,17 +49,19 @@ void main() {
     expect(client.pendingHeartbeatRef, isNotNull);
   });
 
-  test('emits timeout when the previous heartbeat was not acknowledged',
-      () async {
-    client.connState = SocketStates.open;
-    client.pendingHeartbeatRef = 'stale-ref';
+  test(
+    'emits timeout when the previous heartbeat was not acknowledged',
+    () async {
+      client.connState = SocketStates.open;
+      client.pendingHeartbeatRef = 'stale-ref';
 
-    await client.sendHeartbeat();
-    await pumpEventQueue();
+      await client.sendHeartbeat();
+      await pumpEventQueue();
 
-    expect(statuses, [RealtimeHeartbeatStatus.timeout]);
-    expect(client.pendingHeartbeatRef, isNull);
-  });
+      expect(statuses, [RealtimeHeartbeatStatus.timeout]);
+      expect(client.pendingHeartbeatRef, isNull);
+    },
+  );
 
   test('emits ok when the heartbeat reply succeeds', () async {
     client.pendingHeartbeatRef = 'ref-1';
@@ -80,13 +82,15 @@ void main() {
     expect(statuses, [RealtimeHeartbeatStatus.error]);
   });
 
-  test('does not emit for messages that are not the pending heartbeat',
-      () async {
-    client.pendingHeartbeatRef = 'ref-3';
+  test(
+    'does not emit for messages that are not the pending heartbeat',
+    () async {
+      client.pendingHeartbeatRef = 'ref-3';
 
-    client.onConnMessage(heartbeatReply('other-ref', 'ok'));
-    await pumpEventQueue();
+      client.onConnMessage(heartbeatReply('other-ref', 'ok'));
+      await pumpEventQueue();
 
-    expect(statuses, isEmpty);
-  });
+      expect(statuses, isEmpty);
+    },
+  );
 }

--- a/packages/realtime_client/test/mock_test.dart
+++ b/packages/realtime_client/test/mock_test.dart
@@ -99,12 +99,12 @@ void main() {
                     {
                       'name': 'task',
                       'type': 'text',
-                      'type_modifier': 4294967295
+                      'type_modifier': 4294967295,
                     },
                     {
                       'name': 'status',
                       'type': 'bool',
-                      'type_modifier': 4294967295
+                      'type_modifier': 4294967295,
                     },
                   ],
                   'commit_timestamp': '2021-08-01T08:00:30Z',
@@ -134,12 +134,12 @@ void main() {
                     {
                       'name': 'task',
                       'type': 'text',
-                      'type_modifier': 4294967295
+                      'type_modifier': 4294967295,
                     },
                     {
                       'name': 'status',
                       'type': 'bool',
-                      'type_modifier': 4294967295
+                      'type_modifier': 4294967295,
                     },
                   ],
                   'commit_timestamp': '2022-09-14T02:12:52Z',
@@ -150,7 +150,7 @@ void main() {
                   'type': 'DELETE',
                   if (postgresFilter != null) 'filter': postgresFilter,
                 },
-                'ids': [48673474]
+                'ids': [48673474],
               },
             ]);
             webSocket!.add(deleteString);
@@ -193,12 +193,13 @@ void main() {
       client
           .channel('public:todos')
           .onPostgresChanges(
-              event: PostgresChangeEvent.all,
-              schema: 'public',
-              table: 'todos',
-              callback: (payload) {
-                streamController.add(payload);
-              })
+            event: PostgresChangeEvent.all,
+            schema: 'public',
+            table: 'todos',
+            callback: (payload) {
+              streamController.add(payload);
+            },
+          )
           .subscribe();
 
       expect(
@@ -211,7 +212,7 @@ void main() {
             'eventType': 'INSERT',
             'new': {'id': 3, 'task': 'task 3', 'status': true},
             'old': {},
-            'errors': null
+            'errors': null,
           }),
           PostgresChangePayload.fromPayload({
             'schema': 'public',
@@ -220,7 +221,7 @@ void main() {
             'eventType': 'UPDATE',
             'new': {'id': 2, 'task': 'task 2 updated', 'status': false},
             'old': {'id': 2},
-            'errors': null
+            'errors': null,
           }),
           PostgresChangePayload.fromPayload({
             'schema': 'public',
@@ -229,7 +230,7 @@ void main() {
             'eventType': 'DELETE',
             'new': {},
             'old': {'id': 2},
-            'errors': null
+            'errors': null,
           }),
         ]),
       );
@@ -241,17 +242,18 @@ void main() {
       client
           .channel('public:todos')
           .onPostgresChanges(
-              event: PostgresChangeEvent.all,
-              schema: 'public',
-              table: 'todos',
-              filter: PostgresChangeFilter(
-                type: PostgresChangeFilterType.eq,
-                column: 'id',
-                value: 2,
-              ),
-              callback: (payload) {
-                streamController.add(payload);
-              })
+            event: PostgresChangeEvent.all,
+            schema: 'public',
+            table: 'todos',
+            filter: PostgresChangeFilter(
+              type: PostgresChangeFilterType.eq,
+              column: 'id',
+              value: 2,
+            ),
+            callback: (payload) {
+              streamController.add(payload);
+            },
+          )
           .subscribe();
 
       expect(
@@ -264,7 +266,7 @@ void main() {
             'eventType': 'UPDATE',
             'new': {'id': 2, 'task': 'task 2 updated', 'status': false},
             'old': {'id': 2},
-            'errors': null
+            'errors': null,
           }),
           PostgresChangePayload.fromPayload({
             'schema': 'public',
@@ -273,15 +275,17 @@ void main() {
             'eventType': 'DELETE',
             'new': {},
             'old': {'id': 2},
-            'errors': null
-          })
+            'errors': null,
+          }),
         ]),
       );
     });
 
     test("correct CHANNEL_ERROR data on heartbeat timeout", () async {
-      final subscribeCallback =
-          expectAsync2((RealtimeSubscribeStatus event, error) {
+      final subscribeCallback = expectAsync2((
+        RealtimeSubscribeStatus event,
+        error,
+      ) {
         if (event == RealtimeSubscribeStatus.channelError) {
           expect(error, isA<RealtimeCloseEvent>());
           error as RealtimeCloseEvent;
@@ -291,12 +295,17 @@ void main() {
         }
       }, count: 2);
 
-      final channel = client.channel('public:todos').onPostgresChanges(
+      final channel = client
+          .channel('public:todos')
+          .onPostgresChanges(
             event: PostgresChangeEvent.all,
             schema: 'public',
             table: 'todos',
             filter: PostgresChangeFilter(
-                type: PostgresChangeFilterType.eq, column: 'id', value: 2),
+              type: PostgresChangeFilterType.eq,
+              column: 'id',
+              value: 2,
+            ),
             callback: (payload) {},
           );
 
@@ -360,14 +369,14 @@ void main() {
                   "columns": [
                     {"name": "id", "type": "int4"},
                     {"name": "task", "type": "text"},
-                    {"name": "status", "type": "bool"}
+                    {"name": "status", "type": "bool"},
                   ],
                   "commit_timestamp": "2022-09-24T05:42:01.303668+00:00",
                   "errors": null,
                   "record": {"id": 1, "status": true, "task": "task 1"},
                   "schema": "public",
                   "table": "todos",
-                  "type": "INSERT"
+                  "type": "INSERT",
                 },
               ]);
               webSocket!.add(insertString);
@@ -384,7 +393,7 @@ void main() {
                 "columns": [
                   {"name": "id", "type": "int4"},
                   {"name": "task", "type": "text"},
-                  {"name": "status", "type": "bool"}
+                  {"name": "status", "type": "bool"},
                 ],
                 "commit_timestamp": "2022-09-24T05:42:01.303668+00:00",
                 "errors": null,
@@ -392,7 +401,7 @@ void main() {
                 "record": {"id": 2, "status": false, "task": "task 2 updated"},
                 "schema": "public",
                 "table": "todos",
-                "type": "UPDATE"
+                "type": "UPDATE",
               },
             ]);
             webSocket!.add(updateString);
@@ -408,7 +417,7 @@ void main() {
                 "columns": [
                   {"name": "id", "type": "int4"},
                   {"name": "task", "type": "text"},
-                  {"name": "status", "type": "bool"}
+                  {"name": "status", "type": "bool"},
                 ],
                 "commit_timestamp": "2022-09-24T05:42:01.303668+00:00",
                 "errors": null,
@@ -416,7 +425,7 @@ void main() {
                 "record": {},
                 "schema": "public",
                 "table": "todos",
-                "type": "DELETE"
+                "type": "DELETE",
               },
             ]);
             webSocket!.add(deleteString);
@@ -447,12 +456,13 @@ void main() {
       client
           .channel('public:todos')
           .onPostgresChanges(
-              event: PostgresChangeEvent.all,
-              schema: 'public',
-              table: 'todos',
-              callback: (payload) {
-                streamController.add(payload);
-              })
+            event: PostgresChangeEvent.all,
+            schema: 'public',
+            table: 'todos',
+            callback: (payload) {
+              streamController.add(payload);
+            },
+          )
           .subscribe();
 
       expect(
@@ -465,7 +475,7 @@ void main() {
             'eventType': 'INSERT',
             'new': {'id': 1, 'task': 'task 1', 'status': true},
             'old': {},
-            'errors': null
+            'errors': null,
           }),
           PostgresChangePayload.fromPayload({
             'schema': 'public',
@@ -474,7 +484,7 @@ void main() {
             'eventType': 'UPDATE',
             'new': {'id': 2, 'task': 'task 2 updated', 'status': false},
             'old': {'id': 2},
-            'errors': null
+            'errors': null,
           }),
           PostgresChangePayload.fromPayload({
             'schema': 'public',
@@ -483,7 +493,7 @@ void main() {
             'eventType': 'DELETE',
             'new': {},
             'old': {'id': 2},
-            'errors': null
+            'errors': null,
           }),
         ]),
       );
@@ -495,14 +505,18 @@ void main() {
       client
           .channel('public:todos')
           .onPostgresChanges(
-              event: PostgresChangeEvent.all,
-              schema: 'public',
-              table: 'todos',
-              filter: PostgresChangeFilter(
-                  type: PostgresChangeFilterType.eq, column: 'id', value: 2),
-              callback: (payload) {
-                streamController.add(payload);
-              })
+            event: PostgresChangeEvent.all,
+            schema: 'public',
+            table: 'todos',
+            filter: PostgresChangeFilter(
+              type: PostgresChangeFilterType.eq,
+              column: 'id',
+              value: 2,
+            ),
+            callback: (payload) {
+              streamController.add(payload);
+            },
+          )
           .subscribe();
 
       expect(
@@ -515,7 +529,7 @@ void main() {
             'eventType': 'UPDATE',
             'new': {'id': 2, 'task': 'task 2 updated', 'status': false},
             'old': {'id': 2},
-            'errors': null
+            'errors': null,
           }),
           PostgresChangePayload.fromPayload({
             'schema': 'public',
@@ -524,7 +538,7 @@ void main() {
             'eventType': 'DELETE',
             'new': {},
             'old': {'id': 2},
-            'errors': null
+            'errors': null,
           }),
         ]),
       );

--- a/packages/realtime_client/test/realtime_integration_test.dart
+++ b/packages/realtime_client/test/realtime_integration_test.dart
@@ -107,8 +107,9 @@ void main() {
           },
         );
 
-        final payload =
-            await received.future.timeout(const Duration(seconds: 15));
+        final payload = await received.future.timeout(
+          const Duration(seconds: 15),
+        );
         expect(payload['event'], 'ping');
         expect(payload['payload'], {'value': 42});
       });
@@ -141,8 +142,9 @@ void main() {
           },
         );
 
-        final payload =
-            await received.future.timeout(const Duration(seconds: 15));
+        final payload = await received.future.timeout(
+          const Duration(seconds: 15),
+        );
         expect(payload['payload'], {'x': 1, 'y': 2});
       });
 
@@ -176,8 +178,9 @@ void main() {
           '2026-06-15T00:00:00Z',
         );
 
-        final joinPayload =
-            await joined.future.timeout(const Duration(seconds: 15));
+        final joinPayload = await joined.future.timeout(
+          const Duration(seconds: 15),
+        );
         expect(joinPayload.key, 'user-1');
         expect(joinPayload.newPresences, isNotEmpty);
       });
@@ -198,8 +201,9 @@ void main() {
         await _waitFor(() => channel.presenceState().isNotEmpty);
         await channel.untrack();
 
-        final leavePayload =
-            await left.future.timeout(const Duration(seconds: 15));
+        final leavePayload = await left.future.timeout(
+          const Duration(seconds: 15),
+        );
         expect(leavePayload.key, 'user-2');
         expect(channel.presenceState(), isEmpty);
       });
@@ -250,24 +254,28 @@ void main() {
           await db.execute(
             "INSERT INTO public.todos (task) VALUES ('write tests')",
           );
-          final insert =
-              await inserts.future.timeout(const Duration(seconds: 20));
+          final insert = await inserts.future.timeout(
+            const Duration(seconds: 20),
+          );
           expect(insert.eventType, PostgresChangeEvent.insert);
           expect(insert.newRecord['task'], 'write tests');
 
           await db.execute(
             "UPDATE public.todos SET is_complete = true WHERE task = 'write tests'",
           );
-          final update =
-              await updates.future.timeout(const Duration(seconds: 20));
+          final update = await updates.future.timeout(
+            const Duration(seconds: 20),
+          );
           expect(update.eventType, PostgresChangeEvent.update);
           expect(update.newRecord['is_complete'], isTrue);
           expect(update.oldRecord['is_complete'], isFalse);
 
-          await db
-              .execute("DELETE FROM public.todos WHERE task = 'write tests'");
-          final delete =
-              await deletes.future.timeout(const Duration(seconds: 20));
+          await db.execute(
+            "DELETE FROM public.todos WHERE task = 'write tests'",
+          );
+          final delete = await deletes.future.timeout(
+            const Duration(seconds: 20),
+          );
           expect(delete.eventType, PostgresChangeEvent.delete);
           expect(delete.oldRecord['task'], 'write tests');
         });
@@ -308,8 +316,9 @@ void main() {
             "INSERT INTO public.todos (task, is_complete) VALUES ('matched', true)",
           );
 
-          final payload =
-              await matched.future.timeout(const Duration(seconds: 20));
+          final payload = await matched.future.timeout(
+            const Duration(seconds: 20),
+          );
           expect(payload.newRecord['task'], 'matched');
           expect(payload.newRecord['is_complete'], isTrue);
         });

--- a/packages/realtime_client/test/serializer_test.dart
+++ b/packages/realtime_client/test/serializer_test.dart
@@ -99,7 +99,7 @@ void main() {
           '2',
           'realtime:room',
           'phx_reply',
-          {'status': 'ok'}
+          {'status': 'ok'},
         ]),
       );
 
@@ -220,14 +220,16 @@ void main() {
       expect(metadataLength, greaterThan(0));
 
       // metadata sits after the header and the joinRef/ref/topic/event strings.
-      final metadataStart = Serializer.headerLength +
+      final metadataStart =
+          Serializer.headerLength +
           Serializer.userBroadcastPushMetaLength +
           0 + // joinRef
           0 + // ref
           'realtime:room'.length +
           'file'.length;
-      final metadata = utf8
-          .decode(bytes.sublist(metadataStart, metadataStart + metadataLength));
+      final metadata = utf8.decode(
+        bytes.sublist(metadataStart, metadataStart + metadataLength),
+      );
       expect(jsonDecode(metadata), {'trace_id': 'abc'});
     });
 

--- a/packages/realtime_client/test/socket_test.dart
+++ b/packages/realtime_client/test/socket_test.dart
@@ -14,10 +14,11 @@ import 'package:web_socket_channel/web_socket_channel.dart';
 
 import 'socket_test_stubs.dart';
 
-typedef WebSocketChannelClosure = WebSocketChannel Function(
-  String url,
-  Map<String, String> headers,
-);
+typedef WebSocketChannelClosure =
+    WebSocketChannel Function(
+      String url,
+      Map<String, String> headers,
+    );
 
 /// Generate a JWT token for testing purposes
 ///
@@ -26,7 +27,8 @@ String generateJwt([int? exp]) {
   final header = {'alg': 'HS256', 'typ': 'JWT'};
 
   final now = DateTime.now();
-  final expiry = exp ??
+  final expiry =
+      exp ??
       (now.add(Duration(hours: 1)).millisecondsSinceEpoch / 1000).floor();
 
   final payload = {'exp': expiry};
@@ -53,14 +55,19 @@ void main() {
     mockServer = await HttpServer.bind('localhost', 0);
     WebSocketChannel? channel;
 
-    mockServer.transform(WebSocketTransformer()).listen((webSocket) {
-      channel = IOWebSocketChannel(webSocket);
-      channel!.stream.listen((request) {
-        channel!.sink.add(request);
-      });
-    }, onDone: () {
-      unawaited(channel?.sink.close());
-    });
+    mockServer
+        .transform(WebSocketTransformer())
+        .listen(
+          (webSocket) {
+            channel = IOWebSocketChannel(webSocket);
+            channel!.stream.listen((request) {
+              channel!.sink.add(request);
+            });
+          },
+          onDone: () {
+            unawaited(channel?.sink.close());
+          },
+        );
   });
 
   tearDown(() async {
@@ -69,8 +76,10 @@ void main() {
 
   group('constructor', () {
     test('sets defaults', () async {
-      final socket =
-          RealtimeClient('wss://example.com/socket', params: {'apikey': '123'});
+      final socket = RealtimeClient(
+        'wss://example.com/socket',
+        params: {'apikey': '123'},
+      );
       expect(socket.channels, isEmpty);
       expect(socket.sendBuffer, isEmpty);
       expect(socket.ref, 0);
@@ -84,11 +93,12 @@ void main() {
       expect(socket.timeout, const Duration(milliseconds: 10000));
       expect(socket.heartbeatIntervalMs, Constants.defaultHeartbeatIntervalMs);
       expect(
-        socket.logger is void Function(
-          String? kind,
-          String? msg,
-          dynamic data,
-        ),
+        socket.logger
+            is void Function(
+              String? kind,
+              String? msg,
+              dynamic data,
+            ),
         isFalse,
       );
       expect(
@@ -120,11 +130,12 @@ void main() {
       expect(socket.timeout, const Duration(milliseconds: 40000));
       expect(socket.heartbeatIntervalMs, 60000);
       expect(
-        socket.logger is void Function(
-          String? kind,
-          String? msg,
-          dynamic data,
-        ),
+        socket.logger
+            is void Function(
+              String? kind,
+              String? msg,
+              dynamic data,
+            ),
         isTrue,
       );
       expect(socket.headers['X-Client-Info'], 'supabase-dart/0.0.0');
@@ -141,8 +152,10 @@ void main() {
     });
 
     test('returns endpoint with parameters', () {
-      final socket =
-          RealtimeClient('ws://example.org/chat', params: {'foo': 'bar'});
+      final socket = RealtimeClient(
+        'ws://example.org/chat',
+        params: {'foo': 'bar'},
+      );
       expect(
         socket.endPointURL,
         'ws://example.org/chat/websocket?foo=bar&vsn=2.0.0',
@@ -285,8 +298,9 @@ void main() {
       final mockedSink = MockWebSocketSink();
 
       when(() => mockedSocketChannel.sink).thenReturn(mockedSink);
-      when(() => mockedSink.close(any(), any()))
-          .thenAnswer((_) => Future.value());
+      when(
+        () => mockedSink.close(any(), any()),
+      ).thenAnswer((_) => Future.value());
 
       const tCode = 12;
       const tReason = 'reason';
@@ -330,10 +344,12 @@ void main() {
 
       when(() => mockedSocketChannel.ready).thenAnswer((_) => Future.value());
       when(() => mockedSocketChannel.sink).thenReturn(mockedSink);
-      when(() => mockedSocketChannel.stream)
-          .thenAnswer((_) => streamController.stream);
-      when(() => mockedSink.close(any(), any()))
-          .thenAnswer((_) => Future.value());
+      when(
+        () => mockedSocketChannel.stream,
+      ).thenAnswer((_) => streamController.stream);
+      when(
+        () => mockedSink.close(any(), any()),
+      ).thenAnswer((_) => Future.value());
       when(() => mockedSink.close()).thenAnswer((_) => Future.value());
 
       final mockedSocket = RealtimeClient(
@@ -361,8 +377,11 @@ void main() {
 
       // Wait past the reconnect delay; the scheduled reconnect must be canceled.
       await Future.delayed(const Duration(milliseconds: 60));
-      expect(connectCount, 1,
-          reason: 'must not reopen after a user disconnect');
+      expect(
+        connectCount,
+        1,
+        reason: 'must not reopen after a user disconnect',
+      );
     });
 
     test('reconnects on a manual connect() after an unexpected drop', () async {
@@ -372,8 +391,9 @@ void main() {
       when(() => firstChannel.ready).thenAnswer((_) => Future.value());
       when(() => firstChannel.sink).thenReturn(firstSink);
       when(() => firstChannel.stream).thenAnswer((_) => firstController.stream);
-      when(() => firstSink.close(any(), any()))
-          .thenAnswer((_) => Future.value());
+      when(
+        () => firstSink.close(any(), any()),
+      ).thenAnswer((_) => Future.value());
       when(() => firstSink.close()).thenAnswer((_) => Future.value());
 
       final secondController = StreamController<dynamic>();
@@ -382,10 +402,12 @@ void main() {
       final secondSink = MockWebSocketSink();
       when(() => secondChannel.ready).thenAnswer((_) => Future.value());
       when(() => secondChannel.sink).thenReturn(secondSink);
-      when(() => secondChannel.stream)
-          .thenAnswer((_) => secondController.stream);
-      when(() => secondSink.close(any(), any()))
-          .thenAnswer((_) => Future.value());
+      when(
+        () => secondChannel.stream,
+      ).thenAnswer((_) => secondController.stream);
+      when(
+        () => secondSink.close(any(), any()),
+      ).thenAnswer((_) => Future.value());
       when(() => secondSink.close()).thenAnswer((_) => Future.value());
 
       var connectCount = 0;
@@ -412,8 +434,11 @@ void main() {
       // A manual reconnect must open a fresh connection instead of being a
       // no-op because `conn` still references the dropped socket.
       await mockedSocket.connect();
-      expect(connectCount, 2,
-          reason: 'manual connect() must reconnect after a drop');
+      expect(
+        connectCount,
+        2,
+        reason: 'manual connect() must reconnect after a drop',
+      );
       expect(mockedSocket.connState, SocketStates.open);
 
       await mockedSocket.disconnect();
@@ -425,11 +450,13 @@ void main() {
 
       final failingChannel = MockIOWebSocketChannel();
       final failingSink = MockWebSocketSink();
-      when(() => failingChannel.ready)
-          .thenAnswer((_) => Future.error(Exception('unavailable')));
+      when(
+        () => failingChannel.ready,
+      ).thenAnswer((_) => Future.error(Exception('unavailable')));
       when(() => failingChannel.sink).thenReturn(failingSink);
-      when(() => failingSink.close(any(), any()))
-          .thenAnswer((_) => Future.value());
+      when(
+        () => failingSink.close(any(), any()),
+      ).thenAnswer((_) => Future.value());
       when(() => failingSink.close()).thenAnswer((_) => Future.value());
 
       final successController = StreamController<dynamic>();
@@ -438,10 +465,12 @@ void main() {
       final successSink = MockWebSocketSink();
       when(() => successChannel.ready).thenAnswer((_) => Future.value());
       when(() => successChannel.sink).thenReturn(successSink);
-      when(() => successChannel.stream)
-          .thenAnswer((_) => successController.stream);
-      when(() => successSink.close(any(), any()))
-          .thenAnswer((_) => Future.value());
+      when(
+        () => successChannel.stream,
+      ).thenAnswer((_) => successController.stream);
+      when(
+        () => successSink.close(any(), any()),
+      ).thenAnswer((_) => Future.value());
       when(() => successSink.close()).thenAnswer((_) => Future.value());
 
       final mockedSocket = RealtimeClient(
@@ -516,7 +545,7 @@ void main() {
           'broadcast': {'ack': false, 'self': false},
           'presence': {'key': '', 'enabled': false},
           'private': false,
-        }
+        },
       });
     });
 
@@ -570,8 +599,13 @@ void main() {
     const ref = 'ref';
     // Protocol 2.0.0 text frames are positional arrays:
     // [join_ref, ref, topic, event, payload].
-    final jsonData =
-        json.encode([null, ref, topic, event.eventName(), payload]);
+    final jsonData = json.encode([
+      null,
+      ref,
+      topic,
+      event.eventName(),
+      payload,
+    ]);
 
     IOWebSocketChannel mockedSocketChannel;
     late RealtimeClient mockedSocket;
@@ -596,12 +630,17 @@ void main() {
       unawaited(mockedSocket.connect());
       mockedSocket.connState = SocketStates.open;
 
-      final message =
-          Message(topic: topic, payload: payload, event: event, ref: ref);
+      final message = Message(
+        topic: topic,
+        payload: payload,
+        event: event,
+        ref: ref,
+      );
       mockedSocket.push(message);
 
-      verify(() => mockedSink.add(captureAny(that: equals(jsonData))))
-          .called(1);
+      verify(
+        () => mockedSink.add(captureAny(that: equals(jsonData))),
+      ).called(1);
     });
 
     test('buffers data when not connected', () async {
@@ -610,8 +649,12 @@ void main() {
 
       expect(mockedSocket.sendBuffer, isEmpty);
 
-      final message =
-          Message(topic: topic, payload: payload, event: event, ref: ref);
+      final message = Message(
+        topic: topic,
+        payload: payload,
+        event: event,
+        ref: ref,
+      );
       mockedSocket.push(message);
 
       verifyNever(() => mockedSink.add(any()));
@@ -619,8 +662,9 @@ void main() {
 
       final callback = mockedSocket.sendBuffer[0];
       callback();
-      verify(() => mockedSink.add(captureAny(that: equals(jsonData))))
-          .called(1);
+      verify(
+        () => mockedSink.add(captureAny(that: equals(jsonData))),
+      ).called(1);
     });
 
     test('sends a broadcast with a binary payload as a binary frame', () {
@@ -639,8 +683,9 @@ void main() {
       );
       mockedSocket.push(message);
 
-      verify(() => mockedSink.add(captureAny(that: isA<Uint8List>())))
-          .called(1);
+      verify(
+        () => mockedSink.add(captureAny(that: isA<Uint8List>())),
+      ).called(1);
     });
 
     test('encodes with the legacy object format when version is v1', () {
@@ -665,12 +710,17 @@ void main() {
         'ref': ref,
       });
 
-      final message =
-          Message(topic: topic, payload: payload, event: event, ref: ref);
+      final message = Message(
+        topic: topic,
+        payload: payload,
+        event: event,
+        ref: ref,
+      );
       legacySocket.push(message);
 
-      verify(() => legacySink.add(captureAny(that: equals(legacyData))))
-          .called(1);
+      verify(
+        () => legacySink.add(captureAny(that: equals(legacyData))),
+      ).called(1);
     });
 
     test('uses a custom encode override when provided', () {
@@ -692,8 +742,9 @@ void main() {
         Message(topic: topic, payload: payload, event: event, ref: ref),
       );
 
-      verify(() => customSink.add(captureAny(that: equals('custom-frame'))))
-          .called(1);
+      verify(
+        () => customSink.add(captureAny(that: equals('custom-frame'))),
+      ).called(1);
     });
   });
 
@@ -739,37 +790,41 @@ void main() {
       });
     });
 
-    test('decodes a legacy object frame and dispatches it when version is v1',
-        () {
-      final socket = RealtimeClient(
-        socketEndpoint,
-        version: RealtimeProtocolVersion.v1,
-      );
-      final channel = socket.channel('room');
+    test(
+      'decodes a legacy object frame and dispatches it when version is v1',
+      () {
+        final socket = RealtimeClient(
+          socketEndpoint,
+          version: RealtimeProtocolVersion.v1,
+        );
+        final channel = socket.channel('room');
 
-      Map<String, dynamic>? received;
-      channel.onBroadcast(
-        event: 'cursor',
-        callback: (payload) => received = payload,
-      );
+        Map<String, dynamic>? received;
+        channel.onBroadcast(
+          event: 'cursor',
+          callback: (payload) => received = payload,
+        );
 
-      socket.onConnMessage(json.encode({
-        'topic': 'realtime:room',
-        'event': 'broadcast',
-        'payload': {
+        socket.onConnMessage(
+          json.encode({
+            'topic': 'realtime:room',
+            'event': 'broadcast',
+            'payload': {
+              'type': 'broadcast',
+              'event': 'cursor',
+              'payload': {'x': 1},
+            },
+            'ref': null,
+          }),
+        );
+
+        expect(received, {
           'type': 'broadcast',
           'event': 'cursor',
           'payload': {'x': 1},
-        },
-        'ref': null,
-      }));
-
-      expect(received, {
-        'type': 'broadcast',
-        'event': 'cursor',
-        'payload': {'x': 1},
-      });
-    });
+        });
+      },
+    );
   });
 
   group('makeRef', () {
@@ -806,108 +861,121 @@ void main() {
     final pushPayload = {'access_token': token};
 
     test(
-        "sets access token, updates channels' join payload, and pushes token to channels",
-        () async {
-      final mockedChannel1 = MockChannel();
-      when(() => mockedChannel1.joinedOnce).thenReturn(true);
-      when(() => mockedChannel1.isJoined).thenReturn(true);
-      when(() => mockedChannel1.push(ChannelEvents.accessToken, pushPayload))
-          .thenReturn(MockPush());
+      "sets access token, updates channels' join payload, and pushes token to channels",
+      () async {
+        final mockedChannel1 = MockChannel();
+        when(() => mockedChannel1.joinedOnce).thenReturn(true);
+        when(() => mockedChannel1.isJoined).thenReturn(true);
+        when(
+          () => mockedChannel1.push(ChannelEvents.accessToken, pushPayload),
+        ).thenReturn(MockPush());
 
-      final mockedChannel2 = MockChannel();
-      when(() => mockedChannel2.joinedOnce).thenReturn(true);
-      when(() => mockedChannel2.isJoined).thenReturn(true);
-      when(() => mockedChannel2.push(ChannelEvents.accessToken, pushPayload))
-          .thenReturn(MockPush());
+        final mockedChannel2 = MockChannel();
+        when(() => mockedChannel2.joinedOnce).thenReturn(true);
+        when(() => mockedChannel2.isJoined).thenReturn(true);
+        when(
+          () => mockedChannel2.push(ChannelEvents.accessToken, pushPayload),
+        ).thenReturn(MockPush());
 
-      const tTopic1 = 'topic-1';
-      const tTopic2 = 'topic-2';
+        const tTopic1 = 'topic-1';
+        const tTopic2 = 'topic-2';
 
-      final mockedSocket = SocketWithMockedChannel(socketEndpoint);
-      mockedSocket.mockedChannelLooker.addAll({
-        tTopic1: mockedChannel1,
-        tTopic2: mockedChannel2,
-      });
+        final mockedSocket = SocketWithMockedChannel(socketEndpoint);
+        mockedSocket.mockedChannelLooker.addAll({
+          tTopic1: mockedChannel1,
+          tTopic2: mockedChannel2,
+        });
 
-      final channel1 = mockedSocket.channel(tTopic1);
-      final channel2 = mockedSocket.channel(tTopic2);
+        final channel1 = mockedSocket.channel(tTopic1);
+        final channel2 = mockedSocket.channel(tTopic2);
 
-      await mockedSocket.setAuth(token);
+        await mockedSocket.setAuth(token);
 
-      expect(mockedSocket.accessToken, token);
+        expect(mockedSocket.accessToken, token);
 
-      verify(() => channel1.updateJoinPayload(updateJoinPayload)).called(1);
-      verify(() => channel2.updateJoinPayload(updateJoinPayload)).called(1);
-      verify(() => channel1.push(ChannelEvents.accessToken, pushPayload))
-          .called(1);
-      verify(() => channel2.push(ChannelEvents.accessToken, pushPayload))
-          .called(1);
-    });
+        verify(() => channel1.updateJoinPayload(updateJoinPayload)).called(1);
+        verify(() => channel2.updateJoinPayload(updateJoinPayload)).called(1);
+        verify(
+          () => channel1.push(ChannelEvents.accessToken, pushPayload),
+        ).called(1);
+        verify(
+          () => channel2.push(ChannelEvents.accessToken, pushPayload),
+        ).called(1);
+      },
+    );
 
     test(
-        "sets access token, updates channels' join payload, and pushes token to channels if is not a jwt",
-        () async {
-      final mockedChannel1 = MockChannel();
-      final mockedChannel2 = MockChannel();
-      final mockedChannel3 = MockChannel();
+      "sets access token, updates channels' join payload, and pushes token to channels if is not a jwt",
+      () async {
+        final mockedChannel1 = MockChannel();
+        final mockedChannel2 = MockChannel();
+        final mockedChannel3 = MockChannel();
 
-      when(() => mockedChannel1.joinedOnce).thenReturn(true);
-      when(() => mockedChannel1.isJoined).thenReturn(true);
-      when(() => mockedChannel1.push(ChannelEvents.accessToken, any()))
-          .thenReturn(MockPush());
+        when(() => mockedChannel1.joinedOnce).thenReturn(true);
+        when(() => mockedChannel1.isJoined).thenReturn(true);
+        when(
+          () => mockedChannel1.push(ChannelEvents.accessToken, any()),
+        ).thenReturn(MockPush());
 
-      when(() => mockedChannel2.joinedOnce).thenReturn(false);
-      when(() => mockedChannel2.isJoined).thenReturn(false);
-      when(() => mockedChannel2.push(ChannelEvents.accessToken, any()))
-          .thenReturn(MockPush());
+        when(() => mockedChannel2.joinedOnce).thenReturn(false);
+        when(() => mockedChannel2.isJoined).thenReturn(false);
+        when(
+          () => mockedChannel2.push(ChannelEvents.accessToken, any()),
+        ).thenReturn(MockPush());
 
-      when(() => mockedChannel3.joinedOnce).thenReturn(true);
-      when(() => mockedChannel3.isJoined).thenReturn(true);
-      when(() => mockedChannel3.push(ChannelEvents.accessToken, any()))
-          .thenReturn(MockPush());
+        when(() => mockedChannel3.joinedOnce).thenReturn(true);
+        when(() => mockedChannel3.isJoined).thenReturn(true);
+        when(
+          () => mockedChannel3.push(ChannelEvents.accessToken, any()),
+        ).thenReturn(MockPush());
 
-      const tTopic1 = 'test-topic1';
-      const tTopic2 = 'test-topic2';
-      const tTopic3 = 'test-topic3';
+        const tTopic1 = 'test-topic1';
+        const tTopic2 = 'test-topic2';
+        const tTopic3 = 'test-topic3';
 
-      final mockedSocket = SocketWithMockedChannel(socketEndpoint);
-      mockedSocket.mockedChannelLooker.addAll({
-        tTopic1: mockedChannel1,
-        tTopic2: mockedChannel2,
-        tTopic3: mockedChannel3,
-      });
+        final mockedSocket = SocketWithMockedChannel(socketEndpoint);
+        mockedSocket.mockedChannelLooker.addAll({
+          tTopic1: mockedChannel1,
+          tTopic2: mockedChannel2,
+          tTopic3: mockedChannel3,
+        });
 
-      final channel1 = mockedSocket.channel(tTopic1);
-      final channel2 = mockedSocket.channel(tTopic2);
-      final channel3 = mockedSocket.channel(tTopic3);
+        final channel1 = mockedSocket.channel(tTopic1);
+        final channel2 = mockedSocket.channel(tTopic2);
+        final channel3 = mockedSocket.channel(tTopic3);
 
-      const authToken = 'sb-key';
-      final expectedPushPayload = {'access_token': authToken};
-      final expectedUpdateJoinPayload = {
-        'access_token': authToken,
-        'version': Constants.defaultHeaders['X-Client-Info'],
-      };
+        const authToken = 'sb-key';
+        final expectedPushPayload = {'access_token': authToken};
+        final expectedUpdateJoinPayload = {
+          'access_token': authToken,
+          'version': Constants.defaultHeaders['X-Client-Info'],
+        };
 
-      await mockedSocket.setAuth(authToken);
+        await mockedSocket.setAuth(authToken);
 
-      expect(mockedSocket.accessToken, authToken);
+        expect(mockedSocket.accessToken, authToken);
 
-      verify(() => channel1.updateJoinPayload(expectedUpdateJoinPayload))
-          .called(1);
-      verify(() => channel2.updateJoinPayload(expectedUpdateJoinPayload))
-          .called(1);
-      verify(() => channel3.updateJoinPayload(expectedUpdateJoinPayload))
-          .called(1);
+        verify(
+          () => channel1.updateJoinPayload(expectedUpdateJoinPayload),
+        ).called(1);
+        verify(
+          () => channel2.updateJoinPayload(expectedUpdateJoinPayload),
+        ).called(1);
+        verify(
+          () => channel3.updateJoinPayload(expectedUpdateJoinPayload),
+        ).called(1);
 
-      verify(() =>
-              channel1.push(ChannelEvents.accessToken, expectedPushPayload))
-          .called(1);
-      verifyNever(
-          () => channel2.push(ChannelEvents.accessToken, expectedPushPayload));
-      verify(() =>
-              channel3.push(ChannelEvents.accessToken, expectedPushPayload))
-          .called(1);
-    });
+        verify(
+          () => channel1.push(ChannelEvents.accessToken, expectedPushPayload),
+        ).called(1);
+        verifyNever(
+          () => channel2.push(ChannelEvents.accessToken, expectedPushPayload),
+        );
+        verify(
+          () => channel3.push(ChannelEvents.accessToken, expectedPushPayload),
+        ).called(1);
+      },
+    );
   });
 
   group('sendHeartbeat', () {
@@ -953,82 +1021,91 @@ void main() {
 
   group('connect/disconnect race condition', () {
     test(
-        'connect does not crash if disconnect nullifies connection during await ready',
-        () async {
-      final readyCompleter = Completer<void>();
-      final mockedSocketChannel = MockIOWebSocketChannel();
-      final mockedSink = MockWebSocketSink();
+      'connect does not crash if disconnect nullifies connection during await ready',
+      () async {
+        final readyCompleter = Completer<void>();
+        final mockedSocketChannel = MockIOWebSocketChannel();
+        final mockedSink = MockWebSocketSink();
 
-      when(() => mockedSocketChannel.ready)
-          .thenAnswer((_) => readyCompleter.future);
-      when(() => mockedSocketChannel.sink).thenReturn(mockedSink);
-      when(() => mockedSink.close(any(), any()))
-          .thenAnswer((_) => Future.value());
-      when(() => mockedSink.close()).thenAnswer((_) => Future.value());
+        when(
+          () => mockedSocketChannel.ready,
+        ).thenAnswer((_) => readyCompleter.future);
+        when(() => mockedSocketChannel.sink).thenReturn(mockedSink);
+        when(
+          () => mockedSink.close(any(), any()),
+        ).thenAnswer((_) => Future.value());
+        when(() => mockedSink.close()).thenAnswer((_) => Future.value());
 
-      final socket = RealtimeClient(
-        socketEndpoint,
-        transport: (url, headers) => mockedSocketChannel,
-      );
+        final socket = RealtimeClient(
+          socketEndpoint,
+          transport: (url, headers) => mockedSocketChannel,
+        );
 
-      // Start connect — it will suspend at await ready
-      final connectFuture = socket.connect();
+        // Start connect — it will suspend at await ready
+        final connectFuture = socket.connect();
 
-      // Start disconnect (also suspends on ready since state is connecting)
-      final disconnectFuture = socket.disconnect();
+        // Start disconnect (also suspends on ready since state is connecting)
+        final disconnectFuture = socket.disconnect();
 
-      // Now complete the ready future — both connect and disconnect can proceed
-      readyCompleter.complete();
-      await disconnectFuture;
-      await connectFuture;
+        // Now complete the ready future — both connect and disconnect can proceed
+        readyCompleter.complete();
+        await disconnectFuture;
+        await connectFuture;
 
-      // Should NOT have transitioned to open because disconnect nullified connection
-      expect(socket.connState, isNot(SocketStates.open));
-      expect(socket.conn, isNull);
-    });
+        // Should NOT have transitioned to open because disconnect nullified connection
+        expect(socket.connState, isNot(SocketStates.open));
+        expect(socket.conn, isNull);
+      },
+    );
 
-    test('connect bails out when connState changes during await ready',
-        () async {
-      final readyCompleter = Completer<void>();
-      final mockedSocketChannel = MockIOWebSocketChannel();
-      final mockedSink = MockWebSocketSink();
+    test(
+      'connect bails out when connState changes during await ready',
+      () async {
+        final readyCompleter = Completer<void>();
+        final mockedSocketChannel = MockIOWebSocketChannel();
+        final mockedSink = MockWebSocketSink();
 
-      when(() => mockedSocketChannel.ready)
-          .thenAnswer((_) => readyCompleter.future);
-      when(() => mockedSocketChannel.sink).thenReturn(mockedSink);
-      when(() => mockedSink.close(any(), any()))
-          .thenAnswer((_) => Future.value());
-      when(() => mockedSink.close()).thenAnswer((_) => Future.value());
+        when(
+          () => mockedSocketChannel.ready,
+        ).thenAnswer((_) => readyCompleter.future);
+        when(() => mockedSocketChannel.sink).thenReturn(mockedSink);
+        when(
+          () => mockedSink.close(any(), any()),
+        ).thenAnswer((_) => Future.value());
+        when(() => mockedSink.close()).thenAnswer((_) => Future.value());
 
-      final socket = RealtimeClient(
-        socketEndpoint,
-        transport: (url, headers) => mockedSocketChannel,
-      );
+        final socket = RealtimeClient(
+          socketEndpoint,
+          transport: (url, headers) => mockedSocketChannel,
+        );
 
-      // Start connect
-      final connectFuture = socket.connect();
+        // Start connect
+        final connectFuture = socket.connect();
 
-      // Start disconnect — also awaits ready
-      final disconnectFuture = socket.disconnect();
+        // Start disconnect — also awaits ready
+        final disconnectFuture = socket.disconnect();
 
-      // Complete ready — both proceed
-      readyCompleter.complete();
-      await disconnectFuture;
-      await connectFuture;
+        // Complete ready — both proceed
+        readyCompleter.complete();
+        await disconnectFuture;
+        await connectFuture;
 
-      expect(socket.connState, isNot(SocketStates.open));
-    });
+        expect(socket.connState, isNot(SocketStates.open));
+      },
+    );
 
     test('rapid connect-disconnect-connect cycle does not crash', () async {
       final readyCompleter1 = Completer<void>();
       final mockedSocketChannel1 = MockIOWebSocketChannel();
       final mockedSink1 = MockWebSocketSink();
 
-      when(() => mockedSocketChannel1.ready)
-          .thenAnswer((_) => readyCompleter1.future);
+      when(
+        () => mockedSocketChannel1.ready,
+      ).thenAnswer((_) => readyCompleter1.future);
       when(() => mockedSocketChannel1.sink).thenReturn(mockedSink1);
-      when(() => mockedSink1.close(any(), any()))
-          .thenAnswer((_) => Future.value());
+      when(
+        () => mockedSink1.close(any(), any()),
+      ).thenAnswer((_) => Future.value());
       when(() => mockedSink1.close()).thenAnswer((_) => Future.value());
 
       final readyCompleter2 = Completer<void>();
@@ -1036,13 +1113,16 @@ void main() {
       final mockedSink2 = MockWebSocketSink();
       final streamController2 = StreamController<dynamic>.broadcast();
 
-      when(() => mockedSocketChannel2.ready)
-          .thenAnswer((_) => readyCompleter2.future);
+      when(
+        () => mockedSocketChannel2.ready,
+      ).thenAnswer((_) => readyCompleter2.future);
       when(() => mockedSocketChannel2.sink).thenReturn(mockedSink2);
-      when(() => mockedSocketChannel2.stream)
-          .thenAnswer((_) => streamController2.stream);
-      when(() => mockedSink2.close(any(), any()))
-          .thenAnswer((_) => Future.value());
+      when(
+        () => mockedSocketChannel2.stream,
+      ).thenAnswer((_) => streamController2.stream);
+      when(
+        () => mockedSink2.close(any(), any()),
+      ).thenAnswer((_) => Future.value());
       when(() => mockedSink2.close()).thenAnswer((_) => Future.value());
 
       var callCount = 0;

--- a/packages/realtime_client/test/transformers_test.dart
+++ b/packages/realtime_client/test/transformers_test.dart
@@ -33,20 +33,20 @@ void main() {
           'flags': ['key'],
           'name': 'id',
           'type': 'int8',
-          'type_modifier': 4294967295
+          'type_modifier': 4294967295,
         },
         {
           'flags': [],
           'name': 'name',
           'type': 'text',
-          'type_modifier': 4294967295
+          'type_modifier': 4294967295,
         },
         {
           'flags': [],
           'name': 'continent',
           'type': 'continents',
-          'type_modifier': 4294967295
-        }
+          'type_modifier': 4294967295,
+        },
       ];
       final records = {'id': '253', 'name': 'Singapore', 'continent': null};
       expect(
@@ -64,7 +64,7 @@ void main() {
         {
           'name': 'age',
           'type': 'int4',
-        }
+        },
       ];
       final records = {'first_name': 'Mark', 'age': 23};
       expect(
@@ -82,7 +82,7 @@ void main() {
         {
           'name': 'age',
           'type': 'int4',
-        }
+        },
       ];
       final records = {'first_name': 'Paul', 'age': null};
       expect(
@@ -166,18 +166,18 @@ void main() {
         "columns": [
           {"name": "id", "type": "int8"},
           {"name": "created_at", "type": "timestamptz"},
-          {"name": "content", "type": "text"}
+          {"name": "content", "type": "text"},
         ],
         "commit_timestamp": "2022-09-21T04:15:16.267254+00:00",
         "errors": null,
         "record": {
           "content": "some content",
           "created_at": "2022-09-21T04:15:13+00:00",
-          "id": 4
+          "id": 4,
         },
         "schema": "public",
         "table": "random",
-        "type": "INSERT"
+        "type": "INSERT",
       });
 
       final expectedMap = {
@@ -188,7 +188,7 @@ void main() {
         'new': {
           "content": "some content",
           "created_at": "2022-09-21T04:15:13+00:00",
-          "id": 4
+          "id": 4,
         },
         'old': {},
         'errors': null,
@@ -202,20 +202,20 @@ void main() {
           "columns": [
             {"name": "id", "type": "int8"},
             {"name": "created_at", "type": "timestamptz"},
-            {"name": "content", "type": "text"}
+            {"name": "content", "type": "text"},
           ],
           "commit_timestamp": "2022-09-21T04:59:30Z",
           "errors": null,
           "record": {
             "content": "some content",
             "created_at": "2022-09-21T04:15:13+00:00",
-            "id": 4
+            "id": 4,
           },
           "schema": "public",
           "table": "random",
-          "type": "INSERT"
+          "type": "INSERT",
         },
-        "ids": [48673474, 25993878, 77086988]
+        "ids": [48673474, 25993878, 77086988],
       });
 
       final expectedMap = {
@@ -226,7 +226,7 @@ void main() {
         'new': {
           "content": "some content",
           "created_at": "2022-09-21T04:15:13+00:00",
-          "id": 4
+          "id": 4,
         },
         'old': {},
         'errors': null,

--- a/packages/realtime_client/test/utils/realtime_test_utils.dart
+++ b/packages/realtime_client/test/utils/realtime_test_utils.dart
@@ -31,20 +31,29 @@ String _base64Url(List<int> bytes) =>
 /// accepts as the connection apikey.
 String generateRealtimeToken({String role = 'anon'}) {
   final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
-  final header = _base64Url(utf8.encode(json.encode({
-    'alg': 'HS256',
-    'typ': 'JWT',
-  })));
-  final payload = _base64Url(utf8.encode(json.encode({
-    'role': role,
-    'iat': now,
-    'exp': now + 60 * 60,
-  })));
+  final header = _base64Url(
+    utf8.encode(
+      json.encode({
+        'alg': 'HS256',
+        'typ': 'JWT',
+      }),
+    ),
+  );
+  final payload = _base64Url(
+    utf8.encode(
+      json.encode({
+        'role': role,
+        'iat': now,
+        'exp': now + 60 * 60,
+      }),
+    ),
+  );
   final signingInput = '$header.$payload';
   final signature = _base64Url(
-    Hmac(sha256, utf8.encode(apiJwtSecret))
-        .convert(utf8.encode(signingInput))
-        .bytes,
+    Hmac(
+      sha256,
+      utf8.encode(apiJwtSecret),
+    ).convert(utf8.encode(signingInput)).bytes,
   );
   return '$signingInput.$signature';
 }
@@ -131,8 +140,9 @@ Future<void> primePostgresChanges({
     } else if (status == RealtimeSubscribeStatus.channelError ||
         status == RealtimeSubscribeStatus.timedOut) {
       subscribed.completeError(
-          StateError('warmup subscribe failed: ${status.name}'),
-          StackTrace.current);
+        StateError('warmup subscribe failed: ${status.name}'),
+        StackTrace.current,
+      );
     }
   });
 

--- a/packages/realtime_client/test/websocket_io_test.dart
+++ b/packages/realtime_client/test/websocket_io_test.dart
@@ -23,18 +23,23 @@ Future<ServerSocket> _startUnresponsiveServer() async {
       if (!request.contains('\r\n\r\n')) {
         return;
       }
-      final keyLine = request.split('\r\n').firstWhere(
-          (line) => line.toLowerCase().startsWith('sec-websocket-key:'));
+      final keyLine = request
+          .split('\r\n')
+          .firstWhere(
+            (line) => line.toLowerCase().startsWith('sec-websocket-key:'),
+          );
       final key = keyLine.split(':').last.trim();
       final accept = base64.encode(
         sha1
             .convert(utf8.encode('${key}258EAFA5-E914-47DA-95CA-C5AB0DC85B11'))
             .bytes,
       );
-      socket.write('HTTP/1.1 101 Switching Protocols\r\n'
-          'Upgrade: websocket\r\n'
-          'Connection: Upgrade\r\n'
-          'Sec-WebSocket-Accept: $accept\r\n\r\n');
+      socket.write(
+        'HTTP/1.1 101 Switching Protocols\r\n'
+        'Upgrade: websocket\r\n'
+        'Connection: Upgrade\r\n'
+        'Sec-WebSocket-Accept: $accept\r\n\r\n',
+      );
       // From here on, deliberately ignore everything (including ping frames).
       subscription.onData((_) {});
     });
@@ -43,20 +48,22 @@ Future<ServerSocket> _startUnresponsiveServer() async {
 }
 
 void main() {
-  test('default transport closes the connection when the peer stops responding',
-      () async {
-    final server = await _startUnresponsiveServer();
-    addTearDown(() => server.close());
+  test(
+    'default transport closes the connection when the peer stops responding',
+    () async {
+      final server = await _startUnresponsiveServer();
+      addTearDown(() => server.close());
 
-    final channel = createWebSocketClient(
-      'ws://localhost:${server.port}',
-      const {},
-      pingInterval: const Duration(milliseconds: 200),
-    );
-    await channel.ready;
+      final channel = createWebSocketClient(
+        'ws://localhost:${server.port}',
+        const {},
+        pingInterval: const Duration(milliseconds: 200),
+      );
+      await channel.ready;
 
-    // Without a transport level ping interval this would never complete, since
-    // the dead peer sends neither data nor a close frame.
-    await channel.stream.drain().timeout(const Duration(seconds: 5));
-  });
+      // Without a transport level ping interval this would never complete, since
+      // the dead peer sends neither data nor a close frame.
+      await channel.stream.drain().timeout(const Duration(seconds: 5));
+    },
+  );
 }

--- a/packages/storage_client/example/main.dart
+++ b/packages/storage_client/example/main.dart
@@ -18,7 +18,9 @@ Future<void> main() async {
   // Upload binary file
   final List<int> listBytes = 'Hello world'.codeUnits;
   final Uint8List fileData = Uint8List.fromList(listBytes);
-  final uploadBinaryResponse = await client.from('public').uploadBinary(
+  final uploadBinaryResponse = await client
+      .from('public')
+      .uploadBinary(
         'binaryExample.txt',
         fileData,
         fileOptions: const FileOptions(upsert: true),
@@ -28,13 +30,15 @@ Future<void> main() async {
   // Upload file to bucket "public"
   final file = File('example.txt');
   file.writeAsStringSync('File content');
-  final storageResponse =
-      await client.from('public').upload('example.txt', file);
+  final storageResponse = await client
+      .from('public')
+      .upload('example.txt', file);
   print('upload response : $storageResponse');
 
   // Get download url
-  final urlResponse =
-      await client.from('public').createSignedUrl('example.txt', 60);
+  final urlResponse = await client
+      .from('public')
+      .createSignedUrl('example.txt', 60);
   print('download url : $urlResponse');
 
   // Download text file

--- a/packages/storage_client/lib/src/fetch.dart
+++ b/packages/storage_client/lib/src/fetch.dart
@@ -44,8 +44,10 @@ class Fetch {
       try {
         final data = json.decode(error.body) as Map<String, dynamic>;
 
-        final exception =
-            StorageException.fromJson(data, '${error.statusCode}');
+        final exception = StorageException.fromJson(
+          data,
+          '${error.statusCode}',
+        );
         _log.fine('StorageException for $url', exception, stack);
         return exception;
       } on FormatException catch (_) {
@@ -72,8 +74,9 @@ class Fetch {
   ) async {
     final headers = {...?options?.headers};
     if (method != 'GET') {
-      final hasContentType =
-          headers.keys.any((key) => key.toLowerCase() == 'content-type');
+      final hasContentType = headers.keys.any(
+        (key) => key.toLowerCase() == 'content-type',
+      );
       if (!hasContentType) {
         headers['Content-Type'] = 'application/json';
       }

--- a/packages/storage_client/lib/src/storage_bucket_api.dart
+++ b/packages/storage_client/lib/src/storage_bucket_api.dart
@@ -42,8 +42,10 @@ class StorageBucketApi {
   /// [id] is the unique identifier of the bucket you would like to retrieve.
   Future<Bucket> getBucket(String id) async {
     final FetchOptions options = FetchOptions(headers: headers);
-    final response =
-        await storageFetch.get('$url/bucket/$id', options: options);
+    final response = await storageFetch.get(
+      '$url/bucket/$id',
+      options: options,
+    );
     return Bucket.fromJson(response);
   }
 
@@ -101,8 +103,11 @@ class StorageBucketApi {
   /// [id] is the unique identifier of the bucket you would like to empty.
   Future<String> emptyBucket(String id) async {
     final FetchOptions options = FetchOptions(headers: headers);
-    final response =
-        await storageFetch.post('$url/bucket/$id/empty', {}, options: options);
+    final response = await storageFetch.post(
+      '$url/bucket/$id/empty',
+      {},
+      options: options,
+    );
     return (response as Map<String, dynamic>)['message'] as String;
   }
 

--- a/packages/storage_client/lib/src/storage_client.dart
+++ b/packages/storage_client/lib/src/storage_client.dart
@@ -43,18 +43,19 @@ class SupabaseStorageClient extends StorageBucketApi {
     Client? httpClient,
     int retryAttempts = 0,
     bool useNewHostname = false,
-  })  : assert(
-          retryAttempts >= 0,
-          'retryAttempts has to be greater than or equal to 0',
-        ),
-        _defaultRetryAttempts = retryAttempts,
-        super(
-          useNewHostname ? _transformStorageUrl(url) : url,
-          {...Constants.defaultHeaders, ...headers},
-          httpClient: httpClient,
-        ) {
+  }) : assert(
+         retryAttempts >= 0,
+         'retryAttempts has to be greater than or equal to 0',
+       ),
+       _defaultRetryAttempts = retryAttempts,
+       super(
+         useNewHostname ? _transformStorageUrl(url) : url,
+         {...Constants.defaultHeaders, ...headers},
+         httpClient: httpClient,
+       ) {
     _log.config(
-        'Initialize SupabaseStorageClient v$version with url: $url, retryAttempts: $_defaultRetryAttempts');
+      'Initialize SupabaseStorageClient v$version with url: $url, retryAttempts: $_defaultRetryAttempts',
+    );
     _log.finest('Initialize with headers: $headers');
   }
 

--- a/packages/storage_client/lib/src/storage_file_api.dart
+++ b/packages/storage_client/lib/src/storage_file_api.dart
@@ -54,8 +54,10 @@ class StorageFileApi {
   FetchOptions get _fetchOptions => FetchOptions(headers: headers);
 
   void _assertValidRetryAttempts(int? retryAttempts) {
-    assert(retryAttempts == null || retryAttempts >= 0,
-        'retryAttempts has to be greater or equal to 0');
+    assert(
+      retryAttempts == null || retryAttempts >= 0,
+      'retryAttempts has to be greater or equal to 0',
+    );
   }
 
   /// Uploads a file to an existing bucket.
@@ -414,8 +416,11 @@ class StorageFileApi {
     int expiresIn, {
     DownloadBehavior? download,
   }) async {
-    final results =
-        await createSignedUrlsResult(paths, expiresIn, download: download);
+    final results = await createSignedUrlsResult(
+      paths,
+      expiresIn,
+      download: download,
+    );
     return results
         .whereType<SignedUrlSuccess>()
         .map((r) => SignedUrl(path: r.path, signedUrl: r.signedUrl))
@@ -477,12 +482,16 @@ class StorageFileApi {
   /// [transform] download a transformed variant of the image with the provided options
   ///
   /// [queryParams] additional query parameters to be added to the URL
-  Future<Uint8List> download(String path,
-      {TransformOptions? transform, Map<String, String>? queryParams}) async {
+  Future<Uint8List> download(
+    String path, {
+    TransformOptions? transform,
+    Map<String, String>? queryParams,
+  }) async {
     final wantsTransformations = transform != null;
     final finalPath = _getFinalPath(path);
-    final renderPath =
-        wantsTransformations ? 'render/image/authenticated' : 'object';
+    final renderPath = wantsTransformations
+        ? 'render/image/authenticated'
+        : 'object';
 
     Map<String, String> query = transform?.toQueryParams ?? {};
     query.addAll(queryParams ?? {});
@@ -492,8 +501,10 @@ class StorageFileApi {
     var fetchUrl = Uri.parse('$url/$renderPath/$finalPath');
     fetchUrl = fetchUrl.replace(queryParameters: query);
 
-    final response =
-        await _storageFetch.get(fetchUrl.toString(), options: options);
+    final response = await _storageFetch.get(
+      fetchUrl.toString(),
+      options: options,
+    );
     return response as Uint8List;
   }
 

--- a/packages/storage_client/lib/src/types.dart
+++ b/packages/storage_client/lib/src/types.dart
@@ -40,8 +40,9 @@ class Bucket {
       updatedAt: json['updated_at'] as String,
       public: json['public'] as bool,
       fileSizeLimit: json['file_size_limit'] as int?,
-      allowedMimeTypes:
-          allowedMimeTypes is List ? allowedMimeTypes.cast() : null,
+      allowedMimeTypes: allowedMimeTypes is List
+          ? allowedMimeTypes.cast()
+          : null,
     );
   }
 }
@@ -343,12 +344,11 @@ class StorageException implements Exception {
   factory StorageException.fromJson(
     Map<String, dynamic> json, [
     String? statusCode,
-  ]) =>
-      StorageException(
-        json['message'] as String? ?? json.toString(),
-        error: json['error'] as String?,
-        statusCode: json['statusCode']?.toString() ?? statusCode,
-      );
+  ]) => StorageException(
+    json['message'] as String? ?? json.toString(),
+    error: json['error'] as String?,
+    statusCode: json['statusCode']?.toString() ?? statusCode,
+  );
 
   @override
   String toString() {

--- a/packages/storage_client/pubspec.yaml
+++ b/packages/storage_client/pubspec.yaml
@@ -6,7 +6,7 @@ repository: 'https://github.com/supabase/supabase-flutter/tree/main/packages/sto
 documentation: 'https://supabase.com/docs/reference/dart/storage-createbucket'
 
 environment:
-  sdk: '>=3.4.0 <4.0.0'
+  sdk: '>=3.9.0 <4.0.0'
 
 dependencies:
   http: ^1.2.2

--- a/packages/storage_client/test/basic_test.dart
+++ b/packages/storage_client/test/basic_test.dart
@@ -10,24 +10,24 @@ const String supabaseUrl = 'SUPABASE_TEST_URL';
 const String supabaseKey = 'SUPABASE_TEST_KEY';
 
 Map<String, dynamic> get testBucketJson => {
-      'id': 'test_bucket',
-      'name': 'test_bucket',
-      'owner': 'owner_id',
-      'created_at': '',
-      'updated_at': '',
-      'public': false,
-    };
+  'id': 'test_bucket',
+  'name': 'test_bucket',
+  'owner': 'owner_id',
+  'created_at': '',
+  'updated_at': '',
+  'public': false,
+};
 
 Map<String, dynamic> get testFileObjectJson => {
-      'name': 'test_bucket',
-      'id': 'test_bucket',
-      'bucket_id': 'public',
-      'owner': 'owner_id',
-      'updated_at': null,
-      'created_at': null,
-      'last_accessed_at': null,
-      'buckets': testBucketJson
-    };
+  'name': 'test_bucket',
+  'id': 'test_bucket',
+  'bucket_id': 'public',
+  'owner': 'owner_id',
+  'updated_at': null,
+  'created_at': null,
+  'last_accessed_at': null,
+  'buckets': testBucketJson,
+};
 
 String get bucketUrl => '$supabaseUrl/storage/v1/bucket';
 String get objectUrl => '$supabaseUrl/storage/v1/object';
@@ -136,49 +136,54 @@ void main() {
       expect(response, endsWith('/signed/url'));
     });
 
-    test('createSignedUrl throws StorageException when signedURL is null',
-        () async {
-      customHttpClient.response = {'signedURL': null};
+    test(
+      'createSignedUrl throws StorageException when signedURL is null',
+      () async {
+        customHttpClient.response = {'signedURL': null};
 
-      expect(
-        () => client.from('public').createSignedUrl('missing.txt', 60),
-        throwsA(isA<StorageException>()),
-      );
-    });
+        expect(
+          () => client.from('public').createSignedUrl('missing.txt', 60),
+          throwsA(isA<StorageException>()),
+        );
+      },
+    );
 
-    test('createSignedUrlsResult returns success and failure for mixed paths',
-        () async {
-      customHttpClient.response = [
-        {
-          'path': 'exists.txt',
-          'signedURL': '/storage/v1/object/sign/public/exists.txt?token=abc',
-        },
-        {
-          'path': 'missing.txt',
-          'signedURL': null,
-          'error': 'not_found',
-        },
-      ];
+    test(
+      'createSignedUrlsResult returns success and failure for mixed paths',
+      () async {
+        customHttpClient.response = [
+          {
+            'path': 'exists.txt',
+            'signedURL': '/storage/v1/object/sign/public/exists.txt?token=abc',
+          },
+          {
+            'path': 'missing.txt',
+            'signedURL': null,
+            'error': 'not_found',
+          },
+        ];
 
-      final results = await client
-          .from('public')
-          .createSignedUrlsResult(['exists.txt', 'missing.txt'], 60);
+        final results = await client.from('public').createSignedUrlsResult([
+          'exists.txt',
+          'missing.txt',
+        ], 60);
 
-      expect(results.length, 2);
-      expect(results[0], isA<SignedUrlSuccess>());
-      expect(results[1], isA<SignedUrlFailure>());
+        expect(results.length, 2);
+        expect(results[0], isA<SignedUrlSuccess>());
+        expect(results[1], isA<SignedUrlFailure>());
 
-      final success = results[0] as SignedUrlSuccess;
-      expect(success.path, 'exists.txt');
-      expect(
-        success.signedUrl,
-        endsWith('/storage/v1/object/sign/public/exists.txt?token=abc'),
-      );
+        final success = results[0] as SignedUrlSuccess;
+        expect(success.path, 'exists.txt');
+        expect(
+          success.signedUrl,
+          endsWith('/storage/v1/object/sign/public/exists.txt?token=abc'),
+        );
 
-      final failure = results[1] as SignedUrlFailure;
-      expect(failure.path, 'missing.txt');
-      expect(failure.error, 'not_found');
-    });
+        final failure = results[1] as SignedUrlFailure;
+        expect(failure.path, 'missing.txt');
+        expect(failure.error, 'not_found');
+      },
+    );
 
     // ignore: deprecated_member_use_from_same_package
     test('createSignedUrls (deprecated) omits missing paths', () async {
@@ -195,9 +200,10 @@ void main() {
       ];
 
       // ignore: deprecated_member_use_from_same_package
-      final urls = await client
-          .from('public')
-          .createSignedUrls(['exists.txt', 'missing.txt'], 60);
+      final urls = await client.from('public').createSignedUrls([
+        'exists.txt',
+        'missing.txt',
+      ], 60);
 
       expect(urls.length, 1);
       expect(urls[0].path, 'exists.txt');
@@ -276,7 +282,9 @@ void main() {
     });
 
     test('getPublicUrl appends download with the original file name', () {
-      final response = client.from('files').getPublicUrl(
+      final response = client
+          .from('files')
+          .getPublicUrl(
             'b.txt',
             download: DownloadBehavior.withOriginalName,
           );
@@ -284,8 +292,12 @@ void main() {
     });
 
     test('getPublicUrl appends download with a custom file name', () {
-      final response = client.from('files').getPublicUrl('b.txt',
-          download: DownloadBehavior.named('my file.txt'));
+      final response = client
+          .from('files')
+          .getPublicUrl(
+            'b.txt',
+            download: DownloadBehavior.named('my file.txt'),
+          );
       expect(
         response,
         '$objectUrl/public/files/b.txt?download=my+file.txt',
@@ -302,8 +314,13 @@ void main() {
         'signedURL': '/object/sign/public/b.txt?token=abc',
       };
 
-      final response = await client.from('public').createSignedUrl('b.txt', 60,
-          download: DownloadBehavior.named('report.pdf'));
+      final response = await client
+          .from('public')
+          .createSignedUrl(
+            'b.txt',
+            60,
+            download: DownloadBehavior.named('report.pdf'),
+          );
       expect(response, endsWith('?token=abc&download=report.pdf'));
     });
 
@@ -315,11 +332,13 @@ void main() {
         },
       ];
 
-      final results = await client.from('public').createSignedUrlsResult(
-        ['exists.txt'],
-        60,
-        download: DownloadBehavior.withOriginalName,
-      );
+      final results = await client
+          .from('public')
+          .createSignedUrlsResult(
+            ['exists.txt'],
+            60,
+            download: DownloadBehavior.withOriginalName,
+          );
 
       final success = results.single as SignedUrlSuccess;
       expect(success.signedUrl, endsWith('?token=abc&download='));
@@ -350,8 +369,9 @@ void main() {
       final file = File('a.txt');
       file.writeAsStringSync('File content');
 
-      final uploadTask =
-          client.from('public').upload('a.txt', file, retryAttempts: 1);
+      final uploadTask = client
+          .from('public')
+          .upload('a.txt', file, retryAttempts: 1);
       expect(uploadTask, throwsException);
     });
 
@@ -370,7 +390,9 @@ void main() {
 
       final retryController = StorageRetryController();
 
-      final future = client.from('public').upload(
+      final future = client
+          .from('public')
+          .upload(
             'a.txt',
             file,
             retryController: retryController,
@@ -428,8 +450,11 @@ void main() {
       await expectLater(
         () => client.listBuckets(),
         throwsA(
-          isA<StorageException>()
-              .having((e) => e.statusCode, 'statusCode', '420'),
+          isA<StorageException>().having(
+            (e) => e.statusCode,
+            'statusCode',
+            '420',
+          ),
         ),
       );
     });
@@ -450,7 +475,7 @@ void main() {
     test('X-Client-Info header can be overridden', () {
       client = SupabaseStorageClient('$supabaseUrl/storage/v1', {
         'Authorization': 'Bearer $supabaseKey',
-        'X-Client-Info': 'supabase-dart/0.0.0'
+        'X-Client-Info': 'supabase-dart/0.0.0',
       });
 
       expect(client.headers['X-Client-Info'], 'supabase-dart/0.0.0');
@@ -512,72 +537,54 @@ void main() {
       test('should update legacy prod host to new host', () {
         const inputUrl = 'https://blah.supabase.co/storage/v1';
         const expectedUrl = 'https://blah.storage.supabase.co/v1';
-        client = SupabaseStorageClient(
-            inputUrl,
-            {
-              'Authorization': 'Bearer $supabaseKey',
-            },
-            useNewHostname: true);
+        client = SupabaseStorageClient(inputUrl, {
+          'Authorization': 'Bearer $supabaseKey',
+        }, useNewHostname: true);
         expect(client.url, expectedUrl);
       });
 
       test('should update legacy staging host to new host', () {
         const inputUrl = 'https://blah.supabase.red/storage/v1';
         const expectedUrl = 'https://blah.storage.supabase.red/v1';
-        client = SupabaseStorageClient(
-            inputUrl,
-            {
-              'Authorization': 'Bearer $supabaseKey',
-            },
-            useNewHostname: true);
+        client = SupabaseStorageClient(inputUrl, {
+          'Authorization': 'Bearer $supabaseKey',
+        }, useNewHostname: true);
         expect(client.url, expectedUrl);
       });
 
       test('should accept new host without modification', () {
         const inputUrl = 'https://blah.storage.supabase.co/v1';
         const expectedUrl = 'https://blah.storage.supabase.co/v1';
-        client = SupabaseStorageClient(
-            inputUrl,
-            {
-              'Authorization': 'Bearer $supabaseKey',
-            },
-            useNewHostname: true);
+        client = SupabaseStorageClient(inputUrl, {
+          'Authorization': 'Bearer $supabaseKey',
+        }, useNewHostname: true);
         expect(client.url, expectedUrl);
       });
 
       test('should not modify non-platform hosts', () {
         const inputUrl = 'https://blah.supabase.co.example.com/storage/v1';
         const expectedUrl = 'https://blah.supabase.co.example.com/storage/v1';
-        client = SupabaseStorageClient(
-            inputUrl,
-            {
-              'Authorization': 'Bearer $supabaseKey',
-            },
-            useNewHostname: true);
+        client = SupabaseStorageClient(inputUrl, {
+          'Authorization': 'Bearer $supabaseKey',
+        }, useNewHostname: true);
         expect(client.url, expectedUrl);
       });
 
       test('should support local host with port without modification', () {
         const inputUrl = 'http://localhost:1234/storage/v1';
         const expectedUrl = 'http://localhost:1234/storage/v1';
-        client = SupabaseStorageClient(
-            inputUrl,
-            {
-              'Authorization': 'Bearer $supabaseKey',
-            },
-            useNewHostname: true);
+        client = SupabaseStorageClient(inputUrl, {
+          'Authorization': 'Bearer $supabaseKey',
+        }, useNewHostname: true);
         expect(client.url, expectedUrl);
       });
 
       test('should update legacy supabase.in host to new host', () {
         const inputUrl = 'https://blah.supabase.in/storage/v1';
         const expectedUrl = 'https://blah.storage.supabase.in/v1';
-        client = SupabaseStorageClient(
-            inputUrl,
-            {
-              'Authorization': 'Bearer $supabaseKey',
-            },
-            useNewHostname: true);
+        client = SupabaseStorageClient(inputUrl, {
+          'Authorization': 'Bearer $supabaseKey',
+        }, useNewHostname: true);
         expect(client.url, expectedUrl);
       });
     });

--- a/packages/storage_client/test/client_test.dart
+++ b/packages/storage_client/test/client_test.dart
@@ -45,8 +45,9 @@ void main() {
       'Authorization': 'Bearer $storageKey',
     });
 
-    file = File(join(
-        Directory.current.path, 'test', 'fixtures', 'upload', 'sadcat.jpg'));
+    file = File(
+      join(Directory.current.path, 'test', 'fixtures', 'upload', 'sadcat.jpg'),
+    );
   });
 
   test('List files', () async {
@@ -123,7 +124,9 @@ void main() {
       ),
     );
     final updateRes = await storage.updateBucket(
-        newBucketName, const BucketOptions(public: false));
+      newBucketName,
+      const BucketOptions(public: false),
+    );
     expect(updateRes, 'Successfully updated');
     final getRes = await storage.getBucket(newBucketName);
     expect(getRes.public, isFalse);
@@ -134,8 +137,10 @@ void main() {
 
   test('Empty bucket', () async {
     final response = await storage.emptyBucket(newBucketName);
-    expect(response,
-        'Empty bucket has been queued. Completion may take up to an hour.');
+    expect(
+      response,
+      'Empty bucket has been queued. Completion may take up to an hour.',
+    );
   });
 
   test('Delete bucket', () async {
@@ -157,21 +162,24 @@ void main() {
     });
 
     test('sign url for upload', () async {
-      final response =
-          await storage.from(newBucketName).createSignedUploadUrl(uploadPath);
+      final response = await storage
+          .from(newBucketName)
+          .createSignedUploadUrl(uploadPath);
 
       expect(response.path, uploadPath);
       expect(response.token, isNotEmpty);
       expect(
-          response.signedUrl,
-          contains(
-            '$storageUrl/object/upload/sign/$newBucketName/$uploadPath',
-          ));
+        response.signedUrl,
+        contains(
+          '$storageUrl/object/upload/sign/$newBucketName/$uploadPath',
+        ),
+      );
     });
 
     test('can upload with a signed url', () async {
-      final response =
-          await storage.from(newBucketName).createSignedUploadUrl(uploadPath);
+      final response = await storage
+          .from(newBucketName)
+          .createSignedUploadUrl(uploadPath);
 
       final uploadedPath = await storage
           .from(newBucketName)
@@ -181,20 +189,25 @@ void main() {
     });
 
     test('can upload a binary file with a signed url', () async {
-      final response =
-          await storage.from(newBucketName).createSignedUploadUrl(uploadPath);
+      final response = await storage
+          .from(newBucketName)
+          .createSignedUploadUrl(uploadPath);
 
       final uploadedPath = await storage
           .from(newBucketName)
           .uploadBinaryToSignedUrl(
-              response.path, response.token, file.readAsBytesSync());
+            response.path,
+            response.token,
+            file.readAsBytesSync(),
+          );
 
       expect(uploadedPath, uploadPath);
     });
 
     test('cannot upload to a signed url twice', () async {
-      final response =
-          await storage.from(newBucketName).createSignedUploadUrl(uploadPath);
+      final response = await storage
+          .from(newBucketName)
+          .createSignedUploadUrl(uploadPath);
 
       final uploadedPath = await storage
           .from(newBucketName)
@@ -205,10 +218,16 @@ void main() {
         () => storage
             .from(newBucketName)
             .uploadToSignedUrl(response.path, response.token, file),
-        throwsA(isA<StorageException>()
-            .having((e) => e.error, 'error', 'Duplicate')
-            .having((e) => e.message, 'message', 'The resource already exists')
-            .having((e) => e.statusCode, 'statusCode', '409')),
+        throwsA(
+          isA<StorageException>()
+              .having((e) => e.error, 'error', 'Duplicate')
+              .having(
+                (e) => e.message,
+                'message',
+                'The resource already exists',
+              )
+              .having((e) => e.statusCode, 'statusCode', '409'),
+        ),
       );
     });
 
@@ -234,36 +253,53 @@ void main() {
     });
 
     test('sign url with transform options', () async {
-      final url =
-          await storage.from(newBucketName).createSignedUrl(uploadPath, 2000,
-              transform: TransformOptions(
-                width: 100,
-                height: 100,
-              ));
+      final url = await storage
+          .from(newBucketName)
+          .createSignedUrl(
+            uploadPath,
+            2000,
+            transform: TransformOptions(
+              width: 100,
+              height: 100,
+            ),
+          );
 
       expect(
-          url.contains(
-              '$storageUrl/render/image/sign/$newBucketName/$uploadPath'),
-          isTrue);
+        url.contains(
+          '$storageUrl/render/image/sign/$newBucketName/$uploadPath',
+        ),
+        isTrue,
+      );
     });
 
     test('gets public url with transformation options', () async {
-      final url = storage.from(newBucketName).getPublicUrl(uploadPath,
-          transform: TransformOptions(width: 200, height: 300, quality: 60));
+      final url = storage
+          .from(newBucketName)
+          .getPublicUrl(
+            uploadPath,
+            transform: TransformOptions(width: 200, height: 300, quality: 60),
+          );
 
-      expect(url,
-          '$storageUrl/render/image/public/$newBucketName/$uploadPath?width=200&height=300&quality=60');
+      expect(
+        url,
+        '$storageUrl/render/image/public/$newBucketName/$uploadPath?width=200&height=300&quality=60',
+      );
     });
 
     test('will download a public transformed file', () async {
-      final bytesArray = await storage.from(newBucketName).download(uploadPath,
-          transform: TransformOptions(
-            width: 200,
-            height: 200,
-          ));
+      final bytesArray = await storage
+          .from(newBucketName)
+          .download(
+            uploadPath,
+            transform: TransformOptions(
+              width: 200,
+              height: 200,
+            ),
+          );
 
-      final downloadedFile =
-          await File('${Directory.current.path}/public-image.jpg').create();
+      final downloadedFile = await File(
+        '${Directory.current.path}/public-image.jpg',
+      ).create();
       try {
         await downloadedFile.writeAsBytes(bytesArray);
         final size = await downloadedFile.length();
@@ -281,12 +317,16 @@ void main() {
 
       await storage.from(privateBucketName).upload(uploadPath, file);
 
-      final bytesArray = await storage.from(privateBucketName).download(
-          uploadPath,
-          transform: TransformOptions(width: 200, height: 200));
+      final bytesArray = await storage
+          .from(privateBucketName)
+          .download(
+            uploadPath,
+            transform: TransformOptions(width: 200, height: 200),
+          );
 
-      final downloadedFile =
-          await File('${Directory.current.path}/private-image.jpg').create();
+      final downloadedFile = await File(
+        '${Directory.current.path}/private-image.jpg',
+      ).create();
       try {
         await downloadedFile.writeAsBytes(bytesArray);
         final size = await downloadedFile.length();
@@ -303,18 +343,23 @@ void main() {
     });
 
     test('will return the image as webp when the browser support it', () async {
-      final client = SupabaseStorageClient(storageUrl,
-          {'Authorization': 'Bearer $storageKey', 'Accept': 'image/webp'});
+      final client = SupabaseStorageClient(storageUrl, {
+        'Authorization': 'Bearer $storageKey',
+        'Accept': 'image/webp',
+      });
 
-      final bytesArray = await client.from(newBucketName).download(
+      final bytesArray = await client
+          .from(newBucketName)
+          .download(
             uploadPath,
             transform: TransformOptions(
               width: 200,
               height: 200,
             ),
           );
-      final downloadedFile =
-          await File('${Directory.current.path}/webpimage').create();
+      final downloadedFile = await File(
+        '${Directory.current.path}/webpimage',
+      ).create();
       try {
         await downloadedFile.writeAsBytes(bytesArray);
         final size = await downloadedFile.length();
@@ -330,35 +375,42 @@ void main() {
       }
     });
 
-    test('will return the original image format when format is origin',
-        () async {
-      final client = SupabaseStorageClient(storageUrl,
-          {'Authorization': 'Bearer $storageKey', 'Accept': 'image/webp'});
+    test(
+      'will return the original image format when format is origin',
+      () async {
+        final client = SupabaseStorageClient(storageUrl, {
+          'Authorization': 'Bearer $storageKey',
+          'Accept': 'image/webp',
+        });
 
-      final bytesArray = await client.from(newBucketName).download(
-            uploadPath,
-            transform: TransformOptions(
-              width: 200,
-              height: 200,
-              format: RequestImageFormat.origin,
-            ),
+        final bytesArray = await client
+            .from(newBucketName)
+            .download(
+              uploadPath,
+              transform: TransformOptions(
+                width: 200,
+                height: 200,
+                format: RequestImageFormat.origin,
+              ),
+            );
+        final downloadedFile = await File(
+          '${Directory.current.path}/jpegimage',
+        ).create();
+        try {
+          await downloadedFile.writeAsBytes(bytesArray);
+          final size = await downloadedFile.length();
+          final type = lookupMimeType(
+            downloadedFile.path,
+            headerBytes: downloadedFile.readAsBytesSync(),
           );
-      final downloadedFile =
-          await File('${Directory.current.path}/jpegimage').create();
-      try {
-        await downloadedFile.writeAsBytes(bytesArray);
-        final size = await downloadedFile.length();
-        final type = lookupMimeType(
-          downloadedFile.path,
-          headerBytes: downloadedFile.readAsBytesSync(),
-        );
 
-        expect(size, isPositive);
-        expect(type, 'image/jpeg');
-      } finally {
-        await downloadedFile.delete();
-      }
-    });
+          expect(size, isPositive);
+          expect(type, 'image/jpeg');
+        } finally {
+          await downloadedFile.delete();
+        }
+      },
+    );
   });
 
   group('download option', () {
@@ -366,48 +418,61 @@ void main() {
 
     setUp(() async {
       await findOrCreateBucket(downloadBucket, true);
-      await storage.from(downloadBucket).upload(
+      await storage
+          .from(downloadBucket)
+          .upload(
             uploadPath,
             file,
             fileOptions: const FileOptions(upsert: true),
           );
     });
 
-    test('public url download serves a Content-Disposition attachment',
-        () async {
-      final url = storage.from(downloadBucket).getPublicUrl(uploadPath,
-          download: DownloadBehavior.named('renamed.jpg'));
+    test(
+      'public url download serves a Content-Disposition attachment',
+      () async {
+        final url = storage
+            .from(downloadBucket)
+            .getPublicUrl(
+              uploadPath,
+              download: DownloadBehavior.named('renamed.jpg'),
+            );
 
-      final response = await http.get(Uri.parse(url));
-      expect(response.statusCode, 200);
-      final disposition = response.headers['content-disposition'];
-      expect(disposition, contains('attachment'));
-      expect(disposition, contains('renamed.jpg'));
-    });
+        final response = await http.get(Uri.parse(url));
+        expect(response.statusCode, 200);
+        final disposition = response.headers['content-disposition'];
+        expect(disposition, contains('attachment'));
+        expect(disposition, contains('renamed.jpg'));
+      },
+    );
 
-    test('signed url download serves a Content-Disposition attachment',
-        () async {
-      final url = await storage.from(downloadBucket).createSignedUrl(
-            uploadPath,
-            2000,
-            download: DownloadBehavior.withOriginalName,
-          );
+    test(
+      'signed url download serves a Content-Disposition attachment',
+      () async {
+        final url = await storage
+            .from(downloadBucket)
+            .createSignedUrl(
+              uploadPath,
+              2000,
+              download: DownloadBehavior.withOriginalName,
+            );
 
-      final response = await http.get(Uri.parse(url));
-      expect(response.statusCode, 200);
-      expect(response.headers['content-disposition'], contains('attachment'));
-    });
+        final response = await http.get(Uri.parse(url));
+        expect(response.statusCode, 200);
+        expect(response.headers['content-disposition'], contains('attachment'));
+      },
+    );
   });
 
   group('bucket limits', () {
     test('can upload a file within the file size limit', () async {
       final bucketName = 'with-limit-${DateTime.now()}';
       await storage.createBucket(
-          bucketName,
-          const BucketOptions(
-            public: true,
-            fileSizeLimit: '1mb', // 1mb
-          ));
+        bucketName,
+        const BucketOptions(
+          public: true,
+          fileSizeLimit: '1mb', // 1mb
+        ),
+      );
 
       final res = await storage.from(bucketName).upload(uploadPath, file);
       expect(res, isA<String>());
@@ -416,11 +481,12 @@ void main() {
     test('cannot upload a file that exceed the file size limit', () async {
       final bucketName = 'with-limit-${DateTime.now()}';
       await storage.createBucket(
-          bucketName,
-          const BucketOptions(
-            public: true,
-            fileSizeLimit: '1kb',
-          ));
+        bucketName,
+        const BucketOptions(
+          public: true,
+          fileSizeLimit: '1kb',
+        ),
+      );
 
       final uploadFuture = storage.from(bucketName).upload(uploadPath, file);
       await expectLater(uploadFuture, throwsException);
@@ -429,52 +495,71 @@ void main() {
     test('can upload a file with a valid mime type', () async {
       final bucketName = 'with-limit-${DateTime.now()}';
       await storage.createBucket(
-          bucketName,
-          BucketOptions(
-            public: true,
-            allowedMimeTypes: ['image/png'],
-          ));
+        bucketName,
+        BucketOptions(
+          public: true,
+          allowedMimeTypes: ['image/png'],
+        ),
+      );
 
-      final res = await storage.from(bucketName).upload(uploadPath, file,
-          fileOptions: FileOptions(
-            contentType: 'image/png',
-          ));
+      final res = await storage
+          .from(bucketName)
+          .upload(
+            uploadPath,
+            file,
+            fileOptions: FileOptions(
+              contentType: 'image/png',
+            ),
+          );
       expect(res, isA<String>());
     });
 
     test('cannot upload a file an invalid mime type', () async {
       final bucketName = 'with-limit-${DateTime.now()}';
       await storage.createBucket(
-          bucketName,
-          const BucketOptions(
-            public: true,
-            allowedMimeTypes: ['image/png'],
-          ));
+        bucketName,
+        const BucketOptions(
+          public: true,
+          allowedMimeTypes: ['image/png'],
+        ),
+      );
 
-      final uploadFuture = storage.from(bucketName).upload(uploadPath, file,
-          fileOptions: FileOptions(
-            contentType: 'image/jpeg',
-          ));
+      final uploadFuture = storage
+          .from(bucketName)
+          .upload(
+            uploadPath,
+            file,
+            fileOptions: FileOptions(
+              contentType: 'image/jpeg',
+            ),
+          );
       await expectLater(uploadFuture, throwsException);
     });
   });
 
   group('file operations', () {
     test('copy', () async {
-      final client = SupabaseStorageClient(
-          storageUrl, {'Authorization': 'Bearer $storageKey'});
+      final client = SupabaseStorageClient(storageUrl, {
+        'Authorization': 'Bearer $storageKey',
+      });
 
       await client.from(newBucketName).copy(uploadPath, "$uploadPath 2");
     });
 
     test('copy to different bucket', () async {
-      final client = SupabaseStorageClient(
-          storageUrl, {'Authorization': 'Bearer $storageKey'});
+      final client = SupabaseStorageClient(storageUrl, {
+        'Authorization': 'Bearer $storageKey',
+      });
 
       await expectLater(
         () => client.from('bucket2').download(uploadPath),
-        throwsA(isA<StorageException>()
-            .having((e) => e.statusCode, 'statusCode', '400')),
+        throwsA(
+          isA<StorageException>().having(
+            (e) => e.statusCode,
+            'statusCode',
+            '400',
+          ),
+        ),
       );
       await client
           .from(newBucketName)
@@ -487,13 +572,19 @@ void main() {
     });
 
     test('move to different bucket', () async {
-      final client = SupabaseStorageClient(
-          storageUrl, {'Authorization': 'Bearer $storageKey'});
+      final client = SupabaseStorageClient(storageUrl, {
+        'Authorization': 'Bearer $storageKey',
+      });
 
       await expectLater(
         () => client.from('bucket2').download('$uploadPath 3'),
-        throwsA(isA<StorageException>()
-            .having((e) => e.statusCode, 'statusCode', '400')),
+        throwsA(
+          isA<StorageException>().having(
+            (e) => e.statusCode,
+            'statusCode',
+            '400',
+          ),
+        ),
       );
       await client
           .from(newBucketName)
@@ -505,8 +596,13 @@ void main() {
       }
       await expectLater(
         () => client.from(newBucketName).download(uploadPath),
-        throwsA(isA<StorageException>()
-            .having((e) => e.statusCode, 'statusCode', '400')),
+        throwsA(
+          isA<StorageException>().having(
+            (e) => e.statusCode,
+            'statusCode',
+            '400',
+          ),
+        ),
       );
     });
   });
@@ -518,7 +614,9 @@ void main() {
       'third': 'third',
     };
     final path = "$uploadPath-metadata";
-    await storage.from(newBucketName).upload(
+    await storage
+        .from(newBucketName)
+        .upload(
           path,
           file,
           fileOptions: FileOptions(
@@ -616,30 +714,31 @@ void main() {
     });
 
     test(
-        'setHeader on StorageFileApi does not affect other StorageFileApi instances',
-        () async {
-      customHttpClient.response = [];
-      customHttpClient.statusCode = 200;
+      'setHeader on StorageFileApi does not affect other StorageFileApi instances',
+      () async {
+        customHttpClient.response = [];
+        customHttpClient.statusCode = 200;
 
-      final fileApi1 = client.from('bucket1');
-      final fileApi2 = client.from('bucket2');
+        final fileApi1 = client.from('bucket1');
+        final fileApi2 = client.from('bucket2');
 
-      fileApi1.setHeader('x-header', 'value1');
+        fileApi1.setHeader('x-header', 'value1');
 
-      await fileApi1.list();
-      await fileApi2.list();
+        await fileApi1.list();
+        await fileApi2.list();
 
-      expect(customHttpClient.receivedRequests.length, 2);
-      expect(
-        customHttpClient.receivedRequests[0].headers['x-header'],
-        'value1',
-      );
-      // fileApi2 should not have the header set on fileApi1
-      expect(
-        customHttpClient.receivedRequests[1].headers['x-header'],
-        isNull,
-      );
-    });
+        expect(customHttpClient.receivedRequests.length, 2);
+        expect(
+          customHttpClient.receivedRequests[0].headers['x-header'],
+          'value1',
+        );
+        // fileApi2 should not have the header set on fileApi1
+        expect(
+          customHttpClient.receivedRequests[1].headers['x-header'],
+          isNull,
+        );
+      },
+    );
 
     test('setHeader on StorageFileApi returns this for chaining', () async {
       customHttpClient.response = [];
@@ -706,18 +805,20 @@ void main() {
       );
     });
 
-    test('does not mutate the stored headers map after a non-GET request',
-        () async {
-      customHttpClient.response = [];
-      customHttpClient.statusCode = 200;
+    test(
+      'does not mutate the stored headers map after a non-GET request',
+      () async {
+        customHttpClient.response = [];
+        customHttpClient.statusCode = 200;
 
-      final fileApi = client.from('test-bucket');
-      final headersBefore = Map<String, String>.of(fileApi.headers);
+        final fileApi = client.from('test-bucket');
+        final headersBefore = Map<String, String>.of(fileApi.headers);
 
-      await fileApi.list();
+        await fileApi.list();
 
-      expect(fileApi.headers, equals(headersBefore));
-    });
+        expect(fileApi.headers, equals(headersBefore));
+      },
+    );
   });
 
   group('object keys with reserved URL characters', () {
@@ -731,7 +832,8 @@ void main() {
 
     setUp(() async {
       bucket = await findOrCreateBucket(
-          'reserved-${DateTime.now().millisecondsSinceEpoch}');
+        'reserved-${DateTime.now().millisecondsSinceEpoch}',
+      );
     });
 
     // Valid storage keys that contain characters which are reserved in a URL
@@ -745,7 +847,9 @@ void main() {
 
     for (final key in keys) {
       test('uploads and downloads "$key" as the same object', () async {
-        await storage.from(bucket).upload(
+        await storage
+            .from(bucket)
+            .upload(
               key,
               file,
               fileOptions: const FileOptions(upsert: true),
@@ -771,7 +875,9 @@ void main() {
     for (final invalidKey in ['folder/a#b.txt', 'folder/100%done.txt']) {
       test('rejects "$invalidKey" with an InvalidKey error', () async {
         await expectLater(
-          () => storage.from(bucket).upload(
+          () => storage
+              .from(bucket)
+              .upload(
                 invalidKey,
                 file,
                 fileOptions: const FileOptions(upsert: true),
@@ -805,7 +911,9 @@ void main() {
       customHttpClient.response = [];
       customHttpClient.statusCode = 200;
 
-      await client.from('test-bucket').list(
+      await client
+          .from('test-bucket')
+          .list(
             searchOptions: const SearchOptions(
               sortBy: SortBy(column: 'updated_at'),
             ),
@@ -818,7 +926,9 @@ void main() {
       customHttpClient.response = [];
       customHttpClient.statusCode = 200;
 
-      await client.from('test-bucket').list(
+      await client
+          .from('test-bucket')
+          .list(
             searchOptions: const SearchOptions(
               sortBy: SortBy(order: 'desc'),
             ),
@@ -840,7 +950,9 @@ void main() {
       customHttpClient.response = [];
       customHttpClient.statusCode = 200;
 
-      await client.from('test-bucket').list(
+      await client
+          .from('test-bucket')
+          .list(
             searchOptions: const SearchOptions(
               sortBy: SortBy(column: null, order: null),
             ),
@@ -853,7 +965,9 @@ void main() {
       customHttpClient.response = [];
       customHttpClient.statusCode = 200;
 
-      await client.from('test-bucket').list(
+      await client
+          .from('test-bucket')
+          .list(
             searchOptions: const SearchOptions(
               sortBy: SortBy(column: 'created_at', order: 'desc'),
             ),

--- a/packages/storage_client/test/fetch_test.dart
+++ b/packages/storage_client/test/fetch_test.dart
@@ -36,69 +36,79 @@ class FinalizingRetryHttpClient extends BaseClient {
 
 void main() {
   group('multipart uploads', () {
-    test('retries a binary upload after a failure that finalized the request',
-        () async {
-      final retryClient = FinalizingRetryHttpClient(failuresBeforeSuccess: 1);
-      final client = SupabaseStorageClient(
-        storageUrl,
-        headers,
-        httpClient: retryClient,
-        retryAttempts: 3,
-      );
+    test(
+      'retries a binary upload after a failure that finalized the request',
+      () async {
+        final retryClient = FinalizingRetryHttpClient(failuresBeforeSuccess: 1);
+        final client = SupabaseStorageClient(
+          storageUrl,
+          headers,
+          httpClient: retryClient,
+          retryAttempts: 3,
+        );
 
-      final result = await client
-          .from('bucket')
-          .uploadBinary('folder/file.png', Uint8List.fromList([1, 2, 3]));
+        final result = await client
+            .from('bucket')
+            .uploadBinary('folder/file.png', Uint8List.fromList([1, 2, 3]));
 
-      expect(result, 'public/a.txt');
-      expect(retryClient.attempts, 2);
-    });
+        expect(result, 'public/a.txt');
+        expect(retryClient.attempts, 2);
+      },
+    );
 
-    test('detects content type from the path of a binary signed url upload',
-        () async {
-      final mockClient = CustomHttpClient();
-      mockClient.response = <String, dynamic>{};
-      mockClient.statusCode = 200;
-      final client = SupabaseStorageClient(
-        storageUrl,
-        headers,
-        httpClient: mockClient,
-      );
+    test(
+      'detects content type from the path of a binary signed url upload',
+      () async {
+        final mockClient = CustomHttpClient();
+        mockClient.response = <String, dynamic>{};
+        mockClient.statusCode = 200;
+        final client = SupabaseStorageClient(
+          storageUrl,
+          headers,
+          httpClient: mockClient,
+        );
 
-      await client.from('bucket').uploadBinaryToSignedUrl(
-            'folder/image.png',
-            'signed-token',
-            Uint8List.fromList([1, 2, 3]),
-          );
+        await client
+            .from('bucket')
+            .uploadBinaryToSignedUrl(
+              'folder/image.png',
+              'signed-token',
+              Uint8List.fromList([1, 2, 3]),
+            );
 
-      final request = mockClient.receivedRequests.single as MultipartRequest;
-      expect(request.files.single.contentType.mimeType, 'image/png');
-    });
+        final request = mockClient.receivedRequests.single as MultipartRequest;
+        expect(request.files.single.contentType.mimeType, 'image/png');
+      },
+    );
   });
 
   group('path normalization', () {
-    test('removes leading, trailing and duplicate slashes from the path',
-        () async {
-      final mockClient = CustomHttpClient();
-      mockClient.response = <String, dynamic>{};
-      mockClient.statusCode = 200;
-      final client = SupabaseStorageClient(
-        storageUrl,
-        headers,
-        httpClient: mockClient,
-      );
+    test(
+      'removes leading, trailing and duplicate slashes from the path',
+      () async {
+        final mockClient = CustomHttpClient();
+        mockClient.response = <String, dynamic>{};
+        mockClient.statusCode = 200;
+        final client = SupabaseStorageClient(
+          storageUrl,
+          headers,
+          httpClient: mockClient,
+        );
 
-      final cleanPath = await client.from('bucket').uploadBinaryToSignedUrl(
-            '/folder//image.png/',
-            'signed-token',
-            Uint8List.fromList([1]),
-          );
+        final cleanPath = await client
+            .from('bucket')
+            .uploadBinaryToSignedUrl(
+              '/folder//image.png/',
+              'signed-token',
+              Uint8List.fromList([1]),
+            );
 
-      expect(cleanPath, 'folder/image.png');
+        expect(cleanPath, 'folder/image.png');
 
-      final requestPath = mockClient.receivedRequests.single.url.path;
-      expect(requestPath, endsWith('/bucket/folder/image.png'));
-      expect(requestPath.contains('//'), isFalse);
-    });
+        final requestPath = mockClient.receivedRequests.single.url.path;
+        expect(requestPath, endsWith('/bucket/folder/image.png'));
+        expect(requestPath.contains('//'), isFalse);
+      },
+    );
   });
 }

--- a/packages/supabase/example/pubspec.yaml
+++ b/packages/supabase/example/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 publish_to: none
 
 environment:
-  sdk: '>=3.3.0 <4.0.0'
+  sdk: '>=3.9.0 <4.0.0'
 
 dependencies:
   web: '>=0.5.0 <2.0.0'

--- a/packages/supabase/example/web/main.dart
+++ b/packages/supabase/example/web/main.dart
@@ -17,8 +17,10 @@ void main() {
 
 void exampleUsage(SupabaseClient supabase) async {
   // query data
-  final data =
-      await supabase.from('countries').select().order('name', ascending: true);
+  final data = await supabase
+      .from('countries')
+      .select()
+      .order('name', ascending: true);
   print(data);
 
   // insert data
@@ -75,13 +77,15 @@ void exampleUsage(SupabaseClient supabase) async {
   print('upload response : $storageResponse');
 
   // Get download url
-  final urlResponse =
-      await supabase.storage.from('public').createSignedUrl('example.txt', 60);
+  final urlResponse = await supabase.storage
+      .from('public')
+      .createSignedUrl('example.txt', 60);
   print('download url : $urlResponse');
 
   // Download text file
-  final fileResponse =
-      await supabase.storage.from('public').download('example.txt');
+  final fileResponse = await supabase.storage
+      .from('public')
+      .download('example.txt');
   print('downloaded file : ${String.fromCharCodes(fileResponse)}');
 
   // Delete file

--- a/packages/supabase/lib/src/realtime_client_options.dart
+++ b/packages/supabase/lib/src/realtime_client_options.dart
@@ -8,7 +8,8 @@ class RealtimeClientOptions {
   ///
   /// Defaults to 10 events per second
   @Deprecated(
-      'Client side rate limit has been removed. This option will be ignored.')
+    'Client side rate limit has been removed. This option will be ignored.',
+  )
   final int? eventsPerSecond;
 
   /// Level of realtime server logs to be logged

--- a/packages/supabase/lib/src/supabase_client.dart
+++ b/packages/supabase/lib/src/supabase_client.dart
@@ -130,40 +130,47 @@ class SupabaseClient {
     Map<String, String>? headers,
     Client? httpClient,
     YAJsonIsolate? isolate,
-  })  : _supabaseKey = supabaseKey,
-        _functionsOptions = functionsOptions,
-        _restUrl = '$supabaseUrl/rest/v1',
-        _realtimeUrl = '$supabaseUrl/realtime/v1'.replaceAll('http', 'ws'),
-        _authUrl = '$supabaseUrl/auth/v1',
-        _storageUrl = '$supabaseUrl/storage/v1',
-        _functionsUrl = '$supabaseUrl/functions/v1',
-        _postgrestOptions = postgrestOptions,
-        _headers = {
-          ...Constants.defaultHeaders,
-          ...?headers,
-        },
-        _httpClient = httpClient,
-        _isolate = isolate ?? (YAJsonIsolate()..initialize()),
-        _hasCustomIsolate = isolate != null {
+  }) : _supabaseKey = supabaseKey,
+       _functionsOptions = functionsOptions,
+       _restUrl = '$supabaseUrl/rest/v1',
+       _realtimeUrl = '$supabaseUrl/realtime/v1'.replaceAll('http', 'ws'),
+       _authUrl = '$supabaseUrl/auth/v1',
+       _storageUrl = '$supabaseUrl/storage/v1',
+       _functionsUrl = '$supabaseUrl/functions/v1',
+       _postgrestOptions = postgrestOptions,
+       _headers = {
+         ...Constants.defaultHeaders,
+         ...?headers,
+       },
+       _httpClient = httpClient,
+       _isolate = isolate ?? (YAJsonIsolate()..initialize()),
+       _hasCustomIsolate = isolate != null {
     _authInstance = _initSupabaseAuthClient(
       autoRefreshToken: authOptions.autoRefreshToken,
       gotrueAsyncStorage: authOptions.pkceAsyncStorage,
       authFlowType: authOptions.authFlowType,
     );
-    _authHttpClient =
-        AuthHttpClient(_supabaseKey, httpClient ?? Client(), _getAccessToken);
+    _authHttpClient = AuthHttpClient(
+      _supabaseKey,
+      httpClient ?? Client(),
+      _getAccessToken,
+    );
     rest = _initRestClient();
     functions = _initFunctionsClient();
     storage = _initStorageClient(
-        storageOptions.retryAttempts, storageOptions.useNewHostname);
+      storageOptions.retryAttempts,
+      storageOptions.useNewHostname,
+    );
     realtime = _initRealtimeClient(options: realtimeClientOptions);
     if (accessToken == null) {
       _log.config(
-          'Initialize SupabaseClient v$version with no custom access token');
+        'Initialize SupabaseClient v$version with no custom access token',
+      );
       _listenForAuthEvents();
     } else {
       _log.config(
-          'Initialize SupabaseClient v$version with custom access token');
+        'Initialize SupabaseClient v$version with custom access token',
+      );
     }
   }
 
@@ -219,8 +226,10 @@ class SupabaseClient {
   }
 
   /// Creates a Realtime channel with Broadcast, Presence, and Postgres Changes.
-  RealtimeChannel channel(String name,
-      {RealtimeChannelConfig opts = const RealtimeChannelConfig()}) {
+  RealtimeChannel channel(
+    String name, {
+    RealtimeChannelConfig opts = const RealtimeChannelConfig(),
+  }) {
     return realtime.channel(name, opts);
   }
 
@@ -257,8 +266,9 @@ class SupabaseClient {
         final expiresAt = authInstance.currentSession?.expiresAt;
         if (expiresAt != null) {
           // Failed to refresh the token.
-          final isExpiredWithoutMargin = DateTime.now()
-              .isAfter(DateTime.fromMillisecondsSinceEpoch(expiresAt * 1000));
+          final isExpiredWithoutMargin = DateTime.now().isAfter(
+            DateTime.fromMillisecondsSinceEpoch(expiresAt * 1000),
+          );
           if (isExpiredWithoutMargin) {
             // Throw the error instead of making an API request with an expired token.
             _log.warning(
@@ -329,7 +339,9 @@ class SupabaseClient {
   }
 
   SupabaseStorageClient _initStorageClient(
-      int storageRetryAttempts, bool useNewHostname) {
+    int storageRetryAttempts,
+    bool useNewHostname,
+  ) {
     return SupabaseStorageClient(
       _storageUrl,
       {...headers},

--- a/packages/supabase/lib/src/supabase_client_options.dart
+++ b/packages/supabase/lib/src/supabase_client_options.dart
@@ -30,8 +30,10 @@ class StorageClientOptions {
   /// `Invalid Storage request` error. Defaults to `false` (opt-in).
   final bool useNewHostname;
 
-  const StorageClientOptions(
-      {this.retryAttempts = 0, this.useNewHostname = false});
+  const StorageClientOptions({
+    this.retryAttempts = 0,
+    this.useNewHostname = false,
+  });
 }
 
 class FunctionsClientOptions {

--- a/packages/supabase/lib/src/supabase_query_builder.dart
+++ b/packages/supabase/lib/src/supabase_query_builder.dart
@@ -15,13 +15,13 @@ class SupabaseQueryBuilder extends PostgrestQueryBuilder {
     super.httpClient,
     required int incrementId,
     required super.isolate,
-  })  : _realtime = realtime,
-        _schema = schema,
-        _table = table,
-        _incrementId = incrementId,
-        super(
-          url: Uri.parse(url),
-        );
+  }) : _realtime = realtime,
+       _schema = schema,
+       _table = table,
+       _incrementId = incrementId,
+       super(
+         url: Uri.parse(url),
+       );
 
   /// Combines the current state of your table from PostgREST with changes from the realtime server to return real-time data from your table as a [Stream].
   ///

--- a/packages/supabase/lib/src/supabase_query_schema.dart
+++ b/packages/supabase/lib/src/supabase_query_schema.dart
@@ -24,14 +24,14 @@ class SupabaseQuerySchema {
     required Client? authHttpClient,
     required RealtimeClient realtime,
     required PostgrestClient rest,
-  })  : _counter = counter,
-        _restUrl = restUrl,
-        _headers = headers,
-        _schema = schema,
-        _isolate = isolate,
-        _authHttpClient = authHttpClient,
-        _realtime = realtime,
-        _rest = rest;
+  }) : _counter = counter,
+       _restUrl = restUrl,
+       _headers = headers,
+       _schema = schema,
+       _isolate = isolate,
+       _authHttpClient = authHttpClient,
+       _realtime = realtime,
+       _rest = rest;
 
   /// Perform a table operation.
   SupabaseQueryBuilder from(String table) {

--- a/packages/supabase/lib/src/supabase_stream_builder.dart
+++ b/packages/supabase/lib/src/supabase_stream_builder.dart
@@ -95,13 +95,13 @@ class SupabaseStreamBuilder extends Stream<SupabaseStreamEvent> {
     required String table,
     required List<String> primaryKey,
     required bool private,
-  })  : _queryBuilder = queryBuilder,
-        _realtimeTopic = realtimeTopic,
-        _realtimeClient = realtimeClient,
-        _schema = schema,
-        _table = table,
-        _uniqueColumns = primaryKey,
-        _private = private;
+  }) : _queryBuilder = queryBuilder,
+       _realtimeTopic = realtimeTopic,
+       _realtimeClient = realtimeClient,
+       _schema = schema,
+       _table = table,
+       _uniqueColumns = primaryKey,
+       _private = private;
 
   /// Orders the result with the specified [column].
   ///
@@ -183,65 +183,66 @@ class SupabaseStreamBuilder extends Stream<SupabaseStreamEvent> {
 
     _channel!
         .onPostgresChanges(
-            event: PostgresChangeEvent.all,
-            schema: _schema,
-            table: _table,
-            filter: realtimeFilter,
-            callback: (payload) {
-              switch (payload.eventType) {
-                case PostgresChangeEvent.insert:
-                  final newRecord = payload.newRecord;
-                  _streamData.add(newRecord);
-                  _addStream();
-                  break;
-                case PostgresChangeEvent.update:
-                  final updatedIndex = _streamData.indexWhere(
-                    (element) =>
-                        _isTargetRecord(record: element, payload: payload),
-                  );
+          event: PostgresChangeEvent.all,
+          schema: _schema,
+          table: _table,
+          filter: realtimeFilter,
+          callback: (payload) {
+            switch (payload.eventType) {
+              case PostgresChangeEvent.insert:
+                final newRecord = payload.newRecord;
+                _streamData.add(newRecord);
+                _addStream();
+                break;
+              case PostgresChangeEvent.update:
+                final updatedIndex = _streamData.indexWhere(
+                  (element) =>
+                      _isTargetRecord(record: element, payload: payload),
+                );
 
-                  final updatedRecord = payload.newRecord;
-                  if (updatedIndex >= 0) {
-                    _streamData[updatedIndex] = updatedRecord;
-                  } else {
-                    _streamData.add(updatedRecord);
-                  }
+                final updatedRecord = payload.newRecord;
+                if (updatedIndex >= 0) {
+                  _streamData[updatedIndex] = updatedRecord;
+                } else {
+                  _streamData.add(updatedRecord);
+                }
+                _addStream();
+                break;
+              case PostgresChangeEvent.delete:
+                final deletedIndex = _streamData.indexWhere(
+                  (element) =>
+                      _isTargetRecord(record: element, payload: payload),
+                );
+                if (deletedIndex >= 0) {
+                  /// Delete the data from in memory cache if it was found
+                  _streamData.removeAt(deletedIndex);
                   _addStream();
-                  break;
-                case PostgresChangeEvent.delete:
-                  final deletedIndex = _streamData.indexWhere(
-                    (element) =>
-                        _isTargetRecord(record: element, payload: payload),
-                  );
-                  if (deletedIndex >= 0) {
-                    /// Delete the data from in memory cache if it was found
-                    _streamData.removeAt(deletedIndex);
-                    _addStream();
-                  }
-                  break;
-                case PostgresChangeEvent.all:
-                  break;
-              }
-            })
+                }
+                break;
+              case PostgresChangeEvent.all:
+                break;
+            }
+          },
+        )
         .subscribe((status, [error]) {
-      switch (status) {
-        case RealtimeSubscribeStatus.subscribed:
-          // Reload all data after a reconnect from postgrest
-          // First data from postgrest gets loaded before the realtime connect
-          if (_wasSubscribed) {
-            unawaited(_getPostgrestData());
+          switch (status) {
+            case RealtimeSubscribeStatus.subscribed:
+              // Reload all data after a reconnect from postgrest
+              // First data from postgrest gets loaded before the realtime connect
+              if (_wasSubscribed) {
+                unawaited(_getPostgrestData());
+              }
+              _wasSubscribed = true;
+              break;
+            case RealtimeSubscribeStatus.closed:
+              unawaited(_streamController?.close());
+              break;
+            case RealtimeSubscribeStatus.timedOut:
+            case RealtimeSubscribeStatus.channelError:
+              _addException(RealtimeSubscribeException(status, error));
+              break;
           }
-          _wasSubscribed = true;
-          break;
-        case RealtimeSubscribeStatus.closed:
-          unawaited(_streamController?.close());
-          break;
-        case RealtimeSubscribeStatus.timedOut:
-        case RealtimeSubscribeStatus.channelError:
-          _addException(RealtimeSubscribeException(status, error));
-          break;
-      }
-    });
+        });
     unawaited(_getPostgrestData());
   }
 
@@ -274,8 +275,10 @@ class SupabaseStreamBuilder extends Stream<SupabaseStreamEvent> {
     }
     PostgrestTransformBuilder<PostgrestList>? transformQuery;
     if (_orderBy != null) {
-      transformQuery =
-          query.order(_orderBy!.column, ascending: _orderBy!.ascending);
+      transformQuery = query.order(
+        _orderBy!.column,
+        ascending: _orderBy!.ascending,
+      );
     }
     if (_limit != null) {
       transformQuery = (transformQuery ?? query).limit(_limit!);
@@ -305,8 +308,9 @@ class SupabaseStreamBuilder extends Stream<SupabaseStreamEvent> {
     } else if (payload.eventType == PostgresChangeEvent.delete) {
       targetRecord = payload.oldRecord;
     }
-    return _uniqueColumns
-        .every((column) => record[column] == targetRecord[column]);
+    return _uniqueColumns.every(
+      (column) => record[column] == targetRecord[column],
+    );
   }
 
   void _sortData() {
@@ -348,15 +352,18 @@ class SupabaseStreamBuilder extends Stream<SupabaseStreamEvent> {
 
   @override
   Stream<E> asyncMap<E>(
-      FutureOr<E> Function(SupabaseStreamEvent event) convert) {
+    FutureOr<E> Function(SupabaseStreamEvent event) convert,
+  ) {
     // Copied from [Stream.asyncMap]
 
     final controller = BehaviorSubject<E>();
 
     controller.onListen = () {
-      StreamSubscription<SupabaseStreamEvent> subscription = listen(null,
-          onError: controller.addError, // Avoid Zone error replacement.
-          onDone: () => unawaited(controller.close()));
+      StreamSubscription<SupabaseStreamEvent> subscription = listen(
+        null,
+        onError: controller.addError, // Avoid Zone error replacement.
+        onDone: () => unawaited(controller.close()),
+      );
       FutureOr<void> add(E value) {
         controller.add(value);
       }
@@ -390,13 +397,16 @@ class SupabaseStreamBuilder extends Stream<SupabaseStreamEvent> {
 
   @override
   Stream<E> asyncExpand<E>(
-      Stream<E>? Function(SupabaseStreamEvent event) convert) {
+    Stream<E>? Function(SupabaseStreamEvent event) convert,
+  ) {
     //Copied from [Stream.asyncExpand]
     final controller = BehaviorSubject<E>();
     controller.onListen = () {
-      StreamSubscription<SupabaseStreamEvent> subscription = listen(null,
-          onError: controller.addError, // Avoid Zone error replacement.
-          onDone: () => unawaited(controller.close()));
+      StreamSubscription<SupabaseStreamEvent> subscription = listen(
+        null,
+        onError: controller.addError, // Avoid Zone error replacement.
+        onDone: () => unawaited(controller.close()),
+      );
       subscription.onData((SupabaseStreamEvent event) {
         Stream<E>? newStream;
         try {
@@ -407,9 +417,9 @@ class SupabaseStreamBuilder extends Stream<SupabaseStreamEvent> {
         }
         if (newStream != null) {
           subscription.pause();
-          unawaited(controller
-              .addStream(newStream)
-              .whenComplete(subscription.resume));
+          unawaited(
+            controller.addStream(newStream).whenComplete(subscription.resume),
+          );
         }
       });
       controller.onCancel = subscription.cancel;

--- a/packages/supabase/pubspec.yaml
+++ b/packages/supabase/pubspec.yaml
@@ -6,7 +6,7 @@ repository: 'https://github.com/supabase/supabase-flutter/tree/main/packages/sup
 documentation: 'https://supabase.com/docs/reference/dart/introduction'
 
 environment:
-  sdk: '>=3.4.0 <4.0.0'
+  sdk: '>=3.9.0 <4.0.0'
 
 dependencies:
   functions_client: 2.6.4

--- a/packages/supabase/test/client_test.dart
+++ b/packages/supabase/test/client_test.dart
@@ -58,13 +58,15 @@ void main() {
       expect(clientInfo, contains('; runtime=dart'));
     });
 
-    test('X-Client-Info includes structured platform metadata on functions',
-        () {
-      final clientInfo = supabase.functions.headers['X-Client-Info']!;
-      expect(clientInfo, startsWith('supabase-dart/'));
-      expect(clientInfo, contains('; platform=${Platform.operatingSystem}'));
-      expect(clientInfo, contains('; runtime=dart'));
-    });
+    test(
+      'X-Client-Info includes structured platform metadata on functions',
+      () {
+        final clientInfo = supabase.functions.headers['X-Client-Info']!;
+        expect(clientInfo, startsWith('supabase-dart/'));
+        expect(clientInfo, contains('; platform=${Platform.operatingSystem}'));
+        expect(clientInfo, contains('; runtime=dart'));
+      },
+    );
 
     test('X-Client-Info includes structured platform metadata on rest', () {
       final clientInfo = supabase.rest.headers['X-Client-Info']!;
@@ -73,21 +75,26 @@ void main() {
       expect(clientInfo, contains('; runtime=dart'));
     });
 
-    test('X-Client-Info includes structured platform metadata on realtime',
-        () async {
-      final request = await getRealtimeRequest(
-        server: mockServer,
-        supabaseClient: supabase,
-      );
-      final clientInfo = request.headers['X-Client-Info']?.first;
-      expect(clientInfo, startsWith('supabase-dart/'));
-      expect(clientInfo, contains('; platform=${Platform.operatingSystem}'));
-      expect(clientInfo, contains('; runtime=dart'));
-    });
+    test(
+      'X-Client-Info includes structured platform metadata on realtime',
+      () async {
+        final request = await getRealtimeRequest(
+          server: mockServer,
+          supabaseClient: supabase,
+        );
+        final clientInfo = request.headers['X-Client-Info']?.first;
+        expect(clientInfo, startsWith('supabase-dart/'));
+        expect(clientInfo, contains('; platform=${Platform.operatingSystem}'));
+        expect(clientInfo, contains('; runtime=dart'));
+      },
+    );
 
     test('X-Client-Info header is set properly on storage', () {
-      final xClientHeaderBeforeSlash =
-          supabase.storage.headers['X-Client-Info']!.split('/').first;
+      final xClientHeaderBeforeSlash = supabase
+          .storage
+          .headers['X-Client-Info']!
+          .split('/')
+          .first;
       expect(xClientHeaderBeforeSlash, 'supabase-dart');
     });
 
@@ -107,9 +114,13 @@ void main() {
     });
 
     test('log_level query parameter is properly set', () async {
-      supabase = SupabaseClient(supabaseUrl, supabaseKey,
-          realtimeClientOptions:
-              RealtimeClientOptions(logLevel: RealtimeLogLevel.info));
+      supabase = SupabaseClient(
+        supabaseUrl,
+        supabaseKey,
+        realtimeClientOptions: RealtimeClientOptions(
+          logLevel: RealtimeLogLevel.info,
+        ),
+      );
 
       final request = await getRealtimeRequest(
         server: mockServer,
@@ -140,8 +151,9 @@ void main() {
 
   group('auth', () {
     test('properly set Authorization header', () async {
-      final (:sessionString, :accessToken) =
-          getSessionData(DateTime.now().add(Duration(hours: 1)));
+      final (:sessionString, :accessToken) = getSessionData(
+        DateTime.now().add(Duration(hours: 1)),
+      );
 
       final mockServer = await HttpServer.bind('localhost', 0);
       final supabase = SupabaseClient(
@@ -162,7 +174,9 @@ void main() {
       // Check for every request if the Authorization header is set properly
       await for (final req in mockServer) {
         expect(
-            req.headers.value('Authorization')?.split(" ").last, accessToken);
+          req.headers.value('Authorization')?.split(" ").last,
+          accessToken,
+        );
         count++;
         if (count == 4) {
           break;
@@ -204,8 +218,9 @@ void main() {
           }
           gotTokenRefresh = true;
           String sessionString;
-          (accessToken: secondAccessToken, :sessionString) =
-              getSessionData(DateTime.now().add(Duration(hours: 1)));
+          (accessToken: secondAccessToken, :sessionString) = getSessionData(
+            DateTime.now().add(Duration(hours: 1)),
+          );
 
           req.response
             ..statusCode = HttpStatus.ok
@@ -213,8 +228,10 @@ void main() {
             ..write(sessionString);
           await req.response.close();
         } else {
-          expect(req.headers.value('Authorization')?.split(" ").last,
-              secondAccessToken);
+          expect(
+            req.headers.value('Authorization')?.split(" ").last,
+            secondAccessToken,
+          );
           count++;
           if (count == 4) {
             break;
@@ -226,13 +243,21 @@ void main() {
     });
 
     test('create a client with third-party auth accessToken', () async {
-      final supabase = SupabaseClient('URL', 'KEY', accessToken: () async {
-        return 'jwt';
-      });
+      final supabase = SupabaseClient(
+        'URL',
+        'KEY',
+        accessToken: () async {
+          return 'jwt';
+        },
+      );
       expect(
-          () => supabase.auth.currentUser,
-          throwsA(AuthException(
-              'Supabase Client is configured with the accessToken option, accessing supabase.auth is not possible.')));
+        () => supabase.auth.currentUser,
+        throwsA(
+          AuthException(
+            'Supabase Client is configured with the accessToken option, accessing supabase.auth is not possible.',
+          ),
+        ),
+      );
     });
   });
 
@@ -306,12 +331,14 @@ void main() {
         expect(supabase.headers['X-Client-Info'], startsWith('supabase-dart/'));
       });
 
-      test('should preserve apikey on realtime headers when setting headers',
-          () {
-        supabase.headers = {'Custom-Header': 'custom-value'};
+      test(
+        'should preserve apikey on realtime headers when setting headers',
+        () {
+          supabase.headers = {'Custom-Header': 'custom-value'};
 
-        expect(supabase.realtime.headers['apikey'], supabaseKey);
-      });
+          expect(supabase.realtime.headers['apikey'], supabaseKey);
+        },
+      );
 
       test('should not update auth headers when using custom access token', () {
         final customTokenClient = SupabaseClient(
@@ -328,49 +355,56 @@ void main() {
 
     group('Error Handling', () {
       test(
-          'should throw AuthException when accessing auth with custom access token',
-          () {
-        final customTokenClient = SupabaseClient(
-          supabaseUrl,
-          supabaseKey,
-          accessToken: () async => 'custom-token',
-        );
+        'should throw AuthException when accessing auth with custom access token',
+        () {
+          final customTokenClient = SupabaseClient(
+            supabaseUrl,
+            supabaseKey,
+            accessToken: () async => 'custom-token',
+          );
 
-        expect(
-          () => customTokenClient.auth,
-          throwsA(isA<AuthException>()),
-        );
-      });
+          expect(
+            () => customTokenClient.auth,
+            throwsA(isA<AuthException>()),
+          );
+        },
+      );
     });
 
     group('Shared YAJsonIsolate', () {
       test(
-          'does not dispose an injected YAJsonIsolate so the caller retains ownership',
-          () async {
-        final isolate = YAJsonIsolate();
-        await isolate.initialize();
+        'does not dispose an injected YAJsonIsolate so the caller retains ownership',
+        () async {
+          final isolate = YAJsonIsolate();
+          await isolate.initialize();
 
-        final client =
-            SupabaseClient(supabaseUrl, supabaseKey, isolate: isolate);
+          final client = SupabaseClient(
+            supabaseUrl,
+            supabaseKey,
+            isolate: isolate,
+          );
 
-        await client.dispose();
+          await client.dispose();
 
-        // Isolate is still alive — caller owns the lifecycle
-        expect(await isolate.encode({'key': 'value'}), isA<String>());
+          // Isolate is still alive — caller owns the lifecycle
+          expect(await isolate.encode({'key': 'value'}), isA<String>());
 
-        await isolate.dispose();
-      });
+          await isolate.dispose();
+        },
+      );
 
-      test('creates a single isolate shared across rest and functions clients',
-          () async {
-        // Creating a SupabaseClient without providing an isolate should
-        // still result in a single shared isolate (not one per sub-client).
-        // Verified indirectly: dispose() should complete without error,
-        // meaning there is no double-dispose from sub-clients.
-        final client = SupabaseClient(supabaseUrl, supabaseKey);
+      test(
+        'creates a single isolate shared across rest and functions clients',
+        () async {
+          // Creating a SupabaseClient without providing an isolate should
+          // still result in a single shared isolate (not one per sub-client).
+          // Verified indirectly: dispose() should complete without error,
+          // meaning there is no double-dispose from sub-clients.
+          final client = SupabaseClient(supabaseUrl, supabaseKey);
 
-        await client.dispose();
-      });
+          await client.dispose();
+        },
+      );
     });
   });
 

--- a/packages/supabase/test/mock_test.dart
+++ b/packages/supabase/test/mock_test.dart
@@ -46,7 +46,7 @@ void main() {
       if (url == '/rest/v1/todos?select=task%2Cstatus') {
         final jsonString = jsonEncode([
           {'task': 'task 1', 'status': true},
-          {'task': 'task 2', 'status': false}
+          {'task': 'task 2', 'status': false},
         ]);
         request.response
           ..statusCode = HttpStatus.ok
@@ -57,7 +57,7 @@ void main() {
           url == '/rest/v1/rpc/todos?select=%2A') {
         final jsonString = jsonEncode([
           {'id': 1, 'task': 'task 1', 'status': true},
-          {'id': 2, 'task': 'task 2', 'status': false}
+          {'id': 2, 'task': 'task 2', 'status': false},
         ]);
         request.response
           ..statusCode = HttpStatus.ok
@@ -156,9 +156,9 @@ void main() {
                       'table': 'todos',
                       if (realtimeFilter != null) 'filter': realtimeFilter,
                     },
-                  ]
+                  ],
                 },
-                'status': 'ok'
+                'status': 'ok',
               },
             ]);
             webSocket!.add(replyString);
@@ -216,12 +216,12 @@ void main() {
                     {
                       'name': 'task',
                       'type': 'text',
-                      'type_modifier': 4294967295
+                      'type_modifier': 4294967295,
                     },
                     {
                       'name': 'status',
                       'type': 'bool',
-                      'type_modifier': 4294967295
+                      'type_modifier': 4294967295,
                     },
                   ],
                   'commit_timestamp': '2021-08-01T08:00:30Z',
@@ -251,12 +251,12 @@ void main() {
                     {
                       'name': 'task',
                       'type': 'text',
-                      'type_modifier': 4294967295
+                      'type_modifier': 4294967295,
                     },
                     {
                       'name': 'status',
                       'type': 'bool',
-                      'type_modifier': 4294967295
+                      'type_modifier': 4294967295,
                     },
                   ],
                   'commit_timestamp': '2022-09-14T02:12:52Z',
@@ -267,7 +267,7 @@ void main() {
                   'type': 'DELETE',
                   if (realtimeFilter != null) 'filter': realtimeFilter,
                 },
-                'ids': [77086988]
+                'ids': [77086988],
               },
             ]);
             webSocket!.add(deleteString);
@@ -289,12 +289,12 @@ void main() {
                     {
                       'name': 'task',
                       'type': 'text',
-                      'type_modifier': 4294967295
+                      'type_modifier': 4294967295,
                     },
                     {
                       'name': 'status',
                       'type': 'bool',
-                      'type_modifier': 4294967295
+                      'type_modifier': 4294967295,
                     },
                   ],
                   'commit_timestamp': '2021-08-01T08:00:30Z',
@@ -325,12 +325,12 @@ void main() {
                     {
                       'name': 'task',
                       'type': 'text',
-                      'type_modifier': 4294967295
+                      'type_modifier': 4294967295,
                     },
                     {
                       'name': 'status',
                       'type': 'bool',
-                      'type_modifier': 4294967295
+                      'type_modifier': 4294967295,
                     },
                   ],
                   'commit_timestamp': '2022-09-14T02:12:52Z',
@@ -341,7 +341,7 @@ void main() {
                   'type': 'DELETE',
                   if (realtimeFilter != null) 'filter': realtimeFilter,
                 },
-                'ids': [77086988]
+                'ids': [77086988],
               },
             ]);
             webSocket!.add(ignoredDeleteString);
@@ -407,19 +407,21 @@ void main() {
         final data = await supabase.from('todos').select();
         expect(data, [
           {'id': 1, 'task': 'task 1', 'status': true},
-          {'id': 2, 'task': 'task 2', 'status': false}
+          {'id': 2, 'task': 'task 2', 'status': false},
         ]);
       });
 
-      test('Postgrest calls the correct endpoint with custom headers',
-          () async {
-        apiKey = customApiKey;
-        final data = await customHeadersClient.from('todos').select();
-        expect(data, [
-          {'id': 1, 'task': 'task 1', 'status': true},
-          {'id': 2, 'task': 'task 2', 'status': false}
-        ]);
-      });
+      test(
+        'Postgrest calls the correct endpoint with custom headers',
+        () async {
+          apiKey = customApiKey;
+          final data = await customHeadersClient.from('todos').select();
+          expect(data, [
+            {'id': 1, 'task': 'task 1', 'status': true},
+            {'id': 2, 'task': 'task 2', 'status': false},
+          ]);
+        },
+      );
     });
 
     group('stream()', () {
@@ -450,8 +452,7 @@ void main() {
         stream2.listen(expectAsync1((event) {}, count: 5));
       });
 
-      test("stream should emit the last emitted data when listened to",
-          () async {
+      test("stream should emit the last emitted data when listened to", () async {
         final stream = supabase.from('todos').stream(primaryKey: ['id']);
         stream.listen(expectAsync1((event) {}, count: 5));
 
@@ -467,7 +468,7 @@ void main() {
           emitsInOrder([
             containsAllInOrder([
               {'id': 1, 'task': 'task 1', 'status': true},
-              {'id': 2, 'task': 'task 2', 'status': false}
+              {'id': 2, 'task': 'task 2', 'status': false},
             ]),
             containsAllInOrder([
               {'id': 1, 'task': 'task 1', 'status': true},
@@ -493,36 +494,38 @@ void main() {
       });
 
       test('emits data with asyncMap', () {
-        final stream = supabase.from('todos').stream(
-            primaryKey: ['id']).asyncMap((event) => Future.value([event]));
+        final stream = supabase
+            .from('todos')
+            .stream(primaryKey: ['id'])
+            .asyncMap((event) => Future.value([event]));
         expect(
           stream,
           emitsInOrder([
             containsAllInOrder([
               [
                 {'id': 1, 'task': 'task 1', 'status': true},
-                {'id': 2, 'task': 'task 2', 'status': false}
-              ]
+                {'id': 2, 'task': 'task 2', 'status': false},
+              ],
             ]),
             containsAllInOrder([
               [
                 {'id': 1, 'task': 'task 1', 'status': true},
                 {'id': 2, 'task': 'task 2', 'status': false},
                 {'id': 3, 'task': 'task 3', 'status': true},
-              ]
+              ],
             ]),
             containsAllInOrder([
               [
                 {'id': 1, 'task': 'task 1', 'status': true},
                 {'id': 2, 'task': 'task 2 updated', 'status': false},
                 {'id': 3, 'task': 'task 3', 'status': true},
-              ]
+              ],
             ]),
             containsAllInOrder([
               [
                 {'id': 1, 'task': 'task 1', 'status': true},
                 {'id': 3, 'task': 'task 3', 'status': true},
-              ]
+              ],
             ]),
           ]),
         );
@@ -531,7 +534,8 @@ void main() {
       test("can listen twice at the same time with asyncMap", () async {
         final stream = supabase
             .from('todos')
-            .stream(primaryKey: ['id']).asyncMap((event) => event);
+            .stream(primaryKey: ['id'])
+            .asyncMap((event) => event);
         stream.listen(expectAsync1((event) {}, count: 5));
 
         await Future.delayed(Duration(seconds: 3));
@@ -542,14 +546,15 @@ void main() {
 
       test('emits data with custom headers', () {
         apiKey = customApiKey;
-        final stream =
-            customHeadersClient.from('todos').stream(primaryKey: ['id']);
+        final stream = customHeadersClient
+            .from('todos')
+            .stream(primaryKey: ['id']);
         expect(
           stream,
           emitsInOrder([
             containsAllInOrder([
               {'id': 1, 'task': 'task 1', 'status': true},
-              {'id': 2, 'task': 'task 2', 'status': false}
+              {'id': 2, 'task': 'task 2', 'status': false},
             ]),
             containsAllInOrder([
               {'id': 1, 'task': 'task 1', 'status': true},
@@ -561,8 +566,10 @@ void main() {
       });
 
       test('with order', () {
-        final stream =
-            supabase.from('todos').stream(primaryKey: ['id']).order('id');
+        final stream = supabase
+            .from('todos')
+            .stream(primaryKey: ['id'])
+            .order('id');
         expect(
           stream,
           emitsInOrder([
@@ -623,7 +630,7 @@ void main() {
         final data = await supabase.rpc("todos").select();
         expect(data, [
           {'id': 1, 'task': 'task 1', 'status': true},
-          {'id': 2, 'task': 'task 2', 'status': false}
+          {'id': 2, 'task': 'task 2', 'status': false},
         ]);
       });
 
@@ -632,7 +639,7 @@ void main() {
         final data = await customHeadersClient.rpc("todos").select();
         expect(data, [
           {'id': 1, 'task': 'task 1', 'status': true},
-          {'id': 2, 'task': 'task 2', 'status': false}
+          {'id': 2, 'task': 'task 2', 'status': false},
         ]);
       });
     });
@@ -644,12 +651,13 @@ void main() {
         supabase
             .channel('todos')
             .onPostgresChanges(
-                event: PostgresChangeEvent.all,
-                schema: 'public',
-                table: 'todos',
-                callback: (payload) {
-                  unawaited(supabase.from('todos'));
-                })
+              event: PostgresChangeEvent.all,
+              schema: 'public',
+              table: 'todos',
+              callback: (payload) {
+                unawaited(supabase.from('todos'));
+              },
+            )
             .subscribe();
 
         await Future.delayed(const Duration(milliseconds: 700));
@@ -662,8 +670,10 @@ void main() {
   group('realtime filter', () {
     test('can filter stream results with eq', () {
       unawaited(handleRequests(mockServer, expectedFilter: 'status=eq.true'));
-      final stream =
-          supabase.from('todos').stream(primaryKey: ['id']).eq('status', true);
+      final stream = supabase
+          .from('todos')
+          .stream(primaryKey: ['id'])
+          .eq('status', true);
       expect(
         stream,
         emitsInOrder([
@@ -680,36 +690,46 @@ void main() {
 
     test('can filter stream results with neq', () {
       unawaited(handleRequests(mockServer, expectedFilter: 'id=neq.2'));
-      final stream =
-          supabase.from('todos').stream(primaryKey: ['id']).neq('id', 2);
+      final stream = supabase
+          .from('todos')
+          .stream(primaryKey: ['id'])
+          .neq('id', 2);
       expect(stream, emits(isList));
     });
 
     test('can filter stream results with gt', () {
       unawaited(handleRequests(mockServer, expectedFilter: 'id=gt.2'));
-      final stream =
-          supabase.from('todos').stream(primaryKey: ['id']).gt('id', 2);
+      final stream = supabase
+          .from('todos')
+          .stream(primaryKey: ['id'])
+          .gt('id', 2);
       expect(stream, emits(isList));
     });
 
     test('can filter stream results with gte', () {
       unawaited(handleRequests(mockServer, expectedFilter: 'id=gte.2'));
-      final stream =
-          supabase.from('todos').stream(primaryKey: ['id']).gte('id', 2);
+      final stream = supabase
+          .from('todos')
+          .stream(primaryKey: ['id'])
+          .gte('id', 2);
       expect(stream, emits(isList));
     });
 
     test('can filter stream results with lt', () {
       unawaited(handleRequests(mockServer, expectedFilter: 'id=lt.2'));
-      final stream =
-          supabase.from('todos').stream(primaryKey: ['id']).lt('id', 2);
+      final stream = supabase
+          .from('todos')
+          .stream(primaryKey: ['id'])
+          .lt('id', 2);
       expect(stream, emits(isList));
     });
 
     test('can filter stream results with lte', () {
       unawaited(handleRequests(mockServer, expectedFilter: 'id=lte.2'));
-      final stream =
-          supabase.from('todos').stream(primaryKey: ['id']).lte('id', 2);
+      final stream = supabase
+          .from('todos')
+          .stream(primaryKey: ['id'])
+          .lte('id', 2);
       expect(stream, emits(isList));
     });
   });
@@ -718,8 +738,9 @@ void main() {
     test('forwards channelConfig.private=true to realtime join payload', () {
       unawaited(handleRequests(mockServer, expectedPrivate: true));
 
-      final stream =
-          supabase.from('todos').stream(primaryKey: ['id'], private: true);
+      final stream = supabase
+          .from('todos')
+          .stream(primaryKey: ['id'], private: true);
 
       expect(stream, emits(isList));
     });
@@ -745,8 +766,9 @@ void main() {
   group('Error Handling', () {
     group('RealtimeSubscribeException', () {
       test('should create exception with status only', () {
-        final exception =
-            RealtimeSubscribeException(RealtimeSubscribeStatus.timedOut);
+        final exception = RealtimeSubscribeException(
+          RealtimeSubscribeStatus.timedOut,
+        );
 
         expect(exception.status, RealtimeSubscribeStatus.timedOut);
         expect(exception.details, isNull);
@@ -755,7 +777,9 @@ void main() {
 
       test('should create exception with status and details', () {
         final exception = RealtimeSubscribeException(
-            RealtimeSubscribeStatus.channelError, 'Connection failed');
+          RealtimeSubscribeStatus.channelError,
+          'Connection failed',
+        );
 
         expect(exception.status, RealtimeSubscribeStatus.channelError);
         expect(exception.details, 'Connection failed');

--- a/packages/supabase/test/realtime_test.dart
+++ b/packages/supabase/test/realtime_test.dart
@@ -15,8 +15,9 @@ void main() {
     setUp(() async {
       mockServer = await HttpServer.bind('localhost', 0);
 
-      subscription =
-          mockServer.transform(WebSocketTransformer()).listen((webSocket) {
+      subscription = mockServer.transform(WebSocketTransformer()).listen((
+        webSocket,
+      ) {
         final ioChannel = IOWebSocketChannel(webSocket);
         ioChannel.stream.listen((request) {
           ioChannel.sink.add(request);
@@ -51,10 +52,11 @@ void main() {
     test('subscribe on existing subscription fail', () {
       channel
           .onPostgresChanges(
-              event: PostgresChangeEvent.insert,
-              schema: 'public',
-              table: 'countries',
-              callback: (payload) {})
+            event: PostgresChangeEvent.insert,
+            schema: 'public',
+            table: 'countries',
+            callback: (payload) {},
+          )
           .subscribe(
             (event, [errorMsg]) {},
           );

--- a/packages/supabase/test/utilities_test.dart
+++ b/packages/supabase/test/utilities_test.dart
@@ -39,21 +39,24 @@ void main() {
 
   group('Constants', () {
     test('should have default headers with X-Client-Info', () {
-      expect(Constants.defaultHeaders,
-          containsPair('X-Client-Info', startsWith('supabase-dart/')));
+      expect(
+        Constants.defaultHeaders,
+        containsPair('X-Client-Info', startsWith('supabase-dart/')),
+      );
     });
 
     test(
-        'should include structured platform metadata in X-Client-Info when not on web',
-        () {
-      if (!kIsWeb) {
-        final clientInfo = Constants.defaultHeaders['X-Client-Info']!;
-        expect(clientInfo, contains('; platform='));
-        expect(clientInfo, contains('; platform-version='));
-        expect(clientInfo, contains('; runtime=dart'));
-        expect(clientInfo, contains('; runtime-version='));
-      }
-    });
+      'should include structured platform metadata in X-Client-Info when not on web',
+      () {
+        if (!kIsWeb) {
+          final clientInfo = Constants.defaultHeaders['X-Client-Info']!;
+          expect(clientInfo, contains('; platform='));
+          expect(clientInfo, contains('; platform-version='));
+          expect(clientInfo, contains('; runtime=dart'));
+          expect(clientInfo, contains('; runtime-version='));
+        }
+      },
+    );
 
     test('should have platform getter', () {
       if (kIsWeb) {
@@ -113,7 +116,8 @@ void main() {
 
     test('should add Authorization header with access token', () async {
       final uri = Uri.parse(
-          'http://${mockServer.address.host}:${mockServer.port}/test');
+        'http://${mockServer.address.host}:${mockServer.port}/test',
+      );
       final request = http.Request('GET', uri);
 
       await authClient.send(request);
@@ -123,7 +127,8 @@ void main() {
 
     test('should add apikey header', () async {
       final uri = Uri.parse(
-          'http://${mockServer.address.host}:${mockServer.port}/test');
+        'http://${mockServer.address.host}:${mockServer.port}/test',
+      );
       final request = http.Request('GET', uri);
 
       await authClient.send(request);
@@ -139,7 +144,8 @@ void main() {
       );
 
       final uri = Uri.parse(
-          'http://${mockServer.address.host}:${mockServer.port}/test');
+        'http://${mockServer.address.host}:${mockServer.port}/test',
+      );
       final request = http.Request('GET', uri);
 
       await authClientNoToken.send(request);
@@ -149,7 +155,8 @@ void main() {
 
     test('should not override existing Authorization header', () async {
       final uri = Uri.parse(
-          'http://${mockServer.address.host}:${mockServer.port}/test');
+        'http://${mockServer.address.host}:${mockServer.port}/test',
+      );
       final request = http.Request('GET', uri);
       request.headers['Authorization'] = 'Bearer existing-token';
 
@@ -160,7 +167,8 @@ void main() {
 
     test('should not override existing apikey header', () async {
       final uri = Uri.parse(
-          'http://${mockServer.address.host}:${mockServer.port}/test');
+        'http://${mockServer.address.host}:${mockServer.port}/test',
+      );
       final request = http.Request('GET', uri);
       request.headers['apikey'] = 'existing-key';
 

--- a/packages/supabase/test/utils.dart
+++ b/packages/supabase/test/utils.dart
@@ -3,8 +3,15 @@ import 'dart:convert';
 /// Construct session data for a given expiration date
 ({String accessToken, String sessionString}) getSessionData(DateTime dateTime) {
   final expiresAt = dateTime.millisecondsSinceEpoch ~/ 1000;
-  final accessTokenMid = base64.encode(utf8.encode(json.encode(
-      {"exp": expiresAt, "sub": "1234567890", "role": "authenticated"})));
+  final accessTokenMid = base64.encode(
+    utf8.encode(
+      json.encode({
+        "exp": expiresAt,
+        "sub": "1234567890",
+        "role": "authenticated",
+      }),
+    ),
+  );
   final accessToken = "any.$accessTokenMid.any";
   final sessionString =
       '{"access_token":"$accessToken","expires_in":${dateTime.difference(DateTime.now()).inSeconds},"refresh_token":"-yeS4omysFs9tpUYBws9Rg","token_type":"bearer","provider_token":null,"provider_refresh_token":null,"user":{"id":"4d2583da-8de4-49d3-9cd1-37a9a74f55bd","app_metadata":{"provider":"email","providers":["email"]},"user_metadata":{"Hello":"World"},"aud":"","email":"fake1680338105@email.com","phone":"","created_at":"2023-04-01T08:35:05.208586Z","confirmed_at":null,"email_confirmed_at":"2023-04-01T08:35:05.220096086Z","phone_confirmed_at":null,"last_sign_in_at":"2023-04-01T08:35:05.222755878Z","role":"","updated_at":"2023-04-01T08:35:05.226938Z"}}';

--- a/packages/supabase_lints/pubspec.yaml
+++ b/packages/supabase_lints/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: "https://supabase.com"
 repository: "https://github.com/supabase/supabase-flutter/tree/main/packages/supabase_lints"
 
 environment:
-  sdk: ">=3.4.0 <4.0.0"
+  sdk: ">=3.9.0 <4.0.0"
 
 dependencies:
   lints: ^4.0.0

--- a/packages/yet_another_json_isolate/lib/src/_isolates_io.dart
+++ b/packages/yet_another_json_isolate/lib/src/_isolates_io.dart
@@ -25,8 +25,10 @@ class YAJsonIsolate {
   ///
   /// This method is called automatically when the first method is called. Manually initializing before first json de/encode can improve performance.
   Future<void> initialize() async {
-    assert(_hasStartedInitialize == false,
-        'initialize() can only be called once per isolate.');
+    assert(
+      _hasStartedInitialize == false,
+      'initialize() can only be called once per isolate.',
+    );
     _hasStartedInitialize = true;
     await Isolate.spawn(
       _compute,
@@ -78,10 +80,12 @@ class YAJsonIsolate {
 
       // native error; see Isolate.addErrorListener
       case 2:
-        await Future<Never>.error(RemoteError(
-          response[0] as String,
-          response[1] as String,
-        ));
+        await Future<Never>.error(
+          RemoteError(
+            response[0] as String,
+            response[1] as String,
+          ),
+        );
 
       // caught error; see _buildErrorResponse
       case 3:

--- a/packages/yet_another_json_isolate/pubspec.yaml
+++ b/packages/yet_another_json_isolate/pubspec.yaml
@@ -4,7 +4,7 @@ version: 2.1.1
 homepage: https://github.com/supabase-community/json-isolate-dart
 
 environment:
-  sdk: '>=3.4.0 <4.0.0'
+  sdk: '>=3.9.0 <4.0.0'
 
 dependencies:
   async: ^2.8.0


### PR DESCRIPTION
## What

Raises the minimum Dart SDK of the pure-Dart packages (`functions_client`, `gotrue`, `postgrest`, `realtime_client`, `storage_client`, `supabase`, `supabase_lints`, `yet_another_json_isolate`) and the `supabase` web example from `3.4.0`/`3.3.0` to `3.9.0`, matching `supabase_flutter`.

This is the base PR for the pub workspaces + Melos 8 migration (#1525), which is stacked on top of it. Pub workspaces resolve the whole workspace as a unit under a single Dart SDK, so aligning every package on 3.9.0 keeps the toolchain and formatting consistent across the repo.

## Why the large diff

Raising the language version to 3.9 switches `dart format` to its mandatory "tall" style. All affected packages are reformatted accordingly (109 files) — this is a pure formatting change. `supabase_flutter` was already on 3.9, so it is untouched.

## Analyzer fixes surfaced by the new language version

- **postgrest**: 3.9 no longer implicitly promotes the bare `body as dynamic;` statement in `_parseResponse`, which surfaced three `argument_type_not_assignable` errors. The casts are now explicit and behavior-preserving (`body as Iterable` / `body as Map`), guarded by the existing `R == PostgrestList` / `R == PostgrestMap` checks.
- **realtime_client**: the tall formatter wraps a long single-line `if` onto two lines, which then needs braces (`curly_braces_in_flow_control_structures`).

## Validation

- `dart format -l 80 --set-exit-if-changed` is clean across all packages.
- `dart analyze --fatal-infos` passes (verified on `postgrest` and `realtime_client`, which had the only issues).
- `postgrest`'s mock-based tests (response-conversion paths) pass.

## Note

This raises the minimum supported Dart SDK for the affected published packages, which reviewers may want to reflect in the next version bump.