### PR TITLE
chore(database): mark request_timeout parity as not_applicable

### DIFF
--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -10,6 +10,9 @@
 #   - partially_implemented present but with a behavioral difference or gap vs
 #                           supabase-js; a note describes the difference.
 #   - not_implemented       not available.
+#   - not_applicable        does not map onto Dart/Flutter; the only faithful
+#                           implementation would add no real capability. A note
+#                           explains why.
 #
 # Verified against the source in this repository (packages/gotrue, postgrest,
 # storage_client, realtime_client, functions_client, supabase, supabase_flutter).
@@ -338,7 +341,9 @@ features:
   database.configuration.auto_retry:
     status: partially_implemented
     note: "Retries GET/HEAD requests on transient failures with backoff, but the retry count and conditions are hard-coded, not configurable."
-  database.configuration.request_timeout: not_implemented
+  database.configuration.request_timeout:
+    status: not_applicable
+    note: "Requires cancelling in-flight requests at the deadline, but the http.Client transport has no cancellation primitive. The only Dart-native option is Future.timeout, which lets the request keep running and is functionally identical to a caller applying .timeout() themselves, so it adds no real capability. Same reasoning as functions.invocation.timeout; a genuine version would require database.using_modifiers.request_cancellation."
 
   # storage — file buckets
   storage.file_buckets.access_bucket: implemented


### PR DESCRIPTION
## What

Marks `database.configuration.request_timeout` as `not_applicable` in `sdk-compliance.yaml`, and adds the `not_applicable` status to the legend.

## Why

The canonical capability requires cancelling in-flight requests once the deadline is reached. Over Dart's `http.Client` transport there is no cancellation primitive, so the only Dart-native option is `Future.timeout`, which lets the request keep running. That is functionally identical to a caller applying `.timeout()` on the result themselves (the PostgREST builder's existing `.timeout()` already behaves this way), so exposing it as a construction-time option adds no real capability and would be misleading.

This is the same reasoning applied to `functions.invocation.timeout` in #1546. A genuinely useful version would require `database.using_modifiers.request_cancellation`, which stays tracked as `not_implemented`.

## Changes

- Added the `not_applicable` status to the legend in `sdk-compliance.yaml`.
- Set `database.configuration.request_timeout` to `not_applicable` with an explanatory note.