### PR TITLE
chore: enable strict-raw-types in supabase_lints and fix all violations

### DIFF
--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -143,7 +143,7 @@ class GoTrueClient {
   /// Proxy to the web BroadcastChannel API. Should be null on non-web platforms.
   BroadcastChannel? _broadcastChannel;
 
-  StreamSubscription? _broadcastChannelSubscription;
+  StreamSubscription<dynamic>? _broadcastChannelSubscription;
 
   /// {@macro gotrue_client}
   GoTrueClient({

--- a/packages/gotrue/lib/src/types/types.dart
+++ b/packages/gotrue/lib/src/types/types.dart
@@ -2,7 +2,7 @@ import 'package:supabase_common/supabase_common.dart';
 
 typedef BroadcastChannel = ({
   Stream<Map<String, dynamic>> onMessage,
-  void Function(Map) postMessage,
+  void Function(Map<dynamic, dynamic>) postMessage,
   void Function() close,
 });
 

--- a/packages/gotrue/test/passkey_test.dart
+++ b/packages/gotrue/test/passkey_test.dart
@@ -87,7 +87,10 @@ void main() {
         mockClient.lastRequestBody?['challenge_id'],
         PasskeyMockClient.challengeId,
       );
-      expect(mockClient.lastRequestBody?['credential'], isA<Map>());
+      expect(
+        mockClient.lastRequestBody?['credential'],
+        isA<Map<dynamic, dynamic>>(),
+      );
       expect(response.session, isNotNull);
       expect(response.session?.accessToken, 'mock-access-token');
       expect(response.user?.id, PasskeyMockClient.userId);

--- a/packages/gotrue/test/src/types/user_test.dart
+++ b/packages/gotrue/test/src/types/user_test.dart
@@ -331,7 +331,7 @@ void main() {
 
         final json = user.toJson();
 
-        expect(json['identities'], isA<List>());
+        expect(json['identities'], isA<List<dynamic>>());
         expect(json['identities'].length, equals(1));
         expect(json['identities'][0], equals(identity.toJson()));
       });

--- a/packages/postgrest/lib/src/postgrest.dart
+++ b/packages/postgrest/lib/src/postgrest.dart
@@ -112,7 +112,7 @@ class PostgrestClient {
   /// ```
   PostgrestFilterBuilder<T> rpc<T>(
     String fn, {
-    Map? params,
+    Map<dynamic, dynamic>? params,
     bool get = false,
   }) {
     final requestUrl = '$url/rpc/$fn';

--- a/packages/postgrest/lib/src/postgrest_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_builder.dart
@@ -413,7 +413,7 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
   }
 
   /// Convert list filter to query params string
-  String _cleanFilterArray(List filter) {
+  String _cleanFilterArray(List<dynamic> filter) {
     if (filter.every((element) => element is num)) {
       return filter.map((s) => '$s').join(',');
     }

--- a/packages/postgrest/lib/src/postgrest_filter_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_filter_builder.dart
@@ -155,7 +155,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   ///     .select()
   ///     .likeAllOf('username', ['%supa%', '%bot%']);
   /// ```
-  PostgrestFilterBuilder likeAllOf(String column, List<String> patterns) {
+  PostgrestFilterBuilder<T> likeAllOf(String column, List<String> patterns) {
     return copyWithUrl(
       appendSearchParams(column, 'like(all).{${patterns.join(',')}}'),
     );
@@ -169,7 +169,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   ///     .select()
   ///     .likeAnyOf('username', ['%supa%', '%bot%']);
   /// ```
-  PostgrestFilterBuilder likeAnyOf(String column, List<String> patterns) {
+  PostgrestFilterBuilder<T> likeAnyOf(String column, List<String> patterns) {
     return copyWithUrl(
       appendSearchParams(column, 'like(any).{${patterns.join(',')}}'),
     );
@@ -195,7 +195,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   ///     .select()
   ///     .ilikeAllOf('username', ['%supa%', '%bot%']);
   /// ```
-  PostgrestFilterBuilder ilikeAllOf(String column, List<String> patterns) {
+  PostgrestFilterBuilder<T> ilikeAllOf(String column, List<String> patterns) {
     return copyWithUrl(
       appendSearchParams(column, 'ilike(all).{${patterns.join(',')}}'),
     );
@@ -209,7 +209,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   ///     .select()
   ///     .ilikeAnyOf('username', ['%supa%', '%bot%']);
   /// ```
-  PostgrestFilterBuilder ilikeAnyOf(String column, List<String> patterns) {
+  PostgrestFilterBuilder<T> ilikeAnyOf(String column, List<String> patterns) {
     return copyWithUrl(
       appendSearchParams(column, 'ilike(any).{${patterns.join(',')}}'),
     );
@@ -236,7 +236,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   ///     .select()
   ///     .inFilter('status', ['ONLINE', 'OFFLINE']);
   /// ```
-  PostgrestFilterBuilder<T> inFilter(String column, List values) {
+  PostgrestFilterBuilder<T> inFilter(String column, List<dynamic> values) {
     return copyWithUrl(
       appendSearchParams(column, 'in.(${_cleanFilterArray(values)})'),
     );

--- a/packages/postgrest/lib/src/postgrest_query_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_query_builder.dart
@@ -207,7 +207,7 @@ class PostgrestQueryBuilder<T> extends RawPostgrestBuilder<T, T, T> {
   ///     .eq('message', 'foo')
   ///     .select();
   /// ```
-  PostgrestFilterBuilder<T> update(Map values) {
+  PostgrestFilterBuilder<T> update(Map<dynamic, dynamic> values) {
     final newHeaders = {..._headers}..remove('Prefer');
 
     return PostgrestFilterBuilder(
@@ -249,7 +249,7 @@ class PostgrestQueryBuilder<T> extends RawPostgrestBuilder<T, T, T> {
     );
   }
 
-  Uri _setColumnsSearchParam(List values) {
+  Uri _setColumnsSearchParam(List<dynamic> values) {
     final newValues = PostgrestList.from(values);
     final columns = [for (final element in newValues) ...element.keys];
     if (newValues.isNotEmpty) {

--- a/packages/postgrest/lib/src/postgrest_rpc_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_rpc_builder.dart
@@ -1,6 +1,7 @@
 part of 'postgrest_builder.dart';
 
-class PostgrestRpcBuilder extends RawPostgrestBuilder {
+class PostgrestRpcBuilder
+    extends RawPostgrestBuilder<dynamic, dynamic, dynamic> {
   PostgrestRpcBuilder(
     String url, {
     Map<String, String>? headers,

--- a/packages/postgrest/test/basic_test.dart
+++ b/packages/postgrest/test/basic_test.dart
@@ -474,7 +474,7 @@ void main() {
           .withConverter((data) => [data]);
       expect(res, isNotEmpty);
       expect(res.first, isNotEmpty);
-      expect(res.first, isA<List>());
+      expect(res.first, isA<List<dynamic>>());
     });
 
     test('withConverter and count', () async {
@@ -484,7 +484,7 @@ void main() {
           .count(CountOption.exact)
           .withConverter((data) => [data]);
       expect(res.data.first, isNotEmpty);
-      expect(res.data.first, isA<List>());
+      expect(res.data.first, isA<List<dynamic>>());
       expect(res.count, greaterThan(3));
     });
   });

--- a/packages/postgrest/test/filter_test.dart
+++ b/packages/postgrest/test/filter_test.dart
@@ -531,7 +531,7 @@ void main() {
     }
   });
   test('filter on rpc', () async {
-    final List res = await postgrest
+    final List<dynamic> res = await postgrest
         .rpc('get_username_and_status', params: {'name_param': 'supabot'})
         .neq('status', 'ONLINE');
     expect(res, isEmpty);

--- a/packages/postgrest/test/transforms_test.dart
+++ b/packages/postgrest/test/transforms_test.dart
@@ -351,7 +351,7 @@ void main() {
         .limit(1)
         .single()
         .count(CountOption.exact);
-    expect(res.data, isA<Map>());
+    expect(res.data, isA<Map<dynamic, dynamic>>());
     expect(res.count, greaterThan(3));
   });
 
@@ -462,7 +462,7 @@ void main() {
         .explain(format: ExplainFormat.json);
 
     final decoded = jsonDecode(res);
-    expect(decoded, isA<List>());
+    expect(decoded, isA<List<dynamic>>());
     expect((decoded as List).first, contains('Plan'));
   });
 

--- a/packages/realtime_client/lib/src/realtime_client.dart
+++ b/packages/realtime_client/lib/src/realtime_client.dart
@@ -126,8 +126,8 @@ class RealtimeClient {
   final RealtimeDecode decode;
   late TimerCalculation reconnectAfterMs;
   WebSocketChannel? conn;
-  StreamSubscription? _connectionSubscription;
-  List sendBuffer = [];
+  StreamSubscription<dynamic>? _connectionSubscription;
+  List<dynamic> sendBuffer = [];
   Map<String, List<Function>> stateChangeCallbacks = {
     'open': [],
     'close': [],

--- a/packages/realtime_client/lib/src/transformers.dart
+++ b/packages/realtime_client/lib/src/transformers.dart
@@ -249,17 +249,17 @@ dynamic toArray(dynamic value, String type) {
   // Confirm value is a Postgres array by checking curly brackets
   if (openBrace == '{' && closeBrace == '}') {
     final valTrim = value.substring(1, lastIdx);
-    List arr;
+    List<dynamic> array;
 
     // TODO: find a better solution to separate Postgres array data
     try {
-      arr = json.decode('[$valTrim]') as List;
+      array = json.decode('[$valTrim]') as List;
     } catch (_) {
       // WARNING: splitting on comma does not cover all edge cases
-      arr = valTrim != '' ? valTrim.split(',') : [];
+      array = valTrim != '' ? valTrim.split(',') : [];
     }
 
-    return arr.map((val) => convertCell(type, val)).toList();
+    return array.map((val) => convertCell(type, val)).toList();
   }
 
   return value;

--- a/packages/realtime_client/test/channel_test.dart
+++ b/packages/realtime_client/test/channel_test.dart
@@ -409,7 +409,7 @@ void main() {
           'channel': 'topic',
         });
 
-        expect(received, isA<Map>());
+        expect(received, isA<Map<dynamic, dynamic>>());
 
         final system = RealtimeSystemPayload.fromJson(
           Map<String, dynamic>.from(received),

--- a/packages/realtime_client/test/socket_test.dart
+++ b/packages/realtime_client/test/socket_test.dart
@@ -988,7 +988,7 @@ void main() {
         final streamController = StreamController<dynamic>.broadcast();
         final readyCompleter = Completer<void>();
         final capturedMessages = <String>[];
-        final joinSent = Completer<Map>();
+        final joinSent = Completer<Map<dynamic, dynamic>>();
 
         final mockedChannel = MockIOWebSocketChannel();
         final mockedSink = MockWebSocketSink();

--- a/packages/realtime_client/test/websocket_io_test.dart
+++ b/packages/realtime_client/test/websocket_io_test.dart
@@ -16,7 +16,7 @@ Future<ServerSocket> _startUnresponsiveServer() async {
   final server = await ServerSocket.bind('localhost', 0);
   server.listen((socket) {
     final buffer = StringBuffer();
-    late StreamSubscription subscription;
+    late StreamSubscription<dynamic> subscription;
     subscription = socket.listen((data) {
       buffer.write(String.fromCharCodes(data));
       final request = buffer.toString();

--- a/packages/storage_client/test/basic_test.dart
+++ b/packages/storage_client/test/basic_test.dart
@@ -446,7 +446,7 @@ void main() {
       customHttpClient.response = [testFileObjectJson, testFileObjectJson];
 
       final response = await client.from('public').remove(['a.txt', 'b.txt']);
-      expect(response, isA<List>());
+      expect(response, isA<List<dynamic>>());
       expect(response.length, 2);
     });
   });

--- a/packages/supabase/lib/src/supabase_query_builder.dart
+++ b/packages/supabase/lib/src/supabase_query_builder.dart
@@ -1,6 +1,6 @@
 import 'package:supabase/supabase.dart';
 
-class SupabaseQueryBuilder extends PostgrestQueryBuilder {
+class SupabaseQueryBuilder extends PostgrestQueryBuilder<dynamic> {
   final RealtimeClient _realtime;
   final String _schema;
   final String _table;

--- a/packages/supabase/lib/src/supabase_stream_builder.dart
+++ b/packages/supabase/lib/src/supabase_stream_builder.dart
@@ -31,7 +31,7 @@ class RealtimeSubscribeException implements Exception {
 typedef SupabaseStreamEvent = List<Map<String, dynamic>>;
 
 class SupabaseStreamBuilder extends Stream<SupabaseStreamEvent> {
-  final PostgrestQueryBuilder _queryBuilder;
+  final PostgrestQueryBuilder<dynamic> _queryBuilder;
 
   final RealtimeClient _realtimeClient;
 
@@ -72,7 +72,7 @@ class SupabaseStreamBuilder extends Stream<SupabaseStreamEvent> {
   bool _wasSubscribed = false;
 
   SupabaseStreamBuilder({
-    required PostgrestQueryBuilder queryBuilder,
+    required PostgrestQueryBuilder<dynamic> queryBuilder,
     required String realtimeTopic,
     required RealtimeClient realtimeClient,
     required String schema,

--- a/packages/supabase_flutter/lib/src/passkey/passkey_options_mapper.dart
+++ b/packages/supabase_flutter/lib/src/passkey/passkey_options_mapper.dart
@@ -54,7 +54,7 @@ AuthenticateRequestType passkeyAuthenticateRequestFromOptions(
 }
 
 List<Map<String, dynamic>> _normalizeCredentials(List<dynamic> credentials) {
-  return credentials.whereType<Map>().map((credential) {
+  return credentials.whereType<Map<dynamic, dynamic>>().map((credential) {
     final normalized = Map<String, dynamic>.from(credential);
 
     final id = normalized['id'];

--- a/packages/supabase_flutter/lib/src/supabase.dart
+++ b/packages/supabase_flutter/lib/src/supabase.dart
@@ -185,7 +185,7 @@ class Supabase {
   ///
   /// Only set when [Supabase.initialize] is called without a custom
   /// `accessToken`, since session recovery is skipped for third-party auth.
-  CancelableOperation? _restoreSessionCancellableOperation;
+  CancelableOperation<dynamic>? _restoreSessionCancellableOperation;
 
   // Listener for app lifecycle events to handle Realtime reconnection.
   AppLifecycleListener? _lifecycleListener;
@@ -199,7 +199,7 @@ class Supabase {
   /// (e.g. abort a reconnect if the app went back to background).
   AppLifecycleState? _targetLifecycleState;
 
-  StreamSubscription? _logSubscription;
+  StreamSubscription<dynamic>? _logSubscription;
 
   /// Dispose the instance to free up resources.
   Future<void> dispose() async {

--- a/packages/supabase_lints/lib/analysis_options.yaml
+++ b/packages/supabase_lints/lib/analysis_options.yaml
@@ -6,6 +6,10 @@
 # so new code is not held to a rule the rest of the codebase does not yet pass.
 include: package:lints/recommended.yaml
 
+analyzer:
+  language:
+    strict-raw-types: true
+
 linter:
   rules:
     unawaited_futures: true

--- a/packages/yet_another_json_isolate/lib/src/_isolates_io.dart
+++ b/packages/yet_another_json_isolate/lib/src/_isolates_io.dart
@@ -69,7 +69,7 @@ class YAJsonIsolate {
     return _handleRes(await _events.next);
   }
 
-  Future<R> _handleRes<R>(List response) async {
+  Future<R> _handleRes<R>(List<dynamic> response) async {
     final int type = response.length;
     assert(1 <= type && type <= 3);
 


### PR DESCRIPTION
## What

Enables the `strict-raw-types` analyzer language mode in the shared `supabase_lints` config and fixes the **33** resulting violations across the monorepo.

## Why

Raw types (generics used without explicit type arguments) silently weaken type safety. Turning on `strict-raw-types` catches them and keeps new code from reintroducing them.

## Changes

- `packages/supabase_lints/lib/analysis_options.yaml`: enable `analyzer: language: strict-raw-types: true`.
- Fix all 33 violations (22 in `lib/`, 11 in tests).

All changes are **non-breaking**:

- Raw generic types made explicit as `<dynamic>` (identical type): `Map` → `Map<dynamic, dynamic>`, `List` → `List<dynamic>`, `StreamSubscription`/`CancelableOperation` → `<dynamic>`, `PostgrestQueryBuilder` → `PostgrestQueryBuilder<dynamic>`, `RawPostgrestBuilder` → `RawPostgrestBuilder<dynamic, dynamic, dynamic>`.
- Four `PostgrestFilterBuilder` return types restored to `<T>` (`likeAllOf`, `likeAnyOf`, `ilikeAllOf`, `ilikeAnyOf`) — return-type narrowing, which is safe.
- Local variable renamed `arr` → `array` in `transformers.dart`.

## Out of scope

Actually threading real type parameters through the postgrest/supabase builders (instead of `<dynamic>`) is a breaking API change, tracked for v3 in #1581.

## Verification

- `dart analyze packages` → No issues found!
- Code formatted with `dart format`.
- gotrue mock-based unit tests pass.
