### PR TITLE
feat(functions): expose FunctionsFetchException/FunctionsRelayException/FunctionsHttpException subtypes

### DIFF
--- a/packages/functions_client/lib/src/functions_client.dart
+++ b/packages/functions_client/lib/src/functions_client.dart
@@ -165,7 +165,7 @@ class FunctionsClient {
     try {
       response = await (_httpClient?.send(request) ?? request.send());
     } catch (error) {
-      throw FunctionsFetchError(details: error);
+      throw FunctionsFetchException(details: error);
     }
     final responseType =
         (response.headers['Content-Type'] ??
@@ -219,13 +219,13 @@ class FunctionsClient {
       return FunctionResponse(data: data, status: response.statusCode);
     }
     if (isRelayError) {
-      throw FunctionsRelayError(
+      throw FunctionsRelayException(
         status: response.statusCode,
         details: data,
         reasonPhrase: response.reasonPhrase,
       );
     }
-    throw FunctionsHttpError(
+    throw FunctionsHttpException(
       status: response.statusCode,
       details: data,
       reasonPhrase: response.reasonPhrase,

--- a/packages/functions_client/lib/src/functions_client.dart
+++ b/packages/functions_client/lib/src/functions_client.dart
@@ -161,7 +161,12 @@ class FunctionsClient {
 
     _log.finest('Request: ${request.method} ${request.url} ${request.headers}');
 
-    final response = await (_httpClient?.send(request) ?? request.send());
+    final http.StreamedResponse response;
+    try {
+      response = await (_httpClient?.send(request) ?? request.send());
+    } catch (error) {
+      throw FunctionsFetchError(details: error);
+    }
     final responseType =
         (response.headers['Content-Type'] ??
                 response.headers['content-type'] ??
@@ -170,8 +175,11 @@ class FunctionsClient {
             .trim()
             .toLowerCase();
 
+    final isRelayError = response.headers['x-relay-error'] == 'true';
     final isSuccessStatus =
-        200 <= response.statusCode && response.statusCode < 300;
+        200 <= response.statusCode &&
+        response.statusCode < 300 &&
+        !isRelayError;
 
     final dynamic data;
 
@@ -210,7 +218,14 @@ class FunctionsClient {
     if (isSuccessStatus) {
       return FunctionResponse(data: data, status: response.statusCode);
     }
-    throw FunctionException(
+    if (isRelayError) {
+      throw FunctionsRelayError(
+        status: response.statusCode,
+        details: data,
+        reasonPhrase: response.reasonPhrase,
+      );
+    }
+    throw FunctionsHttpError(
       status: response.statusCode,
       details: data,
       reasonPhrase: response.reasonPhrase,

--- a/packages/functions_client/lib/src/types.dart
+++ b/packages/functions_client/lib/src/types.dart
@@ -47,8 +47,8 @@ class FunctionException implements Exception {
 ///
 /// The originating error is available in [details] and [status] is `0` since no
 /// response reached the client.
-class FunctionsFetchError extends FunctionException {
-  const FunctionsFetchError({
+class FunctionsFetchException extends FunctionException {
+  const FunctionsFetchException({
     super.details,
     super.reasonPhrase,
   }) : super(status: 0);
@@ -56,8 +56,8 @@ class FunctionsFetchError extends FunctionException {
 
 /// Thrown when the Supabase relay returns an error while invoking the Edge
 /// Function, indicated by the `x-relay-error` response header.
-class FunctionsRelayError extends FunctionException {
-  const FunctionsRelayError({
+class FunctionsRelayException extends FunctionException {
+  const FunctionsRelayException({
     required super.status,
     super.details,
     super.reasonPhrase,
@@ -65,8 +65,8 @@ class FunctionsRelayError extends FunctionException {
 }
 
 /// Thrown when the Edge Function itself responds with a non-2xx status code.
-class FunctionsHttpError extends FunctionException {
-  const FunctionsHttpError({
+class FunctionsHttpException extends FunctionException {
+  const FunctionsHttpException({
     required super.status,
     super.details,
     super.reasonPhrase,

--- a/packages/functions_client/lib/src/types.dart
+++ b/packages/functions_client/lib/src/types.dart
@@ -39,5 +39,36 @@ class FunctionException implements Exception {
 
   @override
   String toString() =>
-      'FunctionException(status: $status, details: $details, reasonPhrase: $reasonPhrase)';
+      '$runtimeType(status: $status, details: $details, reasonPhrase: $reasonPhrase)';
+}
+
+/// Thrown when the request to the Edge Function could not be sent, for example
+/// because of a network or transport failure, before any response was received.
+///
+/// The originating error is available in [details] and [status] is `0` since no
+/// response reached the client.
+class FunctionsFetchError extends FunctionException {
+  const FunctionsFetchError({
+    super.details,
+    super.reasonPhrase,
+  }) : super(status: 0);
+}
+
+/// Thrown when the Supabase relay returns an error while invoking the Edge
+/// Function, indicated by the `x-relay-error` response header.
+class FunctionsRelayError extends FunctionException {
+  const FunctionsRelayError({
+    required super.status,
+    super.details,
+    super.reasonPhrase,
+  });
+}
+
+/// Thrown when the Edge Function itself responds with a non-2xx status code.
+class FunctionsHttpError extends FunctionException {
+  const FunctionsHttpError({
+    required super.status,
+    super.details,
+    super.reasonPhrase,
+  });
 }

--- a/packages/functions_client/test/custom_http_client.dart
+++ b/packages/functions_client/test/custom_http_client.dart
@@ -15,7 +15,21 @@ class CustomHttpClient extends BaseClient {
     receivedRequests = receivedRequests..add(request);
     request.finalize();
 
-    if (request.url.path.endsWith("error-function")) {
+    if (request.url.path.endsWith('network-error')) {
+      // Simulate a transport failure before any response is received.
+      throw ClientException('Connection failed', request.url);
+    } else if (request.url.path.endsWith('relay-error')) {
+      return StreamedResponse(
+        Stream.value(utf8.encode(jsonEncode({"error": "relay down"}))),
+        500,
+        request: request,
+        headers: {
+          "Content-Type": "application/json",
+          "x-relay-error": "true",
+        },
+        reasonPhrase: "Internal Server Error",
+      );
+    } else if (request.url.path.endsWith("error-function")) {
       //Return custom status code to check for usage of this client.
       return StreamedResponse(
         Stream.value(utf8.encode(jsonEncode({"key": "Hello World"}))),

--- a/packages/functions_client/test/functions_dart_test.dart
+++ b/packages/functions_client/test/functions_dart_test.dart
@@ -26,16 +26,16 @@ void main() {
       await expectLater(
         () => functionsCustomHttpClient.invoke('error-function'),
         throwsA(
-          isA<FunctionsHttpError>().having((e) => e.status, 'status', 420),
+          isA<FunctionsHttpException>().having((e) => e.status, 'status', 420),
         ),
       );
     });
 
-    test('a non-2xx response throws a FunctionsHttpError', () async {
+    test('a non-2xx response throws a FunctionsHttpException', () async {
       await expectLater(
         () => functionsCustomHttpClient.invoke('error-function'),
         throwsA(
-          isA<FunctionsHttpError>()
+          isA<FunctionsHttpException>()
               .having((e) => e.status, 'status', 420)
               .having(
                 (e) => e.reasonPhrase,
@@ -47,22 +47,22 @@ void main() {
       );
     });
 
-    test('a relay error throws a FunctionsRelayError', () async {
+    test('a relay error throws a FunctionsRelayException', () async {
       await expectLater(
         () => functionsCustomHttpClient.invoke('relay-error'),
         throwsA(
-          isA<FunctionsRelayError>()
+          isA<FunctionsRelayException>()
               .having((e) => e.status, 'status', 500)
               .having((e) => e.details, 'details', {'error': 'relay down'}),
         ),
       );
     });
 
-    test('a transport failure throws a FunctionsFetchError', () async {
+    test('a transport failure throws a FunctionsFetchException', () async {
       await expectLater(
         () => functionsCustomHttpClient.invoke('network-error'),
         throwsA(
-          isA<FunctionsFetchError>()
+          isA<FunctionsFetchException>()
               .having((e) => e.status, 'status', 0)
               .having((e) => e.details, 'details', isA<ClientException>()),
         ),

--- a/packages/functions_client/test/functions_dart_test.dart
+++ b/packages/functions_client/test/functions_dart_test.dart
@@ -26,8 +26,57 @@ void main() {
       await expectLater(
         () => functionsCustomHttpClient.invoke('error-function'),
         throwsA(
-          isA<FunctionException>().having((e) => e.status, 'status', 420),
+          isA<FunctionsHttpError>().having((e) => e.status, 'status', 420),
         ),
+      );
+    });
+
+    test('a non-2xx response throws a FunctionsHttpError', () async {
+      await expectLater(
+        () => functionsCustomHttpClient.invoke('error-function'),
+        throwsA(
+          isA<FunctionsHttpError>()
+              .having((e) => e.status, 'status', 420)
+              .having(
+                (e) => e.reasonPhrase,
+                'reasonPhrase',
+                'Enhance Your Calm',
+              )
+              .having((e) => e.details, 'details', {'key': 'Hello World'}),
+        ),
+      );
+    });
+
+    test('a relay error throws a FunctionsRelayError', () async {
+      await expectLater(
+        () => functionsCustomHttpClient.invoke('relay-error'),
+        throwsA(
+          isA<FunctionsRelayError>()
+              .having((e) => e.status, 'status', 500)
+              .having((e) => e.details, 'details', {'error': 'relay down'}),
+        ),
+      );
+    });
+
+    test('a transport failure throws a FunctionsFetchError', () async {
+      await expectLater(
+        () => functionsCustomHttpClient.invoke('network-error'),
+        throwsA(
+          isA<FunctionsFetchError>()
+              .having((e) => e.status, 'status', 0)
+              .having((e) => e.details, 'details', isA<ClientException>()),
+        ),
+      );
+    });
+
+    test('the subtypes remain catchable as FunctionException', () async {
+      await expectLater(
+        () => functionsCustomHttpClient.invoke('relay-error'),
+        throwsA(isA<FunctionException>()),
+      );
+      await expectLater(
+        () => functionsCustomHttpClient.invoke('network-error'),
+        throwsA(isA<FunctionException>()),
       );
     });
 

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -465,7 +465,15 @@ features:
   realtime.configuration.deferred_disconnect: not_implemented
 
   # functions
-  functions.invocation.invoke: implemented
+  functions.invocation.invoke:
+    status: implemented
+    symbols:
+      - FunctionsFetchError
+      - FunctionsFetchError.FunctionsFetchError
+      - FunctionsRelayError
+      - FunctionsRelayError.FunctionsRelayError
+      - FunctionsHttpError
+      - FunctionsHttpError.FunctionsHttpError
   functions.invocation.set_auth_token: implemented
   functions.invocation.method_override: implemented
   functions.invocation.streaming_response: implemented

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -468,12 +468,12 @@ features:
   functions.invocation.invoke:
     status: implemented
     symbols:
-      - FunctionsFetchError
-      - FunctionsFetchError.FunctionsFetchError
-      - FunctionsRelayError
-      - FunctionsRelayError.FunctionsRelayError
-      - FunctionsHttpError
-      - FunctionsHttpError.FunctionsHttpError
+      - FunctionsFetchException
+      - FunctionsFetchException.FunctionsFetchException
+      - FunctionsRelayException
+      - FunctionsRelayException.FunctionsRelayException
+      - FunctionsHttpException
+      - FunctionsHttpException.FunctionsHttpException
   functions.invocation.set_auth_token: implemented
   functions.invocation.method_override: implemented
   functions.invocation.streaming_response: implemented

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -465,9 +465,7 @@ features:
   realtime.configuration.deferred_disconnect: not_implemented
 
   # functions
-  functions.invocation.invoke:
-    status: partially_implemented
-    note: "Invocation works, but errors surface as a single FunctionException; the FunctionsFetchError/FunctionsRelayError/FunctionsHttpError distinction is not exposed."
+  functions.invocation.invoke: implemented
   functions.invocation.set_auth_token: implemented
   functions.invocation.method_override: implemented
   functions.invocation.streaming_response: implemented


### PR DESCRIPTION
## What

Introduces three error subtypes as subclasses of the existing `FunctionException`, so consumers can match on the failure mode:

- **`FunctionsFetchException`** — network/transport failure reaching the function, before any response is received. The originating error is available in `details`; `status` is `0`.
- **`FunctionsRelayException`** — error returned by the relay, detected via the `x-relay-error: true` response header.
- **`FunctionsHttpException`** — non-2xx response from the function itself.

`invoke()` now throws the appropriate subtype depending on the failure mode.

## Naming

The subtypes use the `Exception` suffix (not `Error`) to follow Dart's `Error`/`Exception` distinction: they are meant to be caught, extend `FunctionException` (which implements `Exception`), and wrap an underlying `ClientException`. This also keeps them consistent with the base class name.

## Why non-breaking

Existing `catch` blocks that catch `FunctionException` continue to work unchanged; the new subtypes only refine the type consumers can optionally match on. No existing signature or default behavior changes. `toString()` now uses `\$runtimeType` so subtypes print their own name.

A follow-up for making `FunctionException` a `sealed` class (breaking, enabling exhaustive `switch`) is tracked in #1550 for v3.

## Tests

Added `network-error` and `relay-error` fixtures to the custom HTTP client, plus cases asserting each subtype is thrown, that `status`/`details`/`reasonPhrase` are populated, and that the subtypes remain catchable as `FunctionException`.

Closes SDK-1258