### PR TITLE
feat(postgrest): support aborting requests

### DIFF
--- a/packages/postgrest/lib/postgrest.dart
+++ b/packages/postgrest/lib/postgrest.dart
@@ -1,6 +1,8 @@
 /// PostgREST client for Dart. Provides an ORM interface to PostgREST.
 library;
 
+export 'package:http/http.dart' show RequestAbortedException;
+
 export 'src/postgrest.dart';
 export 'src/postgrest_builder.dart';
 export 'src/types.dart';

--- a/packages/postgrest/lib/src/postgrest_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_builder.dart
@@ -91,6 +91,7 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
   final YAJsonIsolate? _isolate;
   final CountOption? _count;
   final _RetryConfig _retry;
+  final Future<void>? _abortTrigger;
   final _log = Logger('supabase.postgrest');
 
   /// HTTP status codes that trigger an automatic retry by default.
@@ -114,6 +115,7 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
     int retryCount = 3,
     Set<int> retryableStatusCodes = defaultRetryableStatusCodes,
     @visibleForTesting Duration Function(int attempt)? retryDelay,
+    Future<void>? abortTrigger,
   }) : this._(
          url: url,
          headers: headers,
@@ -131,6 +133,7 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
            statusCodes: retryableStatusCodes,
            delay: retryDelay,
          ),
+         abortTrigger: abortTrigger,
        );
 
   PostgrestBuilder._({
@@ -145,6 +148,7 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
     bool maybeSingle = false,
     PostgrestConverter<S, R>? converter,
     required _RetryConfig retry,
+    Future<void>? abortTrigger,
   }) : _maybeSingle = maybeSingle,
        _method = method,
        _converter = converter,
@@ -155,7 +159,8 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
        _isolate = isolate,
        _count = count,
        _body = body,
-       _retry = retry;
+       _retry = retry,
+       _abortTrigger = abortTrigger;
 
   PostgrestBuilder<T, S, R> _copyWith({
     Uri? url,
@@ -169,6 +174,7 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
     bool? maybeSingle,
     PostgrestConverter<S, R>? converter,
     _RetryConfig? retry,
+    Future<void>? abortTrigger,
   }) {
     return PostgrestBuilder._(
       url: url ?? _url,
@@ -182,6 +188,7 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
       maybeSingle: maybeSingle ?? _maybeSingle,
       converter: converter ?? _converter,
       retry: retry ?? _retry,
+      abortTrigger: abortTrigger ?? _abortTrigger,
     );
   }
 
@@ -197,6 +204,24 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
       _copyWith(
         retry: _retry.copyWith(enabled: enabled, count: count),
       );
+
+  /// Aborts this request when [completer] completes.
+  ///
+  /// ```dart
+  /// final completer = Completer<void>();
+  /// Timer(const Duration(seconds: 5), completer.complete);
+  /// try {
+  ///   await supabase.from('users').select().abortCompleter(completer);
+  /// } on RequestAbortedException {
+  ///   // The request was aborted before it completed.
+  /// }
+  /// ```
+  ///
+  /// Aborting is only effective when the underlying [Client] supports it and
+  /// does not trigger a retry. Completing [completer] after the response has
+  /// finished has no effect.
+  PostgrestBuilder<T, S, R> abortCompleter(Completer<void> completer) =>
+      _copyWith(abortTrigger: completer.future);
 
   PostgrestBuilder<T, S, R> setHeader(String key, String value) {
     return _copyWith(
@@ -237,8 +262,11 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
     final bodyStr = jsonEncode(_body);
     _log.finest("Request: ${method.value} $_url");
 
+    final abortTrigger = _abortTrigger;
     final Future<http.Response> Function() send;
-    if (method == HttpMethod.get) {
+    if (abortTrigger != null) {
+      send = () => _sendAbortable(method, execHeaders, bodyStr, abortTrigger);
+    } else if (method == HttpMethod.get) {
       send = () => (_httpClient?.get ?? http.get)(_url, headers: execHeaders);
     } else if (method == HttpMethod.post) {
       send = () => (_httpClient?.post ?? http.post)(
@@ -271,6 +299,31 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
     return await _parseResponse(response, method);
   }
 
+  Future<http.Response> _sendAbortable(
+    HttpMethod method,
+    Map<String, String> execHeaders,
+    String bodyStr,
+    Future<void> abortTrigger,
+  ) async {
+    final request = http.AbortableRequest(
+      method.value,
+      _url,
+      abortTrigger: abortTrigger,
+    )..headers.addAll(execHeaders);
+    if (method == HttpMethod.post ||
+        method == HttpMethod.put ||
+        method == HttpMethod.patch) {
+      request.body = bodyStr;
+    }
+
+    final client = _httpClient ?? http.Client();
+    try {
+      return await http.Response.fromStream(await client.send(request));
+    } finally {
+      if (_httpClient == null) client.close();
+    }
+  }
+
   Future<http.Response> _executeWithRetry(
     Future<http.Response> Function() send,
     HttpMethod method,
@@ -297,6 +350,9 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
             attempt == maxRetries) {
           return response;
         }
+      } on http.RequestAbortedException {
+        // An aborted request is intentional, so it must not be retried.
+        rethrow;
       } on Exception {
         if (attempt == maxRetries) rethrow;
       }

--- a/packages/postgrest/lib/src/postgrest_filter_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_filter_builder.dart
@@ -534,6 +534,11 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   }
 
   @override
+  PostgrestFilterBuilder<T> abortCompleter(Completer<void> completer) {
+    return PostgrestFilterBuilder(_copyWith(abortTrigger: completer.future));
+  }
+
+  @override
   PostgrestFilterBuilder<T> setHeader(String key, String value) {
     return PostgrestFilterBuilder(
       _copyWith(headers: {..._headers, key: value}),

--- a/packages/postgrest/lib/src/postgrest_query_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_query_builder.dart
@@ -24,6 +24,7 @@ class PostgrestQueryBuilder<T> extends RawPostgrestBuilder<T, T, T> {
     Set<int> retryableStatusCodes =
         PostgrestBuilder.defaultRetryableStatusCodes,
     Duration Function(int attempt)? retryDelay,
+    Future<void>? abortTrigger,
   }) : super(
          PostgrestBuilder(
            url: url,
@@ -36,6 +37,7 @@ class PostgrestQueryBuilder<T> extends RawPostgrestBuilder<T, T, T> {
            retryCount: retryCount,
            retryableStatusCodes: retryableStatusCodes,
            retryDelay: retryDelay,
+           abortTrigger: abortTrigger,
          ),
        );
 
@@ -293,6 +295,24 @@ class PostgrestQueryBuilder<T> extends RawPostgrestBuilder<T, T, T> {
       retryCount: count ?? _retry.count,
       retryableStatusCodes: _retry.statusCodes,
       retryDelay: _retry.delay,
+      abortTrigger: _abortTrigger,
+    );
+  }
+
+  @override
+  PostgrestQueryBuilder<T> abortCompleter(Completer<void> completer) {
+    return PostgrestQueryBuilder(
+      url: _url,
+      headers: _headers,
+      httpClient: _httpClient,
+      method: _method,
+      schema: _schema,
+      isolate: _isolate,
+      retryEnabled: _retry.enabled,
+      retryCount: _retry.count,
+      retryableStatusCodes: _retry.statusCodes,
+      retryDelay: _retry.delay,
+      abortTrigger: completer.future,
     );
   }
 
@@ -309,6 +329,7 @@ class PostgrestQueryBuilder<T> extends RawPostgrestBuilder<T, T, T> {
       retryCount: _retry.count,
       retryableStatusCodes: _retry.statusCodes,
       retryDelay: _retry.delay,
+      abortTrigger: _abortTrigger,
     );
   }
 }

--- a/packages/postgrest/lib/src/postgrest_transform_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_transform_builder.dart
@@ -16,6 +16,11 @@ class PostgrestTransformBuilder<T> extends RawPostgrestBuilder<T, T, T> {
   }
 
   @override
+  PostgrestTransformBuilder<T> abortCompleter(Completer<void> completer) {
+    return PostgrestTransformBuilder(_copyWith(abortTrigger: completer.future));
+  }
+
+  @override
   PostgrestTransformBuilder<T> setHeader(String key, String value) {
     return PostgrestTransformBuilder(
       _copyWith(headers: {..._headers, key: value}),

--- a/packages/postgrest/lib/src/raw_postgrest_builder.dart
+++ b/packages/postgrest/lib/src/raw_postgrest_builder.dart
@@ -15,6 +15,7 @@ class RawPostgrestBuilder<T, S, R> extends PostgrestBuilder<T, S, R> {
         maybeSingle: builder._maybeSingle,
         converter: builder._converter,
         retry: builder._retry,
+        abortTrigger: builder._abortTrigger,
       );
 
   /// Very similar to [_copyWith], but allows changing the generics, therefore [_converter] is omitted
@@ -42,6 +43,7 @@ class RawPostgrestBuilder<T, S, R> extends PostgrestBuilder<T, S, R> {
         count: count ?? _count,
         maybeSingle: maybeSingle ?? _maybeSingle,
         retry: _retry,
+        abortTrigger: _abortTrigger,
       ),
     );
   }
@@ -78,6 +80,7 @@ class RawPostgrestBuilder<T, S, R> extends PostgrestBuilder<T, S, R> {
       maybeSingle: _maybeSingle,
       converter: converter,
       retry: _retry,
+      abortTrigger: _abortTrigger,
     );
   }
 }

--- a/packages/postgrest/lib/src/response_postgrest_builder.dart
+++ b/packages/postgrest/lib/src/response_postgrest_builder.dart
@@ -15,6 +15,7 @@ class ResponsePostgrestBuilder<T, S, R> extends PostgrestBuilder<T, S, R> {
         maybeSingle: builder._maybeSingle,
         converter: builder._converter,
         retry: builder._retry,
+        abortTrigger: builder._abortTrigger,
       );
 
   @override
@@ -52,6 +53,7 @@ class ResponsePostgrestBuilder<T, S, R> extends PostgrestBuilder<T, S, R> {
       maybeSingle: _maybeSingle,
       converter: converter,
       retry: _retry,
+      abortTrigger: _abortTrigger,
     );
   }
 }

--- a/packages/postgrest/test/abort_test.dart
+++ b/packages/postgrest/test/abort_test.dart
@@ -1,0 +1,124 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:http/http.dart';
+import 'package:postgrest/postgrest.dart';
+import 'package:test/test.dart';
+
+StreamedResponse _ok(BaseRequest request) => StreamedResponse(
+  Stream.value(Uint8List.fromList('[]'.codeUnits)),
+  200,
+  request: request,
+  headers: {'content-type': 'application/json'},
+);
+
+/// Mimics a client that supports [Abortable]: a request stays pending until
+/// either [release] is called (success) or its `abortTrigger` completes.
+class _AbortMockClient extends BaseClient {
+  final List<BaseRequest> requests = [];
+  final _gate = Completer<void>();
+
+  int get callCount => requests.length;
+
+  void release() {
+    if (!_gate.isCompleted) _gate.complete();
+  }
+
+  @override
+  Future<StreamedResponse> send(BaseRequest request) {
+    requests.add(request);
+    final completer = Completer<StreamedResponse>();
+    if (request case Abortable(:final abortTrigger?)) {
+      unawaited(
+        abortTrigger.whenComplete(() {
+          if (!completer.isCompleted) {
+            completer.completeError(RequestAbortedException(request.url));
+          }
+        }),
+      );
+    }
+    unawaited(
+      _gate.future.whenComplete(() {
+        if (!completer.isCompleted) completer.complete(_ok(request));
+      }),
+    );
+    return completer.future;
+  }
+}
+
+PostgrestClient _buildClient(_AbortMockClient mock) {
+  return PostgrestClient(
+    'http://localhost:3000',
+    httpClient: mock,
+    retryDelay: (_) => Duration.zero,
+  );
+}
+
+void main() {
+  group('abortCompleter', () {
+    test('aborts a GET request before it completes', () async {
+      final mock = _AbortMockClient();
+      final client = _buildClient(mock);
+      final abort = Completer<void>();
+
+      final future = client.from('users').select().abortCompleter(abort);
+      abort.complete();
+
+      await expectLater(future, throwsA(isA<RequestAbortedException>()));
+    });
+
+    test('aborts an insert (POST) request', () async {
+      final mock = _AbortMockClient();
+      final client = _buildClient(mock);
+      final abort = Completer<void>();
+
+      final future = client
+          .from('users')
+          .insert({'name': 'foo'})
+          .abortCompleter(abort);
+      abort.complete();
+
+      await expectLater(future, throwsA(isA<RequestAbortedException>()));
+    });
+
+    test('does not retry an aborted retryable request', () async {
+      final mock = _AbortMockClient();
+      final client = _buildClient(mock);
+      final abort = Completer<void>();
+
+      final future = client.from('users').select().abortCompleter(abort);
+      abort.complete();
+
+      await expectLater(future, throwsA(isA<RequestAbortedException>()));
+      expect(mock.callCount, 1);
+    });
+
+    test('completes normally when the completer never fires', () async {
+      final mock = _AbortMockClient();
+      final client = _buildClient(mock);
+
+      final future = client
+          .from('users')
+          .select()
+          .abortCompleter(Completer<void>());
+      mock.release();
+
+      expect(await future, isEmpty);
+    });
+
+    test('survives further chaining after abortCompleter', () async {
+      final mock = _AbortMockClient();
+      final client = _buildClient(mock);
+      final abort = Completer<void>();
+
+      final future = client
+          .from('users')
+          .select()
+          .abortCompleter(abort)
+          .eq('name', 'foo');
+      abort.complete();
+
+      await expectLater(future, throwsA(isA<RequestAbortedException>()));
+    });
+  });
+}

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -359,7 +359,11 @@ features:
     status: implemented
     symbols:
       - PostgrestTransformBuilder.stripNulls
-  database.using_modifiers.request_cancellation: not_implemented
+  database.using_modifiers.request_cancellation:
+    status: implemented
+    symbols:
+      - PostgrestBuilder.abortCompleter
+      - RequestAbortedException
 
   # database — configuration
   database.configuration.auto_retry:


### PR DESCRIPTION
## Summary

Adds request aborting to the PostgREST client, following up on the discussion in #1560 (comment): now that the repo is on `http ^1.6.0`, in-flight requests can actually be cancelled via the [`Abortable`](https://pub.dev/packages/http#aborting-requests) API, so the reasoning that removed cancellation-based features from #1560 no longer applies.

> Stacked on top of #1560 (base branch `worktree-SDK-1270`). Review/merge that first.

New per-request API on `PostgrestBuilder`:

```dart
final abort = Completer<void>();
Timer(const Duration(seconds: 5), abort.complete);
try {
  final data = await supabase.from('users').select().abortCompleter(abort);
} on RequestAbortedException {
  // The request was aborted before it completed.
}
```

- `PostgrestBuilder.abortCompleter(Completer<void> completer)` — aborts the request when `completer` completes. Available on the query, filter and transform builders, and preserved across further chaining.
- When triggered, the request throws `RequestAbortedException` (re-exported from `package:http`).
- Aborting short-circuits the auto-retry loop: an aborted request is intentional and is never retried.
- The abortable path is only used when a completer is set, so all existing requests keep their exact current send behavior.

## Design notes

- The API name follows the proposal in #1368 (`abortCompleter`). `supabase-js` uses `abortSignal`; since Dart has no `AbortSignal`, a `Completer<void>` is the idiomatic equivalent. Open to `abortSignal(Future<void>)` instead if preferred, which would also allow `Future.delayed`-based timeouts directly.
- Aborting depends on the underlying `Client` supporting it (the platform `IOClient` / `BrowserClient` in `http` 1.6 do).

## Request timeout

`database.configuration.request_timeout` is still `not_applicable` in the matrix. It is now technically feasible to build a real per-request timeout on top of this (a `Future.delayed` as the abort trigger), so that entry could be revisited in a follow-up if we want a first-class timeout option.

## Compliance matrix

- `database.using_modifiers.request_cancellation` → `implemented`

## Tests

`packages/postgrest/test/abort_test.dart`: aborting a GET, aborting an insert (POST), no-retry-on-abort, normal completion when never triggered, and preservation across chaining.

Closes #1368
