### PR TITLE
fix(gotrue): OAuth server throws FormatException instead of ArgumentE…

### DIFF
--- a/packages/gotrue/lib/src/gotrue_oauth_api.dart
+++ b/packages/gotrue/lib/src/gotrue_oauth_api.dart
@@ -58,10 +58,9 @@ class OAuthAuthorizationDetailsResponse {
     final user = json['user'] == null ? null : User.fromJson(json['user']);
 
     if (user == null) {
-      throw ArgumentError.value(
-        json,
-        'json',
+      throw FormatException(
         'The provided JSON should contain a parseable user object',
+        json.toString(),
       );
     }
 

--- a/packages/gotrue/test/src/gotrue_oauth_api_test.dart
+++ b/packages/gotrue/test/src/gotrue_oauth_api_test.dart
@@ -61,7 +61,7 @@ void main() {
 
       expect(
         () => OAuthAuthorizationDetailsResponse.fromJson(json),
-        throwsArgumentError,
+        throwsFormatException,
       );
     });
   });


### PR DESCRIPTION
## What kind of change does this PR introduce?

As mentioned in [this discussion](https://github.com/supabase/supabase-flutter/pull/1499#discussion_r3506322065) for #1499, the  `OAuthAuthorizationDetailsResponse.fromJson` best throws a `FormatException` to be inline with the rest of the codebase.

## What is the current behavior?

Currently, when a JSON without a `user` key is parsed by the `OAuthAuthorizationDetailsResponse.fromJson` factory, the factory throws an `ArgumentError`.

## What is the new behavior?

Now, when a JSON without a `user` key is parsed by the `OAuthAuthorizationDetailsResponse.fromJson` factory, the 
factory throws a `FormatException`.

## Additional context

@spydon from the discussion I had the idea that you updated this, but I haven't found any related changes, so I've made a small PR to fix this.