### PR TITLE
feat(gotrue): add currentPassword to UserAttributes

### DIFF
--- a/packages/gotrue/lib/src/types/user_attributes.dart
+++ b/packages/gotrue/lib/src/types/user_attributes.dart
@@ -20,12 +20,21 @@ class UserAttributes {
   /// The `data` should be a JSON object that includes user-specific info, such as their first and last name.
   Object? data;
 
+  /// The user's current password.
+  ///
+  /// This is only used when the user is changing their password and the
+  /// `GOTRUE_SECURITY_UPDATE_PASSWORD_REQUIRE_CURRENT_PASSWORD` setting is
+  /// enabled on the auth server, in which case the current password is required
+  /// to verify the change.
+  String? currentPassword;
+
   UserAttributes({
     this.email,
     this.phone,
     this.password,
     this.nonce,
     this.data,
+    this.currentPassword,
   }) : assert(data == null || data is List || data is Map);
 
   Map<String, dynamic> toJson() {
@@ -35,6 +44,7 @@ class UserAttributes {
       'nonce': ?nonce,
       'password': ?password,
       'data': ?data,
+      'current_password': ?currentPassword,
     };
   }
 
@@ -49,6 +59,7 @@ class UserAttributes {
         other.phone == phone &&
         other.password == password &&
         other.nonce == nonce &&
+        other.currentPassword == currentPassword &&
         mapEquals(other.data, data);
   }
 
@@ -58,6 +69,7 @@ class UserAttributes {
         phone.hashCode ^
         password.hashCode ^
         nonce.hashCode ^
+        currentPassword.hashCode ^
         data.hashCode;
   }
 }

--- a/packages/gotrue/test/src/types/user_attributes_test.dart
+++ b/packages/gotrue/test/src/types/user_attributes_test.dart
@@ -56,6 +56,34 @@ void main() {
       // assert
       expect(userAttributesOne, isNot(equals(userAttributesThree)));
     });
+
+    test('currentPassword is serialized as current_password', () {
+      final userAttributes = UserAttributes(
+        password: 'new-password',
+        currentPassword: 'old-password',
+      );
+
+      expect(userAttributes.toJson(), {
+        'password': 'new-password',
+        'current_password': 'old-password',
+      });
+    });
+
+    test('currentPassword is omitted from JSON when null', () {
+      final userAttributes = UserAttributes(password: 'new-password');
+
+      expect(userAttributes.toJson().containsKey('current_password'), isFalse);
+    });
+
+    test('Attributes with different currentPassword are not equal', () {
+      final withCurrentPassword = UserAttributes(
+        password: password,
+        currentPassword: 'old-password',
+      );
+      final withoutCurrentPassword = UserAttributes(password: password);
+
+      expect(withCurrentPassword, isNot(equals(withoutCurrentPassword)));
+    });
   });
 
   group('Admin user attributes', () {

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -53,6 +53,8 @@ features:
   auth.session.update_user:
     status: partially_implemented
     note: "Does not send a PKCE code_challenge when changing email under the PKCE flow."
+    symbols:
+      - UserAttributes.currentPassword
   auth.session.get_claims: implemented
   auth.session.sign_out:
     status: partially_implemented


### PR DESCRIPTION
## Summary

Adds an optional `currentPassword` field to `UserAttributes`. When the auth server has `GOTRUE_SECURITY_UPDATE_PASSWORD_REQUIRE_CURRENT_PASSWORD` enabled, changing a password requires the current password to be sent for verification.

The field is serialized as `current_password`, which is the key the auth server reads (`json:"current_password"`). Note that supabase-js currently sends the raw camelCase `currentPassword`, which the server does not read; a separate fix has been opened against supabase-js.

## Changes

- `packages/gotrue/lib/src/types/user_attributes.dart` — add nullable `currentPassword` field, include it in `toJson()` as `current_password`, and in `==`/`hashCode`.
- `packages/gotrue/test/src/types/user_attributes_test.dart` — tests for serialization, null-omission, and equality.

## Outcome

Implemented.

## References

- Linear: SDK-753
- supabase-js: PR #2131 / commit f681484
- auth server: supabase/auth PR #2364

## Compliance matrix

`auth.session.update_user` already tracked as `partially_implemented`; no status change.