### PR TITLE
feat(gotrue): add channel parameter to mfa.challenge()

### DIFF
--- a/packages/gotrue/lib/src/gotrue_mfa_api.dart
+++ b/packages/gotrue/lib/src/gotrue_mfa_api.dart
@@ -132,8 +132,12 @@ class GoTrueMFAApi {
   /// Prepares a challenge used to verify that a user has access to a MFA factor.
   ///
   /// [factorId] System assigned identifier for authenticator device as returned by enroll
+  ///
+  /// [channel] Messaging channel to use for phone factors (e.g. whatsapp or sms).
+  /// Defaults to the server's behavior (sms) when omitted.
   Future<AuthMFAChallengeResponse> challenge({
     required String factorId,
+    OtpChannel? channel,
   }) async {
     final session = _client.currentSession;
 
@@ -142,6 +146,7 @@ class GoTrueMFAApi {
       RequestMethodType.post,
       options: GotrueRequestOptions(
         headers: _client._headers,
+        body: channel == null ? null : {'channel': channel.name},
         jwt: session?.accessToken,
       ),
     );

--- a/packages/gotrue/test/mfa_challenge_mock_test.dart
+++ b/packages/gotrue/test/mfa_challenge_mock_test.dart
@@ -1,0 +1,76 @@
+import 'dart:convert';
+
+import 'package:gotrue/gotrue.dart';
+import 'package:http/http.dart';
+import 'package:test/test.dart';
+
+import 'utils.dart';
+
+/// Captures the body sent to the MFA challenge endpoint and returns a valid
+/// challenge response.
+class MfaChallengeMockClient extends BaseClient {
+  Map<String, dynamic>? lastChallengeBody;
+
+  @override
+  Future<StreamedResponse> send(BaseRequest request) async {
+    if (request is Request && request.url.path.endsWith('/challenge')) {
+      try {
+        lastChallengeBody = json.decode(request.body) as Map<String, dynamic>;
+      } catch (_) {
+        // Ignore non-JSON bodies.
+      }
+    }
+
+    return StreamedResponse(
+      Stream.value(
+        utf8.encode(
+          jsonEncode({
+            'id': 'mock-challenge-id',
+            'type': 'phone',
+            'expires_at': 9999999999,
+          }),
+        ),
+      ),
+      200,
+      request: request,
+    );
+  }
+}
+
+void main() {
+  late GoTrueClient client;
+  late MfaChallengeMockClient mockClient;
+
+  setUp(() {
+    mockClient = MfaChallengeMockClient();
+    client = GoTrueClient(
+      url: 'https://example.com',
+      httpClient: mockClient,
+      asyncStorage: TestAsyncStorage(),
+    );
+  });
+
+  test('challenge() omits the channel by default', () async {
+    await client.mfa.challenge(factorId: 'factor-id');
+
+    expect(mockClient.lastChallengeBody?.containsKey('channel'), isFalse);
+  });
+
+  test('challenge() forwards the whatsapp channel', () async {
+    await client.mfa.challenge(
+      factorId: 'factor-id',
+      channel: OtpChannel.whatsapp,
+    );
+
+    expect(mockClient.lastChallengeBody?['channel'], 'whatsapp');
+  });
+
+  test('challenge() forwards the sms channel', () async {
+    await client.mfa.challenge(
+      factorId: 'factor-id',
+      channel: OtpChannel.sms,
+    );
+
+    expect(mockClient.lastChallengeBody?['channel'], 'sms');
+  });
+}

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -78,9 +78,7 @@ features:
   auth.mfa.enroll:
     status: partially_implemented
     note: "Supports totp and phone factor types only; webauthn enrollment is handled via the separate passkey API."
-  auth.mfa.challenge:
-    status: partially_implemented
-    note: "No channel parameter (sms/whatsapp) for phone factors; always uses SMS."
+  auth.mfa.challenge: implemented
   auth.mfa.verify: implemented
   auth.mfa.challenge_and_verify: implemented
   auth.mfa.unenroll: implemented


### PR DESCRIPTION
## What

Adds an optional `channel` parameter (`sms` / `whatsapp`) to `GoTrueMFAApi.challenge()` for phone factors, matching supabase-js.

```dart
await supabase.auth.mfa.challenge(
  factorId: factorId,
  channel: OtpChannel.whatsapp,
);
```

## Why

Parity gap tracked in `sdk-compliance.yaml` (`auth.mfa.challenge` was `partially_implemented`): there was no way to pick the messaging channel for phone MFA challenges, so it always used SMS.

## How

- Reuses the existing `OtpChannel` enum (already used by `signInWithOtp`, `signUp`, `resend`) instead of introducing a new type.
- The parameter is nullable and only added to the request body when provided, so when omitted the server's existing SMS default applies. This keeps the change non-breaking; existing callers send the exact same request as before.
- Updated `sdk-compliance.yaml` to mark `auth.mfa.challenge` as `implemented`.

## Tests

Added `packages/gotrue/test/mfa_challenge_mock_test.dart` covering the default (no channel), `whatsapp`, and `sms` cases via a mock HTTP client that asserts the forwarded request body.

Resolves SDK-1260.
