### PR TITLE
feat(client): add session-URL-detection predicate and persistSession flag

### DIFF
--- a/packages/supabase_flutter/lib/src/flutter_go_true_client_options.dart
+++ b/packages/supabase_flutter/lib/src/flutter_go_true_client_options.dart
@@ -7,12 +7,34 @@ class FlutterAuthClientOptions extends AuthClientOptions {
   /// when a valid URI is detected.
   final bool detectSessionInUri;
 
+  /// An optional predicate that decides whether an incoming deep link should be
+  /// treated as an auth callback and exchanged for a session.
+  ///
+  /// When null, the default heuristic is used, which treats a link as an auth
+  /// callback if it carries any of the `access_token`, `code`, `error`,
+  /// `error_code`, or `error_description` parameters (in the query or the
+  /// fragment).
+  ///
+  /// Provide a custom predicate to disambiguate links when your app uses those
+  /// same parameters for other purposes, or to restrict detection to specific
+  /// redirect paths.
+  final bool Function(Uri uri)? detectSessionInUriPredicate;
+
+  /// Whether to persist the session to [localStorage].
+  ///
+  /// When false and no [localStorage] is provided, sessions are kept
+  /// in memory only and are not restored across app restarts. Supplying a
+  /// custom [localStorage] always takes precedence over this flag.
+  final bool persistSession;
+
   const FlutterAuthClientOptions({
     super.authFlowType,
     super.autoRefreshToken,
     super.pkceAsyncStorage,
     this.localStorage,
     this.detectSessionInUri = true,
+    this.detectSessionInUriPredicate,
+    this.persistSession = true,
   });
 
   FlutterAuthClientOptions copyWith({
@@ -21,6 +43,8 @@ class FlutterAuthClientOptions extends AuthClientOptions {
     LocalStorage? localStorage,
     GotrueAsyncStorage? pkceAsyncStorage,
     bool? detectSessionInUri,
+    bool Function(Uri uri)? detectSessionInUriPredicate,
+    bool? persistSession,
   }) {
     return FlutterAuthClientOptions(
       authFlowType: authFlowType ?? this.authFlowType,
@@ -28,6 +52,9 @@ class FlutterAuthClientOptions extends AuthClientOptions {
       localStorage: localStorage ?? this.localStorage,
       pkceAsyncStorage: pkceAsyncStorage ?? this.pkceAsyncStorage,
       detectSessionInUri: detectSessionInUri ?? this.detectSessionInUri,
+      detectSessionInUriPredicate:
+          detectSessionInUriPredicate ?? this.detectSessionInUriPredicate,
+      persistSession: persistSession ?? this.persistSession,
     );
   }
 }

--- a/packages/supabase_flutter/lib/src/supabase.dart
+++ b/packages/supabase_flutter/lib/src/supabase.dart
@@ -125,10 +125,12 @@ class Supabase {
     }
     if (authOptions.localStorage == null) {
       authOptions = authOptions.copyWith(
-        localStorage: SharedPreferencesLocalStorage(
-          persistSessionKey:
-              "sb-${Uri.parse(url).host.split(".").first}-auth-token",
-        ),
+        localStorage: authOptions.persistSession
+            ? SharedPreferencesLocalStorage(
+                persistSessionKey:
+                    "sb-${Uri.parse(url).host.split(".").first}-auth-token",
+              )
+            : const EmptyLocalStorage(),
       );
     }
     _instance._init(

--- a/packages/supabase_flutter/lib/src/supabase_auth.dart
+++ b/packages/supabase_flutter/lib/src/supabase_auth.dart
@@ -60,6 +60,10 @@ class SupabaseAuth with WidgetsBindingObserver {
   /// Whether to automatically refresh the token
   late bool _autoRefreshToken;
 
+  /// Optional custom predicate to decide whether a deep link is an auth
+  /// callback. When null, [_defaultIsAuthCallbackDeeplink] is used.
+  bool Function(Uri uri)? _detectSessionInUriPredicate;
+
   /// **ATTENTION**: `getInitialLink`/`getInitialUri` should be handled
   /// ONLY ONCE in your app's lifetime, since it is not meant to change
   /// throughout your app's life.
@@ -85,6 +89,7 @@ class SupabaseAuth with WidgetsBindingObserver {
   }) async {
     _localStorage = options.localStorage!;
     _autoRefreshToken = options.autoRefreshToken;
+    _detectSessionInUriPredicate = options.detectSessionInUriPredicate;
 
     _authSubscription = Supabase.instance.client.auth.onAuthStateChange.listen(
       (data) {
@@ -199,8 +204,22 @@ class SupabaseAuth with WidgetsBindingObserver {
     }
   }
 
-  /// If _authCallbackUrlHost not init, we treat all deep links as auth callback
+  /// Decides whether an incoming deep link should be exchanged for a session.
+  ///
+  /// Uses the custom predicate supplied via
+  /// [FlutterAuthClientOptions.detectSessionInUriPredicate] when available,
+  /// otherwise falls back to [_defaultIsAuthCallbackDeeplink].
   bool _isAuthCallbackDeeplink(Uri uri) {
+    final predicate = _detectSessionInUriPredicate;
+    if (predicate != null) {
+      return predicate(uri);
+    }
+    return _defaultIsAuthCallbackDeeplink(uri);
+  }
+
+  /// Default heuristic: treat a deep link as an auth callback when it carries
+  /// any of the auth-related parameters, in the query or the fragment.
+  bool _defaultIsAuthCallbackDeeplink(Uri uri) {
     final fragmentParameters = Uri.splitQueryString(uri.fragment);
     bool hasParameter(String key) =>
         uri.queryParameters.containsKey(key) ||

--- a/packages/supabase_flutter/test/deep_link_test.dart
+++ b/packages/supabase_flutter/test/deep_link_test.dart
@@ -5,6 +5,7 @@ library;
 import 'dart:async';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 import 'widget_test_stubs.dart';
@@ -99,6 +100,155 @@ void main() {
         'new@email.com',
       );
     });
+  });
+
+  group('Custom session-URL-detection predicate', () {
+    test(
+      'predicate returning false suppresses detection of an otherwise valid '
+      'auth callback',
+      () async {
+        final pkceHttpClient = PkceHttpClient();
+
+        mockAppLink(
+          mockMethodChannel: false,
+          mockEventChannel: true,
+          initialLink: 'com.supabase://callback/?code=my-code-verifier',
+        );
+        final pkceAsyncStorage = MockAsyncStorage();
+        await pkceAsyncStorage.setItem(
+          key: 'supabase.auth.token-code-verifier',
+          value: 'raw-code-verifier',
+        );
+        await Supabase.initialize(
+          url: supabaseUrl,
+          publishableKey: supabaseKey,
+          debug: false,
+          httpClient: pkceHttpClient,
+          authOptions: FlutterAuthClientOptions(
+            localStorage: const MockEmptyLocalStorage(),
+            pkceAsyncStorage: pkceAsyncStorage,
+            detectSessionInUriPredicate: (uri) => false,
+          ),
+        );
+
+        await Future.delayed(const Duration(milliseconds: 500));
+        expect(pkceHttpClient.requestCount, 0);
+      },
+    );
+
+    test(
+      'predicate governs detection based on the incoming uri',
+      () async {
+        final pkceHttpClient = PkceHttpClient();
+        final receivedUris = <Uri>[];
+
+        mockAppLink(
+          mockMethodChannel: false,
+          mockEventChannel: true,
+          initialLink: 'com.supabase://callback/?code=my-code-verifier',
+        );
+        final pkceAsyncStorage = MockAsyncStorage();
+        await pkceAsyncStorage.setItem(
+          key: 'supabase.auth.token-code-verifier',
+          value: 'raw-code-verifier',
+        );
+        await Supabase.initialize(
+          url: supabaseUrl,
+          publishableKey: supabaseKey,
+          debug: false,
+          httpClient: pkceHttpClient,
+          authOptions: FlutterAuthClientOptions(
+            localStorage: const MockEmptyLocalStorage(),
+            pkceAsyncStorage: pkceAsyncStorage,
+            detectSessionInUriPredicate: (uri) {
+              receivedUris.add(uri);
+              return uri.queryParameters.containsKey('code');
+            },
+          ),
+        );
+
+        await Future.delayed(const Duration(milliseconds: 500));
+        expect(receivedUris.single.queryParameters['code'], 'my-code-verifier');
+        expect(pkceHttpClient.requestCount, 1);
+        expect(pkceHttpClient.lastRequestBody['auth_code'], 'my-code-verifier');
+      },
+    );
+  });
+
+  group('persistSession flag', () {
+    // With url '', the default persist session key resolves to this value.
+    const persistSessionKey = 'sb--auth-token';
+
+    test(
+      'persists the session to the default storage when persistSession is true',
+      () async {
+        SharedPreferences.setMockInitialValues({});
+        final pkceHttpClient = PkceHttpClient();
+
+        mockAppLink(
+          mockMethodChannel: false,
+          mockEventChannel: true,
+          initialLink: 'com.supabase://callback/?code=my-code-verifier',
+        );
+        final pkceAsyncStorage = MockAsyncStorage();
+        await pkceAsyncStorage.setItem(
+          key: 'supabase.auth.token-code-verifier',
+          value: 'raw-code-verifier',
+        );
+        await Supabase.initialize(
+          url: supabaseUrl,
+          publishableKey: supabaseKey,
+          debug: false,
+          httpClient: pkceHttpClient,
+          authOptions: FlutterAuthClientOptions(
+            pkceAsyncStorage: pkceAsyncStorage,
+          ),
+        );
+
+        await Supabase.instance.client.auth.onAuthStateChange
+            .firstWhere((state) => state.event == AuthChangeEvent.signedIn)
+            .timeout(const Duration(seconds: 5));
+
+        final preferences = await SharedPreferences.getInstance();
+        expect(preferences.getString(persistSessionKey), isNotNull);
+      },
+    );
+
+    test(
+      'does not persist the session when persistSession is false',
+      () async {
+        SharedPreferences.setMockInitialValues({});
+        final pkceHttpClient = PkceHttpClient();
+
+        mockAppLink(
+          mockMethodChannel: false,
+          mockEventChannel: true,
+          initialLink: 'com.supabase://callback/?code=my-code-verifier',
+        );
+        final pkceAsyncStorage = MockAsyncStorage();
+        await pkceAsyncStorage.setItem(
+          key: 'supabase.auth.token-code-verifier',
+          value: 'raw-code-verifier',
+        );
+        await Supabase.initialize(
+          url: supabaseUrl,
+          publishableKey: supabaseKey,
+          debug: false,
+          httpClient: pkceHttpClient,
+          authOptions: FlutterAuthClientOptions(
+            pkceAsyncStorage: pkceAsyncStorage,
+            persistSession: false,
+          ),
+        );
+
+        await Supabase.instance.client.auth.onAuthStateChange
+            .firstWhere((state) => state.event == AuthChangeEvent.signedIn)
+            .timeout(const Duration(seconds: 5));
+
+        final preferences = await SharedPreferences.getInstance();
+        expect(preferences.getString(persistSessionKey), isNull);
+      },
+    );
   });
 
   group('Deep Link with error query parameter', () {

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -480,12 +480,15 @@ features:
   client.authentication_integration.cross_client_token_sync: implemented
   client.authentication_integration.oauth_flow_type: implemented
   client.authentication_integration.session_url_detection:
-    status: partially_implemented
-    note: "supabase_flutter exposes detectSessionInUri as a boolean only; there is no custom predicate to disambiguate redirects."
+    status: implemented
+    symbols:
+      - FlutterAuthClientOptions.detectSessionInUri
+      - FlutterAuthClientOptions.detectSessionInUriPredicate
   client.session_management.custom_storage: implemented
   client.session_management.persist_session:
-    status: partially_implemented
-    note: "No persistSession flag; in-memory-only sessions are achievable by supplying an EmptyLocalStorage backend."
+    status: implemented
+    symbols:
+      - FlutterAuthClientOptions.persistSession
   client.request_configuration.custom_http_client: implemented
   client.request_configuration.global_headers: implemented
   client.observability.trace_propagation: not_implemented


### PR DESCRIPTION
## Summary

Implements the two `partially_implemented` client initialization options tracked by SDK-1272:

- **`FlutterAuthClientOptions.detectSessionInUriPredicate`** — an optional `bool Function(Uri)` predicate that decides whether an incoming deep link should be treated as an auth callback and exchanged for a session. When null, the existing default heuristic (checks for `access_token`, `code`, `error`, `error_code`, `error_description` in the query or fragment) is used. This lets apps disambiguate redirects when they use those same parameters for other purposes.
- **`FlutterAuthClientOptions.persistSession`** — a real flag (default `true`). When `false` and no `localStorage` is supplied, sessions are kept in memory only (`EmptyLocalStorage` is selected automatically), so opting out of persistence no longer requires manually wiring up an `EmptyLocalStorage` backend. Supplying a custom `localStorage` still takes precedence.

Both are new optional initialization options, so existing `Supabase.initialize` calls are unaffected.

## Outcome

implemented

## Reference

Derived from the compliance matrix (`sdk-compliance.yaml`); mirrors supabase-js `detectSessionInUrl` / `persistSession` GoTrue client options.

## Tests

Added to `packages/supabase_flutter/test/deep_link_test.dart`:
- predicate returning `false` suppresses detection of an otherwise valid auth callback
- predicate governs detection based on the incoming URI (and receives the URI)
- `persistSession: true` persists to the default storage
- `persistSession: false` keeps the session in memory only

All 63 `supabase_flutter` tests pass; `melos format` and `dart analyze` clean.

## Compliance matrix

- `client.authentication_integration.session_url_detection` → `implemented`
- `client.session_management.persist_session` → `implemented`

SDK-1272