### PR TITLE
chore: adopt null-aware elements now that minimum Dart SDK is 3.9

### DIFF
--- a/packages/gotrue/lib/src/gotrue_admin_api.dart
+++ b/packages/gotrue/lib/src/gotrue_admin_api.dart
@@ -118,8 +118,8 @@ class GoTrueAdminApi {
     final options = GotrueRequestOptions(
       headers: _headers,
       query: {
-        if (page != null) 'page': page.toString(),
-        if (perPage != null) 'per_page': perPage.toString(),
+        'page': ?page?.toString(),
+        'per_page': ?perPage?.toString(),
       },
     );
     final response = await _fetch.request(
@@ -138,7 +138,7 @@ class GoTrueAdminApi {
   }) async {
     final body = {
       'email': email,
-      if (data != null) 'data': data,
+      'data': ?data,
     };
     final fetchOptions = GotrueRequestOptions(
       headers: _headers,
@@ -186,10 +186,10 @@ class GoTrueAdminApi {
     final body = {
       'email': email,
       'type': type.snakeCase,
-      if (data != null) 'data': data,
-      if (redirectTo != null) 'redirect_to': redirectTo,
-      if (password != null) 'password': password,
-      if (newEmail != null) 'new_email': newEmail,
+      'data': ?data,
+      'redirect_to': ?redirectTo,
+      'password': ?password,
+      'new_email': ?newEmail,
     };
 
     final fetchOptions = GotrueRequestOptions(headers: _headers, body: body);

--- a/packages/gotrue/lib/src/gotrue_admin_oauth_api.dart
+++ b/packages/gotrue/lib/src/gotrue_admin_oauth_api.dart
@@ -76,8 +76,8 @@ class GoTrueAdminOAuthApi {
       options: GotrueRequestOptions(
         headers: _headers,
         query: {
-          if (page != null) 'page': page.toString(),
-          if (perPage != null) 'per_page': perPage.toString(),
+          'page': ?page?.toString(),
+          'per_page': ?perPage?.toString(),
         },
       ),
     );

--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -605,11 +605,11 @@ class GoTrueClient {
       // For recovery type with tokenHash, exclude email/phone
       if (!isRecoveryWithTokenHash && email != null) 'email': email,
       if (!isRecoveryWithTokenHash && phone != null) 'phone': phone,
-      if (token != null) 'token': token,
+      'token': ?token,
       'type': type.snakeCase,
       'redirect_to': redirectTo,
       'gotrue_meta_security': {'captcha_token': captchaToken},
-      if (tokenHash != null) 'token_hash': tokenHash,
+      'token_hash': ?tokenHash,
     };
     final fetchOptions = GotrueRequestOptions(headers: _headers, body: body);
     final response = await _fetch.request(
@@ -665,9 +665,9 @@ class GoTrueClient {
       RequestMethodType.post,
       options: GotrueRequestOptions(
         body: {
-          if (providerId != null) 'provider_id': providerId,
-          if (domain != null) 'domain': domain,
-          if (redirectTo != null) 'redirect_to': redirectTo,
+          'provider_id': ?providerId,
+          'domain': ?domain,
+          'redirect_to': ?redirectTo,
           if (captchaToken != null)
             'gotrue_meta_security': {'captcha_token': captchaToken},
           'skip_http_redirect': true,
@@ -753,8 +753,8 @@ class GoTrueClient {
         : null;
 
     final body = {
-      if (email != null) 'email': email,
-      if (phone != null) 'phone': phone,
+      'email': ?email,
+      'phone': ?phone,
       'type': type.snakeCase,
       'gotrue_meta_security': {'captcha_token': captchaToken},
       if (email != null) ...{

--- a/packages/gotrue/lib/src/types/jwt.dart
+++ b/packages/gotrue/lib/src/types/jwt.dart
@@ -31,8 +31,8 @@ class JwtHeader {
   Map<String, dynamic> toJson() {
     return {
       'alg': alg,
-      if (kid != null) 'kid': kid,
-      if (typ != null) 'typ': typ,
+      'kid': ?kid,
+      'typ': ?typ,
     };
   }
 }

--- a/packages/gotrue/lib/src/types/types.dart
+++ b/packages/gotrue/lib/src/types/types.dart
@@ -275,13 +275,11 @@ class CreateOAuthClientParams {
   Map<String, dynamic> toJson() {
     return {
       'client_name': clientName,
-      if (clientUri != null) 'client_uri': clientUri,
+      'client_uri': ?clientUri,
       'redirect_uris': redirectUris,
-      if (grantTypes != null)
-        'grant_types': grantTypes!.map((e) => e.value).toList(),
-      if (responseTypes != null)
-        'response_types': responseTypes!.map((e) => e.value).toList(),
-      if (scope != null) 'scope': scope,
+      'grant_types': ?grantTypes?.map((e) => e.value).toList(),
+      'response_types': ?responseTypes?.map((e) => e.value).toList(),
+      'scope': ?scope,
     };
   }
 }
@@ -318,14 +316,12 @@ class UpdateOAuthClientParams {
 
   Map<String, dynamic> toJson() {
     return {
-      if (clientName != null) 'client_name': clientName,
-      if (clientUri != null) 'client_uri': clientUri,
-      if (redirectUris != null) 'redirect_uris': redirectUris,
-      if (grantTypes != null)
-        'grant_types': grantTypes!.map((e) => e.value).toList(),
-      if (responseTypes != null)
-        'response_types': responseTypes!.map((e) => e.value).toList(),
-      if (scope != null) 'scope': scope,
+      'client_name': ?clientName,
+      'client_uri': ?clientUri,
+      'redirect_uris': ?redirectUris,
+      'grant_types': ?grantTypes?.map((e) => e.value).toList(),
+      'response_types': ?responseTypes?.map((e) => e.value).toList(),
+      'scope': ?scope,
     };
   }
 }

--- a/packages/gotrue/lib/src/types/user_attributes.dart
+++ b/packages/gotrue/lib/src/types/user_attributes.dart
@@ -30,11 +30,11 @@ class UserAttributes {
 
   Map<String, dynamic> toJson() {
     return {
-      if (email != null) 'email': email,
-      if (phone != null) 'phone': phone,
-      if (nonce != null) 'nonce': nonce,
-      if (password != null) 'password': password,
-      if (data != null) 'data': data,
+      'email': ?email,
+      'phone': ?phone,
+      'nonce': ?nonce,
+      'password': ?password,
+      'data': ?data,
     };
   }
 
@@ -116,15 +116,15 @@ class AdminUserAttributes extends UserAttributes {
   @override
   Map<String, dynamic> toJson() {
     return {
-      if (email != null) 'email': email,
-      if (phone != null) 'phone': phone,
-      if (password != null) 'password': password,
-      if (data != null) 'data': data,
-      if (userMetadata != null) 'user_metadata': userMetadata,
-      if (appMetadata != null) 'app_metadata': appMetadata,
-      if (emailConfirm != null) 'email_confirm': emailConfirm,
-      if (phoneConfirm != null) 'phone_confirm': phoneConfirm,
-      if (banDuration != null) 'ban_duration': banDuration,
+      'email': ?email,
+      'phone': ?phone,
+      'password': ?password,
+      'data': ?data,
+      'user_metadata': ?userMetadata,
+      'app_metadata': ?appMetadata,
+      'email_confirm': ?emailConfirm,
+      'phone_confirm': ?phoneConfirm,
+      'ban_duration': ?banDuration,
     };
   }
 

--- a/packages/gotrue/test/mocks/passkey_mock_client.dart
+++ b/packages/gotrue/test/mocks/passkey_mock_client.dart
@@ -106,9 +106,9 @@ class PasskeyMockClient extends BaseClient {
   }) {
     return {
       'id': id,
-      if (friendlyName != null) 'friendly_name': friendlyName,
+      'friendly_name': ?friendlyName,
       'created_at': '2025-01-01T00:00:00Z',
-      if (lastUsedAt != null) 'last_used_at': lastUsedAt,
+      'last_used_at': ?lastUsedAt,
     };
   }
 

--- a/packages/postgrest/lib/src/postgrest_transform_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_transform_builder.dart
@@ -46,7 +46,7 @@ class PostgrestTransformBuilder<T> extends RawPostgrestBuilder<T, T, T> {
     final url = overrideSearchParams('select', cleanedColumns);
     final prefer = _emptyPreferAsNull(newHeaders['Prefer']);
     newHeaders['Prefer'] = [
-      if (prefer != null) prefer,
+      ?prefer,
       'return=representation',
     ].join(',');
     return PostgrestTransformBuilder(

--- a/packages/realtime_client/lib/src/message.dart
+++ b/packages/realtime_client/lib/src/message.dart
@@ -49,8 +49,8 @@ class Message {
           ? event.eventName()
           : 'heartbeat',
       'payload': processedPayload,
-      if (ref != null) 'ref': ref,
-      if (joinRef != null) 'join_ref': joinRef,
+      'ref': ?ref,
+      'join_ref': ?joinRef,
     };
   }
 }

--- a/packages/realtime_client/lib/src/types.dart
+++ b/packages/realtime_client/lib/src/types.dart
@@ -93,10 +93,10 @@ class ChannelFilter {
 
   Map<String, String> toMap() {
     return {
-      if (event != null) 'event': event!,
-      if (schema != null) 'schema': schema!,
-      if (table != null) 'table': table!,
-      if (filter != null) 'filter': filter!,
+      'event': ?event,
+      'schema': ?schema,
+      'table': ?table,
+      'filter': ?filter,
     };
   }
 }

--- a/packages/realtime_client/test/mock_test.dart
+++ b/packages/realtime_client/test/mock_test.dart
@@ -60,7 +60,7 @@ void main() {
                     'schema': 'public',
                     'table': 'todos',
                     'type': 'INSERT',
-                    if (postgresFilter != null) 'filter': postgresFilter,
+                    'filter': ?postgresFilter,
                     'columns': [
                       {
                         'name': 'id',
@@ -114,7 +114,7 @@ void main() {
                   'schema': 'public',
                   'table': 'todos',
                   'type': 'UPDATE',
-                  if (postgresFilter != null) 'filter': postgresFilter,
+                  'filter': ?postgresFilter,
                 },
               },
             ]);
@@ -148,7 +148,7 @@ void main() {
                   'schema': 'public',
                   'table': 'todos',
                   'type': 'DELETE',
-                  if (postgresFilter != null) 'filter': postgresFilter,
+                  'filter': ?postgresFilter,
                 },
                 'ids': [48673474],
               },

--- a/packages/storage_client/lib/src/storage_bucket_api.dart
+++ b/packages/storage_client/lib/src/storage_bucket_api.dart
@@ -18,10 +18,8 @@ class StorageBucketApi {
       'id': id,
       'name': id,
       'public': bucketOptions.public,
-      if (bucketOptions.fileSizeLimit != null)
-        'file_size_limit': bucketOptions.fileSizeLimit,
-      if (bucketOptions.allowedMimeTypes != null)
-        'allowed_mime_types': bucketOptions.allowedMimeTypes,
+      'file_size_limit': ?bucketOptions.fileSizeLimit,
+      'allowed_mime_types': ?bucketOptions.allowedMimeTypes,
     };
   }
 

--- a/packages/storage_client/lib/src/storage_file_api.dart
+++ b/packages/storage_client/lib/src/storage_file_api.dart
@@ -323,7 +323,7 @@ class StorageFileApi {
         'bucketId': bucketId,
         'sourceKey': fromPath,
         'destinationKey': toPath,
-        if (destinationBucket != null) 'destinationBucket': destinationBucket,
+        'destinationBucket': ?destinationBucket,
       },
       options: options,
     );
@@ -351,7 +351,7 @@ class StorageFileApi {
         'bucketId': bucketId,
         'sourceKey': fromPath,
         'destinationKey': toPath,
-        if (destinationBucket != null) 'destinationBucket': destinationBucket,
+        'destinationBucket': ?destinationBucket,
       },
       options: options,
     );
@@ -385,7 +385,7 @@ class StorageFileApi {
       '$url/object/sign/$finalPath',
       {
         'expiresIn': expiresIn,
-        if (transform != null) 'transform': transform.toQueryParams,
+        'transform': ?transform?.toQueryParams,
       },
       options: options,
     );

--- a/packages/supabase/test/mock_test.dart
+++ b/packages/supabase/test/mock_test.dart
@@ -154,7 +154,7 @@ void main() {
                       'event': '*',
                       'schema': 'public',
                       'table': 'todos',
-                      if (realtimeFilter != null) 'filter': realtimeFilter,
+                      'filter': ?realtimeFilter,
                     },
                   ],
                 },
@@ -178,7 +178,7 @@ void main() {
                   'schema': 'public',
                   'table': 'todos',
                   'type': 'INSERT',
-                  if (realtimeFilter != null) 'filter': realtimeFilter,
+                  'filter': ?realtimeFilter,
                   'columns': [
                     {
                       'name': 'id',
@@ -231,7 +231,7 @@ void main() {
                   'schema': 'public',
                   'table': 'todos',
                   'type': 'UPDATE',
-                  if (realtimeFilter != null) 'filter': realtimeFilter,
+                  'filter': ?realtimeFilter,
                 },
               },
             ]);
@@ -265,7 +265,7 @@ void main() {
                   'schema': 'public',
                   'table': 'todos',
                   'type': 'DELETE',
-                  if (realtimeFilter != null) 'filter': realtimeFilter,
+                  'filter': ?realtimeFilter,
                 },
                 'ids': [77086988],
               },
@@ -304,7 +304,7 @@ void main() {
                   'schema': 'public',
                   'table': 'todos',
                   'type': 'UPDATE',
-                  if (realtimeFilter != null) 'filter': realtimeFilter,
+                  'filter': ?realtimeFilter,
                 },
               },
             ]);
@@ -339,7 +339,7 @@ void main() {
                   'schema': 'public',
                   'table': 'todos',
                   'type': 'DELETE',
-                  if (realtimeFilter != null) 'filter': realtimeFilter,
+                  'filter': ?realtimeFilter,
                 },
                 'ids': [77086988],
               },

--- a/packages/supabase_lints/lib/analysis_options.yaml
+++ b/packages/supabase_lints/lib/analysis_options.yaml
@@ -56,10 +56,8 @@ dcm:
     prefer-prefixed-global-constants: false
     prefer-switch-with-enums: false
 
-    # Blocked until the minimum Dart SDK is raised. The fixes these rules
-    # suggest rely on language features newer than our current floor of 3.4.0,
-    # so they cannot be enabled yet.
-    prefer-null-aware-elements: false # needs null-aware elements (Dart 3.8)
-    prefer-returning-shorthands: false # needs dot shorthands (Dart 3.9)
-    prefer-shorthands-with-enums: false # needs dot shorthands (Dart 3.9)
-    prefer-shorthands-with-static-fields: false # needs dot shorthands (Dart 3.9)
+    # Blocked until dot shorthands stabilize. They are still an experimental
+    # language feature, so code targeting our 3.9.0 floor cannot use them.
+    prefer-returning-shorthands: false # needs dot shorthands (experimental)
+    prefer-shorthands-with-enums: false # needs dot shorthands (experimental)
+    prefer-shorthands-with-static-fields: false # needs dot shorthands (experimental)


### PR DESCRIPTION
## What

Now that the minimum Dart SDK is 3.9, this adopts the null-aware elements language feature (stabilized in Dart 3.8) across the codebase.

- Enable the previously SDK-gated `prefer-null-aware-elements` DCM rule in `supabase_lints`.
- Rewrite all 65 flagged collection literals to use null-aware elements (`?element`) instead of `if (x != null)` guards:
  - List/set: `if (prefer != null) prefer` → `?prefer`
  - Map value: `if (email != null) 'email': email` → `'email': ?email`
  - Guarded chains: `if (grantTypes != null) 'grant_types': grantTypes!.map(...)` → `'grant_types': ?grantTypes?.map(...)`

## Dot shorthands

The config previously claimed the three dot-shorthand rules needed "Dart 3.9". That is inaccurate: dot shorthands are still an **experimental** language feature and cannot be used by code targeting the 3.9 floor (verified: `Color c = .green;` still errors at language 3.9 on Dart 3.12). Those rules stay disabled, and their comment is corrected to reflect this.

## Verification

- `dcm analyze packages examples` → 0 `prefer-null-aware-elements` violations
- `dart analyze` → clean across all touched packages
- `dart format` → no reformatting needed
- `realtime_client` `mock_test.dart` passes (including the `with filter` case that exercises a changed path)