### PR TITLE
refactor(auth): use OAuthProvider.name and cover custom OIDC providers

### DIFF
--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -472,7 +472,7 @@ class GoTrueClient {
       options: GotrueRequestOptions(
         headers: _headers,
         body: {
-          'provider': provider.snakeCase,
+          'provider': provider.name,
           'id_token': idToken,
           'nonce': nonce,
           'gotrue_meta_security': {'captcha_token': captchaToken},
@@ -1071,7 +1071,7 @@ class GoTrueClient {
         headers: _headers,
         jwt: _currentSession?.accessToken,
         body: {
-          'provider': provider.snakeCase,
+          'provider': provider.name,
           'id_token': idToken,
           'nonce': nonce,
           'gotrue_meta_security': {'captcha_token': captchaToken},
@@ -1338,7 +1338,7 @@ class GoTrueClient {
     required Map<String, String>? queryParams,
     bool skipBrowserRedirect = false,
   }) async {
-    final urlParams = {'provider': provider.snakeCase};
+    final urlParams = {'provider': provider.name};
     if (scopes != null) {
       urlParams['scopes'] = scopes;
     }

--- a/packages/gotrue/test/provider_test.dart
+++ b/packages/gotrue/test/provider_test.dart
@@ -53,6 +53,32 @@ void main() {
       );
       expect(provider, OAuthProvider.github);
     });
+
+    test('signIn() with custom OIDC provider', () async {
+      final res = await client.getOAuthSignInUrl(
+        provider: OAuthProvider('custom:my-oidc-provider'),
+      );
+      expect(
+        res.url,
+        startsWith(
+          '$gotrueUrl/authorize?provider=custom%3Amy-oidc-provider',
+        ),
+      );
+      expect(res.provider, OAuthProvider('custom:my-oidc-provider'));
+      expect(res.provider.name, 'custom:my-oidc-provider');
+    });
+
+    test('signIn() with custom OIDC provider and options', () async {
+      final res = await client.getOAuthSignInUrl(
+        provider: OAuthProvider('custom:my-oidc-provider'),
+        redirectTo: 'https://localhost:9000/callback',
+        scopes: 'openid profile email',
+      );
+      expect(res.url, contains('provider=custom%3Amy-oidc-provider'));
+      expect(res.url, contains('redirect_to='));
+      expect(res.url, contains('scopes='));
+      expect(res.provider.name, 'custom:my-oidc-provider');
+    });
   });
 
   group('getSessionFromUrl()', () {

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -26,14 +26,11 @@ features:
   auth.sign_in.sign_in_with_otp: implemented
   auth.sign_in.sign_in_with_oauth:
     status: partially_implemented
-    note: "Exposed as getOAuthSignInUrl (gotrue) and signInWithOAuth (supabase_flutter); the skipBrowserRedirect option is not publicly exposed."
-  auth.sign_in.sign_in_with_id_token: implemented
-  auth.sign_in.custom_oauth_provider:
-    status: implemented
-    note: "Custom OIDC providers are passed as OAuthProvider('custom:name'); the identifier is sent to the API unchanged, matching supabase-js's custom: prefix support."
+    note: "Exposed as getOAuthSignInUrl (gotrue) and signInWithOAuth (supabase_flutter); the skipBrowserRedirect option is not publicly exposed. Custom OIDC providers are supported via OAuthProvider('custom:name'); the identifier is sent to the API unchanged, matching supabase-js's custom: prefix support."
     symbols:
       - OAuthProvider
       - OAuthProvider.OAuthProvider
+  auth.sign_in.sign_in_with_id_token: implemented
   auth.sign_in.sign_in_with_sso:
     status: partially_implemented
     note: "Exposed as getSSOSignInUrl, which returns Future<String> (the URL) rather than the structured {url} response used by JS."

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -28,6 +28,12 @@ features:
     status: partially_implemented
     note: "Exposed as getOAuthSignInUrl (gotrue) and signInWithOAuth (supabase_flutter); the skipBrowserRedirect option is not publicly exposed."
   auth.sign_in.sign_in_with_id_token: implemented
+  auth.sign_in.custom_oauth_provider:
+    status: implemented
+    note: "Custom OIDC providers are passed as OAuthProvider('custom:name'); the identifier is sent to the API unchanged, matching supabase-js's custom: prefix support."
+    symbols:
+      - OAuthProvider
+      - OAuthProvider.OAuthProvider
   auth.sign_in.sign_in_with_sso:
     status: partially_implemented
     note: "Exposed as getSSOSignInUrl, which returns Future<String> (the URL) rather than the structured {url} response used by JS."


### PR DESCRIPTION
## Summary

`OAuthProvider` already accepts arbitrary identifiers, so a custom OIDC provider passed as `OAuthProvider('custom:my-oidc-provider')` already worked at runtime and was forwarded to the GoTrue API unchanged, matching supabase-js's `custom:` prefix behavior. This PR does not change that runtime behavior. It cleans up the internal serialization and adds coverage and documentation for it.

## What changed

- Switched provider serialization in `signInWithIdToken` and `getOAuthSignInUrl` from the deprecated `OAuthProvider.snakeCase` getter to `OAuthProvider.name`. Both return the identifier verbatim, so this is behavior-neutral.
- Added unit tests confirming custom OIDC provider sign-in URL generation, with and without options.
- Updated the compliance matrix note under `auth.sign_in.sign_in_with_oauth` to record that custom OIDC providers are supported.

## Notes

- No normalization is applied to the provider name. The value is forwarded to the server as-is, so built-in providers keep working unchanged and there are no breaking changes.
- The `snakeCase` to `name` change does not affect built-in providers, because `snakeCase` already returned `name` verbatim.

## Reference

- supabase-js PR: supabase/supabase-js#2134
- Linear: SDK-752