### PR TITLE
refactor(storage): drop direct http_parser dependency

### DIFF
--- a/packages/storage_client/lib/src/fetch.dart
+++ b/packages/storage_client/lib/src/fetch.dart
@@ -4,8 +4,6 @@ import 'dart:typed_data';
 
 import 'package:http/http.dart' as http;
 import 'package:http/http.dart';
-// ignore: unnecessary_import — needed for http < 1.6.0 which doesn't re-export MediaType
-import 'package:http_parser/http_parser.dart';
 import 'package:logging/logging.dart';
 import 'package:mime/mime.dart';
 import 'package:retry/retry.dart';

--- a/packages/storage_client/pubspec.yaml
+++ b/packages/storage_client/pubspec.yaml
@@ -19,7 +19,6 @@ resolution: workspace
 
 dependencies:
   http: ^1.6.0
-  http_parser: ^4.1.0
   mime: '>=2.0.0 <3.0.0'
   retry: ^3.1.2
   meta: ^1.16.0


### PR DESCRIPTION
## What

Removes the direct `http_parser` dependency from `storage_client`.

`MediaType` was the only symbol used from `http_parser` (in `fetch.dart`). Since `http` 1.6.0, `package:http` re-exports `MediaType`:

```dart
export 'package:http_parser/http_parser.dart' show MediaType;
```

The direct import was already flagged `// ignore: unnecessary_import — needed for http < 1.6.0 which doesn't re-export MediaType`. As the package now requires `http: ^1.6.0`, that compatibility shim is obsolete: `MediaType` resolves through the existing `package:http/http.dart` import.

## Why

One fewer direct dependency to track, with zero in-house code and no behavior change.

## Testing

`dart analyze` clean; storage_client mime/content-type tests pass.