### PR TITLE
fix(realtime): patch channel join payloads with access token before flushing

### DIFF
--- a/packages/realtime_client/lib/src/realtime_client.dart
+++ b/packages/realtime_client/lib/src/realtime_client.dart
@@ -567,7 +567,7 @@ class RealtimeClient {
   void _onConnOpen() {
     log('transport', 'connected to $endPointURL');
     log('transport', 'connected', null, Level.FINE);
-    _flushSendBuffer();
+    unawaited(_resolveAccessTokenAndFlush());
     reconnectTimer.reset();
     if (heartbeatTimer != null) heartbeatTimer!.cancel();
     heartbeatTimer = Timer.periodic(
@@ -636,6 +636,38 @@ class RealtimeClient {
         callback();
       }
       sendBuffer = [];
+    }
+  }
+
+  /// Resolves the access token before flushing the send buffer so that
+  /// buffered channel join payloads carry the correct token.
+  ///
+  /// When [RealtimeChannel.subscribe] runs before an asynchronous access token
+  /// has resolved (common when [customAccessToken] reads from async storage),
+  /// the buffered join payload has no `access_token`. That buffered message
+  /// captured the stale payload, so once auth has settled the join payloads are
+  /// patched with the resolved token, the stale buffered joins are dropped, and
+  /// the join is re-sent for any channel still joining.
+  Future<void> _resolveAccessTokenAndFlush() async {
+    try {
+      if (customAccessToken != null) {
+        await setAuth(null);
+        if (accessToken != null) {
+          for (final channel in channels) {
+            channel.updateJoinPayload({'access_token': accessToken!});
+          }
+          sendBuffer = [];
+          for (final channel in channels) {
+            if (channel.isJoining) {
+              channel.forceRejoin();
+            }
+          }
+        }
+      }
+    } catch (error) {
+      log('transport', 'error resolving access token on connect', error);
+    } finally {
+      _flushSendBuffer();
     }
   }
 

--- a/packages/realtime_client/test/socket_test.dart
+++ b/packages/realtime_client/test/socket_test.dart
@@ -978,6 +978,73 @@ void main() {
     );
   });
 
+  group('access token on connect', () {
+    test(
+      'resolves the token and patches buffered join payloads before flushing',
+      () async {
+        final token = generateJwt();
+        var tokenCallbackCalls = 0;
+
+        final streamController = StreamController<dynamic>.broadcast();
+        final readyCompleter = Completer<void>();
+        final capturedMessages = <String>[];
+
+        final mockedChannel = MockIOWebSocketChannel();
+        final mockedSink = MockWebSocketSink();
+        when(() => mockedChannel.sink).thenReturn(mockedSink);
+        when(
+          () => mockedChannel.ready,
+        ).thenAnswer((_) => readyCompleter.future);
+        when(
+          () => mockedChannel.stream,
+        ).thenAnswer((_) => streamController.stream);
+        when(
+          () => mockedSink.close(any(), any()),
+        ).thenAnswer((_) => Future.value());
+        when(() => mockedSink.close()).thenAnswer((_) => Future.value());
+        when(() => mockedSink.add(any())).thenAnswer((invocation) {
+          capturedMessages.add(invocation.positionalArguments.first as String);
+        });
+
+        final socket = RealtimeClient(
+          socketEndpoint,
+          transport: (url, headers) => mockedChannel,
+          customAccessToken: () async {
+            tokenCallbackCalls++;
+            return token;
+          },
+        );
+
+        final channel = socket.channel('realtime:test');
+        channel.subscribe();
+
+        // The join is buffered while the socket is still connecting and the
+        // token has not resolved yet, so it carries no access_token.
+        expect(socket.sendBuffer, isNotEmpty);
+        expect(capturedMessages, isEmpty);
+
+        // Once the connection is ready the token is resolved and the buffered
+        // join is re-sent with the token patched into its payload.
+        readyCompleter.complete();
+        await Future.delayed(const Duration(milliseconds: 50));
+
+        expect(tokenCallbackCalls, greaterThan(0));
+        expect(socket.accessToken, token);
+
+        final joinPayloads = capturedMessages
+            .map((raw) => json.decode(raw) as List)
+            .where((frame) => frame[3] == ChannelEvents.join.eventName())
+            .map((frame) => frame[4] as Map)
+            .toList();
+        expect(joinPayloads, isNotEmpty);
+        expect(joinPayloads.last['access_token'], token);
+
+        await socket.disconnect();
+        await streamController.close();
+      },
+    );
+  });
+
   group('sendHeartbeat', () {
     IOWebSocketChannel mockedSocketChannel;
     late RealtimeClient mockedSocket;

--- a/packages/realtime_client/test/socket_test.dart
+++ b/packages/realtime_client/test/socket_test.dart
@@ -988,6 +988,7 @@ void main() {
         final streamController = StreamController<dynamic>.broadcast();
         final readyCompleter = Completer<void>();
         final capturedMessages = <String>[];
+        final joinSent = Completer<Map>();
 
         final mockedChannel = MockIOWebSocketChannel();
         final mockedSink = MockWebSocketSink();
@@ -1003,7 +1004,13 @@ void main() {
         ).thenAnswer((_) => Future.value());
         when(() => mockedSink.close()).thenAnswer((_) => Future.value());
         when(() => mockedSink.add(any())).thenAnswer((invocation) {
-          capturedMessages.add(invocation.positionalArguments.first as String);
+          final raw = invocation.positionalArguments.first as String;
+          capturedMessages.add(raw);
+          final frame = json.decode(raw) as List;
+          if (frame[3] == ChannelEvents.join.eventName() &&
+              !joinSent.isCompleted) {
+            joinSent.complete(frame[4] as Map);
+          }
         });
 
         final socket = RealtimeClient(
@@ -1026,18 +1033,13 @@ void main() {
         // Once the connection is ready the token is resolved and the buffered
         // join is re-sent with the token patched into its payload.
         readyCompleter.complete();
-        await Future.delayed(const Duration(milliseconds: 50));
+        final joinPayload = await joinSent.future.timeout(
+          const Duration(seconds: 5),
+        );
 
         expect(tokenCallbackCalls, greaterThan(0));
         expect(socket.accessToken, token);
-
-        final joinPayloads = capturedMessages
-            .map((raw) => json.decode(raw) as List)
-            .where((frame) => frame[3] == ChannelEvents.join.eventName())
-            .map((frame) => frame[4] as Map)
-            .toList();
-        expect(joinPayloads, isNotEmpty);
-        expect(joinPayloads.last['access_token'], token);
+        expect(joinPayload['access_token'], token);
 
         await socket.disconnect();
         await streamController.close();

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -422,9 +422,6 @@ features:
       - RealtimeClient.onHeartbeat
       - RealtimeHeartbeatStatus
   realtime.client.set_auth_token: implemented
-  realtime.client.join_payload_access_token:
-    status: implemented
-    note: "On connect the access token is resolved before the send buffer is flushed; buffered channel join payloads are patched with the token and re-sent so subscriptions authenticate correctly when the token resolves asynchronously (e.g. read from async storage)."
 
   # realtime — subscriptions
   realtime.subscriptions.broadcast: implemented
@@ -462,7 +459,9 @@ features:
   realtime.configuration.custom_websocket_transport: implemented
   realtime.configuration.reconnect_backoff: implemented
   realtime.configuration.heartbeat_interval: implemented
-  realtime.configuration.access_token_callback: implemented
+  realtime.configuration.access_token_callback:
+    status: implemented
+    note: "On connect the access token is resolved before the send buffer is flushed; buffered channel join payloads are patched with the token and re-sent so subscriptions authenticate correctly when the token resolves asynchronously (e.g. read from async storage)."
   realtime.configuration.custom_logger: implemented
   realtime.configuration.binary_protocol: implemented
   realtime.configuration.deferred_disconnect: not_implemented

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -422,6 +422,9 @@ features:
       - RealtimeClient.onHeartbeat
       - RealtimeHeartbeatStatus
   realtime.client.set_auth_token: implemented
+  realtime.client.join_payload_access_token:
+    status: implemented
+    note: "On connect the access token is resolved before the send buffer is flushed; buffered channel join payloads are patched with the token and re-sent so subscriptions authenticate correctly when the token resolves asynchronously (e.g. read from async storage)."
 
   # realtime — subscriptions
   realtime.subscriptions.broadcast: implemented


### PR DESCRIPTION
## Summary

When `subscribe()` runs before an asynchronous access token has resolved (common when the token is read from async storage, e.g. React Native / Expo, or a third-party `accessToken` callback), the buffered `phx_join` payload captured at subscribe time carries no `access_token`. When the connection opens the token-less join is flushed to the server, which accepts the join but cannot evaluate RLS, so `postgres_changes` events are silently filtered out.

This ports the supabase-js fix to the Dart realtime client: on connection open, the access token is now resolved before the send buffer is flushed. Once auth has settled, buffered channel join payloads are patched with the resolved token, the stale buffered joins are dropped, and the join is re-sent for any channel still joining.

## Outcome

**implemented** (bug fix). No public API changes; the fix is internal to the connect flow in `RealtimeClient`.

## Changes

- `packages/realtime_client/lib/src/realtime_client.dart` — `_onConnOpen` now delegates to a new async `_resolveAccessTokenAndFlush` that resolves the token via `setAuth`, patches each channel's join payload, clears the stale send buffer, and re-sends joins for channels still joining before flushing.
- `packages/realtime_client/test/socket_test.dart` — new test verifying a buffered join is re-sent with the resolved token patched into its payload.
- `sdk-compliance.yaml` — added `realtime.client.join_payload_access_token` as `implemented`.

## Testing

- `packages/realtime_client` unit tests (`socket_test.dart`, `channel_test.dart`) pass.
- Realtime integration tests (protocol 1.0.0 and 2.0.0) pass against the local backend.

## References

- Linear: SDK-754
- supabase-js: PR #2136, commit `c35fba4`
- Compliance matrix: `realtime.client.join_payload_access_token` → `implemented`