### PR TITLE
feat(storage): add cacheNonce parameter for cache invalidation

### DIFF
--- a/packages/storage_client/lib/src/storage_file_api.dart
+++ b/packages/storage_client/lib/src/storage_file_api.dart
@@ -372,11 +372,15 @@ class StorageFileApi {
   /// browser by setting the response's `Content-Disposition` header. Use
   /// [DownloadBehavior.withOriginalName] to keep the original file name or
   /// [DownloadBehavior.named] to override it.
+  ///
+  /// [cacheNonce] appends a `cacheNonce` query parameter to the URL to bypass
+  /// CDN caching for a specific file version.
   Future<String> createSignedUrl(
     String path,
     int expiresIn, {
     TransformOptions? transform,
     DownloadBehavior? download,
+    String? cacheNonce,
   }) async {
     final finalPath = _getFinalPath(path);
     final options = _fetchOptions;
@@ -393,7 +397,11 @@ class StorageFileApi {
     if (signedUrlPath == null) {
       throw StorageException('No signed URL returned by API');
     }
-    return _withDownload('$url$signedUrlPath', download);
+    return _withUrlOptions(
+      '$url$signedUrlPath',
+      download: download,
+      cacheNonce: cacheNonce,
+    );
   }
 
   // TODO(v3): Remove this deprecated overload and rename createSignedUrlsResult
@@ -414,11 +422,13 @@ class StorageFileApi {
     List<String> paths,
     int expiresIn, {
     DownloadBehavior? download,
+    String? cacheNonce,
   }) async {
     final results = await createSignedUrlsResult(
       paths,
       expiresIn,
       download: download,
+      cacheNonce: cacheNonce,
     );
     return results
         .whereType<SignedUrlSuccess>()
@@ -443,10 +453,14 @@ class StorageFileApi {
   /// browser by setting the response's `Content-Disposition` header. Use
   /// [DownloadBehavior.withOriginalName] to keep the original file name or
   /// [DownloadBehavior.named] to override it.
+  ///
+  /// [cacheNonce] appends a `cacheNonce` query parameter to each URL to bypass
+  /// CDN caching for a specific file version.
   Future<List<SignedUrlResult>> createSignedUrlsResult(
     List<String> paths,
     int expiresIn, {
     DownloadBehavior? download,
+    String? cacheNonce,
   }) async {
     final options = _fetchOptions;
     final response = await _storageFetch.post(
@@ -463,7 +477,11 @@ class StorageFileApi {
       if (signedUrlPath != null) {
         return SignedUrlSuccess(
           path: path,
-          signedUrl: _withDownload('$url$signedUrlPath', download),
+          signedUrl: _withUrlOptions(
+            '$url$signedUrlPath',
+            download: download,
+            cacheNonce: cacheNonce,
+          ),
         );
       }
       return SignedUrlFailure(
@@ -481,10 +499,14 @@ class StorageFileApi {
   /// [transform] download a transformed variant of the image with the provided options
   ///
   /// [queryParams] additional query parameters to be added to the URL
+  ///
+  /// [cacheNonce] adds a `cacheNonce` query parameter to bypass CDN caching for
+  /// a specific file version.
   Future<Uint8List> download(
     String path, {
     TransformOptions? transform,
     Map<String, String>? queryParams,
+    String? cacheNonce,
   }) async {
     final transformationQuery = transform?.toQueryParams ?? {};
     final wantsTransformations = transformationQuery.isNotEmpty;
@@ -493,7 +515,11 @@ class StorageFileApi {
         ? 'render/image/authenticated'
         : 'object';
 
-    final query = {...transformationQuery, ...?queryParams};
+    final query = {
+      ...transformationQuery,
+      ...?queryParams,
+      'cacheNonce': ?cacheNonce,
+    };
 
     final options = FetchOptions(headers, noResolveJson: true);
 
@@ -548,10 +574,14 @@ class StorageFileApi {
   /// browser by setting the response's `Content-Disposition` header. Use
   /// [DownloadBehavior.withOriginalName] to keep the original file name or
   /// [DownloadBehavior.named] to override it.
+  ///
+  /// [cacheNonce] appends a `cacheNonce` query parameter to the URL to bypass
+  /// CDN caching for a specific file version.
   String getPublicUrl(
     String path, {
     TransformOptions? transform,
     DownloadBehavior? download,
+    String? cacheNonce,
   }) {
     final finalPath = _getFinalPath(path);
 
@@ -566,18 +596,33 @@ class StorageFileApi {
       publicUrl = publicUrl.replace(queryParameters: transformationQuery);
     }
 
-    return _withDownload(publicUrl.toString(), download);
+    return _withUrlOptions(
+      publicUrl.toString(),
+      download: download,
+      cacheNonce: cacheNonce,
+    );
   }
 
-  /// Appends a `download` query parameter to [urlString] when [download] is
-  /// set, so the response is served with a `Content-Disposition` header.
-  String _withDownload(String urlString, DownloadBehavior? download) {
-    if (download == null) {
-      return urlString;
+  /// Appends the optional `download` and `cacheNonce` query parameters to
+  /// [urlString], in that order, when they are set.
+  String _withUrlOptions(
+    String urlString, {
+    DownloadBehavior? download,
+    String? cacheNonce,
+  }) {
+    var result = urlString;
+    if (download != null) {
+      result = _appendQueryParameter(result, 'download', download.queryValue);
     }
+    if (cacheNonce != null) {
+      result = _appendQueryParameter(result, 'cacheNonce', cacheNonce);
+    }
+    return result;
+  }
+
+  String _appendQueryParameter(String urlString, String key, String value) {
     final separator = urlString.contains('?') ? '&' : '?';
-    return '$urlString${separator}download='
-        '${Uri.encodeQueryComponent(download.queryValue)}';
+    return '$urlString$separator$key=${Uri.encodeQueryComponent(value)}';
   }
 
   /// Deletes files within the same bucket

--- a/packages/storage_client/test/basic_test.dart
+++ b/packages/storage_client/test/basic_test.dart
@@ -442,6 +442,62 @@ void main() {
       expect(success.signedUrl, endsWith('?token=abc&download='));
     });
 
+    test('getPublicUrl appends cacheNonce', () {
+      final response = client
+          .from('files')
+          .getPublicUrl('b.txt', cacheNonce: 'v2');
+      expect(response, '$objectUrl/public/files/b.txt?cacheNonce=v2');
+    });
+
+    test('getPublicUrl appends download before cacheNonce', () {
+      final response = client
+          .from('files')
+          .getPublicUrl(
+            'b.txt',
+            download: DownloadBehavior.withOriginalName,
+            cacheNonce: 'v2',
+          );
+      expect(response, '$objectUrl/public/files/b.txt?download=&cacheNonce=v2');
+    });
+
+    test('download appends cacheNonce query parameter', () async {
+      final file = File('a.txt');
+      file.writeAsStringSync('Updated content');
+      customHttpClient.response = file.readAsBytesSync();
+
+      await client.from('public_bucket').download('b.txt', cacheNonce: 'v2');
+
+      final request = customHttpClient.receivedRequests.first;
+      expect(request.url.queryParameters, {'cacheNonce': 'v2'});
+    });
+
+    test('createSignedUrl appends cacheNonce to the token query', () async {
+      customHttpClient.response = {
+        'signedURL': '/object/sign/public/b.txt?token=abc',
+      };
+
+      final response = await client
+          .from('public')
+          .createSignedUrl('b.txt', 60, cacheNonce: 'v2');
+      expect(response, endsWith('?token=abc&cacheNonce=v2'));
+    });
+
+    test('createSignedUrlsResult appends cacheNonce to each URL', () async {
+      customHttpClient.response = [
+        {
+          'path': 'exists.txt',
+          'signedURL': '/object/sign/public/exists.txt?token=abc',
+        },
+      ];
+
+      final results = await client
+          .from('public')
+          .createSignedUrlsResult(['exists.txt'], 60, cacheNonce: 'v2');
+
+      final success = results.single as SignedUrlSuccess;
+      expect(success.signedUrl, endsWith('?token=abc&cacheNonce=v2'));
+    });
+
     test('should remove file', () async {
       customHttpClient.response = [testFileObjectJson, testFileObjectJson];
 

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -394,7 +394,7 @@ features:
   storage.file_buckets.create_signed_urls: implemented
   storage.file_buckets.create_signed_upload_url: implemented
   storage.file_buckets.get_public_url: implemented
-  storage.file_buckets.url_cache_nonce: not_implemented
+  storage.file_buckets.url_cache_nonce: implemented
   storage.file_buckets.file_exists: implemented
   storage.file_buckets.file_info: implemented
   storage.file_buckets.create_file_bucket: implemented


### PR DESCRIPTION
## Summary

Adds an optional `cacheNonce` parameter to the URL-generating storage methods so callers can bypass CDN caching for a specific file version. When set, a `cacheNonce` query parameter is appended to the generated URL.

Methods updated:
- `getPublicUrl`
- `createSignedUrl`
- `createSignedUrls` / `createSignedUrlsResult`
- `download`

**Outcome:** implemented
**Ticket:** SDK-875
**Reference:** supabase-js PR #2234 (`1ec22ca5`)
**Compliance matrix:** `storage.file_buckets.url_cache_nonce` → implemented

## Notes
- New optional named parameter, so no breaking changes and no new public symbols.
- Unit tests added for `getPublicUrl`, `download`, `createSignedUrl`, and `createSignedUrlsResult` with `cacheNonce` (including ordering after `download`).

## Stacking
First of three stacked PRs for the remaining Storage file-bucket features. Base: `main`.