### PR TITLE
ci: bump melos to ^8.2.0

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -516,10 +516,10 @@ packages:
     dependency: "direct dev"
     description:
       name: melos
-      sha256: "96f91b87dee9f9e5ad2bb6545cb0d7fb75fd43315fba0b9a0e8f37b2238f3078"
+      sha256: "78817a26b8f8dd6e5d4f85da2347da296516dae9664c894e5b887b10bc4aefa0"
       url: "https://pub.dev"
     source: hosted
-    version: "8.1.0"
+    version: "8.2.0"
   meta:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,7 +21,7 @@ workspace:
   - examples/passkeys
 
 dev_dependencies:
-  melos: ^8.1.0
+  melos: ^8.2.0
 
 melos:
   command:


### PR DESCRIPTION
## What

Bumps the `melos` dev_dependency from `^8.1.0` to `^8.2.0` and updates `pubspec.lock` accordingly.

## Why

The "Detect affected packages" CI job runs `dart pub global activate melos` (now 8.2.0) on a Dart-only runner. When the committed lock pinned 8.1.0, the version mismatch made cli_launcher relaunch the pinned melos via `dart run`, whose implicit `dart pub get` fails on this Flutter pub-workspace:

```
Because passkeys_example requires the Flutter SDK, version solving failed.
Flutter users should use `flutter pub` instead of `dart pub`.
```

Keeping the pin in sync with the released version means global == local, so no relaunch happens and the Dart-only job resolves cleanly.

The underlying launcher issue is fixed separately in cli_launcher (relaunch via `flutter pub run` for Flutter workspaces).