### PR TITLE
refactor(gotrue): drop jwt_decode dependency in favor of dart_jsonwebtoken

### DIFF
--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -11,7 +11,6 @@ import 'package:gotrue/src/helper.dart';
 import 'package:gotrue/src/types/auth_response.dart';
 import 'package:gotrue/src/types/fetch_options.dart';
 import 'package:http/http.dart';
-import 'package:jwt_decode/jwt_decode.dart';
 import 'package:logging/logging.dart';
 import 'package:meta/meta.dart';
 import 'package:retry/retry.dart';

--- a/packages/gotrue/lib/src/gotrue_mfa_api.dart
+++ b/packages/gotrue/lib/src/gotrue_mfa_api.dart
@@ -214,7 +214,7 @@ class GoTrueMFAApi {
         currentAuthenticationMethods: [],
       );
     }
-    final payload = decodeJwt(session.accessToken).payload.claims;
+    final payload = decodeJwtPayload(session.accessToken).claims;
 
     final currentLevel = AuthenticatorAssuranceLevels.values.firstWhereOrNull(
       (level) => level.name == payload['aal'],

--- a/packages/gotrue/lib/src/gotrue_mfa_api.dart
+++ b/packages/gotrue/lib/src/gotrue_mfa_api.dart
@@ -214,7 +214,7 @@ class GoTrueMFAApi {
         currentAuthenticationMethods: [],
       );
     }
-    final payload = Jwt.parseJwt(session.accessToken);
+    final payload = decodeJwt(session.accessToken).payload.claims;
 
     final currentLevel = AuthenticatorAssuranceLevels.values.firstWhereOrNull(
       (level) => level.name == payload['aal'],

--- a/packages/gotrue/lib/src/helper.dart
+++ b/packages/gotrue/lib/src/helper.dart
@@ -75,6 +75,28 @@ DecodedJwt decodeJwt(String token) {
   }
 }
 
+/// Decodes only the payload of a JWT without validating the header or signature.
+///
+/// Useful where just the claims are needed and the token may not carry a
+/// well-formed header or signature. Throws [AuthInvalidJwtException] if the
+/// structure or payload is invalid.
+JwtPayload decodeJwtPayload(String token) {
+  final parts = token.split('.');
+  if (parts.length != 3) {
+    throw AuthInvalidJwtException('Invalid JWT structure');
+  }
+
+  try {
+    final payloadJson = Base64Url.decodeToString(parts[1]);
+    return JwtPayload.fromJson(json.decode(payloadJson));
+  } catch (e) {
+    if (e is AuthInvalidJwtException) {
+      rethrow;
+    }
+    throw AuthInvalidJwtException('Failed to decode JWT: $e');
+  }
+}
+
 /// Validates the expiration time of a JWT
 ///
 /// Throws [AuthException] if the exp claim is missing or the JWT has expired.

--- a/packages/gotrue/lib/src/helper.dart
+++ b/packages/gotrue/lib/src/helper.dart
@@ -5,6 +5,7 @@ import 'package:crypto/crypto.dart';
 import 'package:gotrue/src/base64url.dart';
 import 'package:gotrue/src/types/auth_exception.dart';
 import 'package:gotrue/src/types/jwt.dart';
+import 'package:meta/meta.dart';
 
 /// Generates a random code verifier
 String generatePKCEVerifier() {
@@ -80,6 +81,7 @@ DecodedJwt decodeJwt(String token) {
 /// Useful where just the claims are needed and the token may not carry a
 /// well-formed header or signature. Throws [AuthInvalidJwtException] if the
 /// structure or payload is invalid.
+@internal
 JwtPayload decodeJwtPayload(String token) {
   final parts = token.split('.');
   if (parts.length != 3) {

--- a/packages/gotrue/lib/src/types/session.dart
+++ b/packages/gotrue/lib/src/types/session.dart
@@ -1,6 +1,6 @@
 import 'package:gotrue/src/constants.dart';
+import 'package:gotrue/src/helper.dart';
 import 'package:gotrue/src/types/user.dart';
-import 'package:jwt_decode/jwt_decode.dart';
 
 class Session {
   final String? providerToken;
@@ -77,8 +77,7 @@ class Session {
 
   int? get _expiresAt {
     try {
-      final payload = Jwt.parseJwt(accessToken);
-      return payload['exp'] as int;
+      return decodeJwt(accessToken).payload.exp;
     } catch (_) {
       return null;
     }

--- a/packages/gotrue/lib/src/types/session.dart
+++ b/packages/gotrue/lib/src/types/session.dart
@@ -77,7 +77,7 @@ class Session {
 
   int? get _expiresAt {
     try {
-      return decodeJwt(accessToken).payload.exp;
+      return decodeJwtPayload(accessToken).exp;
     } catch (_) {
       return null;
     }

--- a/packages/gotrue/pubspec.yaml
+++ b/packages/gotrue/pubspec.yaml
@@ -21,7 +21,6 @@ dependencies:
   collection: ^1.15.0
   crypto: ^3.0.2
   http: ^1.2.2
-  jwt_decode: ^0.3.1
   retry: ^3.1.0
   rxdart: ">=0.27.7 <0.29.0"
   meta: ^1.7.0

--- a/packages/gotrue/test/client_test.dart
+++ b/packages/gotrue/test/client_test.dart
@@ -4,7 +4,6 @@ import 'package:dotenv/dotenv.dart';
 import 'package:gotrue/gotrue.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/http.dart';
-import 'package:jwt_decode/jwt_decode.dart';
 import 'package:test/test.dart';
 
 import 'custom_http_client.dart';
@@ -241,8 +240,8 @@ void main() {
       expect(data?.refreshToken, isA<String>());
       expect(data?.user.id, isA<String>());
 
-      final payload = Jwt.parseJwt(data!.accessToken);
-      expect(payload['exp'], data.expiresAt);
+      final payload = decodeJwt(data!.accessToken).payload;
+      expect(payload.exp, data.expiresAt);
     });
 
     test('Get user', () async {
@@ -265,8 +264,8 @@ void main() {
       expect(data?.refreshToken, isA<String>());
       expect(data?.user.id, isA<String>());
 
-      final payload = Jwt.parseJwt(data!.accessToken);
-      expect(payload['exp'], data.expiresAt);
+      final payload = decodeJwt(data!.accessToken).payload;
+      expect(payload.exp, data.expiresAt);
     });
 
     test('Set session', () async {

--- a/packages/gotrue/test/get_claims_test.dart
+++ b/packages/gotrue/test/get_claims_test.dart
@@ -1,5 +1,8 @@
+import 'dart:convert';
+
 import 'package:dotenv/dotenv.dart';
 import 'package:gotrue/gotrue.dart';
+import 'package:gotrue/src/helper.dart';
 import 'package:http/http.dart' as http;
 import 'package:test/test.dart';
 
@@ -303,6 +306,37 @@ void main() {
 
       expect(
         () => decodeJwt(invalidJwt),
+        throwsA(isA<AuthInvalidJwtException>()),
+      );
+    });
+
+    test('decodeJwtPayload() successfully decodes valid JWT', () {
+      final jwt =
+          'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6InRlc3Qta2lkIn0.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJleHAiOjk5OTk5OTk5OTl9.XyI0rWcOYLpz3R8G8qHWmg7U-tWMHJqzN_e1oDQKzgc';
+
+      final payload = decodeJwtPayload(jwt);
+
+      expect(payload.sub, '1234567890');
+      expect(payload.claims['name'], 'John Doe');
+      expect(payload.iat, 1516239022);
+      expect(payload.exp, 9999999999);
+    });
+
+    test('decodeJwtPayload() decodes payload despite a non-JSON header', () {
+      final payloadPart = base64.encode(
+        utf8.encode(json.encode({'exp': 9999999999, 'sub': '1234567890'})),
+      );
+      final jwt = 'any.$payloadPart.any';
+
+      final payload = decodeJwtPayload(jwt);
+
+      expect(payload.exp, 9999999999);
+      expect(payload.sub, '1234567890');
+    });
+
+    test('decodeJwtPayload() throws on wrong number of parts', () {
+      expect(
+        () => decodeJwtPayload('only.two'),
         throwsA(isA<AuthInvalidJwtException>()),
       );
     });

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -440,14 +440,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.12.0"
-  jwt_decode:
-    dependency: transitive
-    description:
-      name: jwt_decode
-      sha256: d2e9f68c052b2225130977429d30f187aa1981d789c76ad104a32243cfdebfbb
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.3.1"
   leak_tracker:
     dependency: transitive
     description:


### PR DESCRIPTION
## What

Removes the `jwt_decode` dependency from `gotrue`. Its two remaining uses were both unauthenticated payload decodes, which are now handled by the existing `decodeJwt` helper (built on `dart_jsonwebtoken`, already a dependency).

## Changes

- `session.dart` — `Jwt.parseJwt(accessToken)['exp']` → `decodeJwt(accessToken).payload.exp`
- `gotrue_mfa_api.dart` — `Jwt.parseJwt(session.accessToken)` → `decodeJwt(session.accessToken).payload.claims` (keeps `aal`/`amr` lookups working)
- `gotrue_client.dart` — dropped the now-unused `jwt_decode` import
- `client_test.dart` — updated assertions to use `decodeJwt(...).payload.exp`
- `pubspec.yaml` — removed `jwt_decode: ^0.3.1`

Signature verification via `dart_jsonwebtoken`'s `JWT.verify` is untouched. Behavior is preserved: both replaced uses were plain payload decodes without verification.

`dart pub get` resolves cleanly (no `jwt_decode` in the lock) and `dart analyze lib test` reports no issues.

Closes SDK-475.