### PR TITLE
refactor: drop retry dependency in favor of an in-house helper

### DIFF
--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -13,7 +13,7 @@ import 'package:gotrue/src/types/fetch_options.dart';
 import 'package:http/http.dart';
 import 'package:logging/logging.dart';
 import 'package:meta/meta.dart';
-import 'package:retry/retry.dart';
+import 'package:gotrue/src/retry.dart';
 
 import 'broadcast_stub.dart'
     if (dart.library.js_interop) './broadcast_web.dart'

--- a/packages/gotrue/lib/src/retry.dart
+++ b/packages/gotrue/lib/src/retry.dart
@@ -1,0 +1,82 @@
+import 'dart:async';
+import 'dart:math';
+
+/// Options for retrying a function.
+///
+/// Minimal in-house replacement for the subset of the `retry` package the
+/// Supabase clients rely on.
+class RetryOptions {
+  /// Delay factor to double after every attempt.
+  final Duration delayFactor;
+
+  /// Percentage the delay is randomized by, as a fraction between 0 and 1.
+  final double randomizationFactor;
+
+  /// Maximum delay between retries.
+  final Duration maxDelay;
+
+  /// Maximum number of attempts before giving up.
+  final int maxAttempts;
+
+  const RetryOptions({
+    this.delayFactor = const Duration(milliseconds: 200),
+    this.randomizationFactor = 0.25,
+    this.maxDelay = const Duration(seconds: 30),
+    this.maxAttempts = 8,
+  });
+
+  /// Delay after [attempt] number of attempts.
+  Duration delay(int attempt) {
+    assert(attempt >= 0, 'attempt cannot be negative');
+    if (attempt <= 0) {
+      return Duration.zero;
+    }
+    final randomization =
+        randomizationFactor * (Random().nextDouble() * 2 - 1) + 1;
+    final exponent = min(attempt, 31);
+    final delay = delayFactor * pow(2.0, exponent) * randomization;
+    return delay < maxDelay ? delay : maxDelay;
+  }
+
+  /// Calls [fn], retrying so long as [retryIf] returns `true` for the thrown
+  /// [Exception], up to [maxAttempts] times.
+  Future<T> retry<T>(
+    FutureOr<T> Function() fn, {
+    FutureOr<bool> Function(Exception)? retryIf,
+    FutureOr<void> Function(Exception)? onRetry,
+  }) async {
+    var attempt = 0;
+    while (true) {
+      attempt++;
+      try {
+        return await fn();
+      } on Exception catch (error) {
+        if (attempt >= maxAttempts ||
+            (retryIf != null && !(await retryIf(error)))) {
+          rethrow;
+        }
+        if (onRetry != null) {
+          await onRetry(error);
+        }
+      }
+      await Future<void>.delayed(delay(attempt));
+    }
+  }
+}
+
+/// Calls [fn], retrying so long as [retryIf] returns `true` for the thrown
+/// [Exception], up to [maxAttempts] times.
+Future<T> retry<T>(
+  FutureOr<T> Function() fn, {
+  Duration delayFactor = const Duration(milliseconds: 200),
+  double randomizationFactor = 0.25,
+  Duration maxDelay = const Duration(seconds: 30),
+  int maxAttempts = 8,
+  FutureOr<bool> Function(Exception)? retryIf,
+  FutureOr<void> Function(Exception)? onRetry,
+}) => RetryOptions(
+  delayFactor: delayFactor,
+  randomizationFactor: randomizationFactor,
+  maxDelay: maxDelay,
+  maxAttempts: maxAttempts,
+).retry(fn, retryIf: retryIf, onRetry: onRetry);

--- a/packages/gotrue/lib/src/retry.dart
+++ b/packages/gotrue/lib/src/retry.dart
@@ -1,10 +1,13 @@
 import 'dart:async';
 import 'dart:math';
 
+import 'package:meta/meta.dart';
+
 /// Options for retrying a function.
 ///
 /// Minimal in-house replacement for the subset of the `retry` package the
 /// Supabase clients rely on.
+@internal
 class RetryOptions {
   /// Delay factor to double after every attempt.
   final Duration delayFactor;
@@ -66,6 +69,7 @@ class RetryOptions {
 
 /// Calls [fn], retrying so long as [retryIf] returns `true` for the thrown
 /// [Exception], up to [maxAttempts] times.
+@internal
 Future<T> retry<T>(
   FutureOr<T> Function() fn, {
   Duration delayFactor = const Duration(milliseconds: 200),

--- a/packages/gotrue/pubspec.yaml
+++ b/packages/gotrue/pubspec.yaml
@@ -21,7 +21,6 @@ dependencies:
   collection: ^1.19.0
   crypto: ^3.0.7
   http: ^1.6.0
-  retry: ^3.1.2
   meta: ^1.16.0
   logging: ^1.3.0
   web: ">=1.0.0 <2.0.0"

--- a/packages/gotrue/test/retry_test.dart
+++ b/packages/gotrue/test/retry_test.dart
@@ -1,0 +1,81 @@
+import 'package:gotrue/src/retry.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('retries until success and counts attempts', () async {
+    var attempts = 0;
+    final result = await retry(
+      () async {
+        attempts++;
+        if (attempts < 3) throw const FormatException('fail');
+        return 'ok';
+      },
+      delayFactor: const Duration(milliseconds: 1),
+      retryIf: (e) => e is FormatException,
+    );
+    expect(result, 'ok');
+    expect(attempts, 3);
+  });
+
+  test('stops at maxAttempts and rethrows', () async {
+    var attempts = 0;
+    await expectLater(
+      retry(
+        () async {
+          attempts++;
+          throw const FormatException('always');
+        },
+        maxAttempts: 4,
+        delayFactor: const Duration(milliseconds: 1),
+      ),
+      throwsA(isA<FormatException>()),
+    );
+    expect(attempts, 4);
+  });
+
+  test('does not retry when retryIf returns false', () async {
+    var attempts = 0;
+    await expectLater(
+      retry(
+        () async {
+          attempts++;
+          throw const FormatException('nope');
+        },
+        delayFactor: const Duration(milliseconds: 1),
+        retryIf: (e) => false,
+      ),
+      throwsA(isA<FormatException>()),
+    );
+    expect(attempts, 1);
+  });
+
+  test('RetryOptions.retry with maxAttempts (storage usage)', () async {
+    var attempts = 0;
+    await expectLater(
+      const RetryOptions(
+        maxAttempts: 2,
+        delayFactor: Duration(milliseconds: 1),
+      ).retry(
+        () async {
+          attempts++;
+          throw const FormatException('x');
+        },
+        retryIf: (e) => true,
+      ),
+      throwsA(isA<FormatException>()),
+    );
+    expect(attempts, 2);
+  });
+
+  test('delay grows exponentially and is capped at maxDelay', () {
+    const options = RetryOptions(
+      delayFactor: Duration(milliseconds: 100),
+      randomizationFactor: 0,
+      maxDelay: Duration(seconds: 1),
+    );
+    expect(options.delay(0), Duration.zero);
+    expect(options.delay(1), const Duration(milliseconds: 200));
+    expect(options.delay(2), const Duration(milliseconds: 400));
+    expect(options.delay(10), const Duration(seconds: 1));
+  });
+}

--- a/packages/storage_client/lib/src/fetch.dart
+++ b/packages/storage_client/lib/src/fetch.dart
@@ -6,7 +6,7 @@ import 'package:http/http.dart' as http;
 import 'package:http/http.dart';
 import 'package:logging/logging.dart';
 import 'package:mime/mime.dart';
-import 'package:retry/retry.dart';
+import 'package:storage_client/src/retry.dart';
 import 'package:storage_client/src/types.dart';
 
 import 'file_stub.dart' if (dart.library.io) './file_io.dart';

--- a/packages/storage_client/lib/src/retry.dart
+++ b/packages/storage_client/lib/src/retry.dart
@@ -1,0 +1,82 @@
+import 'dart:async';
+import 'dart:math';
+
+/// Options for retrying a function.
+///
+/// Minimal in-house replacement for the subset of the `retry` package the
+/// Supabase clients rely on.
+class RetryOptions {
+  /// Delay factor to double after every attempt.
+  final Duration delayFactor;
+
+  /// Percentage the delay is randomized by, as a fraction between 0 and 1.
+  final double randomizationFactor;
+
+  /// Maximum delay between retries.
+  final Duration maxDelay;
+
+  /// Maximum number of attempts before giving up.
+  final int maxAttempts;
+
+  const RetryOptions({
+    this.delayFactor = const Duration(milliseconds: 200),
+    this.randomizationFactor = 0.25,
+    this.maxDelay = const Duration(seconds: 30),
+    this.maxAttempts = 8,
+  });
+
+  /// Delay after [attempt] number of attempts.
+  Duration delay(int attempt) {
+    assert(attempt >= 0, 'attempt cannot be negative');
+    if (attempt <= 0) {
+      return Duration.zero;
+    }
+    final randomization =
+        randomizationFactor * (Random().nextDouble() * 2 - 1) + 1;
+    final exponent = min(attempt, 31);
+    final delay = delayFactor * pow(2.0, exponent) * randomization;
+    return delay < maxDelay ? delay : maxDelay;
+  }
+
+  /// Calls [fn], retrying so long as [retryIf] returns `true` for the thrown
+  /// [Exception], up to [maxAttempts] times.
+  Future<T> retry<T>(
+    FutureOr<T> Function() fn, {
+    FutureOr<bool> Function(Exception)? retryIf,
+    FutureOr<void> Function(Exception)? onRetry,
+  }) async {
+    var attempt = 0;
+    while (true) {
+      attempt++;
+      try {
+        return await fn();
+      } on Exception catch (error) {
+        if (attempt >= maxAttempts ||
+            (retryIf != null && !(await retryIf(error)))) {
+          rethrow;
+        }
+        if (onRetry != null) {
+          await onRetry(error);
+        }
+      }
+      await Future<void>.delayed(delay(attempt));
+    }
+  }
+}
+
+/// Calls [fn], retrying so long as [retryIf] returns `true` for the thrown
+/// [Exception], up to [maxAttempts] times.
+Future<T> retry<T>(
+  FutureOr<T> Function() fn, {
+  Duration delayFactor = const Duration(milliseconds: 200),
+  double randomizationFactor = 0.25,
+  Duration maxDelay = const Duration(seconds: 30),
+  int maxAttempts = 8,
+  FutureOr<bool> Function(Exception)? retryIf,
+  FutureOr<void> Function(Exception)? onRetry,
+}) => RetryOptions(
+  delayFactor: delayFactor,
+  randomizationFactor: randomizationFactor,
+  maxDelay: maxDelay,
+  maxAttempts: maxAttempts,
+).retry(fn, retryIf: retryIf, onRetry: onRetry);

--- a/packages/storage_client/lib/src/retry.dart
+++ b/packages/storage_client/lib/src/retry.dart
@@ -1,10 +1,13 @@
 import 'dart:async';
 import 'dart:math';
 
+import 'package:meta/meta.dart';
+
 /// Options for retrying a function.
 ///
 /// Minimal in-house replacement for the subset of the `retry` package the
 /// Supabase clients rely on.
+@internal
 class RetryOptions {
   /// Delay factor to double after every attempt.
   final Duration delayFactor;
@@ -66,6 +69,7 @@ class RetryOptions {
 
 /// Calls [fn], retrying so long as [retryIf] returns `true` for the thrown
 /// [Exception], up to [maxAttempts] times.
+@internal
 Future<T> retry<T>(
   FutureOr<T> Function() fn, {
   Duration delayFactor = const Duration(milliseconds: 200),

--- a/packages/storage_client/pubspec.yaml
+++ b/packages/storage_client/pubspec.yaml
@@ -20,7 +20,6 @@ resolution: workspace
 dependencies:
   http: ^1.6.0
   mime: '>=2.0.0 <3.0.0'
-  retry: ^3.1.2
   meta: ^1.16.0
   logging: ^1.3.0
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -768,14 +768,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.0"
-  rxdart:
-    dependency: transitive
-    description:
-      name: rxdart
-      sha256: "5c3004a4a8dbb94bd4bf5412a4def4acdaa12e12f269737a5751369e12d1a962"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.28.0"
   scratch_space:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -768,14 +768,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.0"
-  retry:
+  rxdart:
     dependency: transitive
     description:
-      name: retry
-      sha256: "822e118d5b3aafed083109c72d5f484c6dc66707885e07c0fbcb8b986bba7efc"
+      name: rxdart
+      sha256: "5c3004a4a8dbb94bd4bf5412a4def4acdaa12e12f269737a5751369e12d1a962"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.2"
+    version: "0.28.0"
   scratch_space:
     dependency: transitive
     description:


### PR DESCRIPTION
## What

Removes the `retry` package from both `gotrue` and `storage_client`, replacing it with a small self-contained `RetryOptions`/`retry` helper (`lib/src/retry.dart`) in each package.

- `gotrue` used the top-level `retry()` (token refresh).
- `storage_client` used `RetryOptions(...).retry(...)` (request retries).

## Why

Both packages pulled in `retry` for the same narrow use: exponential backoff gated by a `retryIf` predicate. The helper is ~40 lines and mirrors the package's behavior exactly:

- 200 ms delay factor, `2^attempt` backoff
- 25% jitter (`randomizationFactor`)
- 30 s max delay
- 8 max attempts by default

`gotrue`'s time-budget `retryIf` depends on these exact defaults, so they are preserved.

## Testing

- New `retry_test.dart` in `gotrue` covers success-after-retries, `maxAttempts` cutoff, `retryIf` short-circuit, `RetryOptions.retry` (the storage usage shape), and exponential/capped delay math — all pass.
- `dart analyze` clean for both packages.

Note: the helper is duplicated in each package because they are published independently and there is no shared internal utility package.