### PR TITLE
ci: Remove subject pattern

### DIFF
--- a/.github/workflows/title-validation.yml
+++ b/.github/workflows/title-validation.yml
@@ -25,9 +25,3 @@ jobs:
       - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          subjectPattern: ^(?![A-Z]).+$
-          subjectPatternError: |
-            The subject "{subject}" found in the pull request title "{title}"
-            didn't match the configured pattern. Please ensure that the subject
-            doesn't start with an uppercase character.


### PR DESCRIPTION
## What kind of change does this PR introduce?

Removes the enforced subject pattern (start with uppercase character).

## What is the current behavior?

Forces uppercase character.

## What is the new behavior?

Doesn't enforce uppercase character.

## Additional context

We should allow for example `fix: OAuth ...`
