### PR TITLE
fix: skip packages without lib/src in update-version script

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,10 +38,10 @@ melos:
       description: Updates the version.dart file for each package except yet_another_json_isolate
       run: |
         for d in packages/*/ ; do
+          [ -f "${d}lib/src/version.dart" ] || continue
           version=$(awk '/version:/ {
             pos=match($2, /[0-9]+\.[0-9]+\.[0-9]+/);
             print substr($2, pos); }' $d/pubspec.yaml)
           echo "const version = '$version';" > $d/lib/src/version.dart
         done
-        rm packages/yet_another_json_isolate/lib/src/version.dart
         git add packages/*/lib/src/version.dart


### PR DESCRIPTION
## What

The `update-version` melos script (run as a `preCommit` hook during `melos version`) iterated over every `packages/*/` and redirected output into `$d/lib/src/version.dart`. This failed for `supabase_lints`, which is a lints-only package with no `lib/src/` directory:

```
ERROR: /bin/sh: line 4: packages/supabase_lints//lib/src/version.dart: No such file or directory
```

The package was added after the script was written and was never accounted for.

## Fix

Only update packages that already have a `version.dart` file:

```sh
[ -f "${d}lib/src/version.dart" ] || continue
```

This naturally skips `supabase_lints` (no `lib/src/version.dart`) and `yet_another_json_isolate` (intentionally keeps no tracked `version.dart`), which also lets us drop the fragile `rm packages/yet_another_json_isolate/lib/src/version.dart` line.

## Verification

Dry-run of the updated loop writes `version.dart` for the seven packages that have one and skips both `supabase_lints` and `yet_another_json_isolate`.