### PR TITLE
fix(storage): guard against empty transform routing through render endpoint

### DIFF
--- a/packages/storage_client/lib/src/storage_file_api.dart
+++ b/packages/storage_client/lib/src/storage_file_api.dart
@@ -487,13 +487,14 @@ class StorageFileApi {
     TransformOptions? transform,
     Map<String, String>? queryParams,
   }) async {
-    final wantsTransformations = transform != null;
+    final transformationQuery = transform?.toQueryParams ?? {};
+    final wantsTransformations = transformationQuery.isNotEmpty;
     final finalPath = _getFinalPath(path);
     final renderPath = wantsTransformations
         ? 'render/image/authenticated'
         : 'object';
 
-    Map<String, String> query = transform?.toQueryParams ?? {};
+    Map<String, String> query = transformationQuery;
     query.addAll(queryParams ?? {});
 
     final options = FetchOptions(headers: headers, noResolveJson: true);
@@ -556,13 +557,16 @@ class StorageFileApi {
   }) {
     final finalPath = _getFinalPath(path);
 
-    final wantsTransformation = transform != null;
-    final renderPath = wantsTransformation ? 'render/image' : 'object';
     final transformationQuery = transform?.toQueryParams;
+    final wantsTransformation =
+        transformationQuery != null && transformationQuery.isNotEmpty;
+    final renderPath = wantsTransformation ? 'render/image' : 'object';
 
     var publicUrl = Uri.parse('$url/$renderPath/public/$finalPath');
 
-    publicUrl = publicUrl.replace(queryParameters: transformationQuery);
+    if (wantsTransformation) {
+      publicUrl = publicUrl.replace(queryParameters: transformationQuery);
+    }
 
     return _withDownload(publicUrl.toString(), download);
   }

--- a/packages/storage_client/test/basic_test.dart
+++ b/packages/storage_client/test/basic_test.dart
@@ -309,6 +309,55 @@ void main() {
       expect(response, '$objectUrl/public/files/b.txt');
     });
 
+    test('getPublicUrl with empty transform does not use render endpoint', () {
+      final response = client
+          .from('files')
+          .getPublicUrl('b.txt', transform: const TransformOptions());
+      expect(response, '$objectUrl/public/files/b.txt');
+      expect(response, isNot(contains('/render/image/')));
+    });
+
+    test('getPublicUrl with actual transform uses render endpoint', () {
+      final response = client
+          .from('files')
+          .getPublicUrl('b.txt', transform: const TransformOptions(width: 200));
+      expect(
+        response,
+        '$supabaseUrl/storage/v1/render/image/public/files/b.txt?width=200',
+      );
+    });
+
+    test('download with empty transform does not use render endpoint', () async {
+      final file = File('a.txt');
+      file.writeAsStringSync('Updated content');
+      customHttpClient.response = file.readAsBytesSync();
+
+      await client
+          .from('public_bucket')
+          .download('b.txt', transform: const TransformOptions());
+
+      final request = customHttpClient.receivedRequests.first;
+      expect(request.url.toString(), contains('/object/public_bucket/b.txt'));
+      expect(request.url.toString(), isNot(contains('/render/image/')));
+    });
+
+    test('download with actual transform uses render endpoint', () async {
+      final file = File('a.txt');
+      file.writeAsStringSync('Updated content');
+      customHttpClient.response = file.readAsBytesSync();
+
+      await client
+          .from('public_bucket')
+          .download('b.txt', transform: const TransformOptions(width: 200));
+
+      final request = customHttpClient.receivedRequests.first;
+      expect(
+        request.url.toString(),
+        contains('/render/image/authenticated/public_bucket/b.txt'),
+      );
+      expect(request.url.queryParameters, {'width': '200'});
+    });
+
     test('createSignedUrl appends download to the token query', () async {
       customHttpClient.response = {
         'signedURL': '/object/sign/public/b.txt?token=abc',

--- a/packages/storage_client/test/basic_test.dart
+++ b/packages/storage_client/test/basic_test.dart
@@ -327,19 +327,22 @@ void main() {
       );
     });
 
-    test('download with empty transform does not use render endpoint', () async {
-      final file = File('a.txt');
-      file.writeAsStringSync('Updated content');
-      customHttpClient.response = file.readAsBytesSync();
+    test(
+      'download with empty transform does not use render endpoint',
+      () async {
+        final file = File('a.txt');
+        file.writeAsStringSync('Updated content');
+        customHttpClient.response = file.readAsBytesSync();
 
-      await client
-          .from('public_bucket')
-          .download('b.txt', transform: const TransformOptions());
+        await client
+            .from('public_bucket')
+            .download('b.txt', transform: const TransformOptions());
 
-      final request = customHttpClient.receivedRequests.first;
-      expect(request.url.toString(), contains('/object/public_bucket/b.txt'));
-      expect(request.url.toString(), isNot(contains('/render/image/')));
-    });
+        final request = customHttpClient.receivedRequests.first;
+        expect(request.url.toString(), contains('/object/public_bucket/b.txt'));
+        expect(request.url.toString(), isNot(contains('/render/image/')));
+      },
+    );
 
     test('download with actual transform uses render endpoint', () async {
       final file = File('a.txt');


### PR DESCRIPTION
## Summary

An empty or default `TransformOptions()` was routing `download()` and `getPublicUrl()` through the `/render/image/` endpoint unnecessarily. Previously the decision was based on `transform != null`, so any `TransformOptions` instance, even one with all-null fields, switched to the render path. Now routing only switches to the render endpoint when the transform options actually produce query parameters.

**Outcome:** implemented (bug fix)

## Behavior

- `download(path)` without transform uses `/object/` endpoint
- `download(path, transform: TransformOptions())` with empty transform uses `/object/` endpoint
- `download(path, transform: TransformOptions(width: 200))` uses `/render/image/authenticated/` endpoint
- Same logic for `getPublicUrl()`

## Tests

Added unit tests in `packages/storage_client/test/basic_test.dart` covering empty vs actual transform routing for both `download()` and `getPublicUrl()`. All storage_client unit tests pass.

## Reference

- Linear: SDK-878
- supabase-js PR: https://github.com/supabase/supabase-js/pull/2219 (commit `993bb5fc`)

## Compliance matrix

`storage.file_buckets.download_with_transform` and `storage.file_buckets.get_public_url` remain `implemented`; this fix brings their routing behavior in line with supabase-js, so no status change was required.