### PR TITLE
chore(auth): mark webauthn MFA enrollment not applicable in Dart

### DIFF
--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -79,10 +79,7 @@ features:
   # auth — MFA
   auth.mfa.enroll:
     status: partially_implemented
-    note: "Supports totp and phone factor types only; webauthn enrollment is handled via the separate passkey API."
-  auth.mfa.webauthn_enroll:
-    status: not_applicable
-    note: "supabase-js runs the WebAuthn ceremony inline in the browser and patches the credential creation options' user.name before calling navigator.credentials.create. Dart delegates the device ceremony to a platform passkey plugin and never patches credential options client-side, and exposes WebAuthn through the passkey API (which has no friendlyName parameter, as the server generates the name), so the client-side fallback naming logic has no Dart equivalent."
+    note: "Supports totp and phone factor types only. WebAuthn enrollment has no Dart equivalent: supabase-js runs the WebAuthn ceremony inline in the browser and patches the credential creation options' user.name client-side, whereas Dart delegates the device ceremony to a platform passkey plugin and exposes WebAuthn through the separate passkey API (which has no friendlyName parameter, as the server generates the name)."
   auth.mfa.challenge:
     status: partially_implemented
     note: "No channel parameter (sms/whatsapp) for phone factors; always uses SMS."

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -10,6 +10,8 @@
 #   - partially_implemented present but with a behavioral difference or gap vs
 #                           supabase-js; a note describes the difference.
 #   - not_implemented       not available.
+#   - not_applicable        no meaningful Dart equivalent; feature is JS/platform
+#                           specific. A note explains why it does not apply.
 #
 # Verified against the source in this repository (packages/gotrue, postgrest,
 # storage_client, realtime_client, functions_client, supabase, supabase_flutter).
@@ -78,6 +80,9 @@ features:
   auth.mfa.enroll:
     status: partially_implemented
     note: "Supports totp and phone factor types only; webauthn enrollment is handled via the separate passkey API."
+  auth.mfa.webauthn_enroll:
+    status: not_applicable
+    note: "supabase-js runs the WebAuthn ceremony inline in the browser and patches the credential creation options' user.name before calling navigator.credentials.create. Dart delegates the device ceremony to a platform passkey plugin and never patches credential options client-side, and exposes WebAuthn through the passkey API (which has no friendlyName parameter, as the server generates the name), so the client-side fallback naming logic has no Dart equivalent."
   auth.mfa.challenge:
     status: partially_implemented
     note: "No channel parameter (sms/whatsapp) for phone factors; always uses SMS."


### PR DESCRIPTION
## Summary

SDK-701 tracks a supabase-js bug fix (PR supabase/supabase-js#1763, commit f99a58c) in the WebAuthn MFA enrollment flow: `mfa.webauthn.enroll` runs the WebAuthn ceremony inline in the browser and patches the credential creation options' `user.name` before calling `navigator.credentials.create()`. The fix corrects the fallback naming so a provided `friendlyName` is used, falling back to user data only when it is absent.

## Outcome: not_applicable

The Dart SDK does not perform the client-side WebAuthn ceremony inline. It:

- exposes only the server side of the ceremony through the `passkey` API in `gotrue` (get options / verify credential), which never touches `user.name`;
- delegates the device ceremony to a platform passkey plugin, with `supabase_flutter`'s `passkey_options_mapper.dart` handing the raw server options to the plugin;
- rejects `webauthn` in `mfa.enroll` (already documented on `auth.mfa.enroll`), routing WebAuthn through the passkey API instead;
- has no `friendlyName` parameter on passkey registration, as the server generates the friendly name.

There is therefore no client-side option-patching step where the SDK-701 bug could exist, and the `friendlyName` fallback cannot be reproduced faithfully in the passkey idiom. This is a JS/browser-ceremony concern with no meaningful Dart equivalent.

## Compliance matrix

Added `auth.mfa.webauthn_enroll` → `not_applicable` with a note explaining the divergence, and documented the `not_applicable` status in the header comment block.

Ref: SDK-701