### PR TITLE
feat(supabase_flutter): default debug logging off under flutter test

### DIFF
--- a/packages/supabase_flutter/lib/src/supabase.dart
+++ b/packages/supabase_flutter/lib/src/supabase.dart
@@ -13,6 +13,7 @@ import 'package:supabase_flutter/src/supabase_auth.dart';
 
 import 'hot_restart_cleanup_stub.dart'
     if (dart.library.js_interop) 'hot_restart_cleanup_web.dart';
+import 'platform_stub.dart' if (dart.library.io) 'platform_io.dart';
 import 'version.dart';
 
 final _log = Logger('supabase.supabase_flutter');
@@ -103,7 +104,7 @@ class Supabase {
       return _instance;
     }
 
-    _instance._debugEnable = debug ?? kDebugMode;
+    _instance._debugEnable = debug ?? (kDebugMode && !isRunningInFlutterTest);
 
     if (_instance._debugEnable) {
       _instance._logSubscription = Logger('supabase').onRecord.listen((record) {

--- a/packages/supabase_flutter/test/debug_default_test.dart
+++ b/packages/supabase_flutter/test/debug_default_test.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import 'widget_test_stubs.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    mockAppLink();
+  });
+
+  tearDown(() async {
+    try {
+      await Supabase.instance.dispose();
+    } catch (_) {
+      // Ignore dispose errors
+    }
+  });
+
+  test('debug defaults to off when running under flutter test', () async {
+    final logs = <String>[];
+    final originalDebugPrint = debugPrint;
+    debugPrint = (String? message, {int? wrapWidth}) {
+      if (message != null) logs.add(message);
+    };
+    addTearDown(() => debugPrint = originalDebugPrint);
+
+    await Supabase.initialize(
+      url: '',
+      publishableKey: '',
+      authOptions: FlutterAuthClientOptions(
+        localStorage: const MockLocalStorage(),
+        pkceAsyncStorage: MockAsyncStorage(),
+      ),
+    );
+
+    expect(logs.any((log) => log.contains('Supabase init completed')), isFalse);
+  });
+
+  test('explicit debug: true still logs under flutter test', () async {
+    final logs = <String>[];
+    final originalDebugPrint = debugPrint;
+    debugPrint = (String? message, {int? wrapWidth}) {
+      if (message != null) logs.add(message);
+    };
+    addTearDown(() => debugPrint = originalDebugPrint);
+
+    await Supabase.initialize(
+      url: '',
+      publishableKey: '',
+      debug: true,
+      authOptions: FlutterAuthClientOptions(
+        localStorage: const MockLocalStorage(),
+        pkceAsyncStorage: MockAsyncStorage(),
+      ),
+    );
+
+    expect(logs.any((log) => log.contains('Supabase init completed')), isTrue);
+  });
+}

--- a/packages/supabase_flutter/test/debug_default_test.dart
+++ b/packages/supabase_flutter/test/debug_default_test.dart
@@ -7,8 +7,14 @@ import 'widget_test_stubs.dart';
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
+  final logs = <String>[];
+
   setUp(() {
+    logs.clear();
     mockAppLink();
+    debugPrint = (String? message, {int? wrapWidth}) {
+      if (message != null) logs.add(message);
+    };
   });
 
   tearDown(() async {
@@ -19,34 +25,29 @@ void main() {
     }
   });
 
-  test('debug defaults to off when running under flutter test', () async {
-    final logs = <String>[];
-    final originalDebugPrint = debugPrint;
-    debugPrint = (String? message, {int? wrapWidth}) {
-      if (message != null) logs.add(message);
-    };
-    addTearDown(() => debugPrint = originalDebugPrint);
+  test(
+    'debug defaults to off when running under flutter test',
+    () async {
+      await Supabase.initialize(
+        url: '',
+        publishableKey: '',
+        authOptions: FlutterAuthClientOptions(
+          localStorage: const MockLocalStorage(),
+          pkceAsyncStorage: MockAsyncStorage(),
+        ),
+      );
 
-    await Supabase.initialize(
-      url: '',
-      publishableKey: '',
-      authOptions: FlutterAuthClientOptions(
-        localStorage: const MockLocalStorage(),
-        pkceAsyncStorage: MockAsyncStorage(),
-      ),
-    );
-
-    expect(logs.any((log) => log.contains('Supabase init completed')), isFalse);
-  });
+      expect(
+        logs.any((log) => log.contains('Supabase init completed')),
+        isFalse,
+      );
+    },
+    // The default relies on the FLUTTER_TEST environment variable, which is only
+    // readable through dart:io and therefore unavailable on web.
+    skip: kIsWeb,
+  );
 
   test('explicit debug: true still logs under flutter test', () async {
-    final logs = <String>[];
-    final originalDebugPrint = debugPrint;
-    debugPrint = (String? message, {int? wrapWidth}) {
-      if (message != null) logs.add(message);
-    };
-    addTearDown(() => debugPrint = originalDebugPrint);
-
     await Supabase.initialize(
       url: '',
       publishableKey: '',

--- a/packages/supabase_flutter/test/dispose_test.dart
+++ b/packages/supabase_flutter/test/dispose_test.dart
@@ -20,6 +20,7 @@ void main() {
       await Supabase.initialize(
         url: '',
         publishableKey: '',
+        debug: false,
         accessToken: () async => 'custom-access-token',
       );
 

--- a/packages/supabase_flutter/test/initialization_test.dart
+++ b/packages/supabase_flutter/test/initialization_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
@@ -9,6 +10,10 @@ void main() {
 
   const supabaseUrl = '';
   const supabaseKey = '';
+
+  setUpAll(() {
+    debugPrint = (String? message, {int? wrapWidth}) {};
+  });
 
   group('Supabase initialization', () {
     setUp(() {
@@ -29,6 +34,7 @@ void main() {
         await Supabase.initialize(
           url: supabaseUrl,
           publishableKey: supabaseKey,
+          debug: false,
         );
       });
     });
@@ -39,6 +45,7 @@ void main() {
         await Supabase.initialize(
           url: supabaseUrl,
           publishableKey: supabaseKey,
+          debug: false,
           authOptions: const FlutterAuthClientOptions(
             localStorage: localStorage,
           ),
@@ -66,6 +73,7 @@ void main() {
         await Supabase.initialize(
           url: supabaseUrl,
           publishableKey: supabaseKey,
+          debug: false,
           authOptions: const FlutterAuthClientOptions(
             authFlowType: AuthFlowType.pkce,
           ),
@@ -79,6 +87,7 @@ void main() {
         await Supabase.initialize(
           url: supabaseUrl,
           publishableKey: supabaseKey,
+          debug: false,
           httpClient: httpClient,
         );
       });
@@ -87,6 +96,7 @@ void main() {
         await Supabase.initialize(
           url: supabaseUrl,
           publishableKey: supabaseKey,
+          debug: false,
           accessToken: () async => 'custom-access-token',
         );
 
@@ -104,6 +114,7 @@ void main() {
         await Supabase.initialize(
           url: supabaseUrl,
           publishableKey: supabaseKey,
+          debug: false,
         );
 
         // Dispose
@@ -116,6 +127,7 @@ void main() {
         await Supabase.initialize(
           url: supabaseUrl,
           publishableKey: supabaseKey,
+          debug: false,
         );
       });
 

--- a/packages/supabase_flutter/test/widget_test.dart
+++ b/packages/supabase_flutter/test/widget_test.dart
@@ -19,6 +19,7 @@ void main() {
     await Supabase.initialize(
       url: supabaseUrl,
       publishableKey: supabaseKey,
+      debug: false,
       authOptions: FlutterAuthClientOptions(
         localStorage: const MockLocalStorage(),
         pkceAsyncStorage: MockAsyncStorage(),


### PR DESCRIPTION
## What

Makes `Supabase.initialize`'s `debug` option default to `false` when running under `flutter test`, so tests no longer emit `INFO`/`CONFIG` log noise unless they explicitly opt in with `debug: true`.

## Why

`debug` defaults to `debug ?? kDebugMode`. Under `flutter test`, `kDebugMode` is `true`, so every test that doesn't pass `debug: false` attaches the log subscription and spams the console (`***** Supabase init completed *****`, etc.). Rather than sprinkling `debug: false` across every test, this fixes the default at the source.

This is the more general fix behind #1529 (which added `debug: false` per call). With this change those manual additions are no longer needed, so **#1529 can be closed in favor of this**.

## How

Reuses the existing web-safe `isRunningInFlutterTest` getter (already used in `supabase_auth.dart`, defined via the `platform_stub.dart` / `platform_io.dart` conditional import, which reads the `FLUTTER_TEST` env var):

```dart
_instance._debugEnable = debug ?? (kDebugMode && !isRunningInFlutterTest);
```

Production behavior is unchanged: `isRunningInFlutterTest` is `false` outside tests (and the web stub returns `false`), so the expression reduces to the previous `debug ?? kDebugMode`.

## Verification

- New `test/debug_default_test.dart` asserts the default is off under `flutter test` and that explicit `debug: true` still logs.
- Full `packages/supabase_flutter` suite: all 59 tests pass with no stray supabase log output; `flutter analyze --no-fatal-infos` is clean.