### PR TITLE
chore: clean up package metadata, READMEs, and examples

### DIFF
--- a/packages/functions_client/README.md
+++ b/packages/functions_client/README.md
@@ -1,4 +1,28 @@
-# `functions-dart`
+<br />
+<p align="center">
+  <a href="https://supabase.com">
+    <img alt="Supabase Logo" width="300" src="https://raw.githubusercontent.com/supabase/supabase/master/packages/common/assets/images/logo-preview.jpg">
+  </a>
+
+  <h1 align="center">functions_client</h1>
+
+  <p align="center">
+    Dart client library to interact with <a href="https://supabase.com/docs/guides/functions">Supabase Edge Functions</a>.
+  </p>
+
+  <p align="center">
+    <a href="https://supabase.com/docs/guides/functions">Guides</a>
+    ·
+    <a href="https://supabase.com/docs/reference/dart/functions-invoke">Reference Docs</a>
+  </p>
+</p>
+
+<div align="center">
+
+[![pub package](https://img.shields.io/pub/v/functions_client.svg)](https://pub.dev/packages/functions_client)
+[![pub test](https://github.com/supabase/supabase-flutter/workflows/Test/badge.svg)](https://github.com/supabase/supabase-flutter/actions?query=workflow%3ATest)
+
+</div>
 
 ## Docs
 

--- a/packages/functions_client/example/functions_dart_example.dart
+++ b/packages/functions_client/example/functions_dart_example.dart
@@ -1,1 +1,26 @@
-void main() {}
+// ignore_for_file: avoid_print
+
+import 'package:functions_client/functions_client.dart';
+
+/// Example to use with Supabase Edge Functions https://supabase.com/
+Future<void> main() async {
+  const supabaseUrl = '';
+  const supabaseKey = '';
+  final client = FunctionsClient(
+    '$supabaseUrl/functions/v1',
+    {
+      'Authorization': 'Bearer $supabaseKey',
+    },
+  );
+
+  try {
+    final response = await client.invoke(
+      'get_countries',
+      body: {'name': 'The Shire'},
+    );
+    print('status: ${response.status}');
+    print('data: ${response.data}');
+  } on FunctionException catch (error) {
+    print('Function error: ${error.status} ${error.details}');
+  }
+}

--- a/packages/functions_client/pubspec.yaml
+++ b/packages/functions_client/pubspec.yaml
@@ -3,7 +3,14 @@ description: A dart client library for the Supabase functions.
 version: 2.6.4
 homepage: 'https://supabase.com'
 repository: 'https://github.com/supabase/supabase-flutter/tree/main/packages/functions_client'
+issue_tracker: 'https://github.com/supabase/supabase-flutter/issues'
 documentation: 'https://supabase.com/docs/reference/dart/functions-invoke'
+topics:
+  - supabase
+  - functions
+  - edge-functions
+  - backend
+  - api
 
 environment:
   sdk: '>=3.9.0 <4.0.0'

--- a/packages/gotrue/README.md
+++ b/packages/gotrue/README.md
@@ -1,9 +1,28 @@
-# gotrue
+<br />
+<p align="center">
+  <a href="https://supabase.com">
+    <img alt="Supabase Logo" width="300" src="https://raw.githubusercontent.com/supabase/supabase/master/packages/common/assets/images/logo-preview.jpg">
+  </a>
 
-Dart client for the [GoTrue](https://github.com/supabase/gotrue) API.
+  <h1 align="center">gotrue</h1>
+
+  <p align="center">
+    Dart client library for <a href="https://supabase.com/docs/guides/auth">Supabase Auth</a>.
+  </p>
+
+  <p align="center">
+    <a href="https://supabase.com/docs/guides/auth">Guides</a>
+    ·
+    <a href="https://supabase.com/docs/reference/dart/auth-signup">Reference Docs</a>
+  </p>
+</p>
+
+<div align="center">
 
 [![pub package](https://img.shields.io/pub/v/gotrue.svg)](https://pub.dev/packages/gotrue)
-[![pub test](https://github.com/supabase/gotrue-dart/workflows/Test/badge.svg)](https://github.com/supabase/gotrue-dart/actions?query=workflow%3ATest)
+[![pub test](https://github.com/supabase/supabase-flutter/workflows/Test/badge.svg)](https://github.com/supabase/supabase-flutter/actions?query=workflow%3ATest)
+
+</div>
 
 ## Docs
 

--- a/packages/gotrue/example/main.dart
+++ b/packages/gotrue/example/main.dart
@@ -1,13 +1,16 @@
+// ignore_for_file: avoid_print
+
 import 'package:gotrue/gotrue.dart';
 
-Future<bool> main(List<String> arguments) async {
+/// Example to use with Supabase Auth https://supabase.com/
+Future<void> main() async {
   const gotrueUrl = 'http://localhost:9999';
-  const annonToken = '';
+  const supabaseKey = '';
   final client = GoTrueClient(
     url: gotrueUrl,
     headers: {
-      'Authorization': 'Bearer $annonToken',
-      'apikey': annonToken,
+      'Authorization': 'Bearer $supabaseKey',
+      'apikey': supabaseKey,
     },
   );
 
@@ -16,12 +19,11 @@ Future<bool> main(List<String> arguments) async {
       email: 'email',
       password: '12345',
     );
-    print('Logged in, uid: ${login.session!.user.id}');
+    print('Logged in, user id: ${login.session!.user.id}');
   } on AuthException catch (error) {
-    print('Sign in Error: ${error.message}');
+    print('Sign in error: ${error.message}');
   }
 
   await client.signOut();
   print('Logged out!');
-  return true;
 }

--- a/packages/gotrue/pubspec.yaml
+++ b/packages/gotrue/pubspec.yaml
@@ -3,7 +3,14 @@ description: A dart client library for the GoTrue API.
 version: 2.26.0
 homepage: "https://supabase.com"
 repository: "https://github.com/supabase/supabase-flutter/tree/main/packages/gotrue"
+issue_tracker: "https://github.com/supabase/supabase-flutter/issues"
 documentation: "https://supabase.com/docs/reference/dart/auth-signup"
+topics:
+  - supabase
+  - auth
+  - authentication
+  - backend
+  - api
 
 environment:
   sdk: ">=3.9.0 <4.0.0"

--- a/packages/postgrest/README.md
+++ b/packages/postgrest/README.md
@@ -1,9 +1,28 @@
-# Postgrest Dart
+<br />
+<p align="center">
+  <a href="https://supabase.com">
+    <img alt="Supabase Logo" width="300" src="https://raw.githubusercontent.com/supabase/supabase/master/packages/common/assets/images/logo-preview.jpg">
+  </a>
 
-Dart client for [PostgREST](https://postgrest.org). The goal of this library is to make an "ORM-like" restful interface.
+  <h1 align="center">postgrest</h1>
+
+  <p align="center">
+    Dart client library for <a href="https://postgrest.org">PostgREST</a>, providing an ORM-like interface to the <a href="https://supabase.com/docs/guides/database">Supabase database</a>.
+  </p>
+
+  <p align="center">
+    <a href="https://supabase.com/docs/guides/database">Guides</a>
+    ·
+    <a href="https://supabase.com/docs/reference/dart/select">Reference Docs</a>
+  </p>
+</p>
+
+<div align="center">
 
 [![pub package](https://img.shields.io/pub/v/postgrest.svg)](https://pub.dev/packages/postgrest)
-[![pub test](https://github.com/supabase/postgrest-dart/workflows/Test/badge.svg)](https://github.com/supabase/postgrest-dart/actions?query=workflow%3ATest)
+[![pub test](https://github.com/supabase/supabase-flutter/workflows/Test/badge.svg)](https://github.com/supabase/supabase-flutter/actions?query=workflow%3ATest)
+
+</div>
 
 ## Docs
 

--- a/packages/postgrest/example/main.dart
+++ b/packages/postgrest/example/main.dart
@@ -1,6 +1,6 @@
 import 'package:postgrest/postgrest.dart';
 
-/// Example to use with Supabase API https://supabase.io/
+/// Example to use with Supabase API https://supabase.com/
 dynamic main() async {
   const supabaseUrl = '';
   const supabaseKey = '';

--- a/packages/postgrest/pubspec.yaml
+++ b/packages/postgrest/pubspec.yaml
@@ -3,7 +3,14 @@ description: PostgREST client for Dart. This library provides an ORM interface t
 version: 2.8.0
 homepage: 'https://supabase.com'
 repository: 'https://github.com/supabase/supabase-flutter/tree/main/packages/postgrest'
+issue_tracker: 'https://github.com/supabase/supabase-flutter/issues'
 documentation: 'https://supabase.com/docs/reference/dart/select'
+topics:
+  - supabase
+  - postgrest
+  - database
+  - orm
+  - api
 
 environment:
   sdk: '>=3.9.0 <4.0.0'

--- a/packages/realtime_client/README.md
+++ b/packages/realtime_client/README.md
@@ -1,17 +1,34 @@
-# realtime_client
+<br />
+<p align="center">
+  <a href="https://supabase.com">
+    <img alt="Supabase Logo" width="300" src="https://raw.githubusercontent.com/supabase/supabase/master/packages/common/assets/images/logo-preview.jpg">
+  </a>
 
-Listens to changes in a PostgreSQL Database and via websockets.
+  <h1 align="center">realtime_client</h1>
 
-A dart client for Supabase [Realtime](https://github.com/supabase/realtime) server.
+  <p align="center">
+    Dart client library for <a href="https://supabase.com/docs/guides/realtime">Supabase Realtime</a>, to listen to changes in a PostgreSQL database over websockets.
+  </p>
+
+  <p align="center">
+    <a href="https://supabase.com/docs/guides/realtime">Guides</a>
+    ·
+    <a href="https://supabase.com/docs/reference/dart/subscribe">Reference Docs</a>
+  </p>
+</p>
+
+<div align="center">
 
 [![pub package](https://img.shields.io/pub/v/realtime_client.svg)](https://pub.dev/packages/realtime_client)
-[![pub test](https://github.com/supabase/realtime-dart/workflows/Test/badge.svg)](https://github.com/supabase/realtime-dart/actions?query=workflow%3ATest)
+[![pub test](https://github.com/supabase/supabase-flutter/workflows/Test/badge.svg)](https://github.com/supabase/supabase-flutter/actions?query=workflow%3ATest)
+
+</div>
 
 ## Docs
 
 The docs can be found on the official Supabase website.
 
-- [Dart reference](https://supabase.com/docs/reference/dart/stream)
+- [Dart reference](https://supabase.com/docs/reference/dart/subscribe)
 - [Realtime guide](https://supabase.com/docs/guides/realtime)
 
 ## Testing
@@ -33,10 +50,10 @@ dart test
 supabase stop
 ```
 
-## Credits
-
-- https://github.com/supabase/realtime-js - ported from realtime-js library
-
 ## License
 
 This repo is licensed under MIT.
+
+## Credits
+
+- https://github.com/supabase/realtime-js - ported from realtime-js library

--- a/packages/realtime_client/example/main.dart
+++ b/packages/realtime_client/example/main.dart
@@ -1,6 +1,6 @@
 import 'package:realtime_client/realtime_client.dart';
 
-/// Example to use with Supabase Realtime https://supabase.io/
+/// Example to use with Supabase Realtime https://supabase.com/
 Future<void> main() async {
   final socket = RealtimeClient(
     'ws://SUPABASE_API_ENDPOINT/realtime/v1',

--- a/packages/realtime_client/pubspec.yaml
+++ b/packages/realtime_client/pubspec.yaml
@@ -3,7 +3,14 @@ description: Listens to changes in a PostgreSQL Database and via websockets. Thi
 version: 2.11.0
 homepage: 'https://supabase.com'
 repository: 'https://github.com/supabase/supabase-flutter/tree/main/packages/realtime_client'
+issue_tracker: 'https://github.com/supabase/supabase-flutter/issues'
 documentation: 'https://supabase.com/docs/reference/dart/subscribe'
+topics:
+  - supabase
+  - realtime
+  - websocket
+  - database
+  - backend
 
 environment:
   sdk: '>=3.9.0 <4.0.0'

--- a/packages/storage_client/README.md
+++ b/packages/storage_client/README.md
@@ -1,18 +1,35 @@
-# storage_client
+<br />
+<p align="center">
+  <a href="https://supabase.com">
+    <img alt="Supabase Logo" width="300" src="https://raw.githubusercontent.com/supabase/supabase/master/packages/common/assets/images/logo-preview.jpg">
+  </a>
 
-Dart client library to interact with Supabase Storage.
+  <h1 align="center">storage_client</h1>
 
-- Documentation: https://supabase.io/docs/reference/dart/storage-createbucket
+  <p align="center">
+    Dart client library to interact with <a href="https://supabase.com/docs/guides/storage">Supabase Storage</a>.
+  </p>
+
+  <p align="center">
+    <a href="https://supabase.com/docs/guides/storage">Guides</a>
+    ·
+    <a href="https://supabase.com/docs/reference/dart/file-buckets-createbucket">Reference Docs</a>
+  </p>
+</p>
+
+<div align="center">
 
 [![pub package](https://img.shields.io/pub/v/storage_client.svg)](https://pub.dev/packages/storage_client)
-[![pub test](https://github.com/supabase/storage-dart/workflows/Test/badge.svg)](https://github.com/supabase/storage-dart/actions?query=workflow%3ATest)
+[![pub test](https://github.com/supabase/supabase-flutter/workflows/Test/badge.svg)](https://github.com/supabase/supabase-flutter/actions?query=workflow%3ATest)
+
+</div>
 
 ## Docs
 
 The docs can be found on the official Supabase website.
 
-- [Dart reference](https://supabase.com/docs/reference/dart/storage-createbucket)
-- [Realtime guide](https://supabase.com/docs/guides/storage)
+- [Dart reference](https://supabase.com/docs/reference/dart/file-buckets-createbucket)
+- [Storage guide](https://supabase.com/docs/guides/storage)
 
 ## License
 

--- a/packages/storage_client/pubspec.yaml
+++ b/packages/storage_client/pubspec.yaml
@@ -3,7 +3,14 @@ description: Dart client library to interact with Supabase Storage. Supabase Sto
 version: 2.6.0
 homepage: 'https://supabase.com'
 repository: 'https://github.com/supabase/supabase-flutter/tree/main/packages/storage_client'
-documentation: 'https://supabase.com/docs/reference/dart/storage-createbucket'
+issue_tracker: 'https://github.com/supabase/supabase-flutter/issues'
+documentation: 'https://supabase.com/docs/reference/dart/file-buckets-createbucket'
+topics:
+  - supabase
+  - storage
+  - s3
+  - files
+  - backend
 
 environment:
   sdk: '>=3.9.0 <4.0.0'

--- a/packages/supabase/README.md
+++ b/packages/supabase/README.md
@@ -1,6 +1,28 @@
-# supabase
+<br />
+<p align="center">
+  <a href="https://supabase.com">
+    <img alt="Supabase Logo" width="300" src="https://raw.githubusercontent.com/supabase/supabase/master/packages/common/assets/images/logo-preview.jpg">
+  </a>
 
-A Dart client for [Supabase](https://supabase.io/).
+  <h1 align="center">supabase</h1>
+
+  <p align="center">
+    Dart client library for <a href="https://supabase.com">Supabase</a>, for use in non-Flutter Dart environments.
+  </p>
+
+  <p align="center">
+    <a href="https://supabase.com/docs">Guides</a>
+    ·
+    <a href="https://supabase.com/docs/reference/dart/introduction">Reference Docs</a>
+  </p>
+</p>
+
+<div align="center">
+
+[![pub package](https://img.shields.io/pub/v/supabase.svg)](https://pub.dev/packages/supabase)
+[![pub test](https://github.com/supabase/supabase-flutter/workflows/Test/badge.svg)](https://github.com/supabase/supabase-flutter/actions?query=workflow%3ATest)
+
+</div>
 
 > **Note**
 >
@@ -8,14 +30,9 @@ A Dart client for [Supabase](https://supabase.io/).
 >
 > If you are developing a Flutter application, use [supabase_flutter](https://pub.dev/packages/supabase_flutter) instead. `supabase` package is for non-Flutter Dart environments.
 
-[![pub package](https://img.shields.io/pub/v/supabase.svg)](https://pub.dev/packages/supabase)
-[![pub test](https://github.com/supabase/supabase-dart/workflows/Test/badge.svg)](https://github.com/supabase/supabase-dart/actions?query=workflow%3ATest)
-
----
-
 ## What is Supabase
 
-[Supabase](https://supabase.io/docs/) is an open source Firebase alternative. We are a service to:
+[Supabase](https://supabase.com/docs) is an open source Firebase alternative. We are a service to:
 
 - listen to database changes
 - query your tables, including filtering, pagination, and deeply nested relationships (like GraphQL)
@@ -27,7 +44,7 @@ A Dart client for [Supabase](https://supabase.io/).
 
 The docs can be found on the official Supabase website.
 
-- [Dart reference](https://supabase.com/docs/reference/dart)
+- [Dart reference](https://supabase.com/docs/reference/dart/introduction)
 - [Supabase docs](https://supabase.com/docs)
 
 ## License

--- a/packages/supabase/example/README.md
+++ b/packages/supabase/example/README.md
@@ -1,6 +1,6 @@
 #### Examples
 
-- Flutter user management: https://github.com/supabase/supabase/tree/master/examples/flutter-user-management
+- Flutter user management: https://github.com/supabase/supabase/tree/master/examples/user-management/flutter-user-management
 - Extended flutter user management with web support, github login, recovery password flow
   - https://github.com/phamhieu/supabase-flutter-demo
 - Spot, open source geo based video sharing social app created with Flutter

--- a/packages/supabase/pubspec.yaml
+++ b/packages/supabase/pubspec.yaml
@@ -3,7 +3,14 @@ description: A dart client for Supabase. This client makes it simple for develop
 version: 2.14.0
 homepage: 'https://supabase.com'
 repository: 'https://github.com/supabase/supabase-flutter/tree/main/packages/supabase'
+issue_tracker: 'https://github.com/supabase/supabase-flutter/issues'
 documentation: 'https://supabase.com/docs/reference/dart/introduction'
+topics:
+  - supabase
+  - backend
+  - database
+  - auth
+  - api
 
 environment:
   sdk: '>=3.9.0 <4.0.0'

--- a/packages/supabase_flutter/pubspec.yaml
+++ b/packages/supabase_flutter/pubspec.yaml
@@ -3,7 +3,14 @@ description: Flutter integration for Supabase. This package makes it simple for 
 version: 2.16.0
 homepage: 'https://supabase.com'
 repository: 'https://github.com/supabase/supabase-flutter/tree/main/packages/supabase_flutter'
+issue_tracker: 'https://github.com/supabase/supabase-flutter/issues'
 documentation: 'https://supabase.com/docs/reference/dart/introduction'
+topics:
+  - supabase
+  - flutter
+  - backend
+  - auth
+  - database
 
 environment:
   sdk: '>=3.9.0 <4.0.0'

--- a/packages/supabase_lints/README.md
+++ b/packages/supabase_lints/README.md
@@ -1,7 +1,24 @@
-# supabase_lints
+<br />
+<p align="center">
+  <a href="https://supabase.com">
+    <img alt="Supabase Logo" width="300" src="https://raw.githubusercontent.com/supabase/supabase/master/packages/common/assets/images/logo-preview.jpg">
+  </a>
 
-Shared analyzer and [DCM](https://dcm.dev) lint configuration for the Supabase
-Flutter packages. It is meant for internal use across this monorepo.
+  <h1 align="center">supabase_lints</h1>
+
+  <p align="center">
+    Shared analyzer and <a href="https://dcm.dev">DCM</a> lint configuration for the Supabase Flutter packages.
+  </p>
+</p>
+
+<div align="center">
+
+[![pub package](https://img.shields.io/pub/v/supabase_lints.svg)](https://pub.dev/packages/supabase_lints)
+[![pub test](https://github.com/supabase/supabase-flutter/workflows/Test/badge.svg)](https://github.com/supabase/supabase-flutter/actions?query=workflow%3ATest)
+
+</div>
+
+This package is meant for internal use across this monorepo.
 
 ## Usage
 
@@ -29,3 +46,7 @@ include: package:supabase_lints/analysis_options_flutter.yaml
 Both configurations enable the DCM `recommended` preset. Rules that the existing
 codebase does not yet pass are disabled in `analysis_options.yaml` and are
 re-enabled one by one as the violations get fixed.
+
+## License
+
+This repo is licensed under MIT.

--- a/packages/supabase_lints/pubspec.yaml
+++ b/packages/supabase_lints/pubspec.yaml
@@ -3,6 +3,11 @@ description: Shared analyzer and DCM lint configuration for the Supabase Flutter
 version: 0.1.0
 homepage: "https://supabase.com"
 repository: "https://github.com/supabase/supabase-flutter/tree/main/packages/supabase_lints"
+issue_tracker: "https://github.com/supabase/supabase-flutter/issues"
+topics:
+  - lints
+  - analysis
+  - supabase
 
 environment:
   sdk: ">=3.9.0 <4.0.0"

--- a/packages/yet_another_json_isolate/README.md
+++ b/packages/yet_another_json_isolate/README.md
@@ -1,6 +1,22 @@
-# Yet Another Json Isolate
+<br />
+<p align="center">
+  <a href="https://supabase.com">
+    <img alt="Supabase Logo" width="300" src="https://raw.githubusercontent.com/supabase/supabase/master/packages/common/assets/images/logo-preview.jpg">
+  </a>
 
-Dart package for simple JSON parsing using isolates, because the world can never have enough JSON parsers.
+  <h1 align="center">yet_another_json_isolate</h1>
+
+  <p align="center">
+    Simplify and improve JSON parsing in isolates by keeping one isolate running per instance.
+  </p>
+</p>
+
+<div align="center">
+
+[![pub package](https://img.shields.io/pub/v/yet_another_json_isolate.svg)](https://pub.dev/packages/yet_another_json_isolate)
+[![pub test](https://github.com/supabase/supabase-flutter/workflows/Test/badge.svg)](https://github.com/supabase/supabase-flutter/actions?query=workflow%3ATest)
+
+</div>
 
 ## Usage
 
@@ -17,3 +33,7 @@ final json = await isolate.decode(responseBody);
 // dispose when no longer needed
 isolate.dispose();
 ```
+
+## License
+
+This repo is licensed under MIT.

--- a/packages/yet_another_json_isolate/pubspec.yaml
+++ b/packages/yet_another_json_isolate/pubspec.yaml
@@ -1,7 +1,14 @@
 name: yet_another_json_isolate
 description: Package to simplify and improve JSON parsing in isolates by keeping one isolate running per instance.
 version: 2.1.1
-homepage: https://github.com/supabase-community/json-isolate-dart
+homepage: 'https://supabase.com'
+repository: 'https://github.com/supabase/supabase-flutter/tree/main/packages/yet_another_json_isolate'
+issue_tracker: 'https://github.com/supabase/supabase-flutter/issues'
+topics:
+  - json
+  - isolate
+  - parsing
+  - async
 
 environment:
   sdk: '>=3.9.0 <4.0.0'


### PR DESCRIPTION
## What

Housekeeping pass over every package to make the published pub.dev metadata and supporting files consistent and correct.

### pubspec.yaml (all packages)
- Add `topics` (pub.dev tags) to every package.
- Add `issue_tracker` pointing to the monorepo issues.
- Fix `yet_another_json_isolate` metadata that pointed at the stale `supabase-community/json-isolate-dart` repo (`homepage`/`repository`/`issue_tracker`).
- Fix the broken `documentation` link in `storage_client` (`storage-createbucket` → `file-buckets-createbucket`).

### READMEs
- Standardize every package README to the same header format as `supabase_flutter` (logo, title, description, `Guides · Reference Docs`, badges).
- Fix stale badge URLs that pointed at archived per-package repos (`gotrue-dart`, `postgrest-dart`, `realtime-dart`, `storage-dart`, `supabase-dart`) to the monorepo.
- Use the Supabase wordmark logo (`logo-preview.jpg`). A single `<img>` is used instead of a `<picture>` element because pub.dev does not honor `<picture>` / `prefers-color-scheme`, which would leave a white-text logo invisible on pub.dev's light background. See dart-lang/pub-dev#6363. The `logo-preview.jpg` asset has a dark card baked in, so it stays visible on both light and dark backgrounds.
- Add missing `License` sections to `yet_another_json_isolate` and `supabase_lints`.

### Examples
- Replace the empty `functions_client` example with a real invoke example.
- Fix the misspelled `annonToken` variable and align naming in the `gotrue` example.
- Update stale `supabase.io` comment URLs to `supabase.com`.
- Fix a 404 link in the `supabase` example README.

### Not touched
- CHANGELOG files (auto-generated by release tooling).
- LICENSE files (verified, all MIT).

## Notes
- Related upstream issue: dart-lang/pub-dev#6363 (pub.dev support for `<picture>` / `prefers-color-scheme`).

Resolves SDK-1246
