### PR TITLE
refactor: modernize dart syntax across client packages

### DIFF
--- a/packages/gotrue/lib/src/fetch.dart
+++ b/packages/gotrue/lib/src/fetch.dart
@@ -159,43 +159,32 @@ class GotrueFetch {
     }
     Response response;
     try {
-      switch (method) {
-        case RequestMethodType.get:
-          response = await (httpClient?.get ?? get)(
-            uri,
-            headers: headers,
-          );
-
-          break;
-        case RequestMethodType.post:
-          response = await (httpClient?.post ?? post)(
-            uri,
-            headers: headers,
-            body: bodyStr,
-          );
-          break;
-        case RequestMethodType.put:
-          response = await (httpClient?.put ?? put)(
-            uri,
-            headers: headers,
-            body: bodyStr,
-          );
-          break;
-        case RequestMethodType.patch:
-          response = await (httpClient?.patch ?? patch)(
-            uri,
-            headers: headers,
-            body: bodyStr,
-          );
-          break;
-        case RequestMethodType.delete:
-          response = await (httpClient?.delete ?? delete)(
-            uri,
-            headers: headers,
-            body: bodyStr,
-          );
-          break;
-      }
+      response = await switch (method) {
+        RequestMethodType.get => (httpClient?.get ?? get)(
+          uri,
+          headers: headers,
+        ),
+        RequestMethodType.post => (httpClient?.post ?? post)(
+          uri,
+          headers: headers,
+          body: bodyStr,
+        ),
+        RequestMethodType.put => (httpClient?.put ?? put)(
+          uri,
+          headers: headers,
+          body: bodyStr,
+        ),
+        RequestMethodType.patch => (httpClient?.patch ?? patch)(
+          uri,
+          headers: headers,
+          body: bodyStr,
+        ),
+        RequestMethodType.delete => (httpClient?.delete ?? delete)(
+          uri,
+          headers: headers,
+          body: bodyStr,
+        ),
+      };
     } catch (e) {
       // fetch failed, likely due to a network or CORS error
       throw AuthRetryableFetchException(message: e.toString());

--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -1379,27 +1379,19 @@ class GoTrueClient {
     required Map<String, String>? queryParams,
     bool skipBrowserRedirect = false,
   }) async {
-    final urlParams = {'provider': provider.name};
-    if (scopes != null) {
-      urlParams['scopes'] = scopes;
-    }
-    if (redirectTo != null) {
-      urlParams['redirect_to'] = redirectTo;
-    }
-    if (queryParams != null) {
-      urlParams.addAll(queryParams);
-    }
     final codeChallenge = await _generatePKCECodeChallenge();
-    if (codeChallenge != null) {
-      urlParams.addAll({
+    final urlParams = {
+      'provider': provider.name,
+      'scopes': ?scopes,
+      'redirect_to': ?redirectTo,
+      ...?queryParams,
+      if (codeChallenge != null) ...{
         'flow_type': _flowType.name,
         'code_challenge': codeChallenge,
         'code_challenge_method': 's256',
-      });
-    }
-    if (skipBrowserRedirect) {
-      urlParams['skip_http_redirect'] = 'true';
-    }
+      },
+      if (skipBrowserRedirect) 'skip_http_redirect': 'true',
+    };
     final oauthUrl = '$url?${Uri(queryParameters: urlParams).query}';
     return OAuthResponse(provider: provider, url: oauthUrl);
   }

--- a/packages/gotrue/lib/src/types/jwt.dart
+++ b/packages/gotrue/lib/src/types/jwt.dart
@@ -238,35 +238,23 @@ class JWK {
   }
 
   /// Allows accessing additional properties using operator[].
-  dynamic operator [](String key) {
-    switch (key) {
-      case 'kty':
-        return kty;
-      case 'key_ops':
-        return keyOps;
-      case 'alg':
-        return alg;
-      case 'kid':
-        return kid;
-      default:
-        return _additionalProperties[key];
-    }
-  }
+  dynamic operator [](String key) => switch (key) {
+    'kty' => kty,
+    'key_ops' => keyOps,
+    'alg' => alg,
+    'kid' => kid,
+    _ => _additionalProperties[key],
+  };
 
   /// Converts this [JWK] to a JSON map.
   Map<String, dynamic> toJson() {
-    final Map<String, dynamic> json = {
+    return {
       'kty': kty,
       'key_ops': keyOps,
       ..._additionalProperties,
+      'alg': ?alg,
+      'kid': ?kid,
     };
-    if (alg != null) {
-      json['alg'] = alg;
-    }
-    if (kid != null) {
-      json['kid'] = kid;
-    }
-    return json;
   }
 
   /// Builds the RSA public key for verifying RS256 JWTs from this JWK's

--- a/packages/gotrue/lib/src/types/jwt.dart
+++ b/packages/gotrue/lib/src/types/jwt.dart
@@ -251,9 +251,9 @@ class JWK {
     return {
       'kty': kty,
       'key_ops': keyOps,
-      ..._additionalProperties,
       'alg': ?alg,
       'kid': ?kid,
+      ..._additionalProperties,
     };
   }
 

--- a/packages/gotrue/lib/src/types/mfa.dart
+++ b/packages/gotrue/lib/src/types/mfa.dart
@@ -81,18 +81,15 @@ class PhoneEnrollment {
     );
   }
 
-  factory PhoneEnrollment._fromJsonValue(dynamic value) {
-    if (value is String) {
-      // Server returns phone number as a string directly
-      return PhoneEnrollment(phone: value);
-    } else if (value is Map<String, dynamic>) {
-      // Server returns phone data as an object
-      return PhoneEnrollment.fromJson(value);
-    }
-    throw ArgumentError(
+  factory PhoneEnrollment._fromJsonValue(dynamic value) => switch (value) {
+    // Server returns phone number as a string directly
+    String() => PhoneEnrollment(phone: value),
+    // Server returns phone data as an object
+    Map<String, dynamic>() => PhoneEnrollment.fromJson(value),
+    _ => throw ArgumentError(
       'Invalid phone enrollment data type: ${value.runtimeType}',
-    );
-  }
+    ),
+  };
 }
 
 class AuthMFAChallengeResponse {

--- a/packages/postgrest/lib/src/postgrest_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_builder.dart
@@ -372,8 +372,8 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
     http.Response response,
     PostgrestException error,
   ) {
-    if (error.details is String &&
-        (error.details as String).contains('Results contain 0 rows')) {
+    if (error.details case final String details
+        when details.contains('Results contain 0 rows')) {
       if (_count != null && response.request!.method != HttpMethod.head.value) {
         if (_converter != null) {
           return PostgrestResponse<S>(data: _converter(null as R), count: 0)

--- a/packages/postgrest/lib/src/postgrest_filter_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_filter_builder.dart
@@ -423,14 +423,12 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
     /// The type of tsquery conversion to use on [query].
     TextSearchType? type,
   }) {
-    var typePart = '';
-    if (type == TextSearchType.plain) {
-      typePart = 'pl';
-    } else if (type == TextSearchType.phrase) {
-      typePart = 'ph';
-    } else if (type == TextSearchType.websearch) {
-      typePart = 'w';
-    }
+    final typePart = switch (type) {
+      TextSearchType.plain => 'pl',
+      TextSearchType.phrase => 'ph',
+      TextSearchType.websearch => 'w',
+      null => '',
+    };
     final configPart = config == null ? '' : '($config)';
     return copyWithUrl(
       appendSearchParams(column, '${typePart}fts$configPart.$query'),

--- a/packages/postgrest/lib/src/postgrest_query_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_query_builder.dart
@@ -251,10 +251,7 @@ class PostgrestQueryBuilder<T> extends RawPostgrestBuilder<T, T, T> {
 
   Uri _setColumnsSearchParam(List values) {
     final newValues = PostgrestList.from(values);
-    final columns = newValues.fold<List<String>>(
-      [],
-      (value, element) => value..addAll(element.keys),
-    );
+    final columns = [for (final element in newValues) ...element.keys];
     if (newValues.isNotEmpty) {
       final uniqueColumns = {...columns}.map((e) => '"$e"').join(',');
       return appendSearchParams("columns", uniqueColumns);

--- a/packages/realtime_client/lib/src/constants.dart
+++ b/packages/realtime_client/lib/src/constants.dart
@@ -67,18 +67,18 @@ extension ChannelEventsExtended on ChannelEvents {
     throw 'No type $type exists';
   }
 
-  String eventName() {
-    if (this == ChannelEvents.accessToken) {
-      return 'access_token';
-    } else if (this == ChannelEvents.postgresChanges) {
-      return 'postgres_changes';
-    } else if (this == ChannelEvents.broadcast) {
-      return 'broadcast';
-    } else if (this == ChannelEvents.presence) {
-      return 'presence';
-    }
-    return 'phx_$name';
-  }
+  String eventName() => switch (this) {
+    ChannelEvents.accessToken => 'access_token',
+    ChannelEvents.postgresChanges => 'postgres_changes',
+    ChannelEvents.broadcast => 'broadcast',
+    ChannelEvents.presence => 'presence',
+    ChannelEvents.close ||
+    ChannelEvents.error ||
+    ChannelEvents.join ||
+    ChannelEvents.reply ||
+    ChannelEvents.leave ||
+    ChannelEvents.heartbeat => 'phx_$name',
+  };
 }
 
 class Transports {

--- a/packages/realtime_client/lib/src/realtime_client.dart
+++ b/packages/realtime_client/lib/src/realtime_client.dart
@@ -401,21 +401,13 @@ class RealtimeClient {
       _heartbeatController.stream;
 
   /// Returns the current state of the socket.
-  String get connectionState {
-    switch (connState) {
-      case SocketStates.connecting:
-        return 'connecting';
-      case SocketStates.open:
-        return 'open';
-      case SocketStates.disconnecting:
-        return 'disconnecting';
-      case SocketStates.disconnected:
-        return 'disconnected';
-      case SocketStates.closed:
-      case null:
-        return 'closed';
-    }
-  }
+  String get connectionState => switch (connState) {
+    SocketStates.connecting => 'connecting',
+    SocketStates.open => 'open',
+    SocketStates.disconnecting => 'disconnecting',
+    SocketStates.disconnected => 'disconnected',
+    SocketStates.closed || null => 'closed',
+  };
 
   /// Returns `true` is the connection is open.
   bool get isConnected => connState == SocketStates.open;

--- a/packages/realtime_client/lib/src/serializer.dart
+++ b/packages/realtime_client/lib/src/serializer.dart
@@ -137,12 +137,10 @@ class Serializer {
   Map<String, dynamic> _binaryDecode(Uint8List buffer) {
     final view = ByteData.sublistView(buffer);
     final kind = view.getUint8(0);
-    switch (kind) {
-      case kindUserBroadcast:
-        return _decodeUserBroadcast(buffer, view);
-      default:
-        return {};
-    }
+    return switch (kind) {
+      kindUserBroadcast => _decodeUserBroadcast(buffer, view),
+      _ => {},
+    };
   }
 
   Map<String, dynamic> _decodeUserBroadcast(Uint8List buffer, ByteData view) {

--- a/packages/realtime_client/lib/src/types.dart
+++ b/packages/realtime_client/lib/src/types.dart
@@ -54,19 +54,14 @@ extension PostgresChangeEventMethods on PostgresChangeEvent {
     return name.toUpperCase();
   }
 
-  static PostgresChangeEvent fromString(String event) {
-    switch (event) {
-      case 'INSERT':
-        return PostgresChangeEvent.insert;
-      case 'UPDATE':
-        return PostgresChangeEvent.update;
-      case 'DELETE':
-        return PostgresChangeEvent.delete;
-    }
-    throw ArgumentError(
+  static PostgresChangeEvent fromString(String event) => switch (event) {
+    'INSERT' => PostgresChangeEvent.insert,
+    'UPDATE' => PostgresChangeEvent.update,
+    'DELETE' => PostgresChangeEvent.delete,
+    _ => throw ArgumentError(
       'Only "INSERT", "UPDATE", or "DELETE" can be can be passed to `fromString()` method.',
-    );
-  }
+    ),
+  };
 }
 
 class ChannelFilter {
@@ -406,27 +401,21 @@ enum PostgresChangeFilterType {
   /// The operator token used in the filter wire format (the part between
   /// `column=` and `.value`). Most match [name], but a few differ because the
   /// enum names avoid Dart reserved words / casing conventions.
-  String get token {
-    switch (this) {
-      case PostgresChangeFilterType.inFilter:
-        return 'in';
-      case PostgresChangeFilterType.isFilter:
-        return 'is';
-      case PostgresChangeFilterType.isDistinct:
-        return 'isdistinct';
-      case PostgresChangeFilterType.eq:
-      case PostgresChangeFilterType.neq:
-      case PostgresChangeFilterType.lt:
-      case PostgresChangeFilterType.lte:
-      case PostgresChangeFilterType.gt:
-      case PostgresChangeFilterType.gte:
-      case PostgresChangeFilterType.like:
-      case PostgresChangeFilterType.ilike:
-      case PostgresChangeFilterType.match:
-      case PostgresChangeFilterType.imatch:
-        return name;
-    }
-  }
+  String get token => switch (this) {
+    PostgresChangeFilterType.inFilter => 'in',
+    PostgresChangeFilterType.isFilter => 'is',
+    PostgresChangeFilterType.isDistinct => 'isdistinct',
+    PostgresChangeFilterType.eq ||
+    PostgresChangeFilterType.neq ||
+    PostgresChangeFilterType.lt ||
+    PostgresChangeFilterType.lte ||
+    PostgresChangeFilterType.gt ||
+    PostgresChangeFilterType.gte ||
+    PostgresChangeFilterType.like ||
+    PostgresChangeFilterType.ilike ||
+    PostgresChangeFilterType.match ||
+    PostgresChangeFilterType.imatch => name,
+  };
 }
 
 /// {@template postgres_change_filter}

--- a/packages/realtime_client/test/realtime_integration_test.dart
+++ b/packages/realtime_client/test/realtime_integration_test.dart
@@ -235,13 +235,10 @@ void main() {
               switch (payload.eventType) {
                 case PostgresChangeEvent.insert:
                   if (!inserts.isCompleted) inserts.complete(payload);
-                  break;
                 case PostgresChangeEvent.update:
                   if (!updates.isCompleted) updates.complete(payload);
-                  break;
                 case PostgresChangeEvent.delete:
                   if (!deletes.isCompleted) deletes.complete(payload);
-                  break;
                 case PostgresChangeEvent.all:
                   break;
               }

--- a/packages/storage_client/lib/src/storage_file_api.dart
+++ b/packages/storage_client/lib/src/storage_file_api.dart
@@ -493,8 +493,7 @@ class StorageFileApi {
         ? 'render/image/authenticated'
         : 'object';
 
-    Map<String, String> query = transformationQuery;
-    query.addAll(queryParams ?? {});
+    final query = {...transformationQuery, ...?queryParams};
 
     final options = FetchOptions(headers, noResolveJson: true);
 

--- a/packages/storage_client/lib/src/types.dart
+++ b/packages/storage_client/lib/src/types.dart
@@ -421,9 +421,9 @@ extension ToQueryParams on TransformOptions {
     return {
       if (width != null) 'width': '$width',
       if (height != null) 'height': '$height',
-      if (resize != null) 'resize': resize!.snakeCase,
+      'resize': ?resize?.snakeCase,
       if (quality != null) 'quality': '$quality',
-      if (format != null) 'format': format!.snakeCase,
+      'format': ?format?.snakeCase,
     };
   }
 }

--- a/packages/supabase/lib/src/supabase_stream_builder.dart
+++ b/packages/supabase/lib/src/supabase_stream_builder.dart
@@ -193,7 +193,6 @@ class SupabaseStreamBuilder extends Stream<SupabaseStreamEvent> {
                 final newRecord = payload.newRecord;
                 _streamData.add(newRecord);
                 _addStream();
-                break;
               case PostgresChangeEvent.update:
                 final updatedIndex = _streamData.indexWhere(
                   (element) =>
@@ -207,7 +206,6 @@ class SupabaseStreamBuilder extends Stream<SupabaseStreamEvent> {
                   _streamData.add(updatedRecord);
                 }
                 _addStream();
-                break;
               case PostgresChangeEvent.delete:
                 final deletedIndex = _streamData.indexWhere(
                   (element) =>
@@ -218,7 +216,6 @@ class SupabaseStreamBuilder extends Stream<SupabaseStreamEvent> {
                   _streamData.removeAt(deletedIndex);
                   _addStream();
                 }
-                break;
               case PostgresChangeEvent.all:
                 break;
             }
@@ -233,14 +230,11 @@ class SupabaseStreamBuilder extends Stream<SupabaseStreamEvent> {
                 unawaited(_getPostgrestData());
               }
               _wasSubscribed = true;
-              break;
             case RealtimeSubscribeStatus.closed:
               unawaited(_streamController?.close());
-              break;
             case RealtimeSubscribeStatus.timedOut:
             case RealtimeSubscribeStatus.channelError:
               _addException(RealtimeSubscribeException(status, error));
-              break;
           }
         });
     unawaited(_getPostgrestData());
@@ -249,43 +243,49 @@ class SupabaseStreamBuilder extends Stream<SupabaseStreamEvent> {
   Future<void> _getPostgrestData() async {
     PostgrestFilterBuilder<PostgrestList> query = _queryBuilder.select();
     if (_streamFilter != null) {
-      switch (_streamFilter!.type) {
-        case PostgresChangeFilterType.eq:
-          query = query.eq(_streamFilter!.column, _streamFilter!.value);
-          break;
-        case PostgresChangeFilterType.neq:
-          query = query.neq(_streamFilter!.column, _streamFilter!.value);
-          break;
-        case PostgresChangeFilterType.lt:
-          query = query.lt(_streamFilter!.column, _streamFilter!.value);
-          break;
-        case PostgresChangeFilterType.lte:
-          query = query.lte(_streamFilter!.column, _streamFilter!.value);
-          break;
-        case PostgresChangeFilterType.gt:
-          query = query.gt(_streamFilter!.column, _streamFilter!.value);
-          break;
-        case PostgresChangeFilterType.gte:
-          query = query.gte(_streamFilter!.column, _streamFilter!.value);
-          break;
-        case PostgresChangeFilterType.inFilter:
-          query = query.inFilter(_streamFilter!.column, _streamFilter!.value);
-          break;
-        case PostgresChangeFilterType.like:
-        case PostgresChangeFilterType.ilike:
-        case PostgresChangeFilterType.isFilter:
-        case PostgresChangeFilterType.match:
-        case PostgresChangeFilterType.imatch:
-        case PostgresChangeFilterType.isDistinct:
-          // These operators are only reachable through the realtime
-          // `onPostgresChanges` API, not through `.stream()`'s filter builder,
-          // so they can never be set on `_streamFilter`. Guard the exhaustive
-          // switch defensively in case that ever changes.
-          throw UnsupportedError(
-            'The "${_streamFilter!.type.name}" filter is not supported by '
-            '`.stream()`. Use one of eq, neq, lt, lte, gt, gte or inFilter.',
-          );
-      }
+      query = switch (_streamFilter!.type) {
+        PostgresChangeFilterType.eq => query.eq(
+          _streamFilter!.column,
+          _streamFilter!.value,
+        ),
+        PostgresChangeFilterType.neq => query.neq(
+          _streamFilter!.column,
+          _streamFilter!.value,
+        ),
+        PostgresChangeFilterType.lt => query.lt(
+          _streamFilter!.column,
+          _streamFilter!.value,
+        ),
+        PostgresChangeFilterType.lte => query.lte(
+          _streamFilter!.column,
+          _streamFilter!.value,
+        ),
+        PostgresChangeFilterType.gt => query.gt(
+          _streamFilter!.column,
+          _streamFilter!.value,
+        ),
+        PostgresChangeFilterType.gte => query.gte(
+          _streamFilter!.column,
+          _streamFilter!.value,
+        ),
+        PostgresChangeFilterType.inFilter => query.inFilter(
+          _streamFilter!.column,
+          _streamFilter!.value,
+        ),
+        // These operators are only reachable through the realtime
+        // `onPostgresChanges` API, not through `.stream()`'s filter builder,
+        // so they can never be set on `_streamFilter`. Guard the exhaustive
+        // switch defensively in case that ever changes.
+        PostgresChangeFilterType.like ||
+        PostgresChangeFilterType.ilike ||
+        PostgresChangeFilterType.isFilter ||
+        PostgresChangeFilterType.match ||
+        PostgresChangeFilterType.imatch ||
+        PostgresChangeFilterType.isDistinct => throw UnsupportedError(
+          'The "${_streamFilter!.type.name}" filter is not supported by '
+          '`.stream()`. Use one of eq, neq, lt, lte, gt, gte or inFilter.',
+        ),
+      };
     }
     PostgrestTransformBuilder<PostgrestList>? transformQuery;
     if (_orderBy != null) {

--- a/packages/supabase_lints/lib/analysis_options.yaml
+++ b/packages/supabase_lints/lib/analysis_options.yaml
@@ -10,8 +10,6 @@ linter:
   rules:
     unawaited_futures: true
     discarded_futures: true
-    # Modern-syntax rules (Dart 3.9 floor): enhanced enums over plain classes,
-    # and no redundant trailing breaks in switch statements.
     use_enums: true
     unnecessary_breaks: true
 
@@ -22,7 +20,6 @@ dcm:
   extends:
     - recommended
   rules:
-    # Prefer value-returning switch expressions over switch statements.
     prefer-switch-expression: true
     # Keep web and WASM support: dart:html / dart:js / dart:js_util work on the
     # JS web target but break WASM, and dart:io / dart:ffi break both. The web

--- a/packages/supabase_lints/lib/analysis_options.yaml
+++ b/packages/supabase_lints/lib/analysis_options.yaml
@@ -10,6 +10,10 @@ linter:
   rules:
     unawaited_futures: true
     discarded_futures: true
+    # Modern-syntax rules (Dart 3.9 floor): enhanced enums over plain classes,
+    # and no redundant trailing breaks in switch statements.
+    use_enums: true
+    unnecessary_breaks: true
 
 formatter:
   trailing_commas: preserve
@@ -18,6 +22,8 @@ dcm:
   extends:
     - recommended
   rules:
+    # Prefer value-returning switch expressions over switch statements.
+    prefer-switch-expression: true
     # Keep web and WASM support: dart:html / dart:js / dart:js_util work on the
     # JS web target but break WASM, and dart:io / dart:ffi break both. The web
     # interop libraries below are replaced by dart:js_interop + package:web, and


### PR DESCRIPTION
## What

Sweeps the client packages for code that can use syntax introduced in Dart 3.9 or earlier (our minimum SDK floor), and adds lint rules so new code keeps to the modern style.

All changes are behavior-preserving refactors.

### Switch expressions (replacing value-returning switch statements / if-else chains)
- `postgrest`: `textSearch` type mapping
- `realtime_client`: `connectionState`, `PostgresChangeFilterType.token`, `PostgresChangeEvent.fromString`, `ChannelEventsExtended.eventName`, `_binaryDecode`
- `gotrue`: `JWK operator[]`, `fetch` HTTP method dispatch, `PhoneEnrollment._fromJsonValue`
- `supabase`: `_getPostgrestData` filter dispatch

### Null-aware collection elements (`{'k': ?v}`) and spreads (`...?`)
- `storage_client`: `ToQueryParams`
- `gotrue`: `JWK.toJson`, `getOAuthSignInUrl` url params

### Collection-for / spread (replacing `fold` / `addAll`)
- `postgrest`: `_setColumnsSearchParam`
- `storage_client`: `download` query merge

### if-case pattern (replacing manual `is` + cast)
- `postgrest`: `_handleMaybeSingleError`

## Lint rules added to `supabase_lints`
- `use_enums` (core)
- `unnecessary_breaks` (core)
- `prefer-switch-expression` (DCM)

Enum switches are kept exhaustive (no `_` wildcard) so `avoid-wildcard-cases-with-enums` stays satisfied.

## Testing
- `dart analyze` clean across all packages with the new rules.
- `dcm analyze` reports no new issues (one pre-existing `avoid-inferrable-type-arguments` in `gotrue_oauth_api.dart` is untouched).
- Package test suites pass; remaining failures are pre-existing integration tests that require a running local Supabase instance.

Closes SDK-1283
