### PR TITLE
fix(gotrue): handle already-consented OAuth authorization responses

### DIFF
--- a/packages/gotrue/lib/src/gotrue_oauth_api.dart
+++ b/packages/gotrue/lib/src/gotrue_oauth_api.dart
@@ -24,11 +24,37 @@ class OAuthAuthorizedClient {
   }
 }
 
-/// Response type representing the details of a pending OAuth authorization
-/// request.
+/// Result returned by [GoTrueOAuthApi.getAuthorizationDetails].
+///
+/// The OAuth 2.1 server responds in one of two ways, depending on whether the
+/// signed-in user has already granted consent to the requesting client:
+///
+/// * [OAuthAuthorizationDetailsResponse] — consent is still required, so the
+///   requesting client, user and requested scopes are returned for display in
+///   a consent screen.
+/// * [OAuthAuthorizationRedirectResponse] — the user already granted consent
+///   to this client, so the server short-circuits the consent flow and returns
+///   only the redirect URL the caller should navigate to.
 ///
 /// Only relevant when the OAuth 2.1 server is enabled in Supabase Auth.
-class OAuthAuthorizationDetailsResponse {
+sealed class OAuthAuthorizationResponse {
+  const OAuthAuthorizationResponse();
+
+  factory OAuthAuthorizationResponse.fromJson(Map<String, dynamic> json) {
+    // When consent was already granted, the server short-circuits the flow and
+    // returns a redirect-only body ({"redirect_url": ...}) with no client or
+    // user information.
+    return json.containsKey('redirect_url')
+        ? OAuthAuthorizationRedirectResponse.fromJson(json)
+        : OAuthAuthorizationDetailsResponse.fromJson(json);
+  }
+}
+
+/// Response type representing the details of a pending OAuth authorization
+/// request that still requires the user's consent.
+///
+/// Only relevant when the OAuth 2.1 server is enabled in Supabase Auth.
+class OAuthAuthorizationDetailsResponse extends OAuthAuthorizationResponse {
   /// The unique identifier for this authorization request.
   final String authorizationId;
 
@@ -70,6 +96,29 @@ class OAuthAuthorizationDetailsResponse {
       user: user,
       scope: json['scope'] as String?,
       redirectUri: json['redirect_uri'] as String,
+    );
+  }
+}
+
+/// Response type returned when the signed-in user has already granted consent
+/// to the requesting client.
+///
+/// The OAuth 2.1 server short-circuits the consent flow and only provides the
+/// redirect URL the caller should navigate to in order to complete the request.
+///
+/// Only relevant when the OAuth 2.1 server is enabled in Supabase Auth.
+class OAuthAuthorizationRedirectResponse extends OAuthAuthorizationResponse {
+  /// The URL the caller should redirect the user to in order to complete the
+  /// already-approved authorization request.
+  final String redirectUrl;
+
+  const OAuthAuthorizationRedirectResponse({required this.redirectUrl});
+
+  factory OAuthAuthorizationRedirectResponse.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    return OAuthAuthorizationRedirectResponse(
+      redirectUrl: json['redirect_url'] as String,
     );
   }
 }
@@ -134,10 +183,13 @@ class GoTrueOAuthApi {
   /// Retrieves details about an OAuth authorization request.
   /// Only relevant when the OAuth 2.1 server is enabled in Supabase Auth.
   ///
-  /// Returns authorization details including client info, scopes, and user information.
-  /// If the response includes only a redirect_url field, it means consent was already given - the caller
-  /// should handle the redirect manually if needed.
-  Future<OAuthAuthorizationDetailsResponse> getAuthorizationDetails(
+  /// Returns an [OAuthAuthorizationDetailsResponse] with the client info,
+  /// scopes and user information when the user still has to consent. When the
+  /// user already granted consent to this client, the server short-circuits the
+  /// flow and an [OAuthAuthorizationRedirectResponse] carrying the redirect URL
+  /// is returned instead. Switch on the sealed [OAuthAuthorizationResponse] to
+  /// handle both cases.
+  Future<OAuthAuthorizationResponse> getAuthorizationDetails(
     String authorizationId,
   ) async {
     final session = _client.currentSession;
@@ -151,7 +203,7 @@ class GoTrueOAuthApi {
       ),
     );
 
-    return OAuthAuthorizationDetailsResponse.fromJson(data);
+    return OAuthAuthorizationResponse.fromJson(data);
   }
 
   /// Approves a pending OAuth authorization request.

--- a/packages/gotrue/lib/src/gotrue_oauth_api.dart
+++ b/packages/gotrue/lib/src/gotrue_oauth_api.dart
@@ -58,10 +58,9 @@ class OAuthAuthorizationDetailsResponse {
     final user = json['user'] == null ? null : User.fromJson(json['user']);
 
     if (user == null) {
-      throw ArgumentError.value(
-        json,
-        'json',
+      throw FormatException(
         'The provided JSON should contain a parseable user object',
+        json.toString(),
       );
     }
 

--- a/packages/gotrue/test/src/gotrue_oauth_api_test.dart
+++ b/packages/gotrue/test/src/gotrue_oauth_api_test.dart
@@ -61,7 +61,7 @@ void main() {
 
       expect(
         () => OAuthAuthorizationDetailsResponse.fromJson(json),
-        throwsArgumentError,
+        throwsFormatException,
       );
     });
   });

--- a/packages/gotrue/test/src/gotrue_oauth_api_test.dart
+++ b/packages/gotrue/test/src/gotrue_oauth_api_test.dart
@@ -64,6 +64,21 @@ void main() {
         throwsFormatException,
       );
     });
+
+    test('parses a redirect-only body into a redirect response', () {
+      final json = {
+        'redirect_url':
+            'http://127.0.0.1:3000/oauth/callback?code=367ba316-8f55-43cd',
+      };
+
+      final actual = OAuthAuthorizationResponse.fromJson(json);
+
+      expect(actual, isA<OAuthAuthorizationRedirectResponse>());
+      expect(
+        (actual as OAuthAuthorizationRedirectResponse).redirectUrl,
+        equals('http://127.0.0.1:3000/oauth/callback?code=367ba316-8f55-43cd'),
+      );
+    });
   });
 
   group('OAuth server', () {
@@ -81,13 +96,15 @@ void main() {
 
       final res = await sut.oauth.getAuthorizationDetails(authorizationId);
 
-      expect(res.authorizationId, equals(authorizationId));
-      expect(res.scope, equals(clientParams.scope));
-      expect(res.redirectUri, equals(clientParams.redirectUris.first));
-      expect(res.client.clientId, equals(client.clientId));
-      expect(res.client.clientName, equals(client.clientName));
-      expect(res.user.id, equals(auth.user?.id));
-      expect(res.user.email, equals(email1));
+      expect(res, isA<OAuthAuthorizationDetailsResponse>());
+      final details = res as OAuthAuthorizationDetailsResponse;
+      expect(details.authorizationId, equals(authorizationId));
+      expect(details.scope, equals(clientParams.scope));
+      expect(details.redirectUri, equals(clientParams.redirectUris.first));
+      expect(details.client.clientId, equals(client.clientId));
+      expect(details.client.clientName, equals(client.clientName));
+      expect(details.user.id, equals(auth.user?.id));
+      expect(details.user.email, equals(email1));
     });
 
     test('approve authorization request', () async {
@@ -148,6 +165,42 @@ void main() {
         ),
       );
     });
+
+    test(
+      'getting details for a new authorization after the client was already '
+      'approved does not throw',
+      () async {
+        final sut = await fixture.build();
+        final clientParams = CreateOAuthClientParams(
+          clientName: 'Test OAuth Client',
+          redirectUris: ['http://127.0.0.1:3000/oauth/callback'],
+          responseTypes: [OAuthClientResponseType.code],
+          scope: 'email',
+        );
+        final client = await fixture.sutCreatesOAuthClient(clientParams);
+        await fixture.sutLogsIn(password: password, email: email1);
+
+        // First authorization: fetch details and approve to record consent.
+        final firstAuthorizationId = await fixture.sutAuthorizesClient(client);
+        await sut.oauth.getAuthorizationDetails(firstAuthorizationId);
+        await sut.oauth.approveAuthorization(firstAuthorizationId);
+
+        // Second authorization for the same client, by the same user.
+        final secondAuthorizationId = await fixture.sutAuthorizesClient(client);
+
+        final res = await sut.oauth.getAuthorizationDetails(
+          secondAuthorizationId,
+        );
+
+        expect(res, isA<OAuthAuthorizationRedirectResponse>());
+        final redirect = res as OAuthAuthorizationRedirectResponse;
+        expect(
+          redirect.redirectUrl,
+          startsWith(clientParams.redirectUris.first),
+        );
+        expect(redirect.redirectUrl, contains('code='));
+      },
+    );
   });
 }
 

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -99,6 +99,9 @@ features:
       - GoTrueOAuthApi
       - GoTrueOAuthApi.GoTrueOAuthApi
       - GoTrueOAuthApi.getAuthorizationDetails
+      - OAuthAuthorizationResponse
+      - OAuthAuthorizationResponse.OAuthAuthorizationResponse
+      - OAuthAuthorizationResponse.fromJson
       - OAuthAuthorizationDetailsResponse
       - OAuthAuthorizationDetailsResponse.OAuthAuthorizationDetailsResponse
       - OAuthAuthorizationDetailsResponse.authorizationId
@@ -107,6 +110,10 @@ features:
       - OAuthAuthorizationDetailsResponse.redirectUri
       - OAuthAuthorizationDetailsResponse.scope
       - OAuthAuthorizationDetailsResponse.user
+      - OAuthAuthorizationRedirectResponse
+      - OAuthAuthorizationRedirectResponse.OAuthAuthorizationRedirectResponse
+      - OAuthAuthorizationRedirectResponse.fromJson
+      - OAuthAuthorizationRedirectResponse.redirectUrl
       - OAuthAuthorizedClient
       - OAuthAuthorizedClient.OAuthAuthorizedClient
       - OAuthAuthorizedClient.clientId


### PR DESCRIPTION
> Stacked on #1535. Review/merge that one first.

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

`getAuthorizationDetails` crashed with a `FormatException` when the OAuth 2.1 server short-circuited the consent flow. This happens when a user who already approved a client starts a new authorization for it: the server returns a redirect-only body (`{"redirect_url": "...?code=..."}`) with no user or client, which the parser rejected because it required a user object.

## What is the new behavior?

`getAuthorizationDetails` now checks whether a `redirect_url` is present returning `OAuthAuthorizationRedirectResponse` when it is present. When the key isn't present the old `OAuthAuthorizationDetailsResponse` object is returned.

Callers now switch on the result and forward the redirect instead of losing it to an exception. Genuinely malformed detail bodies (no redirect_url and no user) still throw, so validation isn't weakened.

## Additional context

BREAKING CHANGE: `getAuthorizationDetails` now returns the sealed `OAuthAuthorizationResponse` instead of `OAuthAuthorizationDetailsResponse`. Callers must switch/cast to access client, user, scope and redirectUri.
