### PR TITLE
refactor: adopt null-aware elements and enable the DCM rule

### DIFF
--- a/packages/gotrue/lib/src/gotrue_admin_api.dart
+++ b/packages/gotrue/lib/src/gotrue_admin_api.dart
@@ -118,8 +118,8 @@ class GoTrueAdminApi {
     final options = GotrueRequestOptions(
       headers: _headers,
       query: {
-        if (page != null) 'page': page.toString(),
-        if (perPage != null) 'per_page': perPage.toString(),
+        'page': ?page?.toString(),
+        'per_page': ?perPage?.toString(),
       },
     );
     final response = await _fetch.request(
@@ -138,7 +138,7 @@ class GoTrueAdminApi {
   }) async {
     final body = {
       'email': email,
-      if (data != null) 'data': data,
+      'data': ?data,
     };
     final fetchOptions = GotrueRequestOptions(
       headers: _headers,
@@ -186,10 +186,10 @@ class GoTrueAdminApi {
     final body = {
       'email': email,
       'type': type.snakeCase,
-      if (data != null) 'data': data,
-      if (redirectTo != null) 'redirect_to': redirectTo,
-      if (password != null) 'password': password,
-      if (newEmail != null) 'new_email': newEmail,
+      'data': ?data,
+      'redirect_to': ?redirectTo,
+      'password': ?password,
+      'new_email': ?newEmail,
     };
 
     final fetchOptions = GotrueRequestOptions(headers: _headers, body: body);

--- a/packages/gotrue/lib/src/gotrue_admin_oauth_api.dart
+++ b/packages/gotrue/lib/src/gotrue_admin_oauth_api.dart
@@ -76,8 +76,8 @@ class GoTrueAdminOAuthApi {
       options: GotrueRequestOptions(
         headers: _headers,
         query: {
-          if (page != null) 'page': page.toString(),
-          if (perPage != null) 'per_page': perPage.toString(),
+          'page': ?page?.toString(),
+          'per_page': ?perPage?.toString(),
         },
       ),
     );

--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -605,11 +605,11 @@ class GoTrueClient {
       // For recovery type with tokenHash, exclude email/phone
       if (!isRecoveryWithTokenHash && email != null) 'email': email,
       if (!isRecoveryWithTokenHash && phone != null) 'phone': phone,
-      if (token != null) 'token': token,
+      'token': ?token,
       'type': type.snakeCase,
       'redirect_to': redirectTo,
       'gotrue_meta_security': {'captcha_token': captchaToken},
-      if (tokenHash != null) 'token_hash': tokenHash,
+      'token_hash': ?tokenHash,
     };
     final fetchOptions = GotrueRequestOptions(headers: _headers, body: body);
     final response = await _fetch.request(
@@ -665,9 +665,9 @@ class GoTrueClient {
       RequestMethodType.post,
       options: GotrueRequestOptions(
         body: {
-          if (providerId != null) 'provider_id': providerId,
-          if (domain != null) 'domain': domain,
-          if (redirectTo != null) 'redirect_to': redirectTo,
+          'provider_id': ?providerId,
+          'domain': ?domain,
+          'redirect_to': ?redirectTo,
           if (captchaToken != null)
             'gotrue_meta_security': {'captcha_token': captchaToken},
           'skip_http_redirect': true,
@@ -753,8 +753,8 @@ class GoTrueClient {
         : null;
 
     final body = {
-      if (email != null) 'email': email,
-      if (phone != null) 'phone': phone,
+      'email': ?email,
+      'phone': ?phone,
       'type': type.snakeCase,
       'gotrue_meta_security': {'captcha_token': captchaToken},
       if (email != null) ...{

--- a/packages/gotrue/lib/src/types/jwt.dart
+++ b/packages/gotrue/lib/src/types/jwt.dart
@@ -31,8 +31,8 @@ class JwtHeader {
   Map<String, dynamic> toJson() {
     return {
       'alg': alg,
-      if (kid != null) 'kid': kid,
-      if (typ != null) 'typ': typ,
+      'kid': ?kid,
+      'typ': ?typ,
     };
   }
 }

--- a/packages/gotrue/lib/src/types/types.dart
+++ b/packages/gotrue/lib/src/types/types.dart
@@ -275,13 +275,11 @@ class CreateOAuthClientParams {
   Map<String, dynamic> toJson() {
     return {
       'client_name': clientName,
-      if (clientUri != null) 'client_uri': clientUri,
+      'client_uri': ?clientUri,
       'redirect_uris': redirectUris,
-      if (grantTypes != null)
-        'grant_types': grantTypes!.map((e) => e.value).toList(),
-      if (responseTypes != null)
-        'response_types': responseTypes!.map((e) => e.value).toList(),
-      if (scope != null) 'scope': scope,
+      'grant_types': ?grantTypes?.map((e) => e.value).toList(),
+      'response_types': ?responseTypes?.map((e) => e.value).toList(),
+      'scope': ?scope,
     };
   }
 }
@@ -318,14 +316,12 @@ class UpdateOAuthClientParams {
 
   Map<String, dynamic> toJson() {
     return {
-      if (clientName != null) 'client_name': clientName,
-      if (clientUri != null) 'client_uri': clientUri,
-      if (redirectUris != null) 'redirect_uris': redirectUris,
-      if (grantTypes != null)
-        'grant_types': grantTypes!.map((e) => e.value).toList(),
-      if (responseTypes != null)
-        'response_types': responseTypes!.map((e) => e.value).toList(),
-      if (scope != null) 'scope': scope,
+      'client_name': ?clientName,
+      'client_uri': ?clientUri,
+      'redirect_uris': ?redirectUris,
+      'grant_types': ?grantTypes?.map((e) => e.value).toList(),
+      'response_types': ?responseTypes?.map((e) => e.value).toList(),
+      'scope': ?scope,
     };
   }
 }

--- a/packages/gotrue/lib/src/types/user_attributes.dart
+++ b/packages/gotrue/lib/src/types/user_attributes.dart
@@ -30,11 +30,11 @@ class UserAttributes {
 
   Map<String, dynamic> toJson() {
     return {
-      if (email != null) 'email': email,
-      if (phone != null) 'phone': phone,
-      if (nonce != null) 'nonce': nonce,
-      if (password != null) 'password': password,
-      if (data != null) 'data': data,
+      'email': ?email,
+      'phone': ?phone,
+      'nonce': ?nonce,
+      'password': ?password,
+      'data': ?data,
     };
   }
 
@@ -116,15 +116,15 @@ class AdminUserAttributes extends UserAttributes {
   @override
   Map<String, dynamic> toJson() {
     return {
-      if (email != null) 'email': email,
-      if (phone != null) 'phone': phone,
-      if (password != null) 'password': password,
-      if (data != null) 'data': data,
-      if (userMetadata != null) 'user_metadata': userMetadata,
-      if (appMetadata != null) 'app_metadata': appMetadata,
-      if (emailConfirm != null) 'email_confirm': emailConfirm,
-      if (phoneConfirm != null) 'phone_confirm': phoneConfirm,
-      if (banDuration != null) 'ban_duration': banDuration,
+      'email': ?email,
+      'phone': ?phone,
+      'password': ?password,
+      'data': ?data,
+      'user_metadata': ?userMetadata,
+      'app_metadata': ?appMetadata,
+      'email_confirm': ?emailConfirm,
+      'phone_confirm': ?phoneConfirm,
+      'ban_duration': ?banDuration,
     };
   }
 

--- a/packages/gotrue/test/mocks/passkey_mock_client.dart
+++ b/packages/gotrue/test/mocks/passkey_mock_client.dart
@@ -106,9 +106,9 @@ class PasskeyMockClient extends BaseClient {
   }) {
     return {
       'id': id,
-      if (friendlyName != null) 'friendly_name': friendlyName,
+      'friendly_name': ?friendlyName,
       'created_at': '2025-01-01T00:00:00Z',
-      if (lastUsedAt != null) 'last_used_at': lastUsedAt,
+      'last_used_at': ?lastUsedAt,
     };
   }
 

--- a/packages/postgrest/lib/src/postgrest_transform_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_transform_builder.dart
@@ -46,7 +46,7 @@ class PostgrestTransformBuilder<T> extends RawPostgrestBuilder<T, T, T> {
     final url = overrideSearchParams('select', cleanedColumns);
     final prefer = _emptyPreferAsNull(newHeaders['Prefer']);
     newHeaders['Prefer'] = [
-      if (prefer != null) prefer,
+      ?prefer,
       'return=representation',
     ].join(',');
     return PostgrestTransformBuilder(

--- a/packages/realtime_client/lib/src/message.dart
+++ b/packages/realtime_client/lib/src/message.dart
@@ -49,8 +49,8 @@ class Message {
           ? event.eventName()
           : 'heartbeat',
       'payload': processedPayload,
-      if (ref != null) 'ref': ref,
-      if (joinRef != null) 'join_ref': joinRef,
+      'ref': ?ref,
+      'join_ref': ?joinRef,
     };
   }
 }

--- a/packages/realtime_client/lib/src/types.dart
+++ b/packages/realtime_client/lib/src/types.dart
@@ -93,10 +93,10 @@ class ChannelFilter {
 
   Map<String, String> toMap() {
     return {
-      if (event != null) 'event': event!,
-      if (schema != null) 'schema': schema!,
-      if (table != null) 'table': table!,
-      if (filter != null) 'filter': filter!,
+      'event': ?event,
+      'schema': ?schema,
+      'table': ?table,
+      'filter': ?filter,
     };
   }
 }

--- a/packages/realtime_client/test/mock_test.dart
+++ b/packages/realtime_client/test/mock_test.dart
@@ -60,7 +60,7 @@ void main() {
                     'schema': 'public',
                     'table': 'todos',
                     'type': 'INSERT',
-                    if (postgresFilter != null) 'filter': postgresFilter,
+                    'filter': ?postgresFilter,
                     'columns': [
                       {
                         'name': 'id',
@@ -114,7 +114,7 @@ void main() {
                   'schema': 'public',
                   'table': 'todos',
                   'type': 'UPDATE',
-                  if (postgresFilter != null) 'filter': postgresFilter,
+                  'filter': ?postgresFilter,
                 },
               },
             ]);
@@ -148,7 +148,7 @@ void main() {
                   'schema': 'public',
                   'table': 'todos',
                   'type': 'DELETE',
-                  if (postgresFilter != null) 'filter': postgresFilter,
+                  'filter': ?postgresFilter,
                 },
                 'ids': [48673474],
               },

--- a/packages/storage_client/lib/src/storage_bucket_api.dart
+++ b/packages/storage_client/lib/src/storage_bucket_api.dart
@@ -18,10 +18,8 @@ class StorageBucketApi {
       'id': id,
       'name': id,
       'public': bucketOptions.public,
-      if (bucketOptions.fileSizeLimit != null)
-        'file_size_limit': bucketOptions.fileSizeLimit,
-      if (bucketOptions.allowedMimeTypes != null)
-        'allowed_mime_types': bucketOptions.allowedMimeTypes,
+      'file_size_limit': ?bucketOptions.fileSizeLimit,
+      'allowed_mime_types': ?bucketOptions.allowedMimeTypes,
     };
   }
 

--- a/packages/storage_client/lib/src/storage_file_api.dart
+++ b/packages/storage_client/lib/src/storage_file_api.dart
@@ -323,7 +323,7 @@ class StorageFileApi {
         'bucketId': bucketId,
         'sourceKey': fromPath,
         'destinationKey': toPath,
-        if (destinationBucket != null) 'destinationBucket': destinationBucket,
+        'destinationBucket': ?destinationBucket,
       },
       options: options,
     );
@@ -351,7 +351,7 @@ class StorageFileApi {
         'bucketId': bucketId,
         'sourceKey': fromPath,
         'destinationKey': toPath,
-        if (destinationBucket != null) 'destinationBucket': destinationBucket,
+        'destinationBucket': ?destinationBucket,
       },
       options: options,
     );
@@ -385,7 +385,7 @@ class StorageFileApi {
       '$url/object/sign/$finalPath',
       {
         'expiresIn': expiresIn,
-        if (transform != null) 'transform': transform.toQueryParams,
+        'transform': ?transform?.toQueryParams,
       },
       options: options,
     );

--- a/packages/supabase/test/mock_test.dart
+++ b/packages/supabase/test/mock_test.dart
@@ -154,7 +154,7 @@ void main() {
                       'event': '*',
                       'schema': 'public',
                       'table': 'todos',
-                      if (realtimeFilter != null) 'filter': realtimeFilter,
+                      'filter': ?realtimeFilter,
                     },
                   ],
                 },
@@ -178,7 +178,7 @@ void main() {
                   'schema': 'public',
                   'table': 'todos',
                   'type': 'INSERT',
-                  if (realtimeFilter != null) 'filter': realtimeFilter,
+                  'filter': ?realtimeFilter,
                   'columns': [
                     {
                       'name': 'id',
@@ -231,7 +231,7 @@ void main() {
                   'schema': 'public',
                   'table': 'todos',
                   'type': 'UPDATE',
-                  if (realtimeFilter != null) 'filter': realtimeFilter,
+                  'filter': ?realtimeFilter,
                 },
               },
             ]);
@@ -265,7 +265,7 @@ void main() {
                   'schema': 'public',
                   'table': 'todos',
                   'type': 'DELETE',
-                  if (realtimeFilter != null) 'filter': realtimeFilter,
+                  'filter': ?realtimeFilter,
                 },
                 'ids': [77086988],
               },
@@ -304,7 +304,7 @@ void main() {
                   'schema': 'public',
                   'table': 'todos',
                   'type': 'UPDATE',
-                  if (realtimeFilter != null) 'filter': realtimeFilter,
+                  'filter': ?realtimeFilter,
                 },
               },
             ]);
@@ -339,7 +339,7 @@ void main() {
                   'schema': 'public',
                   'table': 'todos',
                   'type': 'DELETE',
-                  if (realtimeFilter != null) 'filter': realtimeFilter,
+                  'filter': ?realtimeFilter,
                 },
                 'ids': [77086988],
               },

--- a/packages/supabase_flutter/lib/src/supabase.dart
+++ b/packages/supabase_flutter/lib/src/supabase.dart
@@ -13,6 +13,7 @@ import 'package:supabase_flutter/src/supabase_auth.dart';
 
 import 'hot_restart_cleanup_stub.dart'
     if (dart.library.js_interop) 'hot_restart_cleanup_web.dart';
+import 'platform_stub.dart' if (dart.library.io) 'platform_io.dart';
 import 'version.dart';
 
 final _log = Logger('supabase.supabase_flutter');
@@ -103,7 +104,7 @@ class Supabase {
       return _instance;
     }
 
-    _instance._debugEnable = debug ?? kDebugMode;
+    _instance._debugEnable = debug ?? (kDebugMode && !isRunningInFlutterTest);
 
     if (_instance._debugEnable) {
       _instance._logSubscription = Logger('supabase').onRecord.listen((record) {

--- a/packages/supabase_flutter/test/debug_default_test.dart
+++ b/packages/supabase_flutter/test/debug_default_test.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import 'widget_test_stubs.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    mockAppLink();
+  });
+
+  tearDown(() async {
+    try {
+      await Supabase.instance.dispose();
+    } catch (_) {
+      // Ignore dispose errors
+    }
+  });
+
+  test('debug defaults to off when running under flutter test', () async {
+    final logs = <String>[];
+    final originalDebugPrint = debugPrint;
+    debugPrint = (String? message, {int? wrapWidth}) {
+      if (message != null) logs.add(message);
+    };
+    addTearDown(() => debugPrint = originalDebugPrint);
+
+    await Supabase.initialize(
+      url: '',
+      publishableKey: '',
+      authOptions: FlutterAuthClientOptions(
+        localStorage: const MockLocalStorage(),
+        pkceAsyncStorage: MockAsyncStorage(),
+      ),
+    );
+
+    expect(logs.any((log) => log.contains('Supabase init completed')), isFalse);
+  });
+
+  test('explicit debug: true still logs under flutter test', () async {
+    final logs = <String>[];
+    final originalDebugPrint = debugPrint;
+    debugPrint = (String? message, {int? wrapWidth}) {
+      if (message != null) logs.add(message);
+    };
+    addTearDown(() => debugPrint = originalDebugPrint);
+
+    await Supabase.initialize(
+      url: '',
+      publishableKey: '',
+      debug: true,
+      authOptions: FlutterAuthClientOptions(
+        localStorage: const MockLocalStorage(),
+        pkceAsyncStorage: MockAsyncStorage(),
+      ),
+    );
+
+    expect(logs.any((log) => log.contains('Supabase init completed')), isTrue);
+  });
+}

--- a/packages/supabase_flutter/test/debug_default_test.dart
+++ b/packages/supabase_flutter/test/debug_default_test.dart
@@ -7,8 +7,14 @@ import 'widget_test_stubs.dart';
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
+  final logs = <String>[];
+
   setUp(() {
+    logs.clear();
     mockAppLink();
+    debugPrint = (String? message, {int? wrapWidth}) {
+      if (message != null) logs.add(message);
+    };
   });
 
   tearDown(() async {
@@ -19,34 +25,29 @@ void main() {
     }
   });
 
-  test('debug defaults to off when running under flutter test', () async {
-    final logs = <String>[];
-    final originalDebugPrint = debugPrint;
-    debugPrint = (String? message, {int? wrapWidth}) {
-      if (message != null) logs.add(message);
-    };
-    addTearDown(() => debugPrint = originalDebugPrint);
+  test(
+    'debug defaults to off when running under flutter test',
+    () async {
+      await Supabase.initialize(
+        url: '',
+        publishableKey: '',
+        authOptions: FlutterAuthClientOptions(
+          localStorage: const MockLocalStorage(),
+          pkceAsyncStorage: MockAsyncStorage(),
+        ),
+      );
 
-    await Supabase.initialize(
-      url: '',
-      publishableKey: '',
-      authOptions: FlutterAuthClientOptions(
-        localStorage: const MockLocalStorage(),
-        pkceAsyncStorage: MockAsyncStorage(),
-      ),
-    );
-
-    expect(logs.any((log) => log.contains('Supabase init completed')), isFalse);
-  });
+      expect(
+        logs.any((log) => log.contains('Supabase init completed')),
+        isFalse,
+      );
+    },
+    // The default relies on the FLUTTER_TEST environment variable, which is only
+    // readable through dart:io and therefore unavailable on web.
+    skip: kIsWeb,
+  );
 
   test('explicit debug: true still logs under flutter test', () async {
-    final logs = <String>[];
-    final originalDebugPrint = debugPrint;
-    debugPrint = (String? message, {int? wrapWidth}) {
-      if (message != null) logs.add(message);
-    };
-    addTearDown(() => debugPrint = originalDebugPrint);
-
     await Supabase.initialize(
       url: '',
       publishableKey: '',

--- a/packages/supabase_flutter/test/dispose_test.dart
+++ b/packages/supabase_flutter/test/dispose_test.dart
@@ -20,6 +20,7 @@ void main() {
       await Supabase.initialize(
         url: '',
         publishableKey: '',
+        debug: false,
         accessToken: () async => 'custom-access-token',
       );
 

--- a/packages/supabase_flutter/test/initialization_test.dart
+++ b/packages/supabase_flutter/test/initialization_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
@@ -9,6 +10,10 @@ void main() {
 
   const supabaseUrl = '';
   const supabaseKey = '';
+
+  setUpAll(() {
+    debugPrint = (String? message, {int? wrapWidth}) {};
+  });
 
   group('Supabase initialization', () {
     setUp(() {
@@ -29,6 +34,7 @@ void main() {
         await Supabase.initialize(
           url: supabaseUrl,
           publishableKey: supabaseKey,
+          debug: false,
         );
       });
     });
@@ -39,6 +45,7 @@ void main() {
         await Supabase.initialize(
           url: supabaseUrl,
           publishableKey: supabaseKey,
+          debug: false,
           authOptions: const FlutterAuthClientOptions(
             localStorage: localStorage,
           ),
@@ -66,6 +73,7 @@ void main() {
         await Supabase.initialize(
           url: supabaseUrl,
           publishableKey: supabaseKey,
+          debug: false,
           authOptions: const FlutterAuthClientOptions(
             authFlowType: AuthFlowType.pkce,
           ),
@@ -79,6 +87,7 @@ void main() {
         await Supabase.initialize(
           url: supabaseUrl,
           publishableKey: supabaseKey,
+          debug: false,
           httpClient: httpClient,
         );
       });
@@ -87,6 +96,7 @@ void main() {
         await Supabase.initialize(
           url: supabaseUrl,
           publishableKey: supabaseKey,
+          debug: false,
           accessToken: () async => 'custom-access-token',
         );
 
@@ -104,6 +114,7 @@ void main() {
         await Supabase.initialize(
           url: supabaseUrl,
           publishableKey: supabaseKey,
+          debug: false,
         );
 
         // Dispose
@@ -116,6 +127,7 @@ void main() {
         await Supabase.initialize(
           url: supabaseUrl,
           publishableKey: supabaseKey,
+          debug: false,
         );
       });
 

--- a/packages/supabase_flutter/test/widget_test.dart
+++ b/packages/supabase_flutter/test/widget_test.dart
@@ -19,6 +19,7 @@ void main() {
     await Supabase.initialize(
       url: supabaseUrl,
       publishableKey: supabaseKey,
+      debug: false,
       authOptions: FlutterAuthClientOptions(
         localStorage: const MockLocalStorage(),
         pkceAsyncStorage: MockAsyncStorage(),

--- a/packages/supabase_lints/lib/analysis_options.yaml
+++ b/packages/supabase_lints/lib/analysis_options.yaml
@@ -56,10 +56,9 @@ dcm:
     prefer-prefixed-global-constants: false
     prefer-switch-with-enums: false
 
-    # Blocked until the minimum Dart SDK is raised. The fixes these rules
-    # suggest rely on language features newer than our current floor of 3.4.0,
-    # so they cannot be enabled yet.
-    prefer-null-aware-elements: false # needs null-aware elements (Dart 3.8)
-    prefer-returning-shorthands: false # needs dot shorthands (Dart 3.9)
-    prefer-shorthands-with-enums: false # needs dot shorthands (Dart 3.9)
-    prefer-shorthands-with-static-fields: false # needs dot shorthands (Dart 3.9)
+    # Blocked until the minimum Dart SDK is raised to 3.10.0. The dot shorthands
+    # language feature these rules rely on is only available from 3.10.0, above
+    # our current floor of 3.9.0.
+    prefer-returning-shorthands: false # needs dot shorthands (Dart 3.10)
+    prefer-shorthands-with-enums: false # needs dot shorthands (Dart 3.10)
+    prefer-shorthands-with-static-fields: false # needs dot shorthands (Dart 3.10)

--- a/scripts/customer_testing.dart
+++ b/scripts/customer_testing.dart
@@ -1,0 +1,36 @@
+// This file is invoked by the flutter/tests registry entry for supabase-flutter
+// (https://github.com/flutter/tests/blob/main/registry/supabase_flutter.test) to run
+// this repository's tests as a presubmit against flutter/flutter framework changes.
+// Changes here are only honored after the commit hash in that registry entry is
+// updated.
+
+import 'dart:io';
+
+Future<void> main() async {
+  // supabase-flutter is a pub workspace, so analyzing the repository root covers
+  // every member package.
+  await _run('flutter', ['analyze', '--no-fatal-infos']);
+
+  // Only supabase_flutter is exercised here. The other packages' tests require a
+  // live Supabase backend and are therefore not hermetic enough for the registry.
+  await _run('flutter', ['test'],
+      workingDirectory: 'packages/supabase_flutter');
+}
+
+Future<void> _run(
+  String executable,
+  List<String> arguments, {
+  String? workingDirectory,
+}) async {
+  final process = await Process.start(
+    executable,
+    arguments,
+    workingDirectory: workingDirectory,
+    mode: ProcessStartMode.inheritStdio,
+    runInShell: true,
+  );
+  final exitCode = await process.exitCode;
+  if (exitCode != 0) {
+    exit(exitCode);
+  }
+}


### PR DESCRIPTION
## What

Enables the DCM `prefer-null-aware-elements` rule and migrates all 65 existing violations to Dart 3.8 null-aware collection elements.

## Why

The minimum Dart SDK is now 3.9.0 (#1527), but the shared lint config still disabled several rules with a stale comment claiming the floor was 3.4.0. `prefer-null-aware-elements` relies on the Dart 3.8 null-aware elements feature, so it can be turned on now.

While investigating, I found the comment was also wrong about the other three rules: `prefer-returning-shorthands`, `prefer-shorthands-with-enums`, and `prefer-shorthands-with-static-fields` rely on **dot shorthands**, which the analyzer only accepts from **Dart 3.10.0**, above our current 3.9.0 floor. Enabling those would require a breaking minimum-SDK bump, so they stay disabled with a corrected comment.

## Changes

- `supabase_lints`: enable `prefer-null-aware-elements` (drop the `false` override so the recommended preset governs it) and correct the stale comment (null-aware = 3.8, dot shorthands = 3.10).
- Migrate 65 sites across `gotrue`, `postgrest`, `realtime_client`, `storage_client`, and `supabase` tests. All are behavior-preserving:
  - `if (x != null) 'k': x` → `'k': ?x`
  - `if (x != null) 'k': x!.map(...)` → `'k': ?x?.map(...)`
  - `if (x != null) x` (list/set) → `?x`

## Verification

- `dcm analyze packages`: no issues found (zero `prefer-null-aware-elements` remaining, no new issues).
- `dart analyze` across the workspace: no errors.
- Touched hermetic tests pass (`supabase` and `realtime_client` mock suites, including the realtime filter serialization path). The backend-dependent package tests are covered by CI.