### PR TITLE
refactor(supabase): drop rxdart dependency

### DIFF
--- a/packages/supabase/lib/src/supabase_stream_builder.dart
+++ b/packages/supabase/lib/src/supabase_stream_builder.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 
 import 'package:logging/logging.dart';
-import 'package:rxdart/rxdart.dart';
 import 'package:supabase/supabase.dart';
 
 part 'supabase_stream_filter_builder.dart';
@@ -69,7 +68,7 @@ class SupabaseStreamBuilder extends Stream<SupabaseStreamEvent> {
   final _log = Logger('supabase.supabase');
 
   /// StreamController for `stream()` method.
-  BehaviorSubject<SupabaseStreamEvent>? _streamController;
+  _BehaviorSubject<SupabaseStreamEvent>? _streamController;
 
   /// Contains the combined data of postgrest and realtime to emit as stream.
   SupabaseStreamEvent _streamData = [];
@@ -149,7 +148,7 @@ class SupabaseStreamBuilder extends Stream<SupabaseStreamEvent> {
 
   /// Sets up the stream controller and calls the method to get data as necessary
   void _setupStream() {
-    _streamController ??= BehaviorSubject(
+    _streamController ??= _BehaviorSubject(
       onListen: () {
         _getStreamData();
       },
@@ -370,7 +369,7 @@ class SupabaseStreamBuilder extends Stream<SupabaseStreamEvent> {
   ) {
     // Copied from [Stream.asyncMap]
 
-    final controller = BehaviorSubject<E>();
+    final controller = _BehaviorSubject<E>();
 
     controller.onListen = () {
       StreamSubscription<SupabaseStreamEvent> subscription = listen(
@@ -414,7 +413,7 @@ class SupabaseStreamBuilder extends Stream<SupabaseStreamEvent> {
     Stream<E>? Function(SupabaseStreamEvent event) convert,
   ) {
     //Copied from [Stream.asyncExpand]
-    final controller = BehaviorSubject<E>();
+    final controller = _BehaviorSubject<E>();
     controller.onListen = () {
       StreamSubscription<SupabaseStreamEvent> subscription = listen(
         null,
@@ -445,4 +444,85 @@ class SupabaseStreamBuilder extends Stream<SupabaseStreamEvent> {
     };
     return controller.stream;
   }
+}
+
+/// A minimal broadcast stream controller that replays the most recent event
+/// (value or error) to every new subscriber.
+///
+/// This mirrors the only behavior of rxdart's `BehaviorSubject` that
+/// [SupabaseStreamBuilder] relies on: a listener that subscribes after an
+/// event has already been emitted immediately receives the latest event.
+class _BehaviorSubject<T> {
+  _BehaviorSubject({
+    void Function()? onListen,
+    FutureOr<void> Function()? onCancel,
+  }) : _onListen = onListen,
+       _onCancel = onCancel {
+    _controller = StreamController<T>.broadcast(
+      onListen: () => _onListen?.call(),
+      onCancel: () => _onCancel?.call(),
+    );
+  }
+
+  late final StreamController<T> _controller;
+
+  void Function()? _onListen;
+  FutureOr<void> Function()? _onCancel;
+
+  bool _hasEvent = false;
+  T? _latestValue;
+  Object? _latestError;
+  StackTrace? _latestStackTrace;
+  bool _latestIsError = false;
+
+  set onListen(void Function()? value) => _onListen = value;
+
+  set onCancel(FutureOr<void> Function()? value) => _onCancel = value;
+
+  // Broadcast subjects never pause, so these are no-ops. They exist only to
+  // satisfy the unreachable non-broadcast branch in the copied `asyncMap` and
+  // `asyncExpand` implementations.
+  set onPause(void Function()? value) {}
+
+  set onResume(void Function()? value) {}
+
+  bool get isClosed => _controller.isClosed;
+
+  Stream<T> get stream => Stream.multi((controller) {
+    if (_hasEvent) {
+      if (_latestIsError) {
+        controller.addError(_latestError!, _latestStackTrace);
+      } else {
+        controller.add(_latestValue as T);
+      }
+    }
+
+    final subscription = _controller.stream.listen(
+      controller.addSync,
+      onError: controller.addErrorSync,
+      onDone: controller.closeSync,
+    );
+    controller.onCancel = subscription.cancel;
+  }, isBroadcast: true);
+
+  void add(T event) {
+    _hasEvent = true;
+    _latestIsError = false;
+    _latestValue = event;
+    _latestError = null;
+    _latestStackTrace = null;
+    _controller.add(event);
+  }
+
+  void addError(Object error, [StackTrace? stackTrace]) {
+    _hasEvent = true;
+    _latestIsError = true;
+    _latestError = error;
+    _latestStackTrace = stackTrace;
+    _controller.addError(error, stackTrace);
+  }
+
+  Future<void> addStream(Stream<T> source) => _controller.addStream(source);
+
+  Future<void> close() => _controller.close();
 }

--- a/packages/supabase/pubspec.yaml
+++ b/packages/supabase/pubspec.yaml
@@ -24,7 +24,6 @@ dependencies:
   postgrest: 2.8.0
   realtime_client: 2.11.0
   storage_client: 2.6.0
-  rxdart: ^0.28.0
   yet_another_json_isolate: 2.1.1
   logging: ^1.3.0
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -776,14 +776,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.2"
-  rxdart:
-    dependency: transitive
-    description:
-      name: rxdart
-      sha256: "5c3004a4a8dbb94bd4bf5412a4def4acdaa12e12f269737a5751369e12d1a962"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.28.0"
   scratch_space:
     dependency: transitive
     description:


### PR DESCRIPTION
## What

Removes the `rxdart` dependency from the `supabase` package. It was used in exactly one place: `SupabaseStreamBuilder`, which backed its stream controllers with rxdart's `BehaviorSubject`.

They are replaced with a small, private `_BehaviorSubject<T>` built on top of the standard `dart:async` primitives (`StreamController.broadcast` + `Stream.multi`).

## Why

`rxdart` was pulling in a whole reactive-extensions library for a single feature: latest-value replay for late subscribers. This mirrors what #1566 already did for `gotrue`, and removes `rxdart` from the monorepo entirely.

Note: #1566 only dropped rxdart from `gotrue`; the `supabase` package used it independently, and #1567 merely bumped its version constraint.

## Preserved behavior

- **Latest-value replay** — a new subscriber immediately receives the last emitted event on `.listen()`.
- **Error propagation** — errors are still emitted as stream errors (and the last error is replayed to late subscribers).
- **Broadcast semantics** — multiple simultaneous listeners.
- `onListen` / `onCancel` lifecycle hooks used to lazily start/tear down the realtime + postgrest fetch.

## Testing

`dart analyze` clean and all `supabase` package tests pass (mock_test.dart, client_test.dart).