### PR TITLE
chore: add flutter/tests customer testing script

### DIFF
--- a/scripts/customer_testing.dart
+++ b/scripts/customer_testing.dart
@@ -1,0 +1,36 @@
+// This file is invoked by the flutter/tests registry entry for supabase-flutter
+// (https://github.com/flutter/tests/blob/main/registry/supabase_flutter.test) to run
+// this repository's tests as a presubmit against flutter/flutter framework changes.
+// Changes here are only honored after the commit hash in that registry entry is
+// updated.
+
+import 'dart:io';
+
+Future<void> main() async {
+  // supabase-flutter is a pub workspace, so analyzing the repository root covers
+  // every member package.
+  await _run('flutter', ['analyze', '--no-fatal-infos']);
+
+  // Only supabase_flutter is exercised here. The other packages' tests require a
+  // live Supabase backend and are therefore not hermetic enough for the registry.
+  await _run('flutter', ['test'],
+      workingDirectory: 'packages/supabase_flutter');
+}
+
+Future<void> _run(
+  String executable,
+  List<String> arguments, {
+  String? workingDirectory,
+}) async {
+  final process = await Process.start(
+    executable,
+    arguments,
+    workingDirectory: workingDirectory,
+    mode: ProcessStartMode.inheritStdio,
+    runInShell: true,
+  );
+  final exitCode = await process.exitCode;
+  if (exitCode != 0) {
+    exit(exitCode);
+  }
+}


### PR DESCRIPTION
## What

Adds `scripts/customer_testing.dart`, the entry point invoked by the [flutter/tests](https://github.com/flutter/tests) registry to run this repository's tests as a presubmit against `flutter/flutter` framework changes.

This is the supabase-flutter counterpart of what Flame did in [flutter/tests#489](https://github.com/flutter/tests/pull/489). A companion PR to `flutter/tests` adds the `registry/supabase_flutter.test` entry that clones this repo at a pinned commit and runs this script.

## What the script does

1. `flutter analyze --no-fatal-infos` over the whole pub workspace (covers every member package).
2. `flutter test` in `packages/supabase_flutter`.

Only `supabase_flutter` is exercised because it is hermetic (mock/stub based). The other packages' tests require a live Supabase backend and are therefore not eligible for the registry, which requires hermetic tests (no network, no spawned services).

## Why

So that Flutter framework regressions affecting `supabase_flutter` are caught upstream, before they reach a stable Flutter release.

## Notes

- The registry only honors changes here once the pinned commit in the flutter/tests entry is updated (revision bumps are periodic PRs to flutter/tests).
- Verified locally: `dart run scripts/customer_testing.dart` passes (analyze clean, 57 tests pass).


Part of SDK-1216
