### PR TITLE
fix(storage): make storage_client WASM-compatible

### DIFF
--- a/packages/storage_client/lib/src/fetch.dart
+++ b/packages/storage_client/lib/src/fetch.dart
@@ -11,7 +11,7 @@ import 'package:mime/mime.dart';
 import 'package:retry/retry.dart';
 import 'package:storage_client/src/types.dart';
 
-import 'file_io.dart' if (dart.library.js) './file_stub.dart';
+import 'file_stub.dart' if (dart.library.io) './file_io.dart';
 
 class Fetch {
   final Client? httpClient;

--- a/packages/storage_client/lib/src/storage_file_api.dart
+++ b/packages/storage_client/lib/src/storage_file_api.dart
@@ -3,7 +3,7 @@ import 'dart:typed_data';
 import 'package:storage_client/src/fetch.dart';
 import 'package:storage_client/src/types.dart';
 
-import 'file_io.dart' if (dart.library.js) './file_stub.dart';
+import 'file_stub.dart' if (dart.library.io) './file_io.dart';
 
 class StorageFileApi {
   final String url;


### PR DESCRIPTION
## What

Fixes the WASM incompatibility that lowers `storage_client`'s pub.dev platform support score (partial 10/20 with the note "Package not compatible with runtime wasm").

## Why

Two conditional imports were gated on `dart.library.js`:

```dart
import 'file_io.dart' if (dart.library.js) './file_stub.dart';
```

`dart.library.js` refers to the **legacy** JS library, which is **not** defined under WASM (WASM exposes `dart.library.js_interop`). So a WASM build evaluates the condition to `false` and falls through to the default `file_io.dart`, which does `export 'dart:io' show File;`. `dart:io` is unavailable on web, so WASM compilation fails.

## How

Invert the conditional to the WASM-safe pattern already used by the other packages (`platform_stub` / `dart.library.io`): default to the stub, and only import `dart:io` when it actually exists.

```dart
import 'file_stub.dart' if (dart.library.io) './file_io.dart';
```

- WASM / web: `dart.library.io` is false → uses `file_stub.dart` (no `dart:io`)
- Native (VM, mobile, desktop): `dart.library.io` is true → uses `file_io.dart`

`storage_client` is a transitive dependency of `supabase` and `supabase_flutter`, so this clears the WASM incompatibility for those too.

## Verification

- `dart analyze` passes clean
- `pana` now reports: **WASM-ready: This package is compatible with runtime `wasm`.**