### PR TITLE
chore: fix typos across packages

### DIFF
--- a/examples/launcher/lib/launcher.dart
+++ b/examples/launcher/lib/launcher.dart
@@ -142,7 +142,7 @@ void _printBanner() {
 }
 
 /// Walks up from the current directory until it finds the examples directory,
-/// recognised by its shared `supabase/config.toml`.
+/// recognized by its shared `supabase/config.toml`.
 Directory? _findExamplesRoot() {
   var directory = Directory.current.absolute;
   while (true) {

--- a/packages/functions_client/test/custom_http_client.dart
+++ b/packages/functions_client/test/custom_http_client.dart
@@ -5,7 +5,7 @@ import 'package:http/http.dart';
 class CustomHttpClient extends BaseClient {
   /// List of received requests by the client.
   ///
-  /// Usefull for testing purposes, to check the request was constructed
+  /// Useful for testing purposes, to check the request was constructed
   /// correctly.
   List<BaseRequest> receivedRequests = <BaseRequest>[];
 

--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -186,7 +186,7 @@ class GoTrueClient {
   /// Getter for the headers
   Map<String, String> get headers => _headers;
 
-  /// Returns the current logged in user, asociated to [currentSession] if any;
+  /// Returns the current logged in user, associated to [currentSession] if any;
   User? get currentUser => _currentSession?.user;
 
   /// Returns the current session, if any;
@@ -376,7 +376,7 @@ class GoTrueClient {
     );
   }
 
-  /// Verifies the PKCE code verifyer and retrieves a session.
+  /// Verifies the PKCE code verifier and retrieves a session.
   Future<AuthSessionUrlResponse> exchangeCodeForSession(String authCode) async {
     assert(
       _asyncStorage != null,
@@ -1394,7 +1394,7 @@ class GoTrueClient {
           _log.finest('Received broadcast message: $messageEvent');
           _log.info('Received broadcast event: $rawEvent');
           final event = switch (rawEvent) {
-            // This library sends the js name of the event to be comptabile with
+            // This library sends the js name of the event to be compatible with
             // the js library, so we need to convert it back to the dart name
             'INITIAL_SESSION' => AuthChangeEvent.initialSession,
             'PASSWORD_RECOVERY' => AuthChangeEvent.passwordRecovery,

--- a/packages/gotrue/lib/src/types/auth_response.dart
+++ b/packages/gotrue/lib/src/types/auth_response.dart
@@ -11,7 +11,7 @@ class AuthResponse {
     User? user,
   }) : user = user ?? session?.user;
 
-  /// Instanciates an `AuthResponse` object from json response.
+  /// Instantiates an `AuthResponse` object from json response.
   AuthResponse.fromJson(Map<String, dynamic> json)
     : session = Session.fromJson(json),
       user = User.fromJson(json) ?? Session.fromJson(json)?.user;
@@ -22,7 +22,7 @@ class OAuthResponse {
   final OAuthProvider provider;
   final String url;
 
-  /// Instanciates an `OAuthResponse` object from json response.
+  /// Instantiates an `OAuthResponse` object from json response.
   const OAuthResponse({
     required this.provider,
     required this.url,

--- a/packages/gotrue/test/custom_http_client.dart
+++ b/packages/gotrue/test/custom_http_client.dart
@@ -65,7 +65,7 @@ class NoEmailConfirmationHttpClient extends BaseClient {
 
 /// Client to test out the token refresh retry logic.
 ///
-/// This client will fail the first 3 requests and succede on the 4th one.
+/// This client will fail the first 3 requests and succeed on the 4th one.
 class RetryTestHttpClient extends BaseClient {
   var retryCount = 0;
 

--- a/packages/gotrue/test/src/gotrue_mfa_api_test.dart
+++ b/packages/gotrue/test/src/gotrue_mfa_api_test.dart
@@ -243,7 +243,7 @@ void main() {
       );
     });
 
-    test('Session object can be properly json serielized', () async {
+    test('Session object can be properly json serialized', () async {
       await client.signInWithPassword(password: password, email: email2);
       await client.mfa.challengeAndVerify(factorId: factorId2, code: getTOTP());
       final response = await client.refreshSession();

--- a/packages/realtime_client/example/main.dart
+++ b/packages/realtime_client/example/main.dart
@@ -4,7 +4,7 @@ import 'package:realtime_client/realtime_client.dart';
 Future<void> main() async {
   final socket = RealtimeClient(
     'ws://SUPABASE_API_ENDPOINT/realtime/v1',
-    params: {'apikey': 'SUPABSE_API_KEY'},
+    params: {'apikey': 'SUPABASE_API_KEY'},
     // ignore: avoid_print
     logger: (kind, msg, data) {
       print('$kind $msg $data');

--- a/packages/realtime_client/lib/src/realtime_channel.dart
+++ b/packages/realtime_client/lib/src/realtime_channel.dart
@@ -353,7 +353,7 @@ class RealtimeChannel {
     );
   }
 
-  /// Registers a callback that will be executed when the channel encounteres an error.
+  /// Registers a callback that will be executed when the channel encounters an error.
   void _onError(Function callback) {
     onEvents(
       ChannelEvents.error.eventName(),
@@ -881,7 +881,7 @@ class RealtimeChannel {
       trigger(ChannelEvents.close.eventName(), 'leave', joinRef);
     }
 
-    // Destroy joinPush to avoid connection timeouts during unscription phase
+    // Destroy joinPush to avoid connection timeouts during unsubscription phase
     joinPush.destroy();
 
     final completer = Completer<String>();

--- a/packages/realtime_client/lib/src/realtime_client.dart
+++ b/packages/realtime_client/lib/src/realtime_client.dart
@@ -165,7 +165,7 @@ class RealtimeClient {
   /// [decode] Overrides how incoming frames are deserialized. Defaults to the
   /// codec for [version].
   ///
-  /// [reconnectAfterMs] The optional function that returns the millsec reconnect interval. Defaults to stepped backoff off.
+  /// [reconnectAfterMs] The optional function that returns the millisec reconnect interval. Defaults to stepped backoff off.
   ///
   /// [logLevel] Specifies the log level for the connection on the server.
   ///
@@ -361,7 +361,7 @@ class RealtimeClient {
 
   /// Logs the message. Override `this.logger` for specialized logging.
   ///
-  /// [level] must be [Level.FINEST] for senitive data
+  /// [level] must be [Level.FINEST] for sensitive data
   void log([
     String? kind,
     String? message,

--- a/packages/realtime_client/lib/src/types.dart
+++ b/packages/realtime_client/lib/src/types.dart
@@ -170,7 +170,7 @@ class ReplayOption {
 }
 
 class RealtimeChannelConfig {
-  /// [ack] option instructs server to acknowlege that broadcast message was received
+  /// [ack] option instructs server to acknowledge that broadcast message was received
   final bool ack;
 
   /// [self] option enables client to receive message it broadcasted

--- a/packages/storage_client/lib/src/types.dart
+++ b/packages/storage_client/lib/src/types.dart
@@ -409,7 +409,7 @@ class TransformOptions {
   ///  Specify the format of the image requested.
   ///
   ///  When using 'origin' we force the format to be the same as the original image,
-  ///  bypassing automatic browser optimisation such as webp conversion
+  ///  bypassing automatic browser optimization such as webp conversion
   final RequestImageFormat? format;
 
   /// {@macro transform_options}

--- a/packages/supabase/README.md
+++ b/packages/supabase/README.md
@@ -32,7 +32,7 @@ The docs can be found on the official Supabase website.
 
 ## License
 
-This repo is licenced under MIT.
+This repo is licensed under MIT.
 
 ## Credits
 

--- a/packages/supabase/test/mock_test.dart
+++ b/packages/supabase/test/mock_test.dart
@@ -441,7 +441,7 @@ void main() {
         stream.listen(expectAsync1((event) {}, count: 5));
         stream.listen(expectAsync1((event) {}, count: 5));
 
-        // All realtime events are done emitting, so should receive the currnet data
+        // All realtime events are done emitting, so should receive the current data
       });
 
       test("Create two stream to same table", () async {
@@ -458,7 +458,7 @@ void main() {
 
         await Future.delayed(Duration(seconds: 3));
 
-        // All realtime events are done emitting, so should receive the currnet data
+        // All realtime events are done emitting, so should receive the current data
         stream.listen(expectAsync1((event) {}, count: 1));
       });
       test('emits data', () {
@@ -540,7 +540,7 @@ void main() {
 
         await Future.delayed(Duration(seconds: 3));
 
-        // All realtime events are done emitting, so should receive the currnet data
+        // All realtime events are done emitting, so should receive the current data
         stream.listen(expectAsync1((event) {}, count: 1));
       });
 

--- a/packages/supabase_flutter/README.md
+++ b/packages/supabase_flutter/README.md
@@ -280,7 +280,7 @@ await supabase.auth.signInWithOAuth(
   redirectTo: kIsWeb ? null : 'io.supabase.flutter://callback',
 );
 
-// Listen to auth state changes in order to detect when ther OAuth login is complete.
+// Listen to auth state changes in order to detect when the OAuth login is complete.
 supabase.auth.onAuthStateChange.listen((data) {
   final AuthChangeEvent event = data.event;
   if(event == AuthChangeEvent.signedIn) {
@@ -496,7 +496,7 @@ https://github.com/llfbandit/app_links/tree/master?tab=readme-ov-file#getting-st
 
 ### Platform specific config
 
-Follow the guide to find additional platform specidic condigs for your OAuth provider.
+Follow the guide to find additional platform specific configs for your OAuth provider.
 
 https://supabase.io/docs/guides/auth#third-party-logins
 
@@ -757,7 +757,7 @@ https://supabase.com/docs/reference/dart/upgrade-guide
 
 ## License
 
-This repo is licenced under MIT.
+This repo is licensed under MIT.
 
 ## Resources
 

--- a/packages/supabase_flutter/lib/src/supabase_auth.dart
+++ b/packages/supabase_flutter/lib/src/supabase_auth.dart
@@ -317,7 +317,7 @@ extension GoTrueClientSignInProvider on GoTrueClient {
   /// ```
   ///
   /// The return value of this method is not the auth result, and whether the
-  /// OAuth sign-in has succeded or not should be observed by setting a listener
+  /// OAuth sign-in has succeeded or not should be observed by setting a listener
   /// on [auth.onAuthStateChanged].
   ///
   /// See also:


### PR DESCRIPTION
Ran cspell across the repository and fixed genuine spelling mistakes in comments, doc comments, READMEs, and one example placeholder.

## Fixes

| Typo | Fix |
|------|-----|
| Usefull | Useful |
| asociated | associated |
| comptabile | compatible |
| verifyer | verifier |
| Instanciates | Instantiates |
| succede | succeed |
| serielized | serialized |
| encounteres | encounters |
| unscription | unsubscription |
| senitive | sensitive |
| millsec | millisec |
| acknowlege | acknowledge |
| SUPABSE | SUPABASE |
| succeded | succeeded |
| ther | the |
| specidic / condigs | specific / configs |
| licenced | licensed |
| currnet | current |

No functional changes. Domain terms, test data, base64/JWT strings, and valid British spellings were left untouched.