### PR TITLE
refactor(gotrue): drop rxdart dependency

### DIFF
--- a/packages/gotrue/lib/src/gotrue_admin_custom_providers_api.dart
+++ b/packages/gotrue/lib/src/gotrue_admin_custom_providers_api.dart
@@ -33,7 +33,7 @@ class GoTrueAdminCustomProvidersApi {
       options: GotrueRequestOptions(
         headers: _headers,
         query: {
-          if (type != null) 'type': type.name,
+          'type': ?type?.name,
         },
       ),
     );

--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -15,7 +15,6 @@ import 'package:jwt_decode/jwt_decode.dart';
 import 'package:logging/logging.dart';
 import 'package:meta/meta.dart';
 import 'package:retry/retry.dart';
-import 'package:rxdart/subjects.dart';
 
 import 'broadcast_stub.dart'
     if (dart.library.js_interop) './broadcast_web.dart'
@@ -94,8 +93,8 @@ class GoTrueClient {
   JWKSet? _jwks;
   DateTime? _jwksCachedAt;
 
-  final _onAuthStateChangeController = BehaviorSubject<AuthState>();
-  final _onAuthStateChangeControllerSync = BehaviorSubject<AuthState>(
+  final _onAuthStateChangeController = _ReplaySubject<AuthState>();
+  final _onAuthStateChangeControllerSync = _ReplaySubject<AuthState>(
     sync: true,
   );
 
@@ -1698,4 +1697,72 @@ class GoTrueClient {
       throw AuthInvalidJwtException('Invalid JWT signature: $e');
     }
   }
+}
+
+/// A minimal broadcast stream controller that replays the most recent event
+/// (value or error) to every new subscriber.
+///
+/// This mirrors the only behavior of rxdart's `BehaviorSubject` that gotrue
+/// relies on: a listener that subscribes after an event has already been
+/// emitted immediately receives the latest event. It also preserves
+/// synchronous event delivery when constructed with [sync] set to true.
+class _ReplaySubject<T> {
+  _ReplaySubject({bool sync = false})
+    : _sync = sync,
+      _controller = StreamController<T>.broadcast(sync: sync);
+
+  final bool _sync;
+  final StreamController<T> _controller;
+
+  bool _hasEvent = false;
+  T? _latestValue;
+  Object? _latestError;
+  StackTrace? _latestStackTrace;
+  bool _latestIsError = false;
+
+  Stream<T> get stream => Stream<T>.multi((controller) {
+    // Replay the latest event to the new subscriber, matching the
+    // controller's sync-ness so that a sync subject stays synchronous.
+    if (_hasEvent) {
+      if (_latestIsError) {
+        _sync
+            ? controller.addErrorSync(_latestError!, _latestStackTrace)
+            : controller.addError(_latestError!, _latestStackTrace);
+      } else {
+        _sync
+            ? controller.addSync(_latestValue as T)
+            : controller.add(_latestValue as T);
+      }
+    }
+
+    // Forward live events synchronously so the underlying broadcast
+    // controller's scheduling is the only hop. Without this, the extra
+    // controller would add a second microtask of latency versus a plain
+    // broadcast controller.
+    final subscription = _controller.stream.listen(
+      controller.addSync,
+      onError: controller.addErrorSync,
+      onDone: controller.closeSync,
+    );
+    controller.onCancel = subscription.cancel;
+  }, isBroadcast: true);
+
+  void add(T event) {
+    _hasEvent = true;
+    _latestIsError = false;
+    _latestValue = event;
+    _latestError = null;
+    _latestStackTrace = null;
+    _controller.add(event);
+  }
+
+  void addError(Object error, [StackTrace? stackTrace]) {
+    _hasEvent = true;
+    _latestIsError = true;
+    _latestError = error;
+    _latestStackTrace = stackTrace;
+    _controller.addError(error, stackTrace ?? StackTrace.current);
+  }
+
+  Future<void> close() => _controller.close();
 }

--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -1720,7 +1720,7 @@ class _ReplaySubject<T> {
   StackTrace? _latestStackTrace;
   bool _latestIsError = false;
 
-  Stream<T> get stream => Stream<T>.multi((controller) {
+  Stream<T> get stream => Stream.multi((controller) {
     // Replay the latest event to the new subscriber, matching the
     // controller's sync-ness so that a sync subject stays synchronous.
     if (_hasEvent) {
@@ -1756,12 +1756,12 @@ class _ReplaySubject<T> {
     _controller.add(event);
   }
 
-  void addError(Object error, [StackTrace? stackTrace]) {
+  void addError(Object error, StackTrace stackTrace) {
     _hasEvent = true;
     _latestIsError = true;
     _latestError = error;
     _latestStackTrace = stackTrace;
-    _controller.addError(error, stackTrace ?? StackTrace.current);
+    _controller.addError(error, stackTrace);
   }
 
   Future<void> close() => _controller.close();

--- a/packages/gotrue/lib/src/types/custom_oauth_provider.dart
+++ b/packages/gotrue/lib/src/types/custom_oauth_provider.dart
@@ -193,8 +193,7 @@ class CustomOAuthProvider {
       customClaimsAllowlist: (json['custom_claims_allowlist'] as List?)?.cast(),
       pkceEnabled: json['pkce_enabled'] as bool?,
       attributeMapping: json['attribute_mapping'] as Map<String, dynamic>?,
-      authorizationParams: (json['authorization_params'] as Map?)
-          ?.cast<String, String>(),
+      authorizationParams: (json['authorization_params'] as Map?)?.cast(),
       enabled: json['enabled'] as bool?,
       emailOptional: json['email_optional'] as bool?,
       issuer: json['issuer'] as String?,

--- a/packages/gotrue/pubspec.yaml
+++ b/packages/gotrue/pubspec.yaml
@@ -23,7 +23,6 @@ dependencies:
   http: ^1.2.2
   jwt_decode: ^0.3.1
   retry: ^3.1.0
-  rxdart: ">=0.27.7 <0.29.0"
   meta: ^1.7.0
   logging: ^1.2.0
   web: ">=0.5.0 <2.0.0"


### PR DESCRIPTION
## What

Removes the `rxdart` dependency from `gotrue`. It was used in exactly one place: the two `BehaviorSubject<AuthState>` controllers backing `onAuthStateChange` and `onAuthStateChangeSync`.

They are replaced with a small, private `_ReplaySubject<T>` built on top of the standard `dart:async` primitives (`StreamController.broadcast` + `Stream.multi`).

## Why

`rxdart` was pulling in a whole reactive-extensions library for a single feature: latest-value replay for late subscribers.

## Preserved behavior

- **Latest-value replay** — a new subscriber immediately receives the current `AuthState` on `.listen()`.
- **`sync: true`** delivery for `onAuthStateChangeSync` (synchronous event ordering).
- **Error propagation** — network errors are still emitted as stream errors (and the last error is replayed to late subscribers).
- **Broadcast semantics** — multiple simultaneous listeners.

The forwarding of live events is done synchronously through the per-listener `Stream.multi` controller so the underlying broadcast controller's scheduling is the only hop. This keeps delivery latency identical to `BehaviorSubject` (a naive double-controller would add an extra microtask, which broke an ordering-sensitive test).

## Testing

- Full `gotrue` unit suite passes; the remaining failures are pre-existing integration tests that require a running GoTrue server (confirmed identical failures on `main`).
- Stream behavior (replay, broadcast, sync delivery, error replay/propagation, done-on-close) validated against `BehaviorSubject` semantics.

Closes SDK-1278.
