### PR TITLE
test: remove abbreviations and code smells across package tests

### DIFF
--- a/packages/functions_client/test/custom_http_client.dart
+++ b/packages/functions_client/test/custom_http_client.dart
@@ -11,8 +11,7 @@ class CustomHttpClient extends BaseClient {
 
   @override
   Future<StreamedResponse> send(BaseRequest request) async {
-    // Add request to receivedRequests list.
-    receivedRequests = receivedRequests..add(request);
+    receivedRequests.add(request);
     request.finalize();
 
     if (request.url.path.endsWith('network-error')) {

--- a/packages/functions_client/test/functions_dart_test.dart
+++ b/packages/functions_client/test/functions_dart_test.dart
@@ -24,7 +24,7 @@ void main() {
     });
     test('function throws', () async {
       await expectLater(
-        () => functionsCustomHttpClient.invoke('error-function'),
+        functionsCustomHttpClient.invoke('error-function'),
         throwsA(
           isA<FunctionsHttpException>().having((e) => e.status, 'status', 420),
         ),
@@ -33,7 +33,7 @@ void main() {
 
     test('a non-2xx response throws a FunctionsHttpException', () async {
       await expectLater(
-        () => functionsCustomHttpClient.invoke('error-function'),
+        functionsCustomHttpClient.invoke('error-function'),
         throwsA(
           isA<FunctionsHttpException>()
               .having((e) => e.status, 'status', 420)
@@ -49,7 +49,7 @@ void main() {
 
     test('a relay error throws a FunctionsRelayException', () async {
       await expectLater(
-        () => functionsCustomHttpClient.invoke('relay-error'),
+        functionsCustomHttpClient.invoke('relay-error'),
         throwsA(
           isA<FunctionsRelayException>()
               .having((e) => e.status, 'status', 500)
@@ -60,7 +60,7 @@ void main() {
 
     test('a transport failure throws a FunctionsFetchException', () async {
       await expectLater(
-        () => functionsCustomHttpClient.invoke('network-error'),
+        functionsCustomHttpClient.invoke('network-error'),
         throwsA(
           isA<FunctionsFetchException>()
               .having((e) => e.status, 'status', 0)
@@ -71,11 +71,11 @@ void main() {
 
     test('the subtypes remain catchable as FunctionException', () async {
       await expectLater(
-        () => functionsCustomHttpClient.invoke('relay-error'),
+        functionsCustomHttpClient.invoke('relay-error'),
         throwsA(isA<FunctionException>()),
       );
       await expectLater(
-        () => functionsCustomHttpClient.invoke('network-error'),
+        functionsCustomHttpClient.invoke('network-error'),
         throwsA(isA<FunctionException>()),
       );
     });
@@ -86,7 +86,7 @@ void main() {
         // The error body must be drained and decoded into `details` rather than
         // handed back as an unconsumed stream (which also leaks the connection).
         await expectLater(
-          () => functionsCustomHttpClient.invoke('error-sse'),
+          functionsCustomHttpClient.invoke('error-sse'),
           throwsA(
             isA<FunctionException>()
                 .having((e) => e.status, 'status', 500)
@@ -100,7 +100,7 @@ void main() {
       'error response labeled JSON with a non-JSON body reports the status',
       () async {
         await expectLater(
-          () => functionsCustomHttpClient.invoke('invalid-json-error'),
+          functionsCustomHttpClient.invoke('invalid-json-error'),
           throwsA(
             isA<FunctionException>()
                 .having((e) => e.status, 'status', 500)
@@ -121,7 +121,7 @@ void main() {
         // doesn't parse is a real anomaly, so the FormatException must surface
         // rather than silently degrading to a raw String.
         await expectLater(
-          () => functionsCustomHttpClient.invoke('success-invalid-json'),
+          functionsCustomHttpClient.invoke('success-invalid-json'),
           throwsA(isA<FormatException>()),
         );
       },
@@ -130,24 +130,26 @@ void main() {
     test(
       'an upper-cased application/JSON content type is parsed as JSON',
       () async {
-        final res = await functionsCustomHttpClient.invoke('uppercase-json');
-        expect(res.data, {'key': 'Hello World'});
-        expect(res.status, 200);
+        final response = await functionsCustomHttpClient.invoke(
+          'uppercase-json',
+        );
+        expect(response.data, {'key': 'Hello World'});
+        expect(response.status, 200);
       },
     );
 
     test('function call', () async {
-      final res = await functionsCustomHttpClient.invoke('function');
+      final response = await functionsCustomHttpClient.invoke('function');
       expect(
         customHttpClient.receivedRequests.last.headers["Content-Type"],
         null,
       );
-      expect(res.data, {'key': 'Hello World'});
-      expect(res.status, 200);
+      expect(response.data, {'key': 'Hello World'});
+      expect(response.status, 200);
     });
 
     test('function call with query parameters', () async {
-      final res = await functionsCustomHttpClient.invoke(
+      final response = await functionsCustomHttpClient.invoke(
         'function',
         queryParameters: {'key': 'value'},
       );
@@ -155,14 +157,14 @@ void main() {
       final request = customHttpClient.receivedRequests.last;
 
       expect(request.url.queryParameters, {'key': 'value'});
-      expect(res.data, {'key': 'Hello World'});
-      expect(res.status, 200);
+      expect(response.data, {'key': 'Hello World'});
+      expect(response.status, 200);
     });
 
     test('function call with files', () async {
       final fileName = "file.txt";
       final fileContent = "Hello World";
-      final res = await functionsCustomHttpClient.invoke(
+      final response = await functionsCustomHttpClient.invoke(
         'function',
         queryParameters: {'key': 'value'},
         files: [
@@ -174,10 +176,10 @@ void main() {
 
       expect(request.url.queryParameters, {'key': 'value'});
       expect(request.headers['Content-Type'], contains('multipart/form-data'));
-      expect(res.data, [
+      expect(response.data, [
         {'name': fileName, 'content': fileContent},
       ]);
-      expect(res.status, 200);
+      expect(response.status, 200);
     });
 
     test('dispose isolate', () async {
@@ -194,14 +196,14 @@ void main() {
       );
 
       await client.dispose();
-      final res = await client.invoke('function');
-      expect(res.data, {'key': 'Hello World'});
+      final response = await client.invoke('function');
+      expect(response.data, {'key': 'Hello World'});
     });
 
     test('Listen to SSE event', () async {
-      final res = await functionsCustomHttpClient.invoke('sse');
+      final response = await functionsCustomHttpClient.invoke('sse');
       expect(
-        res.data.transform(const Utf8Decoder()),
+        response.data.transform(const Utf8Decoder()),
         emitsInOrder(
           ['a', 'b', 'c'],
         ),
@@ -212,45 +214,45 @@ void main() {
       test('integer properly encoded', () async {
         await functionsCustomHttpClient.invoke('function', body: 42);
 
-        final req = customHttpClient.receivedRequests.last;
-        expect(req, isA<Request>());
+        final request = customHttpClient.receivedRequests.last;
+        expect(request, isA<Request>());
 
-        req as Request;
-        expect(req.body, '42');
-        expect(req.headers["Content-Type"], contains("application/json"));
+        request as Request;
+        expect(request.body, '42');
+        expect(request.headers["Content-Type"], contains("application/json"));
       });
 
       test('double is properly encoded', () async {
         await functionsCustomHttpClient.invoke('function', body: 42.9);
 
-        final req = customHttpClient.receivedRequests.last;
-        expect(req, isA<Request>());
+        final request = customHttpClient.receivedRequests.last;
+        expect(request, isA<Request>());
 
-        req as Request;
-        expect(req.body, '42.9');
-        expect(req.headers["Content-Type"], contains("application/json"));
+        request as Request;
+        expect(request.body, '42.9');
+        expect(request.headers["Content-Type"], contains("application/json"));
       });
 
       test('string is properly encoded', () async {
         await functionsCustomHttpClient.invoke('function', body: 'ExampleText');
 
-        final req = customHttpClient.receivedRequests.last;
-        expect(req, isA<Request>());
+        final request = customHttpClient.receivedRequests.last;
+        expect(request, isA<Request>());
 
-        req as Request;
-        expect(req.body, 'ExampleText');
-        expect(req.headers["Content-Type"], contains("text/plain"));
+        request as Request;
+        expect(request.body, 'ExampleText');
+        expect(request.headers["Content-Type"], contains("text/plain"));
       });
 
       test('list is properly encoded', () async {
         await functionsCustomHttpClient.invoke('function', body: [1, 2, 3]);
 
-        final req = customHttpClient.receivedRequests.last;
-        expect(req, isA<Request>());
+        final request = customHttpClient.receivedRequests.last;
+        expect(request, isA<Request>());
 
-        req as Request;
-        expect(req.body, '[1,2,3]');
-        expect(req.headers["Content-Type"], contains("application/json"));
+        request as Request;
+        expect(request.body, '[1,2,3]');
+        expect(request.headers["Content-Type"], contains("application/json"));
       });
 
       test('map is properly encoded', () async {
@@ -259,35 +261,38 @@ void main() {
           body: {'thekey': 'thevalue'},
         );
 
-        final req = customHttpClient.receivedRequests.last;
-        expect(req, isA<Request>());
+        final request = customHttpClient.receivedRequests.last;
+        expect(request, isA<Request>());
 
-        req as Request;
-        expect(req.body, '{"thekey":"thevalue"}');
-        expect(req.headers["Content-Type"], contains("application/json"));
+        request as Request;
+        expect(request.body, '{"thekey":"thevalue"}');
+        expect(request.headers["Content-Type"], contains("application/json"));
       });
 
       test('Uint8List is properly encoded as binary data', () async {
         final binaryData = Uint8List.fromList([1, 2, 3, 4, 5]);
         await functionsCustomHttpClient.invoke('function', body: binaryData);
 
-        final req = customHttpClient.receivedRequests.last;
-        expect(req, isA<Request>());
+        final request = customHttpClient.receivedRequests.last;
+        expect(request, isA<Request>());
 
-        req as Request;
-        expect(req.bodyBytes, equals(binaryData));
-        expect(req.headers["Content-Type"], equals("application/octet-stream"));
+        request as Request;
+        expect(request.bodyBytes, equals(binaryData));
+        expect(
+          request.headers["Content-Type"],
+          equals("application/octet-stream"),
+        );
       });
 
       test('null body sends no content-type', () async {
         await functionsCustomHttpClient.invoke('function');
 
-        final req = customHttpClient.receivedRequests.last;
-        expect(req, isA<Request>());
+        final request = customHttpClient.receivedRequests.last;
+        expect(request, isA<Request>());
 
-        req as Request;
-        expect(req.body, '');
-        expect(req.headers.containsKey("Content-Type"), isFalse);
+        request as Request;
+        expect(request.body, '');
+        expect(request.headers.containsKey("Content-Type"), isFalse);
       });
     });
 
@@ -298,8 +303,8 @@ void main() {
           method: HttpMethod.get,
         );
 
-        final req = customHttpClient.receivedRequests.last;
-        expect(req.method, 'GET');
+        final request = customHttpClient.receivedRequests.last;
+        expect(request.method, 'GET');
       });
 
       test('PUT method', () async {
@@ -308,8 +313,8 @@ void main() {
           method: HttpMethod.put,
         );
 
-        final req = customHttpClient.receivedRequests.last;
-        expect(req.method, 'PUT');
+        final request = customHttpClient.receivedRequests.last;
+        expect(request.method, 'PUT');
       });
 
       test('DELETE method', () async {
@@ -318,8 +323,8 @@ void main() {
           method: HttpMethod.delete,
         );
 
-        final req = customHttpClient.receivedRequests.last;
-        expect(req.method, 'DELETE');
+        final request = customHttpClient.receivedRequests.last;
+        expect(request.method, 'DELETE');
       });
 
       test('PATCH method', () async {
@@ -328,8 +333,8 @@ void main() {
           method: HttpMethod.patch,
         );
 
-        final req = customHttpClient.receivedRequests.last;
-        expect(req.method, 'PATCH');
+        final request = customHttpClient.receivedRequests.last;
+        expect(request.method, 'PATCH');
       });
     });
 
@@ -339,8 +344,8 @@ void main() {
 
         await functionsCustomHttpClient.invoke('function');
 
-        final req = customHttpClient.receivedRequests.last;
-        expect(req.headers['Authorization'], 'Bearer new-token');
+        final request = customHttpClient.receivedRequests.last;
+        expect(request.headers['Authorization'], 'Bearer new-token');
       });
 
       test('headers getter returns current headers', () {
@@ -357,8 +362,8 @@ void main() {
           headers: {'Content-Type': 'custom/type'},
         );
 
-        final req = customHttpClient.receivedRequests.last;
-        expect(req.headers['Content-Type'], 'custom/type');
+        final request = customHttpClient.receivedRequests.last;
+        expect(request.headers['Content-Type'], 'custom/type');
       });
 
       test('custom lowercase content-type header overrides defaults', () async {
@@ -368,8 +373,8 @@ void main() {
           headers: {'content-type': 'application/custom+json'},
         );
 
-        final req = customHttpClient.receivedRequests.last;
-        expect(req.headers['content-type'], 'application/custom+json');
+        final request = customHttpClient.receivedRequests.last;
+        expect(request.headers['content-type'], 'application/custom+json');
       });
 
       test('custom headers merge with defaults', () async {
@@ -378,9 +383,9 @@ void main() {
           headers: {'X-Custom': 'value'},
         );
 
-        final req = customHttpClient.receivedRequests.last;
-        expect(req.headers['X-Custom'], 'value');
-        expect(req.headers, contains('X-Client-Info'));
+        final request = customHttpClient.receivedRequests.last;
+        expect(request.headers['X-Custom'], 'value');
+        expect(request.headers, contains('X-Client-Info'));
       });
     });
 
@@ -393,9 +398,12 @@ void main() {
             region: 'us-west-1',
           );
 
-          final req = customHttpClient.receivedRequests.last;
-          expect(req.headers['x-region'], 'us-west-1');
-          expect(req.url.queryParameters['forceFunctionRegion'], 'us-west-1');
+          final request = customHttpClient.receivedRequests.last;
+          expect(request.headers['x-region'], 'us-west-1');
+          expect(
+            request.url.queryParameters['forceFunctionRegion'],
+            'us-west-1',
+          );
         },
       );
 
@@ -405,10 +413,10 @@ void main() {
           region: 'any',
         );
 
-        final req = customHttpClient.receivedRequests.last;
-        expect(req.headers.containsKey('x-region'), isFalse);
+        final request = customHttpClient.receivedRequests.last;
+        expect(request.headers.containsKey('x-region'), isFalse);
         expect(
-          req.url.queryParameters.containsKey('forceFunctionRegion'),
+          request.url.queryParameters.containsKey('forceFunctionRegion'),
           isFalse,
         );
       });
@@ -425,9 +433,12 @@ void main() {
 
           await client.invoke('function');
 
-          final req = customHttpClient.receivedRequests.last;
-          expect(req.headers['x-region'], 'eu-west-1');
-          expect(req.url.queryParameters['forceFunctionRegion'], 'eu-west-1');
+          final request = customHttpClient.receivedRequests.last;
+          expect(request.headers['x-region'], 'eu-west-1');
+          expect(
+            request.url.queryParameters['forceFunctionRegion'],
+            'eu-west-1',
+          );
         },
       );
 
@@ -441,9 +452,9 @@ void main() {
 
         await client.invoke('function', region: 'us-east-1');
 
-        final req = customHttpClient.receivedRequests.last;
-        expect(req.headers['x-region'], 'us-east-1');
-        expect(req.url.queryParameters['forceFunctionRegion'], 'us-east-1');
+        final request = customHttpClient.receivedRequests.last;
+        expect(request.headers['x-region'], 'us-east-1');
+        expect(request.url.queryParameters['forceFunctionRegion'], 'us-east-1');
       });
 
       test('region works with other query parameters', () async {
@@ -453,9 +464,9 @@ void main() {
           queryParameters: {'key': 'value', 'foo': 'bar'},
         );
 
-        final req = customHttpClient.receivedRequests.last;
-        expect(req.headers['x-region'], 'ap-south-1');
-        expect(req.url.queryParameters, {
+        final request = customHttpClient.receivedRequests.last;
+        expect(request.headers['x-region'], 'ap-south-1');
+        expect(request.url.queryParameters, {
           'key': 'value',
           'foo': 'bar',
           'forceFunctionRegion': 'ap-south-1',
@@ -496,9 +507,12 @@ void main() {
           ],
         );
 
-        final req = customHttpClient.receivedRequests.last;
-        expect(req.headers['Content-Type'], contains('multipart/form-data'));
-        expect(req, isA<MultipartRequest>());
+        final request = customHttpClient.receivedRequests.last;
+        expect(
+          request.headers['Content-Type'],
+          contains('multipart/form-data'),
+        );
+        expect(request, isA<MultipartRequest>());
       });
 
       test('multipart with only files', () async {
@@ -507,41 +521,44 @@ void main() {
           files: [MultipartFile.fromString('file', 'content')],
         );
 
-        final req = customHttpClient.receivedRequests.last;
-        expect(req.headers['Content-Type'], contains('multipart/form-data'));
-        expect(req, isA<MultipartRequest>());
+        final request = customHttpClient.receivedRequests.last;
+        expect(
+          request.headers['Content-Type'],
+          contains('multipart/form-data'),
+        );
+        expect(request, isA<MultipartRequest>());
       });
     });
 
     group('Response content types', () {
       test('handles application/octet-stream response', () async {
-        final res = await functionsCustomHttpClient.invoke('binary');
+        final response = await functionsCustomHttpClient.invoke('binary');
 
-        expect(res.data, isA<Uint8List>());
-        expect(res.data, equals(Uint8List.fromList([1, 2, 3, 4, 5])));
-        expect(res.status, 200);
+        expect(response.data, isA<Uint8List>());
+        expect(response.data, equals(Uint8List.fromList([1, 2, 3, 4, 5])));
+        expect(response.status, 200);
       });
 
       test('handles text/plain response', () async {
-        final res = await functionsCustomHttpClient.invoke('text');
+        final response = await functionsCustomHttpClient.invoke('text');
 
-        expect(res.data, isA<String>());
-        expect(res.data, 'Hello World');
-        expect(res.status, 200);
+        expect(response.data, isA<String>());
+        expect(response.data, 'Hello World');
+        expect(response.status, 200);
       });
 
       test('handles empty JSON response', () async {
-        final res = await functionsCustomHttpClient.invoke('empty-json');
+        final response = await functionsCustomHttpClient.invoke('empty-json');
 
-        expect(res.data, '');
-        expect(res.status, 200);
+        expect(response.data, '');
+        expect(response.status, 200);
       });
     });
 
     group('Error handling', () {
       test('FunctionException contains all error details', () async {
         await expectLater(
-          () => functionsCustomHttpClient.invoke('error-function'),
+          functionsCustomHttpClient.invoke('error-function'),
           throwsA(
             isA<FunctionException>()
                 .having((e) => e.status, 'status', 420)

--- a/packages/gotrue/test/admin_test.dart
+++ b/packages/gotrue/test/admin_test.dart
@@ -16,7 +16,7 @@ void main() {
   late GoTrueClient client;
 
   setUp(() async {
-    final res = await http.post(
+    final response = await http.post(
       Uri.parse('http://127.0.0.1:54421/rest/v1/rpc/reset_and_init_auth_data'),
       headers: {
         'apikey': getServiceRoleToken(env),
@@ -24,7 +24,7 @@ void main() {
       },
     );
 
-    if (res.body.isNotEmpty) throw res.body;
+    if (response.body.isNotEmpty) throw response.body;
 
     client = GoTrueClient(
       url: gotrueUrl,
@@ -48,21 +48,21 @@ void main() {
 
   group('User updates', () {
     test('modify email using updateUserById()', () async {
-      final res = await client.admin.updateUserById(
+      final response = await client.admin.updateUserById(
         userId1,
         attributes: AdminUserAttributes(email: 'new@email.com'),
       );
-      expect(res.user!.email, 'new@email.com');
+      expect(response.user!.email, 'new@email.com');
     });
 
     test('modify userMetadata using updateUserById()', () async {
-      final res = await client.admin.updateUserById(
+      final response = await client.admin.updateUserById(
         userId1,
         attributes: AdminUserAttributes(
           userMetadata: {'username': 'newUserName'},
         ),
       );
-      expect(res.user!.userMetadata!['username'], 'newUserName');
+      expect(response.user!.userMetadata!['username'], 'newUserName');
     });
   });
 
@@ -100,22 +100,22 @@ void main() {
       'inviteUserByEmail() creates a new user with an invited_at timestamp',
       () async {
         final newEmail = 'new${Random.secure().nextInt(4096)}@fake.org';
-        final res = await client.admin.inviteUserByEmail(newEmail);
-        expect(res.user, isNotNull);
-        expect(res.user?.email, newEmail);
-        expect(res.user?.invitedAt, isNotNull);
+        final response = await client.admin.inviteUserByEmail(newEmail);
+        expect(response.user, isNotNull);
+        expect(response.user?.email, newEmail);
+        expect(response.user?.invitedAt, isNotNull);
       },
     );
 
     test('createUser() creates a new user', () async {
       final newEmail = 'new${Random.secure().nextInt(4096)}@fake.org';
       final userMetadata = {'name': 'supabase'};
-      final res = await client.admin.createUser(
+      final response = await client.admin.createUser(
         AdminUserAttributes(email: newEmail, userMetadata: userMetadata),
       );
-      expect(res.user, isNotNull);
-      expect(res.user?.email, newEmail);
-      expect(res.user?.userMetadata, userMetadata);
+      expect(response.user, isNotNull);
+      expect(response.user?.email, newEmail);
+      expect(response.user?.userMetadata, userMetadata);
     });
   });
 

--- a/packages/gotrue/test/client_test.dart
+++ b/packages/gotrue/test/client_test.dart
@@ -209,12 +209,12 @@ void main() {
       );
     });
 
-    test('signInWithOtp with email', () async {
-      await client.signInWithOtp(email: newEmail);
+    test('signInWithOtp with email completes successfully', () async {
+      expect(client.signInWithOtp(email: newEmail), completes);
     });
 
-    test('signInWithOtp with phone', () async {
-      await client.signInWithOtp(phone: phone1);
+    test('signInWithOtp with phone completes successfully', () async {
+      expect(client.signInWithOtp(phone: phone1), completes);
     });
 
     test('signInWithPassword() with email', () async {

--- a/packages/gotrue/test/client_test.dart
+++ b/packages/gotrue/test/client_test.dart
@@ -25,7 +25,7 @@ void main() {
     late GoTrueClient clientWithAuthConfirmOff;
 
     setUp(() async {
-      final res = await http.post(
+      final response = await http.post(
         Uri.parse(
           'http://127.0.0.1:54421/rest/v1/rpc/reset_and_init_auth_data',
         ),
@@ -35,7 +35,7 @@ void main() {
           'Authorization': 'Bearer ${getServiceRoleToken(env)}',
         },
       );
-      if (res.body.isNotEmpty) throw res.body;
+      if (response.body.isNotEmpty) throw response.body;
 
       newEmail = getNewEmail();
       newPhone = getNewPhone();
@@ -104,7 +104,7 @@ void main() {
       'signUp() with weak password throws AuthWeakPasswordException',
       () async {
         await expectLater(
-          () => client.signUp(email: newEmail, password: '123'),
+          client.signUp(email: newEmail, password: '123'),
           throwsA(
             isA<AuthWeakPasswordException>().having(
               (e) => e.code,
@@ -126,7 +126,7 @@ void main() {
         'http://my-callback-url.com/welcome#expires_in=$expiresIn&refresh_token=$refreshToken&token_type=$tokenType&provider_token=$providerToken',
       );
       await expectLater(
-        () => client.getSessionFromUrl(urlWithoutAccessToken),
+        client.getSessionFromUrl(urlWithoutAccessToken),
         throwsA(anything),
       );
     });
@@ -139,7 +139,7 @@ void main() {
         'http://my-callback-url.com/#error=unauthorized_client&error_code=401&error_description=${Uri.encodeComponent(errorMessage)}',
       );
       await expectLater(
-        () => client.getSessionFromUrl(urlWithoutAccessToken),
+        client.getSessionFromUrl(urlWithoutAccessToken),
         throwsA(
           isA<AuthException>()
               .having((e) => e.message, 'message', errorMessage)
@@ -183,38 +183,30 @@ void main() {
     });
 
     test('signUp() with autoConfirm off with email', () async {
-      final res = await clientWithAuthConfirmOff.signUp(
+      final response = await clientWithAuthConfirmOff.signUp(
         email: newEmail,
         password: password,
         emailRedirectTo: 'https://localhost:9999/welcome',
       );
-      expect(res.session, isNull);
-      expect(res.user, isNotNull);
-      expect(res.user!.email, 'fake1@email.com');
+      expect(response.session, isNull);
+      expect(response.user, isNotNull);
+      expect(response.user!.email, 'fake1@email.com');
     });
 
-    test(
-      'signUp() with autoConfirm off with phone should fail because Twilio is not setup',
-      () async {
-        try {
-          await clientWithAuthConfirmOff.signUp(
-            phone: phone1,
-            password: password,
-          );
-        } catch (error) {
-          expect(error, isA<AuthException>());
-        }
-      },
-    );
+    test('signUp() with autoConfirm off with phone', () async {
+      final response = await clientWithAuthConfirmOff.signUp(
+        phone: phone1,
+        password: password,
+      );
+      expect(response.session, isNull);
+      expect(response.user, isNotNull);
+    });
 
     test('signUp() with email should throw error if used twice', () async {
-      final localEmail = email1;
-
-      try {
-        await client.signUp(email: localEmail, password: password);
-      } catch (error) {
-        expect(error, isA<AuthException>());
-      }
+      await expectLater(
+        client.signUp(email: email1, password: password),
+        throwsA(isA<AuthException>()),
+      );
     });
 
     test('signInWithOtp with email', () async {
@@ -222,11 +214,7 @@ void main() {
     });
 
     test('signInWithOtp with phone', () async {
-      try {
-        await client.signInWithOtp(phone: phone1);
-      } catch (error) {
-        expect(error, isA<AuthException>());
-      }
+      await client.signInWithOtp(phone: phone1);
     });
 
     test('signInWithPassword() with email', () async {
@@ -289,7 +277,7 @@ void main() {
       'Set session with an empty refresh token throws AuthSessionMissingException',
       () async {
         await expectLater(
-          () => client.setSession(''),
+          client.setSession(''),
           throwsA(isA<AuthSessionMissingException>()),
         );
       },
@@ -373,7 +361,7 @@ void main() {
       'Set session with empty access token throws AuthSessionMissingException',
       () async {
         await expectLater(
-          () => client.setSession('some-refresh-token', accessToken: ''),
+          client.setSession('some-refresh-token', accessToken: ''),
           throwsA(isA<AuthSessionMissingException>()),
         );
       },
@@ -383,7 +371,7 @@ void main() {
       'Set session with malformed access token throws AuthInvalidJwtException',
       () async {
         await expectLater(
-          () => client.setSession(
+          client.setSession(
             'some-refresh-token',
             accessToken: 'not-a-valid-jwt',
           ),
@@ -441,7 +429,7 @@ void main() {
     test('Update user with the same password throws AuthException', () async {
       await client.signInWithPassword(email: email1, password: password);
       await expectLater(
-        () => client.updateUser(UserAttributes(password: password)),
+        client.updateUser(UserAttributes(password: password)),
         throwsA(
           isA<AuthException>().having(
             (e) => e.code,
@@ -476,7 +464,7 @@ void main() {
 
     test('signIn() with the wrong password', () async {
       await expectLater(
-        () => client.signInWithPassword(
+        client.signInWithPassword(
           email: email1,
           password: 'wrong_$password',
         ),
@@ -488,51 +476,51 @@ void main() {
 
     group('The auth client can signin with third-party oAuth providers', () {
       test('signIn() with Provider', () async {
-        final res = await client.getOAuthSignInUrl(
+        final response = await client.getOAuthSignInUrl(
           provider: OAuthProvider.google,
         );
-        expect(res.url, isA<String>());
-        expect(res.provider, OAuthProvider.google);
+        expect(response.url, isA<String>());
+        expect(response.provider, OAuthProvider.google);
       });
 
       test('signIn() with Provider with redirectTo', () async {
-        final res = await client.getOAuthSignInUrl(
+        final response = await client.getOAuthSignInUrl(
           provider: OAuthProvider.google,
           redirectTo: 'https://supabase.com',
         );
         expect(
-          res.url,
+          response.url,
           '$gotrueUrl/authorize?provider=google&redirect_to=https%3A%2F%2Fsupabase.com',
         );
-        expect(res.provider, OAuthProvider.google);
+        expect(response.provider, OAuthProvider.google);
       });
 
       test('signIn() with Provider can append a redirectUrl', () async {
-        final res = await client.getOAuthSignInUrl(
+        final response = await client.getOAuthSignInUrl(
           provider: OAuthProvider.google,
           redirectTo: 'https://localhost:9000/welcome',
         );
-        expect(res.url, isA<String>());
-        expect(res.provider, OAuthProvider.google);
+        expect(response.url, isA<String>());
+        expect(response.provider, OAuthProvider.google);
       });
 
       test('signIn() with Provider can append scopes', () async {
-        final res = await client.getOAuthSignInUrl(
+        final response = await client.getOAuthSignInUrl(
           provider: OAuthProvider.google,
           scopes: 'repo',
         );
-        expect(res.url, isA<String>());
-        expect(res.provider, OAuthProvider.google);
+        expect(response.url, isA<String>());
+        expect(response.provider, OAuthProvider.google);
       });
 
       test('signIn() with Provider can append options', () async {
-        final res = await client.getOAuthSignInUrl(
+        final response = await client.getOAuthSignInUrl(
           provider: OAuthProvider.google,
           redirectTo: 'https://localhost:9000/welcome',
           scopes: 'repo',
         );
-        expect(res.url, isA<String>());
-        expect(res.provider, OAuthProvider.google);
+        expect(response.url, isA<String>());
+        expect(response.provider, OAuthProvider.google);
       });
     });
 
@@ -610,9 +598,9 @@ void main() {
 
     test('Call getLinkIdentityUrl', () async {
       await client.signInWithPassword(email: email1, password: password);
-      final res = await client.getLinkIdentityUrl(OAuthProvider.google);
-      expect(res.url, isA<String>());
-      final uri = Uri.parse(res.url);
+      final response = await client.getLinkIdentityUrl(OAuthProvider.google);
+      expect(response.url, isA<String>());
+      final uri = Uri.parse(response.url);
       expect(uri.host, 'accounts.google.com');
     });
   });
@@ -625,15 +613,23 @@ void main() {
     });
 
     test('signIn()', () async {
-      try {
-        await client.signInWithPassword(email: email1, password: password);
-      } catch (error) {
-        expect(error, isA<AuthUnknownException>());
-        error as AuthUnknownException;
-        expect(error.statusCode, '420');
-        expect(error.originalError, isA<http.Response>());
-        expect(error.message, contains('empty response'));
-      }
+      await expectLater(
+        client.signInWithPassword(email: email1, password: password),
+        throwsA(
+          isA<AuthUnknownException>()
+              .having((e) => e.statusCode, 'statusCode', '420')
+              .having(
+                (e) => e.originalError,
+                'originalError',
+                isA<http.Response>(),
+              )
+              .having(
+                (e) => e.message,
+                'message',
+                contains('empty response'),
+              ),
+        ),
+      );
     });
   });
 
@@ -695,7 +691,7 @@ void main() {
         'http://my-callback-url.com/#error=unauthorized_client&error_code=401&error_description=${Uri.encodeComponent(errorMessage)}',
       );
       await expectLater(
-        () => client.getSessionFromUrl(urlWithoutAccessToken),
+        client.getSessionFromUrl(urlWithoutAccessToken),
         throwsA(
           isA<AuthException>().having(
             (e) => e.message,
@@ -787,7 +783,7 @@ void main() {
       expect(httpClient.refreshCount, 1);
 
       var signedOut = false;
-      final sub = client.onAuthStateChange.listen(
+      final subscription = client.onAuthStateChange.listen(
         (state) {
           if (state.event == AuthChangeEvent.signedOut) signedOut = true;
         },
@@ -807,7 +803,7 @@ void main() {
       expect(signedOut, isFalse);
       expect(client.currentSession, isNotNull);
 
-      await sub.cancel();
+      await subscription.cancel();
     });
   });
 }

--- a/packages/gotrue/test/custom_oauth_provider_test.dart
+++ b/packages/gotrue/test/custom_oauth_provider_test.dart
@@ -32,12 +32,12 @@ void main() {
         );
 
         final provider = OAuthProvider('custom:my-provider');
-        final res = await client.getOAuthSignInUrl(provider: provider);
+        final response = await client.getOAuthSignInUrl(provider: provider);
 
-        expect(res.provider, provider);
-        expect(res.url, startsWith('$gotrueUrl/authorize?'));
+        expect(response.provider, provider);
+        expect(response.url, startsWith('$gotrueUrl/authorize?'));
 
-        final uri = Uri.parse(res.url);
+        final uri = Uri.parse(response.url);
         expect(uri.queryParameters['provider'], 'custom:my-provider');
       },
     );
@@ -64,14 +64,14 @@ void main() {
       // Derive the expected count from the source file so this test stays
       // accurate when new static const providers are added without updating
       // the values list.
-      final src = File('lib/src/types/types.dart').readAsStringSync();
+      final source = File('lib/src/types/types.dart').readAsStringSync();
       // Matches `static const foo = OAuthProvider(` but not the `values` field
       // (which is typed `List<OAuthProvider>` and uses a list literal, not a
       // direct OAuthProvider constructor call).
       final declaredCount = RegExp(
         r'^\s*static\s+const\s+\w+\s*=\s*OAuthProvider\(',
         multiLine: true,
-      ).allMatches(src).length;
+      ).allMatches(source).length;
 
       expect(OAuthProvider.values, contains(OAuthProvider.google));
       expect(OAuthProvider.values, contains(OAuthProvider.linkedinOidc));

--- a/packages/gotrue/test/custom_providers_test.dart
+++ b/packages/gotrue/test/custom_providers_test.dart
@@ -4,7 +4,7 @@ import 'package:test/test.dart';
 void main() {
   group('CreateCustomProviderParams serialization', () {
     test('serializes required fields', () {
-      final params = CreateCustomProviderParams(
+      final parameters = CreateCustomProviderParams(
         providerType: CustomProviderType.oauth2,
         identifier: 'custom:mycompany',
         name: 'My Company',
@@ -12,7 +12,7 @@ void main() {
         clientSecret: 'client-secret',
       );
 
-      final json = params.toJson();
+      final json = parameters.toJson();
 
       expect(json['provider_type'], 'oauth2');
       expect(json['identifier'], 'custom:mycompany');
@@ -22,7 +22,7 @@ void main() {
     });
 
     test('omits custom_claims_allowlist when not provided', () {
-      final params = CreateCustomProviderParams(
+      final parameters = CreateCustomProviderParams(
         providerType: CustomProviderType.oidc,
         identifier: 'custom:mycompany',
         name: 'My Company',
@@ -30,11 +30,14 @@ void main() {
         clientSecret: 'client-secret',
       );
 
-      expect(params.toJson().containsKey('custom_claims_allowlist'), isFalse);
+      expect(
+        parameters.toJson().containsKey('custom_claims_allowlist'),
+        isFalse,
+      );
     });
 
     test('serializes custom_claims_allowlist when provided', () {
-      final params = CreateCustomProviderParams(
+      final parameters = CreateCustomProviderParams(
         providerType: CustomProviderType.oidc,
         identifier: 'custom:mycompany',
         name: 'My Company',
@@ -44,13 +47,13 @@ void main() {
       );
 
       expect(
-        params.toJson()['custom_claims_allowlist'],
+        parameters.toJson()['custom_claims_allowlist'],
         ['groups', 'org_id', 'mail'],
       );
     });
 
     test('serializes an empty custom_claims_allowlist', () {
-      final params = CreateCustomProviderParams(
+      final parameters = CreateCustomProviderParams(
         providerType: CustomProviderType.oidc,
         identifier: 'custom:mycompany',
         name: 'My Company',
@@ -59,25 +62,25 @@ void main() {
         customClaimsAllowlist: [],
       );
 
-      expect(params.toJson()['custom_claims_allowlist'], isEmpty);
+      expect(parameters.toJson()['custom_claims_allowlist'], isEmpty);
     });
   });
 
   group('UpdateCustomProviderParams serialization', () {
     test('omits custom_claims_allowlist when not provided', () {
-      const params = UpdateCustomProviderParams(name: 'New name');
+      const parameters = UpdateCustomProviderParams(name: 'New name');
 
-      final json = params.toJson();
+      final json = parameters.toJson();
       expect(json.containsKey('custom_claims_allowlist'), isFalse);
       expect(json['name'], 'New name');
     });
 
     test('serializes custom_claims_allowlist when provided', () {
-      const params = UpdateCustomProviderParams(
+      const parameters = UpdateCustomProviderParams(
         customClaimsAllowlist: ['groups'],
       );
 
-      expect(params.toJson()['custom_claims_allowlist'], ['groups']);
+      expect(parameters.toJson()['custom_claims_allowlist'], ['groups']);
     });
   });
 

--- a/packages/gotrue/test/fetch_test.dart
+++ b/packages/gotrue/test/fetch_test.dart
@@ -77,7 +77,7 @@ void main() {
 Future<void> _testFetchRequest(Client client) async {
   final GotrueFetch fetch = GotrueFetch(client);
   await expectLater(
-    () => fetch.request(_mockUrl, RequestMethodType.get),
+    fetch.request(_mockUrl, RequestMethodType.get),
     throwsA(
       isA<AuthException>()
           .having((e) => e.code, 'code', 'weak_password')

--- a/packages/gotrue/test/get_claims_test.dart
+++ b/packages/gotrue/test/get_claims_test.dart
@@ -20,7 +20,7 @@ void main() {
     late String newEmail;
 
     setUp(() async {
-      final res = await http.post(
+      final response = await http.post(
         Uri.parse(
           'http://127.0.0.1:54421/rest/v1/rpc/reset_and_init_auth_data',
         ),
@@ -30,7 +30,7 @@ void main() {
           'Authorization': 'Bearer ${getServiceRoleToken(env)}',
         },
       );
-      if (res.body.isNotEmpty) throw res.body;
+      if (response.body.isNotEmpty) throw response.body;
 
       newEmail = getNewEmail();
 
@@ -132,10 +132,10 @@ void main() {
           GetClaimsOptions(allowExpired: true),
         );
         // If we get here, the exp validation was skipped
-      } on AuthException catch (e) {
+      } on AuthException catch (error) {
         // We expect this to fail during getUser() verification,
         // not during exp validation
-        expect(e.message, isNot(contains('expired')));
+        expect(error.message, isNot(contains('expired')));
       }
     });
 
@@ -253,12 +253,12 @@ void main() {
         try {
           await client.getClaims(rs256Jwt);
           // If we get here, the server responded successfully (unlikely in test env)
-        } catch (e) {
+        } catch (error) {
           // The important part is that it should NOT crash with null error
           // It may fail with network error, invalid signature, etc.
           // but the error message should not contain null-related errors
-          expect(e.toString(), isNot(contains('Unexpected null value')));
-          expect(e.toString(), isNot(contains('Null check operator')));
+          expect(error.toString(), isNot(contains('Unexpected null value')));
+          expect(error.toString(), isNot(contains('Null check operator')));
         }
         // Test passes if we get here without null error
       },

--- a/packages/gotrue/test/otp_mock_test.dart
+++ b/packages/gotrue/test/otp_mock_test.dart
@@ -232,16 +232,13 @@ void main() {
       expect(client.currentUser?.phone, testPhone);
     });
 
-    test('reauthenticate() works correctly', () async {
-      // First sign in to set the session
+    test('reauthenticate() completes successfully', () async {
       await client.signInWithPassword(
         phone: testPhone,
         password: testPassword,
       );
 
-      // Then reauthenticate
-      await client.reauthenticate();
-      // This test passes if no exceptions are thrown
+      expect(client.reauthenticate(), completes);
     });
 
     test('reauthenticate() throws when no session', () async {
@@ -356,17 +353,14 @@ void main() {
       );
     });
 
-    test('signInWithOtp() with different channel types', () async {
-      // Test WhatsApp channel
-      await client.signInWithOtp(
-        phone: testPhone,
-        channel: OtpChannel.whatsapp,
+    test('signInWithOtp() completes for different channel types', () async {
+      expect(
+        client.signInWithOtp(phone: testPhone, channel: OtpChannel.whatsapp),
+        completes,
       );
-
-      // Test SMS channel (default)
-      await client.signInWithOtp(
-        phone: testPhone,
-        channel: OtpChannel.sms,
+      expect(
+        client.signInWithOtp(phone: testPhone, channel: OtpChannel.sms),
+        completes,
       );
     });
   });
@@ -442,16 +436,18 @@ void main() {
       );
     });
 
-    test('signInWithOtp() with empty response', () async {
-      final client = GoTrueClient(
-        url: 'https://example.com',
-        httpClient: EmptyResponseClient(),
-        asyncStorage: TestAsyncStorage(),
-      );
+    test(
+      'signInWithOtp() with empty response completes successfully',
+      () async {
+        final client = GoTrueClient(
+          url: 'https://example.com',
+          httpClient: EmptyResponseClient(),
+          asyncStorage: TestAsyncStorage(),
+        );
 
-      // Should not throw an exception
-      await client.signInWithOtp(phone: testPhone);
-    });
+        expect(client.signInWithOtp(phone: testPhone), completes);
+      },
+    );
 
     test(
       'verifyOTP() with neither email nor phone throws assertion error',

--- a/packages/gotrue/test/otp_mock_test.dart
+++ b/packages/gotrue/test/otp_mock_test.dart
@@ -64,7 +64,7 @@ void main() {
 
     test('signInWithOtp() without email or phone should throw', () async {
       await expectLater(
-        () => client.signInWithOtp(),
+        client.signInWithOtp(),
         throwsA(
           isA<AuthException>().having(
             (e) => e.message,
@@ -159,7 +159,7 @@ void main() {
       () async {
         // Recovery type with tokenHash should not accept email/phone
         await expectLater(
-          () => client.verifyOTP(
+          client.verifyOTP(
             email: testEmail,
             tokenHash: 'mock-token-hash',
             type: OtpType.recovery,
@@ -179,7 +179,7 @@ void main() {
 
     test('verifyOTP() without token should throw', () async {
       await expectLater(
-        () => client.verifyOTP(
+        client.verifyOTP(
           email: testEmail,
           type: OtpType.email,
         ),
@@ -246,7 +246,7 @@ void main() {
 
     test('reauthenticate() throws when no session', () async {
       await expectLater(
-        () => client.reauthenticate(),
+        client.reauthenticate(),
         throwsA(isA<AuthSessionMissingException>()),
       );
     });
@@ -338,7 +338,7 @@ void main() {
 
     test('resend() with wrong type for phone throws', () async {
       await expectLater(
-        () => client.resend(
+        client.resend(
           phone: testPhone,
           type: OtpType.signup, // This should be sms or phoneChange for phone
         ),
@@ -348,7 +348,7 @@ void main() {
 
     test('resend() with wrong type for email throws', () async {
       await expectLater(
-        () => client.resend(
+        client.resend(
           email: testEmail,
           type: OtpType.sms, // This should be signup or emailChange for email
         ),
@@ -380,7 +380,7 @@ void main() {
       );
 
       await expectLater(
-        () => client.verifyOTP(
+        client.verifyOTP(
           phone: testPhone,
           token: '123456',
           type: OtpType.sms,
@@ -405,7 +405,7 @@ void main() {
         );
 
         await expectLater(
-          () => client.signInWithPassword(
+          client.signInWithPassword(
             phone: testPhone,
             password: 'wrong-password',
           ),
@@ -428,7 +428,7 @@ void main() {
       );
 
       await expectLater(
-        () => client.signUp(
+        client.signUp(
           phone: testPhone,
           password: testPassword,
         ),
@@ -463,7 +463,7 @@ void main() {
         );
 
         await expectLater(
-          () => client.verifyOTP(
+          client.verifyOTP(
             token: '123456',
             type: OtpType.sms,
           ),
@@ -480,7 +480,7 @@ void main() {
       );
 
       await expectLater(
-        () => client.verifyOTP(
+        client.verifyOTP(
           phone: testPhone,
           token: '123456',
           type: OtpType.sms,
@@ -503,7 +503,7 @@ void main() {
       );
 
       await expectLater(
-        () => client.resend(
+        client.resend(
           email: testEmail,
           phone: testPhone,
           type: OtpType.sms,
@@ -520,7 +520,7 @@ void main() {
       );
 
       await expectLater(
-        () => client.signUp(password: testPassword),
+        client.signUp(password: testPassword),
         throwsA(isA<AssertionError>()),
       );
     });
@@ -535,7 +535,7 @@ void main() {
         );
 
         await expectLater(
-          () => client.signInWithPassword(password: testPassword),
+          client.signInWithPassword(password: testPassword),
           throwsA(
             isA<AuthException>().having(
               (e) => e.message,
@@ -555,7 +555,7 @@ void main() {
       );
 
       await expectLater(
-        () => client.signInWithOtp(phone: testPhone),
+        client.signInWithOtp(phone: testPhone),
         throwsA(
           isA<AuthException>().having((e) => e.statusCode, 'statusCode', '500'),
         ),

--- a/packages/gotrue/test/passkey_test.dart
+++ b/packages/gotrue/test/passkey_test.dart
@@ -292,7 +292,7 @@ void main() {
       addTearDown(disabledClient.dispose);
 
       await expectLater(
-        () => disabledClient.passkey.startAuthentication(),
+        disabledClient.passkey.startAuthentication(),
         throwsA(
           isA<AuthApiException>()
               .having((e) => e.code, 'code', 'passkey_disabled')

--- a/packages/gotrue/test/provider_test.dart
+++ b/packages/gotrue/test/provider_test.dart
@@ -28,23 +28,23 @@ void main() {
   });
   group('Provider sign in', () {
     test('signIn() with Provider', () async {
-      final res = await client.getOAuthSignInUrl(
+      final response = await client.getOAuthSignInUrl(
         provider: OAuthProvider.google,
       );
-      final url = res.url;
-      final provider = res.provider;
+      final url = response.url;
+      final provider = response.provider;
       expect(url, startsWith('$gotrueUrl/authorize?provider=google'));
       expect(provider, OAuthProvider.google);
     });
 
     test('signIn() with Provider and options', () async {
-      final res = await client.getOAuthSignInUrl(
+      final response = await client.getOAuthSignInUrl(
         provider: OAuthProvider.github,
         redirectTo: 'redirectToURL',
         scopes: 'repo',
       );
-      final url = res.url;
-      final provider = res.provider;
+      final url = response.url;
+      final provider = response.provider;
       expect(
         url,
         startsWith(
@@ -55,35 +55,35 @@ void main() {
     });
 
     test('signIn() with custom OIDC provider', () async {
-      final res = await client.getOAuthSignInUrl(
+      final response = await client.getOAuthSignInUrl(
         provider: OAuthProvider('custom:my-oidc-provider'),
       );
       expect(
-        res.url,
+        response.url,
         startsWith(
           '$gotrueUrl/authorize?provider=custom%3Amy-oidc-provider',
         ),
       );
-      expect(res.provider, OAuthProvider('custom:my-oidc-provider'));
-      expect(res.provider.name, 'custom:my-oidc-provider');
+      expect(response.provider, OAuthProvider('custom:my-oidc-provider'));
+      expect(response.provider.name, 'custom:my-oidc-provider');
     });
 
     test('signIn() with custom OIDC provider and options', () async {
-      final res = await client.getOAuthSignInUrl(
+      final response = await client.getOAuthSignInUrl(
         provider: OAuthProvider('custom:my-oidc-provider'),
         redirectTo: 'https://localhost:9000/callback',
         scopes: 'openid profile email',
       );
-      expect(res.url, contains('provider=custom%3Amy-oidc-provider'));
-      expect(res.url, contains('redirect_to='));
-      expect(res.url, contains('scopes='));
-      expect(res.provider.name, 'custom:my-oidc-provider');
+      expect(response.url, contains('provider=custom%3Amy-oidc-provider'));
+      expect(response.url, contains('redirect_to='));
+      expect(response.url, contains('scopes='));
+      expect(response.provider.name, 'custom:my-oidc-provider');
     });
   });
 
   group('getSessionFromUrl()', () {
     setUp(() async {
-      final res = await http.post(
+      final response = await http.post(
         Uri.parse(
           'http://127.0.0.1:54421/rest/v1/rpc/reset_and_init_auth_data',
         ),
@@ -93,7 +93,7 @@ void main() {
           'Authorization': 'Bearer ${getServiceRoleToken(env)}',
         },
       );
-      if (res.body.isNotEmpty) throw res.body;
+      if (response.body.isNotEmpty) throw response.body;
 
       await client.signInWithPassword(email: email1, password: password);
       session = client.currentSession!;
@@ -109,13 +109,13 @@ void main() {
 
       final url =
           'http://my-callback-url.com/welcome#access_token=$accessToken&expires_in=$expiresIn&refresh_token=$refreshToken&token_type=$tokenType&provider_token=$providerToken&provider_refresh_token=$providerRefreshToken';
-      final res = await client.getSessionFromUrl(Uri.parse(url));
-      expect(res.session.accessToken, accessToken);
-      expect(res.session.expiresIn, expiresIn);
-      expect(res.session.refreshToken, refreshToken);
-      expect(res.session.tokenType, tokenType);
-      expect(res.session.providerToken, providerToken);
-      expect(res.session.providerRefreshToken, providerRefreshToken);
+      final response = await client.getSessionFromUrl(Uri.parse(url));
+      expect(response.session.accessToken, accessToken);
+      expect(response.session.expiresIn, expiresIn);
+      expect(response.session.refreshToken, refreshToken);
+      expect(response.session.tokenType, tokenType);
+      expect(response.session.providerToken, providerToken);
+      expect(response.session.providerRefreshToken, providerRefreshToken);
     });
 
     test('parse provider callback url with fragment and query', () async {
@@ -128,13 +128,13 @@ void main() {
 
       final url =
           'http://my-callback-url.com?page=welcome&foo=bar#access_token=$accessToken&expires_in=$expiresIn&refresh_token=$refreshToken&token_type=$tokenType&provider_token=$providerToken&provider_refresh_token=$providerRefreshToken';
-      final res = await client.getSessionFromUrl(Uri.parse(url));
-      expect(res.session.accessToken, accessToken);
-      expect(res.session.expiresIn, expiresIn);
-      expect(res.session.refreshToken, refreshToken);
-      expect(res.session.tokenType, tokenType);
-      expect(res.session.providerToken, providerToken);
-      expect(res.session.providerRefreshToken, providerRefreshToken);
+      final response = await client.getSessionFromUrl(Uri.parse(url));
+      expect(response.session.accessToken, accessToken);
+      expect(response.session.expiresIn, expiresIn);
+      expect(response.session.refreshToken, refreshToken);
+      expect(response.session.tokenType, tokenType);
+      expect(response.session.providerToken, providerToken);
+      expect(response.session.providerRefreshToken, providerRefreshToken);
     });
 
     test('parse provider callback url with missing param error', () async {
@@ -156,15 +156,19 @@ void main() {
     });
 
     test('parse provider callback url with error', () async {
-      const errorDesc = 'my_error_description';
+      const errorDescription = 'my_error_description';
       await expectLater(
         () async {
           const url =
-              'http://my-callback-url.com?page=welcome&foo=bar#error_description=$errorDesc';
+              'http://my-callback-url.com?page=welcome&foo=bar#error_description=$errorDescription';
           await client.getSessionFromUrl(Uri.parse(url));
         },
         throwsA(
-          isA<AuthException>().having((e) => e.message, 'message', errorDesc),
+          isA<AuthException>().having(
+            (e) => e.message,
+            'message',
+            errorDescription,
+          ),
         ),
       );
     });

--- a/packages/gotrue/test/src/constants_test.dart
+++ b/packages/gotrue/test/src/constants_test.dart
@@ -60,7 +60,7 @@ void main() {
 
   group('AuthChangeEvent', () {
     test('has correct enum values', () {
-      expect(AuthChangeEvent.values.length, equals(8));
+      expect(AuthChangeEvent.values, hasLength(8));
       expect(AuthChangeEvent.values, contains(AuthChangeEvent.initialSession));
       expect(
         AuthChangeEvent.values,
@@ -161,7 +161,7 @@ void main() {
 
   group('GenerateLinkType', () {
     test('has correct enum values', () {
-      expect(GenerateLinkType.values.length, equals(7));
+      expect(GenerateLinkType.values, hasLength(7));
       expect(GenerateLinkType.values, contains(GenerateLinkType.signup));
       expect(GenerateLinkType.values, contains(GenerateLinkType.invite));
       expect(GenerateLinkType.values, contains(GenerateLinkType.magiclink));
@@ -244,7 +244,7 @@ void main() {
 
   group('OtpType', () {
     test('has correct enum values', () {
-      expect(OtpType.values.length, equals(8));
+      expect(OtpType.values, hasLength(8));
       expect(OtpType.values, contains(OtpType.sms));
       expect(OtpType.values, contains(OtpType.phoneChange));
       expect(OtpType.values, contains(OtpType.signup));
@@ -258,7 +258,7 @@ void main() {
 
   group('OtpChannel', () {
     test('has correct enum values', () {
-      expect(OtpChannel.values.length, equals(2));
+      expect(OtpChannel.values, hasLength(2));
       expect(OtpChannel.values, contains(OtpChannel.sms));
       expect(OtpChannel.values, contains(OtpChannel.whatsapp));
     });
@@ -273,7 +273,7 @@ void main() {
 
   group('SignOutScope', () {
     test('has correct enum values', () {
-      expect(SignOutScope.values.length, equals(3));
+      expect(SignOutScope.values, hasLength(3));
       expect(SignOutScope.values, contains(SignOutScope.global));
       expect(SignOutScope.values, contains(SignOutScope.local));
       expect(SignOutScope.values, contains(SignOutScope.others));

--- a/packages/gotrue/test/src/gotrue_admin_custom_providers_api_test.dart
+++ b/packages/gotrue/test/src/gotrue_admin_custom_providers_api_test.dart
@@ -22,7 +22,7 @@ void main() {
     return 'custom:flutter-test-$timestamp';
   }
 
-  CreateCustomProviderParams oauth2Params(
+  CreateCustomProviderParams oauth2Parameters(
     String identifier, {
     List<String>? customClaimsAllowlist,
   }) {
@@ -40,7 +40,7 @@ void main() {
   }
 
   setUp(() async {
-    final res = await http.post(
+    final response = await http.post(
       Uri.parse('http://127.0.0.1:54421/rest/v1/rpc/reset_and_init_auth_data'),
       headers: {
         'x-forwarded-for': '127.0.0.1',
@@ -48,7 +48,7 @@ void main() {
         'Authorization': 'Bearer $serviceRoleToken',
       },
     );
-    if (res.body.isNotEmpty) throw res.body;
+    if (response.body.isNotEmpty) throw response.body;
 
     client = GoTrueClient(
       url: gotrueUrl,
@@ -65,7 +65,7 @@ void main() {
       final identifier = newIdentifier();
       try {
         final provider = await client.admin.customProviders.createProvider(
-          oauth2Params(identifier),
+          oauth2Parameters(identifier),
         );
 
         expect(provider.identifier, identifier);
@@ -83,7 +83,7 @@ void main() {
       try {
         // Exercises sending the custom_claims_allowlist field over the wire.
         final provider = await client.admin.customProviders.createProvider(
-          oauth2Params(
+          oauth2Parameters(
             identifier,
             customClaimsAllowlist: ['groups', 'org_id', 'mail'],
           ),
@@ -99,7 +99,7 @@ void main() {
       final identifier = newIdentifier();
       try {
         await client.admin.customProviders.createProvider(
-          oauth2Params(identifier),
+          oauth2Parameters(identifier),
         );
 
         final providers = await client.admin.customProviders.listProviders();
@@ -116,7 +116,7 @@ void main() {
       final identifier = newIdentifier();
       try {
         await client.admin.customProviders.createProvider(
-          oauth2Params(identifier),
+          oauth2Parameters(identifier),
         );
 
         final providers = await client.admin.customProviders.listProviders(
@@ -141,7 +141,7 @@ void main() {
       final identifier = newIdentifier();
       try {
         await client.admin.customProviders.createProvider(
-          oauth2Params(identifier),
+          oauth2Parameters(identifier),
         );
 
         final provider = await client.admin.customProviders.getProvider(
@@ -158,7 +158,7 @@ void main() {
       final identifier = newIdentifier();
       try {
         await client.admin.customProviders.createProvider(
-          oauth2Params(identifier),
+          oauth2Parameters(identifier),
         );
 
         final updated = await client.admin.customProviders.updateProvider(
@@ -183,7 +183,7 @@ void main() {
     test('delete custom provider', () async {
       final identifier = newIdentifier();
       await client.admin.customProviders.createProvider(
-        oauth2Params(identifier),
+        oauth2Parameters(identifier),
       );
 
       await client.admin.customProviders.deleteProvider(identifier);

--- a/packages/gotrue/test/src/gotrue_admin_mfa_api_test.dart
+++ b/packages/gotrue/test/src/gotrue_admin_mfa_api_test.dart
@@ -16,7 +16,7 @@ void main() {
   late GoTrueClient client;
 
   setUp(() async {
-    final res = await http.post(
+    final response = await http.post(
       Uri.parse('http://127.0.0.1:54421/rest/v1/rpc/reset_and_init_auth_data'),
       headers: {
         'x-forwarded-for': '127.0.0.1',
@@ -24,7 +24,7 @@ void main() {
         'Authorization': 'Bearer $serviceRoleToken',
       },
     );
-    if (res.body.isNotEmpty) throw res.body;
+    if (response.body.isNotEmpty) throw response.body;
 
     client = GoTrueClient(
       url: gotrueUrl,
@@ -37,26 +37,26 @@ void main() {
   });
 
   test('list factors', () async {
-    final res = await client.admin.mfa.listFactors(userId: userId2);
-    expect(res.factors.length, 1);
-    final factor = res.factors.first;
+    final response = await client.admin.mfa.listFactors(userId: userId2);
+    expect(response.factors, hasLength(1));
+    final factor = response.factors.first;
     expect(
       factor.createdAt.difference(DateTime.now()) < Duration(seconds: 2),
-      true,
+      isTrue,
     );
     expect(
       factor.updatedAt.difference(DateTime.now()) < Duration(seconds: 2),
-      true,
+      isTrue,
     );
     expect(factor.id, factorId2);
   });
 
   test('delete factor', () async {
-    final res = await client.admin.mfa.deleteFactor(
+    final response = await client.admin.mfa.deleteFactor(
       userId: userId2,
       factorId: factorId2,
     );
 
-    expect(res.id, factorId2);
+    expect(response.id, factorId2);
   });
 }

--- a/packages/gotrue/test/src/gotrue_admin_oauth_api_test.dart
+++ b/packages/gotrue/test/src/gotrue_admin_oauth_api_test.dart
@@ -16,7 +16,7 @@ void main() {
   late GoTrueClient client;
 
   setUp(() async {
-    final res = await http.post(
+    final response = await http.post(
       Uri.parse('http://127.0.0.1:54421/rest/v1/rpc/reset_and_init_auth_data'),
       headers: {
         'x-forwarded-for': '127.0.0.1',
@@ -24,7 +24,7 @@ void main() {
         'Authorization': 'Bearer $serviceRoleToken',
       },
     );
-    if (res.body.isNotEmpty) throw res.body;
+    if (response.body.isNotEmpty) throw response.body;
 
     client = GoTrueClient(
       url: gotrueUrl,
@@ -38,104 +38,108 @@ void main() {
 
   group('OAuth client management', () {
     test('create OAuth client', () async {
-      final params = CreateOAuthClientParams(
+      final parameters = CreateOAuthClientParams(
         clientName: 'Test OAuth Client',
         redirectUris: ['https://example.com/callback'],
         clientUri: 'https://example.com',
         scope: 'openid profile email',
       );
 
-      final res = await client.admin.oauth.createClient(params);
-      expect(res.client, isNotNull);
-      expect(res.client?.clientName, 'Test OAuth Client');
-      expect(res.client?.redirectUris, ['https://example.com/callback']);
-      expect(res.client?.clientSecret, isNotNull);
-      expect(res.client?.clientId, isNotNull);
+      final response = await client.admin.oauth.createClient(parameters);
+      expect(response.client, isNotNull);
+      expect(response.client?.clientName, 'Test OAuth Client');
+      expect(response.client?.redirectUris, ['https://example.com/callback']);
+      expect(response.client?.clientSecret, isNotNull);
+      expect(response.client?.clientId, isNotNull);
     });
 
     test('list OAuth clients', () async {
       // First create a client
-      final params = CreateOAuthClientParams(
+      final parameters = CreateOAuthClientParams(
         clientName: 'Test OAuth Client for List',
         redirectUris: ['https://example.com/callback'],
       );
-      await client.admin.oauth.createClient(params);
+      await client.admin.oauth.createClient(parameters);
 
-      final res = await client.admin.oauth.listClients();
-      expect(res.clients, isNotEmpty);
+      final response = await client.admin.oauth.listClients();
+      expect(response.clients, isNotEmpty);
       // aud is optional
     });
 
     test('get OAuth client by ID', () async {
       // First create a client
-      final params = CreateOAuthClientParams(
+      final parameters = CreateOAuthClientParams(
         clientName: 'Test OAuth Client for Get',
         redirectUris: ['https://example.com/callback'],
       );
-      final createRes = await client.admin.oauth.createClient(params);
-      final clientId = createRes.client!.clientId;
+      final createResponse = await client.admin.oauth.createClient(parameters);
+      final clientId = createResponse.client!.clientId;
 
-      final res = await client.admin.oauth.getClient(clientId);
-      expect(res.client, isNotNull);
-      expect(res.client?.clientId, clientId);
-      expect(res.client?.clientName, 'Test OAuth Client for Get');
+      final response = await client.admin.oauth.getClient(clientId);
+      expect(response.client, isNotNull);
+      expect(response.client?.clientId, clientId);
+      expect(response.client?.clientName, 'Test OAuth Client for Get');
     });
 
     test('update OAuth client', () async {
       // First create a client
-      final createParams = CreateOAuthClientParams(
+      final createParameters = CreateOAuthClientParams(
         clientName: 'Test OAuth Client for Update',
         redirectUris: ['https://example.com/callback'],
       );
-      final createRes = await client.admin.oauth.createClient(createParams);
-      final clientId = createRes.client!.clientId;
+      final createResponse = await client.admin.oauth.createClient(
+        createParameters,
+      );
+      final clientId = createResponse.client!.clientId;
 
       // Update the client
-      final updateParams = UpdateOAuthClientParams(
+      final updateParameters = UpdateOAuthClientParams(
         clientName: 'Updated OAuth Client Name',
       );
-      final updateRes = await client.admin.oauth.updateClient(
+      final updateResponse = await client.admin.oauth.updateClient(
         clientId,
-        updateParams,
+        updateParameters,
       );
-      expect(updateRes.client, isNotNull);
-      expect(updateRes.client?.clientId, clientId);
-      expect(updateRes.client?.clientName, 'Updated OAuth Client Name');
+      expect(updateResponse.client, isNotNull);
+      expect(updateResponse.client?.clientId, clientId);
+      expect(updateResponse.client?.clientName, 'Updated OAuth Client Name');
 
       // Verify the update by getting the client again
-      final getRes = await client.admin.oauth.getClient(clientId);
-      expect(getRes.client?.clientName, 'Updated OAuth Client Name');
+      final getResponse = await client.admin.oauth.getClient(clientId);
+      expect(getResponse.client?.clientName, 'Updated OAuth Client Name');
     });
 
     test('regenerate OAuth client secret', () async {
       // First create a client
-      final params = CreateOAuthClientParams(
+      final parameters = CreateOAuthClientParams(
         clientName: 'Test OAuth Client for Regenerate',
         redirectUris: ['https://example.com/callback'],
       );
-      final createRes = await client.admin.oauth.createClient(params);
-      final clientId = createRes.client!.clientId;
-      final originalSecret = createRes.client!.clientSecret;
+      final createResponse = await client.admin.oauth.createClient(parameters);
+      final clientId = createResponse.client!.clientId;
+      final originalSecret = createResponse.client!.clientSecret;
 
-      final res = await client.admin.oauth.regenerateClientSecret(clientId);
-      expect(res.client, isNotNull);
-      expect(res.client?.clientSecret, isNotNull);
-      expect(res.client?.clientSecret, isNot(originalSecret));
+      final response = await client.admin.oauth.regenerateClientSecret(
+        clientId,
+      );
+      expect(response.client, isNotNull);
+      expect(response.client?.clientSecret, isNotNull);
+      expect(response.client?.clientSecret, isNot(originalSecret));
     });
 
     test('delete OAuth client', () async {
       // First create a client
-      final params = CreateOAuthClientParams(
+      final parameters = CreateOAuthClientParams(
         clientName: 'Test OAuth Client for Delete',
         redirectUris: ['https://example.com/callback'],
       );
-      final createRes = await client.admin.oauth.createClient(params);
-      final clientId = createRes.client!.clientId;
+      final createResponse = await client.admin.oauth.createClient(parameters);
+      final clientId = createResponse.client!.clientId;
 
       // Delete returns 204 No Content with empty body
-      final res = await client.admin.oauth.deleteClient(clientId);
+      final response = await client.admin.oauth.deleteClient(clientId);
       // The server returns 204 with no body, so client will be null
-      expect(res.client, isNull);
+      expect(response.client, isNull);
     });
   });
 
@@ -162,9 +166,9 @@ void main() {
     });
 
     test('updateClient() validates ids', () {
-      final params = UpdateOAuthClientParams(clientName: 'Updated Name');
+      final parameters = UpdateOAuthClientParams(clientName: 'Updated Name');
       expect(
-        () => client.admin.oauth.updateClient('invalid-id', params),
+        () => client.admin.oauth.updateClient('invalid-id', parameters),
         throwsA(isA<ArgumentError>()),
       );
     });

--- a/packages/gotrue/test/src/gotrue_mfa_api_test.dart
+++ b/packages/gotrue/test/src/gotrue_mfa_api_test.dart
@@ -42,7 +42,7 @@ void main() {
 
     late GoTrueClient client;
     setUp(() async {
-      final res = await http.post(
+      final response = await http.post(
         Uri.parse(
           'http://127.0.0.1:54421/rest/v1/rpc/reset_and_init_auth_data',
         ),
@@ -52,7 +52,7 @@ void main() {
           'Authorization': 'Bearer ${getServiceRoleToken(env)}',
         },
       );
-      if (res.body.isNotEmpty) throw res.body;
+      if (response.body.isNotEmpty) throw response.body;
 
       client = GoTrueClient(
         url: gotrueUrl,
@@ -67,13 +67,13 @@ void main() {
     test('enroll totp', () async {
       await client.signInWithPassword(password: password, email: email1);
 
-      final res = await client.mfa.enroll(
+      final response = await client.mfa.enroll(
         issuer: 'MyFriend',
         friendlyName: 'MyFriendName',
       );
-      final uri = Uri.parse(res.totp!.uri);
+      final uri = Uri.parse(response.totp!.uri);
 
-      expect(res.type, FactorType.totp);
+      expect(response.type, FactorType.totp);
       expect(uri.queryParameters['issuer'], 'MyFriend');
       expect(uri.scheme, 'otpauth');
     });
@@ -81,15 +81,15 @@ void main() {
     test('enroll phone', () async {
       await client.signInWithPassword(password: password, email: email1);
 
-      final res = await client.mfa.enroll(
+      final response = await client.mfa.enroll(
         factorType: FactorType.phone,
         phone: '+1234567890',
         friendlyName: 'MyPhone',
       );
 
-      expect(res.type, FactorType.phone);
-      expect(res.phone?.phone, '+1234567890');
-      expect(res.totp, isNull);
+      expect(response.type, FactorType.phone);
+      expect(response.phone?.phone, '+1234567890');
+      expect(response.totp, isNull);
     });
 
     test('enroll phone requires phone number', () async {
@@ -107,43 +107,43 @@ void main() {
     test('challenge', () async {
       await client.signInWithPassword(password: password, email: email1);
 
-      final res = await client.mfa.challenge(factorId: factorId1);
+      final response = await client.mfa.challenge(factorId: factorId1);
 
-      expect(res.expiresAt.isAfter(DateTime.now()), isTrue);
+      expect(response.expiresAt.isAfter(DateTime.now()), isTrue);
     });
 
     test('verify', () async {
       await client.signInWithPassword(password: password, email: email1);
 
       // Create a challenge first
-      final challengeRes = await client.mfa.challenge(factorId: factorId1);
+      final challengeResponse = await client.mfa.challenge(factorId: factorId1);
 
-      final res = await client.mfa.verify(
+      final response = await client.mfa.verify(
         factorId: factorId1,
-        challengeId: challengeRes.id,
+        challengeId: challengeResponse.id,
         code: getTOTP(),
       );
 
-      expect(client.currentSession?.accessToken, res.accessToken);
-      expect(client.currentUser, res.user);
-      expect(client.currentSession?.refreshToken, res.refreshToken);
-      expect(client.currentSession?.expiresIn, res.expiresIn.inSeconds);
+      expect(client.currentSession?.accessToken, response.accessToken);
+      expect(client.currentUser, response.user);
+      expect(client.currentSession?.refreshToken, response.refreshToken);
+      expect(client.currentSession?.expiresIn, response.expiresIn.inSeconds);
     });
 
     test('challenge and verify', () async {
       await client.signInWithPassword(password: password, email: email1);
 
-      expect(client.currentUser!.factors!.length, 1);
+      expect(client.currentUser!.factors!, hasLength(1));
       expect(
         client.currentUser!.factors!.first.status,
         FactorStatus.unverified,
       );
-      final res = await client.mfa.challengeAndVerify(
+      final response = await client.mfa.challengeAndVerify(
         factorId: factorId1,
         code: getTOTP(),
       );
-      expect(client.currentUser, res.user);
-      expect(client.currentUser!.factors!.length, 1);
+      expect(client.currentUser, response.user);
+      expect(client.currentUser!.factors!, hasLength(1));
       expect(client.currentUser!.factors!.first.id, factorId1);
       expect(client.currentUser!.factors!.first.status, FactorStatus.verified);
     });
@@ -153,29 +153,29 @@ void main() {
 
       await client.mfa.challengeAndVerify(factorId: factorId2, code: getTOTP());
 
-      final res = await client.mfa.unenroll(factorId2);
-      expect(res.id, factorId2);
+      final response = await client.mfa.unenroll(factorId2);
+      expect(response.id, factorId2);
     });
 
     test('list factors', () async {
       await client.signInWithPassword(password: password, email: email2);
 
-      final res = await client.mfa.listFactors();
+      final response = await client.mfa.listFactors();
 
-      expect(res.totp.length, 1);
-      expect(res.phone, isEmpty);
-      expect(res.all.length, 1);
-      expect(res.all.first.id, factorId2);
-      expect(res.all.first.status, FactorStatus.verified);
+      expect(response.totp, hasLength(1));
+      expect(response.phone, isEmpty);
+      expect(response.all, hasLength(1));
+      expect(response.all.first.id, factorId2);
+      expect(response.all.first.status, FactorStatus.verified);
       expect(
-        res.all.first.createdAt.difference(DateTime.now()) <
+        response.all.first.createdAt.difference(DateTime.now()) <
             Duration(seconds: 2),
-        true,
+        isTrue,
       );
       expect(
-        res.all.first.updatedAt.difference(DateTime.now()) <
+        response.all.first.updatedAt.difference(DateTime.now()) <
             Duration(seconds: 2),
-        true,
+        isTrue,
       );
     });
 
@@ -183,63 +183,65 @@ void main() {
       await client.signInWithPassword(password: password, email: email1);
 
       // First, enroll a phone factor
-      final enrollRes = await client.mfa.enroll(
+      final enrollResponse = await client.mfa.enroll(
         factorType: FactorType.phone,
         phone: '+1234567890',
         friendlyName: 'TestPhone',
       );
 
       // Verify enrollment worked
-      expect(enrollRes.type, FactorType.phone);
-      expect(enrollRes.phone?.phone, '+1234567890');
+      expect(enrollResponse.type, FactorType.phone);
+      expect(enrollResponse.phone?.phone, '+1234567890');
 
       // Now list factors and check that phone factor appears
-      final listRes = await client.mfa.listFactors();
+      final listResponse = await client.mfa.listFactors();
 
       // Should have 1 phone factor (unverified) and 0 verified phone factors
-      expect(listRes.all.length, greaterThanOrEqualTo(1));
+      expect(listResponse.all.length, greaterThanOrEqualTo(1));
 
       // Find the phone factor we just enrolled
-      final phoneFactor = listRes.all.firstWhere(
+      final phoneFactor = listResponse.all.firstWhere(
         (factor) => factor.factorType == FactorType.phone,
       );
 
-      expect(phoneFactor.id, enrollRes.id);
+      expect(phoneFactor.id, enrollResponse.id);
       expect(phoneFactor.factorType, FactorType.phone);
       expect(phoneFactor.friendlyName, 'TestPhone');
       expect(phoneFactor.status, FactorStatus.unverified);
 
       // Verified phone factors should be empty since we haven't verified yet
-      expect(listRes.phone, isEmpty);
+      expect(listResponse.phone, isEmpty);
 
       // But the factor should appear in the all list
-      expect(listRes.all.any((f) => f.factorType == FactorType.phone), isTrue);
+      expect(
+        listResponse.all.any((f) => f.factorType == FactorType.phone),
+        isTrue,
+      );
     });
 
     test('aal1 for only password', () async {
       await client.signInWithPassword(password: password, email: email2);
-      final res = client.mfa.getAuthenticatorAssuranceLevel();
-      expect(res.currentLevel, AuthenticatorAssuranceLevels.aal1);
-      expect(res.nextLevel, AuthenticatorAssuranceLevels.aal2);
+      final response = client.mfa.getAuthenticatorAssuranceLevel();
+      expect(response.currentLevel, AuthenticatorAssuranceLevels.aal1);
+      expect(response.nextLevel, AuthenticatorAssuranceLevels.aal2);
     });
 
     test('aal2 for password and totp', () async {
       await client.signInWithPassword(password: password, email: email2);
       await client.mfa.challengeAndVerify(factorId: factorId2, code: getTOTP());
-      final res = client.mfa.getAuthenticatorAssuranceLevel();
-      expect(res.currentLevel, AuthenticatorAssuranceLevels.aal2);
-      expect(res.nextLevel, AuthenticatorAssuranceLevels.aal2);
-      final passwordEntry = res.currentAuthenticationMethods.firstWhereOrNull(
-        (element) => element.method == AMRMethod.password,
-      );
-      final totpEntry = res.currentAuthenticationMethods.firstWhereOrNull(
+      final response = client.mfa.getAuthenticatorAssuranceLevel();
+      expect(response.currentLevel, AuthenticatorAssuranceLevels.aal2);
+      expect(response.nextLevel, AuthenticatorAssuranceLevels.aal2);
+      final passwordEntry = response.currentAuthenticationMethods
+          .firstWhereOrNull((element) => element.method == AMRMethod.password);
+      final totpEntry = response.currentAuthenticationMethods.firstWhereOrNull(
         (element) => element.method == AMRMethod.totp,
       );
       expect(passwordEntry, isNotNull);
       expect(totpEntry, isNotNull);
       expect(
         totpEntry!.timestamp.difference(DateTime.now()) < Duration(seconds: 2),
-        true,
+        isTrue,
       );
     });
 

--- a/packages/gotrue/test/src/gotrue_oauth_api_test.dart
+++ b/packages/gotrue/test/src/gotrue_oauth_api_test.dart
@@ -128,23 +128,23 @@ void main() {
   group('OAuth server', () {
     test('get authorization details', () async {
       final sut = await fixture.build();
-      final clientParams = CreateOAuthClientParams(
+      final clientParameters = CreateOAuthClientParams(
         clientName: 'Test OAuth Client',
         redirectUris: ['http://127.0.0.1:3000/oauth/callback'],
         responseTypes: [OAuthClientResponseType.code],
         scope: 'email',
       );
-      final client = await fixture.sutCreatesOAuthClient(clientParams);
+      final client = await fixture.sutCreatesOAuthClient(clientParameters);
       final auth = await fixture.sutLogsIn(password: password, email: email1);
       final authorizationId = await fixture.sutAuthorizesClient(client);
 
-      final res = await sut.oauth.getAuthorizationDetails(authorizationId);
+      final response = await sut.oauth.getAuthorizationDetails(authorizationId);
 
-      expect(res, isA<OAuthAuthorizationDetailsResponse>());
-      final details = res as OAuthAuthorizationDetailsResponse;
+      expect(response, isA<OAuthAuthorizationDetailsResponse>());
+      final details = response as OAuthAuthorizationDetailsResponse;
       expect(details.authorizationId, equals(authorizationId));
-      expect(details.scope, equals(clientParams.scope));
-      expect(details.redirectUri, equals(clientParams.redirectUris.first));
+      expect(details.scope, equals(clientParameters.scope));
+      expect(details.redirectUri, equals(clientParameters.redirectUris.first));
       expect(details.client.clientId, equals(client.clientId));
       expect(details.client.clientName, equals(client.clientName));
       expect(details.user.id, equals(auth.user?.id));
@@ -153,49 +153,55 @@ void main() {
 
     test('approve authorization request', () async {
       final sut = await fixture.build();
-      final clientParams = CreateOAuthClientParams(
+      final clientParameters = CreateOAuthClientParams(
         clientName: 'Test OAuth Client',
         redirectUris: ['http://127.0.0.1:3000/oauth/callback'],
       );
-      final client = await fixture.sutCreatesOAuthClient(clientParams);
+      final client = await fixture.sutCreatesOAuthClient(clientParameters);
       final authorizationId = await fixture.sutAuthorizesClient(client);
       await fixture.sutLogsIn(password: password, email: email1);
 
       await sut.oauth.getAuthorizationDetails(authorizationId);
-      final res = await sut.oauth.approveAuthorization(authorizationId);
+      final response = await sut.oauth.approveAuthorization(authorizationId);
 
-      expect(res.redirectUrl, startsWith(clientParams.redirectUris.first));
-      expect(res.redirectUrl, contains('code='));
+      expect(
+        response.redirectUrl,
+        startsWith(clientParameters.redirectUris.first),
+      );
+      expect(response.redirectUrl, contains('code='));
     });
 
     test('denies authorization request', () async {
       final sut = await fixture.build();
-      final clientParams = CreateOAuthClientParams(
+      final clientParameters = CreateOAuthClientParams(
         clientName: 'Test OAuth Client',
         redirectUris: ['http://127.0.0.1:3000/oauth/callback'],
       );
-      final client = await fixture.sutCreatesOAuthClient(clientParams);
+      final client = await fixture.sutCreatesOAuthClient(clientParameters);
       final authorizationId = await fixture.sutAuthorizesClient(client);
       await fixture.sutLogsIn(password: password, email: email1);
 
       await sut.oauth.getAuthorizationDetails(authorizationId);
-      final res = await sut.oauth.denyAuthorization(authorizationId);
+      final response = await sut.oauth.denyAuthorization(authorizationId);
 
-      expect(res.redirectUrl, startsWith(clientParams.redirectUris.first));
-      expect(res.redirectUrl, contains('error=access_denied'));
       expect(
-        res.redirectUrl,
+        response.redirectUrl,
+        startsWith(clientParameters.redirectUris.first),
+      );
+      expect(response.redirectUrl, contains('error=access_denied'));
+      expect(
+        response.redirectUrl,
         contains('error_description=User+denied+the+request'),
       );
     });
 
     test('approving authorization without getting details throws', () async {
       final sut = await fixture.build();
-      final clientParams = CreateOAuthClientParams(
+      final clientParameters = CreateOAuthClientParams(
         clientName: 'Test OAuth Client',
         redirectUris: ['http://127.0.0.1:3000/oauth/callback'],
       );
-      final client = await fixture.sutCreatesOAuthClient(clientParams);
+      final client = await fixture.sutCreatesOAuthClient(clientParameters);
       final authorizationId = await fixture.sutAuthorizesClient(client);
       await fixture.sutLogsIn(password: password, email: email1);
 
@@ -212,13 +218,13 @@ void main() {
 
     test('lists grants after approving an authorization', () async {
       final sut = await fixture.build();
-      final clientParams = CreateOAuthClientParams(
+      final clientParameters = CreateOAuthClientParams(
         clientName: 'Test OAuth Client',
         redirectUris: ['http://127.0.0.1:3000/oauth/callback'],
         responseTypes: [OAuthClientResponseType.code],
         scope: 'email',
       );
-      final client = await fixture.sutCreatesOAuthClient(clientParams);
+      final client = await fixture.sutCreatesOAuthClient(clientParameters);
       await fixture.sutLogsIn(password: password, email: email1);
       final authorizationId = await fixture.sutAuthorizesClient(client);
       await sut.oauth.getAuthorizationDetails(authorizationId);
@@ -233,13 +239,13 @@ void main() {
 
     test('revokes a grant', () async {
       final sut = await fixture.build();
-      final clientParams = CreateOAuthClientParams(
+      final clientParameters = CreateOAuthClientParams(
         clientName: 'Test OAuth Client',
         redirectUris: ['http://127.0.0.1:3000/oauth/callback'],
         responseTypes: [OAuthClientResponseType.code],
         scope: 'email',
       );
-      final client = await fixture.sutCreatesOAuthClient(clientParams);
+      final client = await fixture.sutCreatesOAuthClient(clientParameters);
       await fixture.sutLogsIn(password: password, email: email1);
       final authorizationId = await fixture.sutAuthorizesClient(client);
       await sut.oauth.getAuthorizationDetails(authorizationId);
@@ -256,13 +262,13 @@ void main() {
       'approved does not throw',
       () async {
         final sut = await fixture.build();
-        final clientParams = CreateOAuthClientParams(
+        final clientParameters = CreateOAuthClientParams(
           clientName: 'Test OAuth Client',
           redirectUris: ['http://127.0.0.1:3000/oauth/callback'],
           responseTypes: [OAuthClientResponseType.code],
           scope: 'email',
         );
-        final client = await fixture.sutCreatesOAuthClient(clientParams);
+        final client = await fixture.sutCreatesOAuthClient(clientParameters);
         await fixture.sutLogsIn(password: password, email: email1);
 
         // First authorization: fetch details and approve to record consent.
@@ -273,15 +279,15 @@ void main() {
         // Second authorization for the same client, by the same user.
         final secondAuthorizationId = await fixture.sutAuthorizesClient(client);
 
-        final res = await sut.oauth.getAuthorizationDetails(
+        final response = await sut.oauth.getAuthorizationDetails(
           secondAuthorizationId,
         );
 
-        expect(res, isA<OAuthAuthorizationRedirectResponse>());
-        final redirect = res as OAuthAuthorizationRedirectResponse;
+        expect(response, isA<OAuthAuthorizationRedirectResponse>());
+        final redirect = response as OAuthAuthorizationRedirectResponse;
         expect(
           redirect.redirectUrl,
-          startsWith(clientParams.redirectUris.first),
+          startsWith(clientParameters.redirectUris.first),
         );
         expect(redirect.redirectUrl, contains('code='));
       },
@@ -312,7 +318,9 @@ class GotrueOauthApiFixture {
   late final String _serviceRoleToken;
 
   Future<OAuthClient> sutCreatesOAuthClient(CreateOAuthClientParams request) {
-    return _client.admin.oauth.createClient(request).then((res) => res.client!);
+    return _client.admin.oauth
+        .createClient(request)
+        .then((response) => response.client!);
   }
 
   Future<String> sutAuthorizesClient(OAuthClient client) async {
@@ -351,7 +359,7 @@ class GotrueOauthApiFixture {
   }
 
   Future<void> _reset() async {
-    final res = await http.post(
+    final response = await http.post(
       Uri.parse('http://127.0.0.1:54421/rest/v1/rpc/reset_and_init_auth_data'),
       headers: {
         'x-forwarded-for': '127.0.0.1',
@@ -359,7 +367,7 @@ class GotrueOauthApiFixture {
         'Authorization': 'Bearer $_serviceRoleToken',
       },
     );
-    if (res.body.isNotEmpty) throw res.body;
+    if (response.body.isNotEmpty) throw response.body;
   }
 
   Future<GoTrueClient> build({bool reset = true}) async {

--- a/packages/gotrue/test/src/set_session_test.dart
+++ b/packages/gotrue/test/src/set_session_test.dart
@@ -43,7 +43,7 @@ class _SetSessionMockClient extends BaseClient {
       // Refresh-token fallback response with a freshly minted access token.
       final exp = DateTime.now().millisecondsSinceEpoch ~/ 1000 + 3600;
       final iat = exp - 3600;
-      final freshAt = _makeRawJwt({
+      final freshAccessToken = _makeRawJwt({
         'exp': exp,
         'iat': iat,
         'sub': 'mock-user-id',
@@ -52,7 +52,7 @@ class _SetSessionMockClient extends BaseClient {
         Stream.value(
           utf8.encode(
             jsonEncode({
-              'access_token': freshAt,
+              'access_token': freshAccessToken,
               'token_type': 'bearer',
               'expires_in': 3600,
               'refresh_token': 'new-refresh-token',
@@ -78,8 +78,8 @@ String _makeRawJwt(Map<String, dynamic> payload) {
     utf8.encode(jsonEncode({'alg': 'HS256', 'typ': 'JWT'})),
   );
   final body = base64Url.encode(utf8.encode(jsonEncode(payload)));
-  const sig = 'AAAA';
-  return '$header.$body.$sig';
+  const signature = 'AAAA';
+  return '$header.$body.$signature';
 }
 
 void main() {
@@ -99,14 +99,14 @@ void main() {
     test('empty refresh token with a non-null access token throws before '
         'inspecting the access token', () async {
       final exp = DateTime.now().millisecondsSinceEpoch ~/ 1000 + 3600;
-      final at = _makeRawJwt({
+      final accessToken = _makeRawJwt({
         'exp': exp,
         'iat': exp - 3600,
         'sub': 'mock-user-id',
       });
 
       await expectLater(
-        () => client.setSession('', accessToken: at),
+        client.setSession('', accessToken: accessToken),
         throwsA(isA<AuthSessionMissingException>()),
       );
       // No network call should have been made.
@@ -117,7 +117,7 @@ void main() {
         'as expired and falls back to the refresh-token path', () async {
       final timeNow = DateTime.now().millisecondsSinceEpoch ~/ 1000;
       // exp is 20 s in the future, inside the 30 s Constants.expiryMargin.
-      final at = _makeRawJwt({
+      final accessToken = _makeRawJwt({
         'exp': timeNow + 20,
         'iat': timeNow - 3580,
         'sub': 'mock-user-id',
@@ -125,27 +125,30 @@ void main() {
 
       final response = await client.setSession(
         'some-refresh-token',
-        accessToken: at,
+        accessToken: accessToken,
       );
 
       expect(response.session, isNotNull);
       // The returned token must be the freshly refreshed one, not our near-expired JWT.
-      expect(response.session?.accessToken, isNot(equals(at)));
+      expect(response.session?.accessToken, isNot(equals(accessToken)));
       expect(mockClient.userCallCount, 0); // /user was NOT called
     });
 
     test('access token with no exp claim is treated as expired and falls back '
         'to the refresh-token path', () async {
       // JWT without an exp claim: decodeJwt succeeds but exp == null.
-      final at = _makeRawJwt({'role': 'authenticated', 'sub': 'mock-user-id'});
+      final accessToken = _makeRawJwt({
+        'role': 'authenticated',
+        'sub': 'mock-user-id',
+      });
 
       final response = await client.setSession(
         'some-refresh-token',
-        accessToken: at,
+        accessToken: accessToken,
       );
 
       expect(response.session, isNotNull);
-      expect(response.session?.accessToken, isNot(equals(at)));
+      expect(response.session?.accessToken, isNot(equals(accessToken)));
       expect(mockClient.userCallCount, 0);
     });
   });
@@ -156,11 +159,15 @@ void main() {
       () async {
         final iat = DateTime.now().millisecondsSinceEpoch ~/ 1000 - 60;
         final exp = iat + 3600;
-        final at = _makeRawJwt({'exp': exp, 'iat': iat, 'sub': 'mock-user-id'});
+        final accessToken = _makeRawJwt({
+          'exp': exp,
+          'iat': iat,
+          'sub': 'mock-user-id',
+        });
 
         final response = await client.setSession(
           'some-refresh-token',
-          accessToken: at,
+          accessToken: accessToken,
         );
 
         // expiresIn should be the total token lifetime (exp - iat = 3600).
@@ -171,11 +178,11 @@ void main() {
     test('expiresIn is null when iat claim is absent', () async {
       final exp = DateTime.now().millisecondsSinceEpoch ~/ 1000 + 3600;
       // JWT without iat.
-      final at = _makeRawJwt({'exp': exp, 'sub': 'mock-user-id'});
+      final accessToken = _makeRawJwt({'exp': exp, 'sub': 'mock-user-id'});
 
       final response = await client.setSession(
         'some-refresh-token',
-        accessToken: at,
+        accessToken: accessToken,
       );
 
       expect(response.session?.expiresIn, isNull);
@@ -184,11 +191,15 @@ void main() {
     test('expiresAt matches the exp claim in the JWT', () async {
       final iat = DateTime.now().millisecondsSinceEpoch ~/ 1000 - 60;
       final exp = iat + 3600;
-      final at = _makeRawJwt({'exp': exp, 'iat': iat, 'sub': 'mock-user-id'});
+      final accessToken = _makeRawJwt({
+        'exp': exp,
+        'iat': iat,
+        'sub': 'mock-user-id',
+      });
 
       final response = await client.setSession(
         'some-refresh-token',
-        accessToken: at,
+        accessToken: accessToken,
       );
 
       // expiresAt is re-derived from the JWT's own exp, not from expiresIn.
@@ -201,11 +212,18 @@ void main() {
         final iat = DateTime.now().millisecondsSinceEpoch ~/ 1000 - 60;
         final exp = iat + 3600;
         const refreshToken = 'my-refresh-token';
-        final at = _makeRawJwt({'exp': exp, 'iat': iat, 'sub': 'mock-user-id'});
+        final accessToken = _makeRawJwt({
+          'exp': exp,
+          'iat': iat,
+          'sub': 'mock-user-id',
+        });
 
-        final response = await client.setSession(refreshToken, accessToken: at);
+        final response = await client.setSession(
+          refreshToken,
+          accessToken: accessToken,
+        );
 
-        expect(response.session?.accessToken, equals(at));
+        expect(response.session?.accessToken, equals(accessToken));
         expect(response.session?.refreshToken, equals(refreshToken));
         expect(response.session?.tokenType, equals('bearer'));
       },
@@ -216,20 +234,24 @@ void main() {
     test('fast path emits signedIn (not tokenRefreshed)', () async {
       final iat = DateTime.now().millisecondsSinceEpoch ~/ 1000 - 60;
       final exp = iat + 3600;
-      final at = _makeRawJwt({'exp': exp, 'iat': iat, 'sub': 'mock-user-id'});
+      final accessToken = _makeRawJwt({
+        'exp': exp,
+        'iat': iat,
+        'sub': 'mock-user-id',
+      });
 
       expect(
         client.onAuthStateChange,
         emits(predicate<AuthState>((s) => s.event == AuthChangeEvent.signedIn)),
       );
 
-      await client.setSession('some-refresh-token', accessToken: at);
+      await client.setSession('some-refresh-token', accessToken: accessToken);
     });
 
     test('expired-fallback path emits tokenRefreshed (not signedIn)', () async {
       final timeNow = DateTime.now().millisecondsSinceEpoch ~/ 1000;
       // Clearly expired token (exp well in the past).
-      final at = _makeRawJwt({
+      final accessToken = _makeRawJwt({
         'exp': timeNow - 100,
         'iat': timeNow - 3700,
         'sub': 'mock-user-id',
@@ -244,7 +266,7 @@ void main() {
         ),
       );
 
-      await client.setSession('some-refresh-token', accessToken: at);
+      await client.setSession('some-refresh-token', accessToken: accessToken);
     });
   });
 }

--- a/packages/gotrue/test/src/token_refresh_race_test.dart
+++ b/packages/gotrue/test/src/token_refresh_race_test.dart
@@ -30,8 +30,8 @@ String _makeRawJwt(Map<String, dynamic> payload) {
     utf8.encode(jsonEncode({'alg': 'HS256', 'typ': 'JWT'})),
   );
   final body = base64Url.encode(utf8.encode(jsonEncode(payload)));
-  const sig = 'AAAA';
-  return '$header.$body.$sig';
+  const signature = 'AAAA';
+  return '$header.$body.$signature';
 }
 
 String _freshAccessToken({String sub = 'mock-user-id'}) {
@@ -43,9 +43,9 @@ String _freshAccessToken({String sub = 'mock-user-id'}) {
 String _tokenResponseJson({
   String refreshToken = 'new-refresh-token',
 }) {
-  final at = _freshAccessToken();
+  final accessToken = _freshAccessToken();
   return jsonEncode({
-    'access_token': at,
+    'access_token': accessToken,
     'token_type': 'bearer',
     'expires_in': 3600,
     'refresh_token': refreshToken,
@@ -183,10 +183,10 @@ void main() {
       // Meanwhile, set a new session via the fast path (valid access token).
       // This bypasses the refresh queue entirely and writes _currentSession
       // immediately, bumping _sessionVersion.
-      final freshAt = _freshAccessToken();
+      final freshAccessToken = _freshAccessToken();
       await client.setSession(
         'new-signin-refresh-token',
-        accessToken: freshAt,
+        accessToken: freshAccessToken,
       );
       expect(client.currentSession?.refreshToken, 'new-signin-refresh-token');
 
@@ -288,10 +288,10 @@ void main() {
       await Future<void>.delayed(Duration.zero);
 
       // While the refresh is pending, set a new valid session (fast path).
-      final freshAt = _freshAccessToken();
+      final freshAccessToken = _freshAccessToken();
       await client.setSession(
         'new-refresh-token',
-        accessToken: freshAt,
+        accessToken: freshAccessToken,
       );
       expect(client.currentSession, isNotNull);
       expect(client.currentSession?.refreshToken, 'new-refresh-token');
@@ -316,8 +316,8 @@ void main() {
         });
 
         // Set an initial session.
-        final freshAt = _freshAccessToken();
-        await client.setSession('initial-token', accessToken: freshAt);
+        final freshAccessToken = _freshAccessToken();
+        await client.setSession('initial-token', accessToken: freshAccessToken);
         events.clear();
 
         // Now make a refresh that will fail with a non-retryable error.

--- a/packages/gotrue/test/src/types/auth_exception_test.dart
+++ b/packages/gotrue/test/src/types/auth_exception_test.dart
@@ -119,12 +119,6 @@ void main() {
 
         expect(exception1, equals(exception2));
       });
-
-      test('returns true for reference equality', () {
-        const exception = AuthException('Test error');
-
-        expect(exception, same(exception));
-      });
     });
 
     group('implements Exception', () {
@@ -495,7 +489,7 @@ void main() {
       expect(exception.message, equals('Password does not meet requirements'));
       expect(exception.statusCode, equals('422'));
       expect(exception.code, equals('weak_password'));
-      expect(exception.reasons.length, equals(3));
+      expect(exception.reasons, hasLength(3));
     });
 
     test('handles unknown HTTP error scenario', () {

--- a/packages/gotrue/test/src/types/session_test.dart
+++ b/packages/gotrue/test/src/types/session_test.dart
@@ -153,7 +153,7 @@ void main() {
 
         final json = session.toJson();
 
-        expect(json.containsKey('expires_at'), isTrue);
+        expect(json, contains('expires_at'));
         expect(json['expires_at'], equals(session.expiresAt));
       });
     });
@@ -490,16 +490,6 @@ void main() {
         );
 
         expect(session1, equals(session2));
-      });
-
-      test('returns true for reference equality', () {
-        final session = Session(
-          accessToken: 'test-token',
-          tokenType: 'bearer',
-          user: mockUser,
-        );
-
-        expect(session, same(session));
       });
     });
 

--- a/packages/gotrue/test/src/types/user_test.dart
+++ b/packages/gotrue/test/src/types/user_test.dart
@@ -192,7 +192,7 @@ void main() {
 
         expect(user, isNotNull);
         expect(user!.identities, isNotNull);
-        expect(user.identities!.length, equals(1));
+        expect(user.identities, hasLength(1));
         expect(user.identities![0].id, equals('identity-1'));
         expect(user.identities![0].provider, equals('email'));
       });
@@ -220,7 +220,7 @@ void main() {
 
         expect(user, isNotNull);
         expect(user!.factors, isNotNull);
-        expect(user.factors!.length, equals(1));
+        expect(user.factors, hasLength(1));
         expect(user.factors![0].id, equals('factor-1'));
         expect(user.factors![0].friendlyName, equals('My Phone'));
       });
@@ -332,7 +332,7 @@ void main() {
         final json = user.toJson();
 
         expect(json['identities'], isA<List>());
-        expect(json['identities'].length, equals(1));
+        expect(json['identities'], hasLength(1));
         expect(json['identities'][0], equals(identity.toJson()));
       });
 
@@ -467,18 +467,6 @@ void main() {
         );
 
         expect(user1, equals(user2));
-      });
-
-      test('returns true for reference equality', () {
-        const user = User(
-          id: '123',
-          appMetadata: {},
-          userMetadata: <String, dynamic>{},
-          aud: 'authenticated',
-          createdAt: '2023-01-01T00:00:00Z',
-        );
-
-        expect(user, same(user));
       });
     });
 
@@ -781,20 +769,6 @@ void main() {
         );
 
         expect(identity1, equals(identity2));
-      });
-
-      test('returns true for reference equality', () {
-        const identity = UserIdentity(
-          id: 'identity-1',
-          userId: '123',
-          identityData: <String, dynamic>{'email': 'test@example.com'},
-          identityId: 'identity-1',
-          provider: 'email',
-          createdAt: '2023-01-01T00:00:00Z',
-          lastSignInAt: '2023-01-01T00:00:00Z',
-        );
-
-        expect(identity, same(identity));
       });
     });
 

--- a/packages/postgrest/test/basic_test.dart
+++ b/packages/postgrest/test/basic_test.dart
@@ -324,7 +324,7 @@ void main() {
 
     test('missing table', () async {
       await expectLater(
-        postgrest.from('missing_table').select(),
+        () => postgrest.from('missing_table').select(),
         throwsA(
           isA<PostgrestException>().having((e) => e.code, 'code', 'PGRST205'),
         ),
@@ -334,17 +334,17 @@ void main() {
     test('connection error', () async {
       final client = PostgrestClient('http://this.url.does.not.exist');
       await expectLater(
-        client.from('user').select(),
+        () => client.from('user').select(),
         throwsA(isA<SocketException>()),
       );
     });
 
     test('Prefer: return=minimal completes successfully', () async {
-      expect(postgrest.from('users').insert({'username': 'bar'}), completes);
+      await postgrest.from('users').insert({'username': 'bar'});
     });
 
     test('select with head:true completes successfully', () async {
-      expect(postgrest.from('users').select('*').head(), completes);
+      await postgrest.from('users').select('*').head();
     });
 
     test('count with head: true, filters', () async {
@@ -428,7 +428,7 @@ void main() {
 
     test('execute without table operation', () async {
       await expectLater(
-        postgrest.from('users'),
+        () => postgrest.from('users'),
         throwsA(isA<ArgumentError>()),
       );
     });
@@ -487,7 +487,7 @@ void main() {
       Timer(Duration(seconds: 1), () => completer.complete());
 
       await expectLater(
-        postgrest
+        () => postgrest
             .rpc('long_running_task')
             .select()
             .abortSignal(completer.future),
@@ -517,7 +517,7 @@ void main() {
 
     test('basic select table', () async {
       await expectLater(
-        postgrestCustomHttpClient.from('users').select(),
+        () => postgrestCustomHttpClient.from('users').select(),
         throwsA(isA<PostgrestException>().having((e) => e.code, 'code', '420')),
       );
     });
@@ -534,7 +534,7 @@ void main() {
     );
     test('basic select table with converter', () async {
       await expectLater(
-        postgrestCustomHttpClient
+        () => postgrestCustomHttpClient
             .from('users')
             .select()
             .withConverter((data) => data),
@@ -543,7 +543,7 @@ void main() {
     });
     test('basic stored procedure call', () async {
       await expectLater(
-        postgrestCustomHttpClient.rpc<String>(
+        () => postgrestCustomHttpClient.rpc<String>(
           'get_status',
           params: {'name_param': 'supabot'},
         ),
@@ -554,7 +554,7 @@ void main() {
 
     test('stored procedure call in read-only access mode', () async {
       await expectLater(
-        postgrestCustomHttpClient.rpc<String>(
+        () => postgrestCustomHttpClient.rpc<String>(
           'get_status',
           params: {'name_param': 'supabot'},
           get: true,
@@ -567,7 +567,7 @@ void main() {
 
     test('non-JSON body on 2xx response throws a structured error', () async {
       await expectLater(
-        postgrestCustomHttpClient.from('non-json-succ').select(),
+        () => postgrestCustomHttpClient.from('non-json-succ').select(),
         throwsA(
           isA<PostgrestException>()
               .having((e) => e.code, 'code', '200')
@@ -582,7 +582,10 @@ void main() {
 
     test('non-JSON body on 2xx response with maybeSingle throws', () async {
       await expectLater(
-        postgrestCustomHttpClient.from('non-json-succ').select().maybeSingle(),
+        () => postgrestCustomHttpClient
+            .from('non-json-succ')
+            .select()
+            .maybeSingle(),
         throwsA(
           isA<PostgrestException>().having((e) => e.code, 'code', '200'),
         ),

--- a/packages/postgrest/test/basic_test.dart
+++ b/packages/postgrest/test/basic_test.dart
@@ -339,12 +339,12 @@ void main() {
       );
     });
 
-    test('Prefer: return=minimal', () async {
-      await postgrest.from('users').insert({'username': 'bar'});
+    test('Prefer: return=minimal completes successfully', () async {
+      expect(postgrest.from('users').insert({'username': 'bar'}), completes);
     });
 
-    test('select with head:true', () async {
-      await postgrest.from('users').select('*').head();
+    test('select with head:true completes successfully', () async {
+      expect(postgrest.from('users').select('*').head(), completes);
     });
 
     test('count with head: true, filters', () async {

--- a/packages/postgrest/test/basic_test.dart
+++ b/packages/postgrest/test/basic_test.dart
@@ -32,56 +32,56 @@ void main() {
     });
 
     test('basic select table', () async {
-      final res = await postgrest.from('users').select();
-      expect(res.length, 4);
+      final response = await postgrest.from('users').select();
+      expect(response.length, 4);
     });
 
     test('stored procedure', () async {
-      final res = await postgrest.rpc<String>(
+      final result = await postgrest.rpc<String>(
         'get_status',
         params: {
           'name_param': 'supabot',
         },
       );
-      expect(res, 'ONLINE');
+      expect(result, 'ONLINE');
     });
 
     test('select on stored procedure', () async {
-      final res = await postgrest
+      final response = await postgrest
           .rpc(
             'get_username_and_status',
             params: {'name_param': 'supabot'},
           )
           .select('status');
       expect(
-        res.first['status'],
+        response.first['status'],
         'ONLINE',
       );
     });
 
     test('stored procedure returns void', () async {
-      final res = await postgrest.rpc('void_func');
-      expect(res, isNull);
+      final result = await postgrest.rpc('void_func');
+      expect(result, isNull);
     });
 
     test('stored procedure returns int', () async {
-      final res = await postgrest.rpc<int>('get_integer');
-      expect(res, isA<int>());
+      final result = await postgrest.rpc<int>('get_integer');
+      expect(result, isA<int>());
     });
 
     test('stored procedure with array parameter', () async {
-      final res = await postgrest.rpc<int>(
+      final result = await postgrest.rpc<int>(
         'get_array_element',
         params: {
           'arr': [37, 420, 64],
           'index': 2,
         },
       );
-      expect(res, 420);
+      expect(result, 420);
     });
 
     test('stored procedure with read-only access mode', () async {
-      final res = await postgrest.rpc<int>(
+      final result = await postgrest.rpc<int>(
         'get_array_element',
         params: {
           'arr': [37, 420, 64],
@@ -89,7 +89,7 @@ void main() {
         },
         get: true,
       );
-      expect(res, 420);
+      expect(result, 420);
     });
 
     test('custom headers', () async {
@@ -160,8 +160,8 @@ void main() {
         schema: 'personal',
         headers: apiHeaders,
       );
-      final res = await client.from('users').select();
-      expect(res.length, 5);
+      final response = await client.from('users').select();
+      expect(response.length, 5);
     });
 
     test('query non-public schema dynamically', () async {
@@ -178,19 +178,19 @@ void main() {
     });
 
     test('on_conflict upsert', () async {
-      final res = await postgrest.from('users').upsert(
+      final response = await postgrest.from('users').upsert(
         {'username': 'dragarcia', 'status': 'OFFLINE'},
         onConflict: 'username',
       ).select();
       expect(
-        res.first['status'],
+        response.first['status'],
         'OFFLINE',
       );
     });
 
     test('upsert', () async {
       final headersBefore = {...postgrest.headers};
-      final res = await postgrest.from('messages').upsert({
+      final response = await postgrest.from('messages').upsert({
         'id': 3,
         'message': 'foo',
         'username': 'supabot',
@@ -199,14 +199,14 @@ void main() {
       final headersAfter = {...postgrest.headers};
 
       expect(headersBefore, headersAfter);
-      expect(res.first['id'], 3);
+      expect(response.first['id'], 3);
 
-      final resMsg = await postgrest.from('messages').select();
-      expect(resMsg.length, 3);
+      final messagesResponse = await postgrest.from('messages').select();
+      expect(messagesResponse.length, 3);
     });
 
     test('ignoreDuplicates upsert', () async {
-      final res = await postgrest
+      final response = await postgrest
           .from('users')
           .upsert(
             {'username': 'dragarcia'},
@@ -214,50 +214,40 @@ void main() {
             ignoreDuplicates: true,
           )
           .select();
-      expect(res, isEmpty);
+      expect(response, isEmpty);
     });
 
     test('insert', () async {
-      final res = await postgrest.from('users').insert(
+      final response = await postgrest.from('users').insert(
         {
           'username': "bot",
           'status': 'OFFLINE',
         },
       ).select();
-      expect(res.length, 1);
-      expect(res.first['status'], 'OFFLINE');
+      expect(response.length, 1);
+      expect(response.first['status'], 'OFFLINE');
     });
 
     test('insert uses default value', () async {
-      final res = await postgrest.from('users').insert(
+      final response = await postgrest.from('users').insert(
         {
           'username': "bot",
         },
       ).select();
-      expect(res.length, 1);
-      expect(res.first['status'], 'ONLINE');
-    });
-
-    test('bulk insert with one row uses default value', () async {
-      final res = await postgrest.from('users').insert(
-        {
-          'username': "bot",
-        },
-      ).select();
-      expect(res.length, 1);
-      expect(res.first['status'], 'ONLINE');
+      expect(response.length, 1);
+      expect(response.first['status'], 'ONLINE');
     });
 
     test('bulk insert', () async {
-      final res = await postgrest.from('messages').insert([
+      final response = await postgrest.from('messages').insert([
         {'id': 4, 'message': 'foo', 'username': 'supabot', 'channel_id': 2},
         {'id': 5, 'message': 'foo', 'username': 'supabot', 'channel_id': 1},
       ]).select();
-      expect(res.length, 2);
+      expect(response.length, 2);
     });
 
     test('bulk insert without column defaults', () async {
-      final res = await postgrest.from('users').insert(
+      final response = await postgrest.from('users').insert(
         [
           {
             'username': "bot",
@@ -268,13 +258,13 @@ void main() {
           },
         ],
       ).select();
-      expect(res.length, 2);
-      expect(res.first['status'], 'OFFLINE');
-      expect(res.last['status'], null);
+      expect(response.length, 2);
+      expect(response.first['status'], 'OFFLINE');
+      expect(response.last['status'], null);
     });
 
     test('bulk insert with column defaults', () async {
-      final res = await postgrest.from('users').insert(
+      final response = await postgrest.from('users').insert(
         [
           {
             'username': "bot",
@@ -286,35 +276,35 @@ void main() {
         ],
         defaultToNull: false,
       ).select();
-      expect(res.length, 2);
-      expect(res.first['status'], 'OFFLINE');
-      expect(res.last['status'], 'ONLINE');
+      expect(response.length, 2);
+      expect(response.first['status'], 'OFFLINE');
+      expect(response.last['status'], 'ONLINE');
     });
 
     test('basic update', () async {
-      final res = await postgrest
+      final response = await postgrest
           .from('messages')
           .update(
             {'channel_id': 2},
           )
           .isFilter("data", null)
           .select();
-      expect(res, isNotEmpty);
-      expect(res, everyElement(containsPair("channel_id", 2)));
+      expect(response, isNotEmpty);
+      expect(response, everyElement(containsPair("channel_id", 2)));
 
       final messages = await postgrest.from('messages').select();
-      for (final rec in messages) {
-        expect(rec['channel_id'], 2);
+      for (final record in messages) {
+        expect(record['channel_id'], 2);
       }
     });
 
     test('basic delete', () async {
-      final res = await postgrest
+      final response = await postgrest
           .from('messages')
           .delete()
           .eq('message', 'Supabase Launch Week is on fire')
           .select();
-      expect(res, [
+      expect(response, [
         {
           'id': 3,
           'data': null,
@@ -325,16 +315,16 @@ void main() {
         },
       ]);
 
-      final resMsg = await postgrest
+      final messagesResponse = await postgrest
           .from('messages')
           .select()
           .eq('message', 'Supabase Launch Week is on fire');
-      expect(resMsg, isEmpty);
+      expect(messagesResponse, isEmpty);
     });
 
     test('missing table', () async {
       await expectLater(
-        () => postgrest.from('missing_table').select(),
+        postgrest.from('missing_table').select(),
         throwsA(
           isA<PostgrestException>().having((e) => e.code, 'code', 'PGRST205'),
         ),
@@ -344,7 +334,7 @@ void main() {
     test('connection error', () async {
       final client = PostgrestClient('http://this.url.does.not.exist');
       await expectLater(
-        () => client.from('user').select(),
+        client.from('user').select(),
         throwsA(isA<SocketException>()),
       );
     });
@@ -366,43 +356,43 @@ void main() {
     });
 
     test('select with head:true, count: exact', () async {
-      final int res = await postgrest.from('users').count(CountOption.exact);
-      expect(res, 4);
+      final int count = await postgrest.from('users').count(CountOption.exact);
+      expect(count, 4);
     });
 
     test('select with count: planned', () async {
-      final res = await postgrest
+      final response = await postgrest
           .from('users')
           .select('*')
           .count(CountOption.planned);
-      final int count = res.count;
+      final int count = response.count;
       expect(count, greaterThanOrEqualTo(0));
     });
 
     test('select with head:true, count: estimated', () async {
-      final int res = await postgrest
+      final int count = await postgrest
           .from('users')
           .count(CountOption.estimated);
-      expect(res, isA<int>());
+      expect(count, isA<int>());
     });
 
     test('select with csv', () async {
-      final res = await postgrest.from('users').select().csv();
-      expect(res, isA<String>());
+      final result = await postgrest.from('users').select().csv();
+      expect(result, isA<String>());
     });
 
     test('stored procedure with count: exact', () async {
-      final res = await postgrest
+      final response = await postgrest
           .rpc<String>(
             'get_status',
             params: {'name_param': 'supabot'},
           )
           .count(CountOption.exact);
-      expect(res.count, greaterThanOrEqualTo(0));
+      expect(response.count, greaterThanOrEqualTo(0));
     });
 
     test('insert with count: exact', () async {
-      final res = await postgrest
+      final response = await postgrest
           .from('users')
           .upsert(
             {'username': 'countexact', 'status': 'OFFLINE'},
@@ -410,11 +400,11 @@ void main() {
           )
           .select()
           .count(CountOption.exact);
-      expect(res.count, 1);
+      expect(response.count, 1);
     });
 
     test('update with count: exact', () async {
-      final res = await postgrest
+      final response = await postgrest
           .from('users')
           .update(
             {'status': 'ONLINE'},
@@ -422,71 +412,71 @@ void main() {
           .eq('username', 'kiwicopple')
           .select()
           .count(CountOption.exact);
-      expect(res.count, 1);
+      expect(response.count, 1);
     });
 
     test('delete with count: exact', () async {
-      final res = await postgrest
+      final response = await postgrest
           .from('users')
           .delete()
           .eq('username', 'kiwicopple')
           .select()
           .count(CountOption.exact);
 
-      expect(res.count, 1);
+      expect(response.count, 1);
     });
 
     test('execute without table operation', () async {
       await expectLater(
-        () => postgrest.from('users'),
+        postgrest.from('users'),
         throwsA(isA<ArgumentError>()),
       );
     });
 
     test('select from uppercase table name', () async {
-      final res = await postgrest.from('TestTable').select();
-      expect(res.length, 2);
+      final response = await postgrest.from('TestTable').select();
+      expect(response.length, 2);
     });
 
     test('insert from uppercase table name', () async {
-      final res = await postgrest.from('TestTable').insert([
+      final response = await postgrest.from('TestTable').insert([
         {'slug': 'new slug'},
       ]).select();
       expect(
-        (res.first)['slug'],
+        (response.first)['slug'],
         'new slug',
       );
     });
 
     test('delete from uppercase table name', () async {
-      final res = await postgrest
+      final response = await postgrest
           .from('TestTable')
           .delete()
           .eq('slug', 'new slug')
           .select()
           .count(CountOption.exact);
-      expect(res.count, 1);
+      expect(response.count, 1);
     });
 
     test('withConverter', () async {
-      final res = await postgrest
+      final response = await postgrest
           .from('users')
           .select()
           .withConverter((data) => [data]);
-      expect(res, isNotEmpty);
-      expect(res.first, isNotEmpty);
-      expect(res.first, isA<List>());
+      expect(response, isNotEmpty);
+      expect(response.first, isNotEmpty);
+      expect(response.first, isA<List>());
     });
 
     test('withConverter and count', () async {
-      final res = await postgrest
+      final response = await postgrest
           .from('users')
           .select()
           .count(CountOption.exact)
           .withConverter((data) => [data]);
-      expect(res.data.first, isNotEmpty);
-      expect(res.data.first, isA<List>());
-      expect(res.count, greaterThan(3));
+      expect(response.data.first, isNotEmpty);
+      expect(response.data.first, isA<List>());
+      expect(response.count, greaterThan(3));
     });
 
     test('aborts long-running function call', () async {
@@ -497,7 +487,7 @@ void main() {
       Timer(Duration(seconds: 1), () => completer.complete());
 
       await expectLater(
-        () => postgrest
+        postgrest
             .rpc('long_running_task')
             .select()
             .abortSignal(completer.future),
@@ -527,7 +517,7 @@ void main() {
 
     test('basic select table', () async {
       await expectLater(
-        () => postgrestCustomHttpClient.from('users').select(),
+        postgrestCustomHttpClient.from('users').select(),
         throwsA(isA<PostgrestException>().having((e) => e.code, 'code', '420')),
       );
     });
@@ -544,7 +534,7 @@ void main() {
     );
     test('basic select table with converter', () async {
       await expectLater(
-        () => postgrestCustomHttpClient
+        postgrestCustomHttpClient
             .from('users')
             .select()
             .withConverter((data) => data),
@@ -553,7 +543,7 @@ void main() {
     });
     test('basic stored procedure call', () async {
       await expectLater(
-        () => postgrestCustomHttpClient.rpc<String>(
+        postgrestCustomHttpClient.rpc<String>(
           'get_status',
           params: {'name_param': 'supabot'},
         ),
@@ -564,7 +554,7 @@ void main() {
 
     test('stored procedure call in read-only access mode', () async {
       await expectLater(
-        () => postgrestCustomHttpClient.rpc<String>(
+        postgrestCustomHttpClient.rpc<String>(
           'get_status',
           params: {'name_param': 'supabot'},
           get: true,
@@ -577,7 +567,7 @@ void main() {
 
     test('non-JSON body on 2xx response throws a structured error', () async {
       await expectLater(
-        () => postgrestCustomHttpClient.from('non-json-succ').select(),
+        postgrestCustomHttpClient.from('non-json-succ').select(),
         throwsA(
           isA<PostgrestException>()
               .having((e) => e.code, 'code', '200')
@@ -592,10 +582,7 @@ void main() {
 
     test('non-JSON body on 2xx response with maybeSingle throws', () async {
       await expectLater(
-        () => postgrestCustomHttpClient
-            .from('non-json-succ')
-            .select()
-            .maybeSingle(),
+        postgrestCustomHttpClient.from('non-json-succ').select().maybeSingle(),
         throwsA(
           isA<PostgrestException>().having((e) => e.code, 'code', '200'),
         ),

--- a/packages/postgrest/test/filter_test.dart
+++ b/packages/postgrest/test/filter_test.dart
@@ -22,46 +22,46 @@ void main() {
   });
 
   test('not', () async {
-    final res = await postgrest
+    final response = await postgrest
         .from('users')
         .select('status')
         .not('status', 'eq', 'OFFLINE');
-    expect(res, isNotEmpty);
-    for (final item in res) {
+    expect(response, isNotEmpty);
+    for (final item in response) {
       expect(item['status'], isNot('OFFLINE'));
     }
   });
 
   test('not with in filter', () async {
-    final res = await postgrest.from('users').select('username').not(
+    final response = await postgrest.from('users').select('username').not(
       'username',
       'in',
       ['supabot', 'kiwicopple'],
     );
-    expect(res, isNotEmpty);
+    expect(response, isNotEmpty);
 
-    for (final item in res) {
+    for (final item in response) {
       expect(item['username'], isNot('supabot'));
       expect(item['username'], isNot('kiwicopple'));
     }
   });
 
   test('not with is null', () async {
-    final res = await postgrest
+    final response = await postgrest
         .from('users')
         .select('username')
         .not('username', 'is', null);
-    expect(res.length, 4);
+    expect(response.length, 4);
   });
 
   test('not with List of values', () async {
-    final res = await postgrest.from('users').select('status').not(
+    final response = await postgrest.from('users').select('status').not(
       'interests',
       'cs',
       ['baseball', 'basketball'],
     );
-    expect(res, isNotEmpty);
-    for (final item in res) {
+    expect(response, isNotEmpty);
+    for (final item in response) {
       expect(
         ((item['interests'] ?? []) as List).contains([
           'baseball',
@@ -73,13 +73,13 @@ void main() {
   });
 
   test('or', () async {
-    final res = await postgrest
+    final response = await postgrest
         .from('users')
         .select('status, username')
         .or('status.eq.OFFLINE,username.eq.supabot');
-    expect(res, isNotEmpty);
+    expect(response, isNotEmpty);
 
-    for (final item in res) {
+    for (final item in response) {
       expect(
         item['username'] == ('supabot') || item['status'] == ('OFFLINE'),
         isTrue,
@@ -89,25 +89,25 @@ void main() {
 
   group("eq", () {
     test('eq string', () async {
-      final res = await postgrest
+      final response = await postgrest
           .from('users')
           .select('username')
           .eq('username', 'supabot');
-      expect(res, isNotEmpty);
+      expect(response, isNotEmpty);
 
-      for (final item in res) {
+      for (final item in response) {
         expect(item['username'], 'supabot');
       }
     });
 
     test('eq list', () async {
-      final res = await postgrest.from('users').select('username').eq(
+      final response = await postgrest.from('users').select('username').eq(
         'interests',
         ["basketball", "baseball"],
       );
-      expect(res, isNotEmpty);
+      expect(response, isNotEmpty);
 
-      for (final item in res) {
+      for (final item in response) {
         expect(item['username'], 'supabot');
       }
     });
@@ -115,93 +115,93 @@ void main() {
 
   group("neq", () {
     test('neq string', () async {
-      final res = await postgrest
+      final response = await postgrest
           .from('users')
           .select('username')
           .neq('username', 'supabot');
-      expect(res, isNotEmpty);
+      expect(response, isNotEmpty);
 
-      for (final item in res) {
+      for (final item in response) {
         expect(item['username'], isNot('supabot'));
       }
     });
 
     test('neq list', () async {
-      final res = await postgrest.from('users').select('username').neq(
+      final response = await postgrest.from('users').select('username').neq(
         'interests',
         ["football"],
       );
-      expect(res, isNotEmpty);
+      expect(response, isNotEmpty);
 
-      final onlyNames = res.map((row) => row["username"]).toList();
+      final onlyNames = response.map((row) => row["username"]).toList();
       expect(onlyNames, ["supabot", "awailas"]);
     });
   });
 
   test('gt', () async {
-    final res = await postgrest.from('messages').select('id').gt('id', 1);
-    expect(res, isNotEmpty);
+    final response = await postgrest.from('messages').select('id').gt('id', 1);
+    expect(response, isNotEmpty);
 
-    for (final item in res) {
+    for (final item in response) {
       expect((item['id'] as int) > 1, isTrue);
     }
   });
 
   test('gte', () async {
-    final res = await postgrest.from('messages').select('id').gte('id', 1);
-    expect(res, isNotEmpty);
+    final response = await postgrest.from('messages').select('id').gte('id', 1);
+    expect(response, isNotEmpty);
 
-    for (final item in res) {
+    for (final item in response) {
       expect((item['id'] as int) < 1, isFalse);
     }
   });
 
   test('lt', () async {
-    final res = await postgrest.from('messages').select('id').lt('id', 2);
-    expect(res, isNotEmpty);
-    for (final item in res) {
+    final response = await postgrest.from('messages').select('id').lt('id', 2);
+    expect(response, isNotEmpty);
+    for (final item in response) {
       expect((item['id'] as int) < 2, isTrue);
     }
   });
 
   test('lte', () async {
-    final res = await postgrest.from('messages').select('id').lte('id', 2);
-    expect(res, isNotEmpty);
-    for (final item in res) {
+    final response = await postgrest.from('messages').select('id').lte('id', 2);
+    expect(response, isNotEmpty);
+    for (final item in response) {
       expect((item['id'] as int) > 2, isFalse);
     }
   });
 
   test('like', () async {
-    final res = await postgrest
+    final response = await postgrest
         .from('users')
         .select('username')
         .like('username', '%supa%');
-    expect(res, isNotEmpty);
-    for (final item in res) {
+    expect(response, isNotEmpty);
+    for (final item in response) {
       expect((item['username'] as String).contains('supa'), isTrue);
     }
   });
 
   test('likeAllOf', () async {
-    PostgrestList res = await postgrest
+    PostgrestList response = await postgrest
         .from('users')
         .select('username')
         .likeAllOf('username', ['%supa%', '%bot%']);
-    expect(res, isNotEmpty);
-    for (final item in res) {
+    expect(response, isNotEmpty);
+    for (final item in response) {
       expect(item['username'], contains('supa'));
       expect(item['username'], contains('bot'));
     }
   });
 
   test('likeAnyOf', () async {
-    PostgrestList res = await postgrest
+    PostgrestList response = await postgrest
         .from('users')
         .select('username')
         .likeAnyOf('username', ['%supa%', '%wai%']);
-    expect(res, isNotEmpty);
-    for (final item in res) {
+    expect(response, isNotEmpty);
+    for (final item in response) {
       expect(
         item['username'].contains('supa') || item['username'].contains('wai'),
         isTrue,
@@ -210,36 +210,36 @@ void main() {
   });
 
   test('ilike', () async {
-    final res = await postgrest
+    final response = await postgrest
         .from('users')
         .select('username')
         .ilike('username', '%SUPA%');
-    expect(res, isNotEmpty);
-    for (final item in res) {
+    expect(response, isNotEmpty);
+    for (final item in response) {
       final user = (item['username'] as String).toLowerCase();
       expect(user.contains('supa'), isTrue);
     }
   });
 
   test('ilikeAllOf', () async {
-    PostgrestList res = await postgrest
+    PostgrestList response = await postgrest
         .from('users')
         .select('username')
         .ilikeAllOf('username', ['%SUPA%', '%bot%']);
-    expect(res, isNotEmpty);
-    for (final item in res) {
+    expect(response, isNotEmpty);
+    for (final item in response) {
       expect(item['username'].toLowerCase(), contains('supa'));
       expect(item['username'].toLowerCase(), contains('bot'));
     }
   });
 
   test('ilikeAnyOf', () async {
-    PostgrestList res = await postgrest
+    PostgrestList response = await postgrest
         .from('users')
         .select('username')
         .ilikeAnyOf('username', ['%SUPA%', '%wai%']);
-    expect(res, isNotEmpty);
-    for (final item in res) {
+    expect(response, isNotEmpty);
+    for (final item in response) {
       expect(
         item['username'].toLowerCase().contains('supa') ||
             item['username'].toLowerCase().contains('wai'),
@@ -249,23 +249,23 @@ void main() {
   });
 
   test('is', () async {
-    final res = await postgrest
+    final response = await postgrest
         .from('users')
         .select('data')
         .isFilter('data', null);
-    expect(res, isNotEmpty);
-    for (final item in res) {
+    expect(response, isNotEmpty);
+    for (final item in response) {
       expect(item['data'], null);
     }
   });
 
   test('in', () async {
-    final res = await postgrest.from('users').select('status').inFilter(
+    final response = await postgrest.from('users').select('status').inFilter(
       'status',
       ['ONLINE', 'OFFLINE'],
     );
-    expect(res, isNotEmpty);
-    for (final item in res) {
+    expect(response, isNotEmpty);
+    for (final item in response) {
       expect(
         item['status'] == 'ONLINE' || item['status'] == 'OFFLINE',
         isTrue,
@@ -275,144 +275,153 @@ void main() {
 
   test('immutable filter', () async {
     final query = postgrest.from("users").select();
-    final res1 = await query.eq("status", "OFFLINE");
-    final res2 = await query.eq("username", "supabot");
+    final firstResponse = await query.eq("status", "OFFLINE");
+    final secondResponse = await query.eq("username", "supabot");
 
-    expect(res1.length, 1);
-    expect(res1.first, containsPair("status", "OFFLINE"));
-    expect(res2.length, 1);
-    expect(res2.first, containsPair("username", "supabot"));
+    expect(firstResponse.length, 1);
+    expect(firstResponse.first, containsPair("status", "OFFLINE"));
+    expect(secondResponse.length, 1);
+    expect(secondResponse.first, containsPair("username", "supabot"));
   });
 
   group("contains", () {
     test('contains range', () async {
-      final res = await postgrest
+      final response = await postgrest
           .from('users')
           .select('username')
           .contains('age_range', '[1,2)');
-      expect(res, isNotEmpty);
+      expect(response, isNotEmpty);
       expect(
-        (res[0])['username'],
+        (response[0])['username'],
         'supabot',
       );
     });
 
     test('contains list', () async {
-      final res = await postgrest.from('users').select('username').contains(
-        'interests',
-        ["basketball", "baseball"],
-      );
-      expect(res, isNotEmpty);
+      final response = await postgrest
+          .from('users')
+          .select('username')
+          .contains(
+            'interests',
+            ["basketball", "baseball"],
+          );
+      expect(response, isNotEmpty);
       expect(
-        (res[0])['username'],
+        (response[0])['username'],
         'supabot',
       );
     });
   });
   group("containedBy", () {
     test('containedBy range', () async {
-      final res = await postgrest
+      final response = await postgrest
           .from('users')
           .select('username')
           .containedBy('age_range', '[0,3)');
-      expect(res, isNotEmpty);
-      expect((res[0])['username'], 'supabot');
+      expect(response, isNotEmpty);
+      expect((response[0])['username'], 'supabot');
     });
 
     test('containedBy list', () async {
-      final res = await postgrest.from('users').select('username').containedBy(
-        'interests',
-        ["basketball", "baseball", "xxxx"],
-      );
-      expect(res, isNotEmpty);
-      expect(res[0]['username'], 'supabot');
+      final response = await postgrest
+          .from('users')
+          .select('username')
+          .containedBy(
+            'interests',
+            ["basketball", "baseball", "xxxx"],
+          );
+      expect(response, isNotEmpty);
+      expect(response[0]['username'], 'supabot');
     });
   });
 
   test('rangeLt', () async {
-    final res = await postgrest
+    final response = await postgrest
         .from('users')
         .select('username')
         .rangeLt('age_range', '[2,25)');
-    expect(res, isNotEmpty);
-    expect(res[0]['username'], 'supabot');
+    expect(response, isNotEmpty);
+    expect(response[0]['username'], 'supabot');
   });
 
   test('rangeGt', () async {
-    final res = await postgrest
+    final response = await postgrest
         .from('users')
         .select('age_range')
         .rangeGt('age_range', '[2,25)');
-    expect(res, isNotEmpty);
-    for (final item in res) {
+    expect(response, isNotEmpty);
+    for (final item in response) {
       expect(item['username'], isNot('supabot'));
     }
   });
 
   test('rangeGte', () async {
-    final res = await postgrest
+    final response = await postgrest
         .from('users')
         .select('age_range')
         .rangeGte('age_range', '[2,25)');
-    expect(res, isNotEmpty);
-    for (final item in res) {
+    expect(response, isNotEmpty);
+    for (final item in response) {
       expect(item['username'], isNot('supabot'));
     }
   });
 
   test('rangeLte', () async {
-    final res = await postgrest
+    final response = await postgrest
         .from('users')
         .select('username')
         .rangeLte('age_range', '[2,25)');
-    expect(res, isNotEmpty);
-    for (final item in res) {
+    expect(response, isNotEmpty);
+    for (final item in response) {
       expect(item['username'], 'supabot');
     }
   });
 
   test('rangeAdjacent', () async {
-    final res = await postgrest
+    final response = await postgrest
         .from('users')
         .select('age_range')
         .rangeAdjacent('age_range', '[2,25)');
-    expect(res.length, 3);
+    expect(response.length, 3);
   });
 
   group("overlap", () {
     test('overlaps range', () async {
-      final res = await postgrest
+      final response = await postgrest
           .from('users')
           .select('username')
           .overlaps('age_range', '[2,25)');
       expect(
-        (res[0])['username'],
+        (response[0])['username'],
         'dragarcia',
       );
     });
 
     test('overlaps list', () async {
-      final res = await postgrest.from('users').select('username').overlaps(
-        'interests',
-        ["basketball", "baseball"],
-      );
+      final response = await postgrest
+          .from('users')
+          .select('username')
+          .overlaps(
+            'interests',
+            ["basketball", "baseball"],
+          );
       expect(
-        (res[0])['username'],
+        (response[0])['username'],
         'supabot',
       );
     });
   });
 
   test('textSearch', () async {
-    final res = await postgrest
+    final response = await postgrest
         .from('users')
         .select('username')
         .textSearch('catchphrase', "'fat' & 'cat'", config: 'english');
-    expect(res[0]['username'], 'supabot');
+    expect(response[0]['username'], 'supabot');
   });
 
   test('textSearch with plainto_tsquery', () async {
-    final res = await postgrest
+    final response = await postgrest
         .from('users')
         .select('username')
         .textSearch(
@@ -421,11 +430,11 @@ void main() {
           config: 'english',
           type: TextSearchType.plain,
         );
-    expect(res[0]['username'], 'supabot');
+    expect(response[0]['username'], 'supabot');
   });
 
   test('textSearch with phraseto_tsquery', () async {
-    final res = await postgrest
+    final response = await postgrest
         .from('users')
         .select('username')
         .textSearch(
@@ -434,11 +443,11 @@ void main() {
           config: 'english',
           type: TextSearchType.phrase,
         );
-    expect(res.length, 2);
+    expect(response.length, 2);
   });
 
   test('textSearch with websearch_to_tsquery', () async {
-    final res = await postgrest
+    final response = await postgrest
         .from('users')
         .select('username')
         .textSearch(
@@ -447,11 +456,11 @@ void main() {
           config: 'english',
           type: TextSearchType.websearch,
         );
-    expect(res[0]['username'], 'supabot');
+    expect(response[0]['username'], 'supabot');
   });
 
   test('multiple filters', () async {
-    final res = await postgrest
+    final response = await postgrest
         .from('users')
         .select()
         .eq('username', 'supabot')
@@ -459,26 +468,26 @@ void main() {
         .overlaps('age_range', '[1,2)')
         .eq('status', 'ONLINE')
         .textSearch('catchphrase', 'cat');
-    expect(res[0]['username'], 'supabot');
+    expect(response[0]['username'], 'supabot');
   });
 
   group("filter", () {
     test('filter', () async {
-      final res = await postgrest
+      final response = await postgrest
           .from('users')
           .select()
           .filter('username', 'eq', 'supabot');
-      expect(res[0]['username'], 'supabot');
+      expect(response[0]['username'], 'supabot');
     });
 
     test('filter in with List of values', () async {
-      final res = await postgrest.from('users').select().filter(
+      final response = await postgrest.from('users').select().filter(
         'username',
         'in',
         ['supabot', 'kiwicopple'],
       );
-      expect(res.length, 2);
-      for (final item in res) {
+      expect(response.length, 2);
+      for (final item in response) {
         expect(
           item['username'] == 'supabot' || item['username'] == 'kiwicopple',
           isTrue,
@@ -488,31 +497,31 @@ void main() {
   });
 
   test('match', () async {
-    final res = await postgrest.from('users').select().match({
+    final response = await postgrest.from('users').select().match({
       'username': 'supabot',
       'status': 'ONLINE',
     });
-    expect(res[0]['username'], 'supabot');
+    expect(response[0]['username'], 'supabot');
   });
 
   test('matchRegex - regex match (case sensitive)', () async {
-    final res = await postgrest
+    final response = await postgrest
         .from('users')
         .select('username')
         .matchRegex('username', '^supa.*');
-    expect(res, isNotEmpty);
-    for (final item in res) {
+    expect(response, isNotEmpty);
+    for (final item in response) {
       expect((item['username'] as String).startsWith('supa'), isTrue);
     }
   });
 
   test('imatchRegex - regex match (case insensitive)', () async {
-    final res = await postgrest
+    final response = await postgrest
         .from('users')
         .select('username')
         .imatchRegex('username', '^SUPA.*');
-    expect(res, isNotEmpty);
-    for (final item in res) {
+    expect(response, isNotEmpty);
+    for (final item in response) {
       expect(
         (item['username'] as String).toLowerCase().startsWith('supa'),
         isTrue,
@@ -521,37 +530,37 @@ void main() {
   });
 
   test('isDistinct', () async {
-    final res = await postgrest
+    final response = await postgrest
         .from('users')
         .select('username,status')
         .isDistinct('status', 'ONLINE');
-    expect(res, isNotEmpty);
-    for (final item in res) {
+    expect(response, isNotEmpty);
+    for (final item in response) {
       expect(item['status'], isNot('ONLINE'));
     }
   });
   test('filter on rpc', () async {
-    final List res = await postgrest
+    final List response = await postgrest
         .rpc('get_username_and_status', params: {'name_param': 'supabot'})
         .neq('status', 'ONLINE');
-    expect(res, isEmpty);
+    expect(response, isEmpty);
   });
 
   test('date range filter 1', () async {
-    final res = await postgrest
+    final response = await postgrest
         .from('messages')
         .select()
         .gte('inserted_at', DateTime.parse('2021-06-24').toIso8601String())
         .lte('inserted_at', DateTime.parse('2021-06-26').toIso8601String());
-    expect(res.length, 1);
+    expect(response.length, 1);
   });
 
   test('date range filter 2', () async {
-    final res = await postgrest
+    final response = await postgrest
         .from('messages')
         .select()
         .gte('inserted_at', DateTime.parse('2021-06-24').toIso8601String())
         .lte('inserted_at', DateTime.parse('2021-06-30').toIso8601String());
-    expect(res.length, 2);
+    expect(response.length, 2);
   });
 }

--- a/packages/postgrest/test/resource_embedding_test.dart
+++ b/packages/postgrest/test/resource_embedding_test.dart
@@ -22,129 +22,129 @@ void main() {
   });
 
   test('embedded select', () async {
-    final res = await postgrest.from('users').select('messages(*)');
+    final response = await postgrest.from('users').select('messages(*)');
     expect(
-      res[0]['messages']!.length,
+      response[0]['messages']!.length,
       3,
     );
     expect(
-      res[1]['messages']!.length,
+      response[1]['messages']!.length,
       0,
     );
   });
 
   test('embedded eq', () async {
-    final res = await postgrest
+    final response = await postgrest
         .from('users')
         .select('messages(*)')
         .eq('messages.channel_id', 1);
     expect(
-      res[0]['messages']!.length,
+      response[0]['messages']!.length,
       2,
     );
     expect(
-      res[1]['messages']!.length,
+      response[1]['messages']!.length,
       0,
     );
     expect(
-      res[2]['messages']!.length,
+      response[2]['messages']!.length,
       0,
     );
     expect(
-      res[3]['messages']!.length,
+      response[3]['messages']!.length,
       0,
     );
   });
 
   test('embedded order', () async {
-    final res = await postgrest
+    final response = await postgrest
         .from('users')
         .select('messages(*)')
         .order('channel_id', referencedTable: 'messages');
     expect(
-      res[0]['messages']!.length,
+      response[0]['messages']!.length,
       3,
     );
     expect(
-      res[1]['messages']!.length,
+      response[1]['messages']!.length,
       0,
     );
     expect(
-      res[0]['messages']![0]['id'],
+      response[0]['messages']![0]['id'],
       2,
     );
   });
 
   test('embedded order on multiple columns', () async {
-    final res = await postgrest
+    final response = await postgrest
         .from('users')
         .select('username, messages(*)')
         .order('username', ascending: true)
         .order('channel_id', referencedTable: 'messages');
     expect(
-      res[0]['username'],
+      response[0]['username'],
       'awailas',
     );
     expect(
-      res[3]['username'],
+      response[3]['username'],
       'supabot',
     );
     expect(
-      (res[0]['messages'] as List).length,
+      (response[0]['messages'] as List).length,
       0,
     );
     expect(
-      (res[3]['messages'] as List).length,
+      (response[3]['messages'] as List).length,
       3,
     );
     expect(
-      (res[3]['messages'] as List)[0]['id'],
+      (response[3]['messages'] as List)[0]['id'],
       2,
     );
   });
 
   test('embedded limit', () async {
-    final res = await postgrest
+    final response = await postgrest
         .from('users')
         .select('messages(*)')
         .limit(1, referencedTable: 'messages');
     expect(
-      res[0]['messages']!.length,
+      response[0]['messages']!.length,
       1,
     );
     expect(
-      res[1]['messages']!.length,
+      response[1]['messages']!.length,
       0,
     );
     expect(
-      res[2]['messages']!.length,
+      response[2]['messages']!.length,
       0,
     );
     expect(
-      res[3]['messages']!.length,
+      response[3]['messages']!.length,
       0,
     );
   });
 
   test('embedded range', () async {
-    final res = await postgrest
+    final response = await postgrest
         .from('users')
         .select('messages(*)')
         .range(1, 1, referencedTable: 'messages');
     expect(
-      res[0]['messages']!.length,
+      response[0]['messages']!.length,
       1,
     );
     expect(
-      res[1]['messages']!.length,
+      response[1]['messages']!.length,
       0,
     );
     expect(
-      res[2]['messages']!.length,
+      response[2]['messages']!.length,
       0,
     );
     expect(
-      res[3]['messages']!.length,
+      response[3]['messages']!.length,
       0,
     );
   });

--- a/packages/postgrest/test/retry_test.dart
+++ b/packages/postgrest/test/retry_test.dart
@@ -9,23 +9,23 @@ import 'package:test/test.dart';
 typedef _ResponseFactory = Future<StreamedResponse> Function(BaseRequest);
 
 _ResponseFactory _ok() =>
-    (req) => Future.value(
+    (request) => Future.value(
       StreamedResponse(
         Stream.value(Uint8List.fromList('[]'.codeUnits)),
         200,
-        request: req,
+        request: request,
         headers: {'content-type': 'application/json'},
       ),
     );
 
 _ResponseFactory _status(int code) =>
-    (req) => Future.value(
+    (request) => Future.value(
       StreamedResponse(
         Stream.value(
           Uint8List.fromList('{"message":"err","code":"$code"}'.codeUnits),
         ),
         code,
-        request: req,
+        request: request,
         headers: {'content-type': 'application/json'},
       ),
     );
@@ -114,11 +114,11 @@ void main() {
     test('HEAD retries on 520 then succeeds', () async {
       final mock = _MockRetryClient([
         _status(520),
-        (req) => Future.value(
+        (request) => Future.value(
           StreamedResponse(
             Stream.empty(),
             200,
-            request: req,
+            request: request,
             headers: {'content-range': '*/4'},
           ),
         ),
@@ -137,7 +137,7 @@ void main() {
       final client = _buildClient(mock);
 
       await expectLater(
-        () => client.from('users').insert({'name': 'foo'}),
+        client.from('users').insert({'name': 'foo'}),
         throwsA(isA<PostgrestException>()),
       );
       expect(mock.callCount, 1);
@@ -160,7 +160,7 @@ void main() {
       final client = _buildClient(mock);
 
       await expectLater(
-        () => client.from('users').select(),
+        client.from('users').select(),
         throwsA(isA<PostgrestException>()),
       );
       expect(mock.callCount, 1);
@@ -182,7 +182,7 @@ void main() {
       final client = _buildClient(mock);
 
       await expectLater(
-        () => client.from('users').insert({'name': 'foo'}),
+        client.from('users').insert({'name': 'foo'}),
         throwsA(isA<SocketException>()),
       );
       expect(mock.callCount, 1);
@@ -198,7 +198,7 @@ void main() {
       final client = _buildClient(mock);
 
       await expectLater(
-        () => client.from('users').select(),
+        client.from('users').select(),
         throwsA(isA<PostgrestException>()),
       );
       expect(mock.callCount, 4);
@@ -209,7 +209,7 @@ void main() {
       final client = _buildClient(mock);
 
       await expectLater(
-        () => client.from('users').select().retry(enabled: false),
+        client.from('users').select().retry(enabled: false),
         throwsA(isA<PostgrestException>()),
       );
       expect(mock.callCount, 1);
@@ -222,7 +222,7 @@ void main() {
         final client = _buildClient(mock, retryEnabled: false);
 
         await expectLater(
-          () => client.from('users').select(),
+          client.from('users').select(),
           throwsA(isA<PostgrestException>()),
         );
         expect(mock.callCount, 1);
@@ -254,7 +254,7 @@ void main() {
         final client = _buildClient(mock);
 
         await expectLater(
-          () => client.from('users').select(),
+          client.from('users').select(),
           throwsA(isA<SocketException>()),
         );
         expect(mock.callCount, 4);
@@ -272,7 +272,7 @@ void main() {
         Timer(Duration(milliseconds: 300), () => completer.complete());
 
         await expectLater(
-          () => client
+          client
               .from('users')
               .select()
               .retry(enabled: true)

--- a/packages/postgrest/test/retry_test.dart
+++ b/packages/postgrest/test/retry_test.dart
@@ -137,7 +137,7 @@ void main() {
       final client = _buildClient(mock);
 
       await expectLater(
-        client.from('users').insert({'name': 'foo'}),
+        () => client.from('users').insert({'name': 'foo'}),
         throwsA(isA<PostgrestException>()),
       );
       expect(mock.callCount, 1);
@@ -160,7 +160,7 @@ void main() {
       final client = _buildClient(mock);
 
       await expectLater(
-        client.from('users').select(),
+        () => client.from('users').select(),
         throwsA(isA<PostgrestException>()),
       );
       expect(mock.callCount, 1);
@@ -182,7 +182,7 @@ void main() {
       final client = _buildClient(mock);
 
       await expectLater(
-        client.from('users').insert({'name': 'foo'}),
+        () => client.from('users').insert({'name': 'foo'}),
         throwsA(isA<SocketException>()),
       );
       expect(mock.callCount, 1);
@@ -198,7 +198,7 @@ void main() {
       final client = _buildClient(mock);
 
       await expectLater(
-        client.from('users').select(),
+        () => client.from('users').select(),
         throwsA(isA<PostgrestException>()),
       );
       expect(mock.callCount, 4);
@@ -209,7 +209,7 @@ void main() {
       final client = _buildClient(mock);
 
       await expectLater(
-        client.from('users').select().retry(enabled: false),
+        () => client.from('users').select().retry(enabled: false),
         throwsA(isA<PostgrestException>()),
       );
       expect(mock.callCount, 1);
@@ -222,7 +222,7 @@ void main() {
         final client = _buildClient(mock, retryEnabled: false);
 
         await expectLater(
-          client.from('users').select(),
+          () => client.from('users').select(),
           throwsA(isA<PostgrestException>()),
         );
         expect(mock.callCount, 1);
@@ -254,7 +254,7 @@ void main() {
         final client = _buildClient(mock);
 
         await expectLater(
-          client.from('users').select(),
+          () => client.from('users').select(),
           throwsA(isA<SocketException>()),
         );
         expect(mock.callCount, 4);
@@ -272,7 +272,7 @@ void main() {
         Timer(Duration(milliseconds: 300), () => completer.complete());
 
         await expectLater(
-          client
+          () => client
               .from('users')
               .select()
               .retry(enabled: true)

--- a/packages/postgrest/test/stack_trace_test.dart
+++ b/packages/postgrest/test/stack_trace_test.dart
@@ -6,13 +6,13 @@ import 'package:postgrest/postgrest.dart';
 import 'package:test/test.dart';
 
 _ResponseFactory _errorStatus(int code) =>
-    (req) => Future.value(
+    (request) => Future.value(
       StreamedResponse(
         Stream.value(
           Uint8List.fromList('{"message":"err","code":"$code"}'.codeUnits),
         ),
         code,
-        request: req,
+        request: request,
         headers: {'content-type': 'application/json'},
       ),
     );

--- a/packages/postgrest/test/transforms_test.dart
+++ b/packages/postgrest/test/transforms_test.dart
@@ -386,7 +386,7 @@ void main() {
 
     test('maybeSingle with multiple rows throws', () async {
       await expectLater(
-        postgrest.from('users').select().maybeSingle(),
+        () => postgrest.from('users').select().maybeSingle(),
         throwsA(
           isA<PostgrestException>().having((e) => e.code, 'code', '406'),
         ),
@@ -394,7 +394,7 @@ void main() {
     });
     test('maybeSingle with multiple inserts throws', () async {
       await expectLater(
-        postgrest
+        () => postgrest
             .from('channels')
             .insert([
               {'data': {}, 'slug': 'channel1'},
@@ -412,7 +412,7 @@ void main() {
       'maybeSingle followed by another transformer preserves the maybeSingle status',
       () async {
         await expectLater(
-          postgrest.from('channels').select().maybeSingle().limit(2),
+          () => postgrest.from('channels').select().maybeSingle().limit(2),
           throwsA(
             isA<PostgrestException>().having((e) => e.code, 'code', '406'),
           ),
@@ -424,7 +424,7 @@ void main() {
       'maybeSingle with converter throws if more than 1 rows were returned',
       () async {
         await expectLater(
-          postgrest
+          () => postgrest
               .from('channels')
               .select()
               .maybeSingle()

--- a/packages/postgrest/test/transforms_test.dart
+++ b/packages/postgrest/test/transforms_test.dart
@@ -26,22 +26,22 @@ void main() {
   });
 
   test('order', () async {
-    final res = await postgrest.from('users').select().order('username');
+    final response = await postgrest.from('users').select().order('username');
     expect(
-      res[1]['username'],
+      response[1]['username'],
       'kiwicopple',
     );
-    expect(res[3]['username'], 'awailas');
+    expect(response[3]['username'], 'awailas');
   });
 
   test('order on multiple columns', () async {
-    final res = await postgrest
+    final response = await postgrest
         .from('users')
         .select()
         .order('status', ascending: true)
         .order('username');
     expect(
-      res.map((row) => row['status']),
+      response.map((row) => row['status']),
       [
         'ONLINE',
         'ONLINE',
@@ -50,7 +50,7 @@ void main() {
       ],
     );
     expect(
-      res.map((row) => row['username']),
+      response.map((row) => row['username']),
       [
         'supabot',
         'dragarcia',
@@ -61,14 +61,14 @@ void main() {
   });
 
   test('order with filters on the same column', () async {
-    final res = await postgrest
+    final response = await postgrest
         .from('users')
         .select()
         .gt('username', 'b')
         .lt('username', 'r')
         .order('username');
     expect(
-      res.map((row) => row['username']),
+      response.map((row) => row['username']),
       [
         'kiwicopple',
         'dragarcia',
@@ -110,8 +110,8 @@ void main() {
   });
 
   test('limit', () async {
-    final res = await postgrest.from('users').select().limit(1);
-    expect(res.length, 1);
+    final response = await postgrest.from('users').select().limit(1);
+    expect(response.length, 1);
   });
 
   test("limit on referenced table", () async {
@@ -147,19 +147,19 @@ void main() {
   test('range', () async {
     const from = 1;
     const to = 2;
-    final res = await postgrest.from('users').select().range(from, to);
+    final response = await postgrest.from('users').select().range(from, to);
     //from -1 so that the index is included
-    expect(res.length, to - (from - 1));
-    expect(res[0]['username'], 'kiwicopple');
-    expect(res[1]['username'], 'awailas');
+    expect(response.length, to - (from - 1));
+    expect(response[0]['username'], 'kiwicopple');
+    expect(response[1]['username'], 'awailas');
   });
 
   test('range 1-1', () async {
     const from = 1;
     const to = 1;
-    final res = await postgrest.from('users').select().range(from, to);
+    final response = await postgrest.from('users').select().range(from, to);
     //from -1 so that the index is included
-    expect(res.length, to - (from - 1));
+    expect(response.length, to - (from - 1));
   });
 
   test("range on referenced table", () async {
@@ -335,24 +335,24 @@ void main() {
   });
 
   test('single', () async {
-    final res = await postgrest
+    final response = await postgrest
         .from('users')
         .select()
         .eq('username', 'supabot')
         .single();
-    expect(res['username'], 'supabot');
-    expect(res['status'], 'ONLINE');
+    expect(response['username'], 'supabot');
+    expect(response['status'], 'ONLINE');
   });
 
   test('single with count', () async {
-    final res = await postgrest
+    final response = await postgrest
         .from('users')
         .select()
         .limit(1)
         .single()
         .count(CountOption.exact);
-    expect(res.data, isA<Map>());
-    expect(res.count, greaterThan(3));
+    expect(response.data, isA<Map>());
+    expect(response.count, greaterThan(3));
   });
 
   group("maybe single", () {
@@ -386,7 +386,7 @@ void main() {
 
     test('maybeSingle with multiple rows throws', () async {
       await expectLater(
-        () => postgrest.from('users').select().maybeSingle(),
+        postgrest.from('users').select().maybeSingle(),
         throwsA(
           isA<PostgrestException>().having((e) => e.code, 'code', '406'),
         ),
@@ -394,7 +394,7 @@ void main() {
     });
     test('maybeSingle with multiple inserts throws', () async {
       await expectLater(
-        () => postgrest
+        postgrest
             .from('channels')
             .insert([
               {'data': {}, 'slug': 'channel1'},
@@ -412,7 +412,7 @@ void main() {
       'maybeSingle followed by another transformer preserves the maybeSingle status',
       () async {
         await expectLater(
-          () => postgrest.from('channels').select().maybeSingle().limit(2),
+          postgrest.from('channels').select().maybeSingle().limit(2),
           throwsA(
             isA<PostgrestException>().having((e) => e.code, 'code', '406'),
           ),
@@ -424,7 +424,7 @@ void main() {
       'maybeSingle with converter throws if more than 1 rows were returned',
       () async {
         await expectLater(
-          () => postgrest
+          postgrest
               .from('channels')
               .select()
               .maybeSingle()
@@ -438,13 +438,13 @@ void main() {
   });
 
   test('explain', () async {
-    final res = await postgrest.from('users').select().explain();
+    final response = await postgrest.from('users').select().explain();
     final regex = RegExp(r'Aggregate  \(cost=.*');
-    expect(regex.hasMatch(res), isTrue);
+    expect(regex.hasMatch(response), isTrue);
   });
 
   test('explain with options', () async {
-    final res = await postgrest
+    final response = await postgrest
         .from('users')
         .select()
         .explain(
@@ -452,23 +452,23 @@ void main() {
           verbose: true,
         );
     final regex = RegExp(r'Aggregate  \(cost=.*');
-    expect(regex.hasMatch(res), isTrue);
+    expect(regex.hasMatch(response), isTrue);
   });
 
   test('explain with json format returns a parseable JSON plan', () async {
-    final res = await postgrest
+    final response = await postgrest
         .from('users')
         .select()
         .explain(format: ExplainFormat.json);
 
-    final decoded = jsonDecode(res);
+    final decoded = jsonDecode(response);
     expect(decoded, isA<List>());
     expect((decoded as List).first, contains('Plan'));
   });
 
   test('geojson', () async {
-    final res = await postgrest.from('addresses').select().geojson();
-    expect(res['type'], 'FeatureCollection');
+    final response = await postgrest.from('addresses').select().geojson();
+    expect(response['type'], 'FeatureCollection');
   });
 
   group('maxAffected integration', () {
@@ -639,14 +639,14 @@ void main() {
     });
 
     test('omits null-valued properties from the response', () async {
-      final res = await postgrest
+      final response = await postgrest
           .from('users')
           .select()
           .eq('username', 'supabot')
           .single()
           .stripNulls();
-      expect(res.containsKey('username'), isTrue);
-      expect(res.containsKey('data'), isFalse);
+      expect(response.containsKey('username'), isTrue);
+      expect(response.containsKey('data'), isFalse);
     });
   });
 }

--- a/packages/postgrest/test/upsert_test.dart
+++ b/packages/postgrest/test/upsert_test.dart
@@ -70,7 +70,7 @@ void main() {
       ];
 
       await expectLater(
-        () => postgrest.from('imported_data').upsert(duplicateData).select(),
+        postgrest.from('imported_data').upsert(duplicateData).select(),
         throwsA(
           isA<PostgrestException>().having((e) => e.code, 'code', '23505'),
         ),

--- a/packages/postgrest/test/upsert_test.dart
+++ b/packages/postgrest/test/upsert_test.dart
@@ -70,7 +70,7 @@ void main() {
       ];
 
       await expectLater(
-        postgrest.from('imported_data').upsert(duplicateData).select(),
+        () => postgrest.from('imported_data').upsert(duplicateData).select(),
         throwsA(
           isA<PostgrestException>().having((e) => e.code, 'code', '23505'),
         ),

--- a/packages/realtime_client/test/channel_test.dart
+++ b/packages/realtime_client/test/channel_test.dart
@@ -589,12 +589,12 @@ void main() {
 
     test("closes channel on 'ok' from server", () {
       final anotherChannel = socket.channel('another');
-      expect(socket.channels.length, 2);
+      expect(socket.channels, hasLength(2));
 
       unawaited(channel.unsubscribe());
       channel.joinPush.trigger('ok', {});
 
-      expect(socket.channels.length, 1);
+      expect(socket.channels, hasLength(1));
       expect(socket.channels[0].topic, anotherChannel.topic);
     });
 
@@ -609,7 +609,7 @@ void main() {
 
     test("able to unsubscribe from * subscription", () {
       channel.onEvents('*', ChannelFilter(), (payload, [ref]) {});
-      expect(socket.channels.length, 1);
+      expect(socket.channels, hasLength(1));
 
       unawaited(channel.unsubscribe());
       channel.joinPush.trigger('ok', {});
@@ -1030,17 +1030,20 @@ void main() {
           payload: {'myKey': 'myValue'},
         );
 
-        final req = await requestFuture;
-        expect(req.uri.path, '/realtime/v1/api/broadcast/myTopic/events/test');
-        expect(req.uri.queryParameters['private'], 'true');
-        expect(req.headers.value('apikey'), 'supabaseKey');
-        expect(req.headers.contentType?.mimeType, 'application/json');
+        final request = await requestFuture;
+        expect(
+          request.uri.path,
+          '/realtime/v1/api/broadcast/myTopic/events/test',
+        );
+        expect(request.uri.queryParameters['private'], 'true');
+        expect(request.headers.value('apikey'), 'supabaseKey');
+        expect(request.headers.contentType?.mimeType, 'application/json');
 
-        final body = json.decode(await utf8.decodeStream(req));
+        final body = json.decode(await utf8.decodeStream(request));
         expect(body, {'myKey': 'myValue'});
 
-        req.response.statusCode = 202;
-        await req.response.close();
+        request.response.statusCode = 202;
+        await request.response.close();
 
         await sendFuture;
       },
@@ -1060,12 +1063,15 @@ void main() {
         payload: {'myKey': 'myValue'},
       );
 
-      final req = await requestFuture;
-      expect(req.uri.path, '/realtime/v1/api/broadcast/myTopic/events/test');
-      expect(req.uri.queryParameters.containsKey('private'), isFalse);
+      final request = await requestFuture;
+      expect(
+        request.uri.path,
+        '/realtime/v1/api/broadcast/myTopic/events/test',
+      );
+      expect(request.uri.queryParameters.containsKey('private'), isFalse);
 
-      req.response.statusCode = 202;
-      await req.response.close();
+      request.response.statusCode = 202;
+      await request.response.close();
 
       await sendFuture;
     });
@@ -1084,14 +1090,14 @@ void main() {
         payload: {'id': 1},
       );
 
-      final req = await requestFuture;
+      final request = await requestFuture;
       expect(
-        req.uri.toString(),
+        request.uri.toString(),
         contains('/api/broadcast/room%3A42/events/user%2Fjoined'),
       );
 
-      req.response.statusCode = 202;
-      await req.response.close();
+      request.response.statusCode = 202;
+      await request.response.close();
 
       await sendFuture;
     });
@@ -1108,18 +1114,18 @@ void main() {
       final requestFuture = mockServer.first;
       final sendFuture = channel.httpSend(event: 'bin', payload: bytes);
 
-      final req = await requestFuture;
-      expect(req.uri.path, '/realtime/v1/api/broadcast/myTopic/events/bin');
-      expect(req.headers.contentType?.mimeType, 'application/octet-stream');
+      final request = await requestFuture;
+      expect(request.uri.path, '/realtime/v1/api/broadcast/myTopic/events/bin');
+      expect(request.headers.contentType?.mimeType, 'application/octet-stream');
 
-      final received = await req.fold<List<int>>(
+      final received = await request.fold<List<int>>(
         <int>[],
-        (acc, chunk) => acc..addAll(chunk),
+        (accumulated, chunk) => accumulated..addAll(chunk),
       );
       expect(received, equals(bytes));
 
-      req.response.statusCode = 202;
-      await req.response.close();
+      request.response.statusCode = 202;
+      await request.response.close();
 
       await sendFuture;
     });
@@ -1136,17 +1142,17 @@ void main() {
       final requestFuture = mockServer.first;
       final sendFuture = channel.httpSend(event: 'bin', payload: bytes.buffer);
 
-      final req = await requestFuture;
-      expect(req.headers.contentType?.mimeType, 'application/octet-stream');
+      final request = await requestFuture;
+      expect(request.headers.contentType?.mimeType, 'application/octet-stream');
 
-      final received = await req.fold<List<int>>(
+      final received = await request.fold<List<int>>(
         <int>[],
-        (acc, chunk) => acc..addAll(chunk),
+        (accumulated, chunk) => accumulated..addAll(chunk),
       );
       expect(received, equals(bytes));
 
-      req.response.statusCode = 202;
-      await req.response.close();
+      request.response.statusCode = 202;
+      await request.response.close();
 
       await sendFuture;
     });
@@ -1166,12 +1172,12 @@ void main() {
         payload: {'data': 'test'},
       );
 
-      final req = await requestFuture;
-      expect(req.headers.value('Authorization'), 'Bearer token123');
-      expect(req.headers.value('apikey'), 'abc123');
+      final request = await requestFuture;
+      expect(request.headers.value('Authorization'), 'Bearer token123');
+      expect(request.headers.value('apikey'), 'abc123');
 
-      req.response.statusCode = 202;
-      await req.response.close();
+      request.response.statusCode = 202;
+      await request.response.close();
 
       await sendFuture;
     });
@@ -1189,10 +1195,10 @@ void main() {
         payload: {'data': 'test'},
       );
 
-      final req = await requestFuture;
-      req.response.statusCode = 500;
-      req.response.write(json.encode({'error': 'Server error'}));
-      await req.response.close();
+      final request = await requestFuture;
+      request.response.statusCode = 500;
+      request.response.write(json.encode({'error': 'Server error'}));
+      await request.response.close();
 
       await expectLater(
         sendFuture,
@@ -1213,10 +1219,10 @@ void main() {
 
       // Don't await the server - let it hang to trigger timeout
       unawaited(
-        mockServer.first.then((req) async {
+        mockServer.first.then((request) async {
           await Future.delayed(const Duration(seconds: 1));
-          req.response.statusCode = 202;
-          await req.response.close();
+          request.response.statusCode = 202;
+          await request.response.close();
         }),
       );
 

--- a/packages/realtime_client/test/realtime_integration_test.dart
+++ b/packages/realtime_client/test/realtime_integration_test.dart
@@ -209,16 +209,16 @@ void main() {
       });
 
       group('postgres changes', () {
-        late Connection db;
+        late Connection database;
 
         setUp(() async {
-          db = await openPostgresConnection();
-          await db.execute('TRUNCATE public.todos RESTART IDENTITY');
+          database = await openPostgresConnection();
+          await database.execute('TRUNCATE public.todos RESTART IDENTITY');
         });
 
         tearDown(() async {
-          await db.execute('TRUNCATE public.todos RESTART IDENTITY');
-          await db.close();
+          await database.execute('TRUNCATE public.todos RESTART IDENTITY');
+          await database.close();
         });
 
         test('receives insert, update and delete events', () async {
@@ -248,7 +248,7 @@ void main() {
           await _subscribe(channel);
           await Future<void>.delayed(const Duration(seconds: 2));
 
-          await db.execute(
+          await database.execute(
             "INSERT INTO public.todos (task) VALUES ('write tests')",
           );
           final insert = await inserts.future.timeout(
@@ -257,7 +257,7 @@ void main() {
           expect(insert.eventType, PostgresChangeEvent.insert);
           expect(insert.newRecord['task'], 'write tests');
 
-          await db.execute(
+          await database.execute(
             "UPDATE public.todos SET is_complete = true WHERE task = 'write tests'",
           );
           final update = await updates.future.timeout(
@@ -267,7 +267,7 @@ void main() {
           expect(update.newRecord['is_complete'], isTrue);
           expect(update.oldRecord['is_complete'], isFalse);
 
-          await db.execute(
+          await database.execute(
             "DELETE FROM public.todos WHERE task = 'write tests'",
           );
           final delete = await deletes.future.timeout(
@@ -298,7 +298,7 @@ void main() {
           await _subscribe(channel);
           await Future<void>.delayed(const Duration(seconds: 2));
 
-          await db.execute(
+          await database.execute(
             "INSERT INTO public.todos (task, is_complete) VALUES ('ignored', false)",
           );
 
@@ -309,7 +309,7 @@ void main() {
             reason: 'the non-matching row must not be delivered',
           );
 
-          await db.execute(
+          await database.execute(
             "INSERT INTO public.todos (task, is_complete) VALUES ('matched', true)",
           );
 

--- a/packages/realtime_client/test/socket_test.dart
+++ b/packages/realtime_client/test/socket_test.dart
@@ -96,7 +96,7 @@ void main() {
         socket.logger
             is void Function(
               String? kind,
-              String? msg,
+              String? message,
               dynamic data,
             ),
         isFalse,
@@ -114,7 +114,7 @@ void main() {
         timeout: const Duration(milliseconds: 40000),
         heartbeatIntervalMs: 60000,
         // ignore: avoid_print
-        logger: (kind, msg, data) => print('[$kind] $msg $data'),
+        logger: (kind, message, data) => print('[$kind] $message $data'),
         headers: {'X-Client-Info': 'supabase-dart/0.0.0'},
       );
       expect(socket.channels, isEmpty);
@@ -133,7 +133,7 @@ void main() {
         socket.logger
             is void Function(
               String? kind,
-              String? msg,
+              String? message,
               dynamic data,
             ),
         isTrue,
@@ -199,15 +199,15 @@ void main() {
     });
 
     test('establishes websocket connection with endpoint', () async {
-      final connFuture = socket.connect();
+      final connectFuture = socket.connect();
       expect(socket.connState, SocketStates.connecting);
 
-      final conn = socket.conn;
+      final connection = socket.conn;
 
-      await connFuture;
+      await connectFuture;
       expect(socket.connState, SocketStates.open);
 
-      expect(conn, isA<IOWebSocketChannel>());
+      expect(connection, isA<IOWebSocketChannel>());
       //! Not verifying connection url
     });
 
@@ -220,9 +220,9 @@ void main() {
       socket.onClose((_) {
         closes += 1;
       });
-      late dynamic lastMsg;
-      socket.onMessage((m) {
-        lastMsg = m;
+      late dynamic lastMessage;
+      socket.onMessage((message) {
+        lastMessage = message;
       });
 
       await socket.connect();
@@ -232,7 +232,7 @@ void main() {
       await socket.sendHeartbeat();
       // need to wait for event to trigger
       await Future.delayed(const Duration(seconds: 1));
-      expect(lastMsg['event'], 'heartbeat');
+      expect(lastMessage['event'], 'heartbeat');
 
       await socket.disconnect();
       await Future.delayed(const Duration(seconds: 1));
@@ -240,22 +240,22 @@ void main() {
     });
 
     test('sets callback for errors', () {
-      dynamic lastErr;
+      dynamic lastError;
       final RealtimeClient erroneousSocket = RealtimeClient('badurl')
-        ..onError((e) {
-          lastErr = e;
+        ..onError((error) {
+          lastError = error;
         });
 
       unawaited(erroneousSocket.connect());
 
-      expect(lastErr, isA<WebSocketException>());
+      expect(lastError, isA<WebSocketException>());
     });
 
     test('is idempotent', () {
       unawaited(socket.connect());
-      final conn = socket.conn;
+      final connection = socket.conn;
       unawaited(socket.connect());
-      expect(socket.conn, conn);
+      expect(socket.conn, connection);
     });
   });
 
@@ -276,15 +276,6 @@ void main() {
       await socket.disconnect();
 
       expect(socket.conn, isNull);
-    });
-
-    test('calls callback', () async {
-      int closes = 0;
-      unawaited(socket.connect());
-      unawaited(socket.disconnect());
-      closes += 1;
-
-      expect(closes, 1);
     });
 
     test('calls connection close callback', () async {
@@ -588,7 +579,7 @@ void main() {
         tParams,
       );
 
-      expect(socket.channels.length, 1);
+      expect(socket.channels, hasLength(1));
 
       final foundChannel = socket.channels[0];
       expect(foundChannel, channel);
@@ -616,7 +607,7 @@ void main() {
       final channel2 = mockedSocket.channel(tTopic2);
 
       mockedSocket.remove(channel1);
-      expect(mockedSocket.channels.length, 1);
+      expect(mockedSocket.channels, hasLength(1));
 
       final foundChannel = mockedSocket.channels[0];
       expect(foundChannel, channel2);
@@ -689,7 +680,7 @@ void main() {
       mockedSocket.push(message);
 
       verifyNever(() => mockedSink.add(any()));
-      expect(mockedSocket.sendBuffer.length, 1);
+      expect(mockedSocket.sendBuffer, hasLength(1));
 
       final callback = mockedSocket.sendBuffer[0];
       callback();

--- a/packages/realtime_client/test/utils/realtime_test_utils.dart
+++ b/packages/realtime_client/test/utils/realtime_test_utils.dart
@@ -119,7 +119,7 @@ Future<void> primePostgresChanges({
 }) async {
   final deadline = DateTime.now().add(timeout);
   final client = createRealtimeClient(RealtimeProtocolVersion.v1);
-  final db = await openPostgresConnection();
+  final database = await openPostgresConnection();
   final received = Completer<void>();
 
   final channel = client.channel('postgres-changes-warmup');
@@ -149,7 +149,9 @@ Future<void> primePostgresChanges({
   try {
     await subscribed.future.timeout(const Duration(seconds: 15));
     while (!received.isCompleted && DateTime.now().isBefore(deadline)) {
-      await db.execute("INSERT INTO public.todos (task) VALUES ('warmup')");
+      await database.execute(
+        "INSERT INTO public.todos (task) VALUES ('warmup')",
+      );
       await Future.any([
         received.future,
         Future<void>.delayed(const Duration(seconds: 2)),
@@ -161,8 +163,8 @@ Future<void> primePostgresChanges({
       );
     }
   } finally {
-    await db.execute('TRUNCATE public.todos RESTART IDENTITY');
-    await db.close();
+    await database.execute('TRUNCATE public.todos RESTART IDENTITY');
+    await database.close();
     await client.removeAllChannels();
     await client.disconnect();
   }

--- a/packages/storage_client/test/basic_test.dart
+++ b/packages/storage_client/test/basic_test.dart
@@ -153,7 +153,7 @@ void main() {
 
       final response = await client.from('public').upload('a.txt', file);
       expect(response, isA<String>());
-      expect(response.endsWith('/a.txt'), isTrue);
+      expect(response, endsWith('/a.txt'));
     });
 
     test('should update file', () async {
@@ -164,7 +164,7 @@ void main() {
 
       final response = await client.from('public').update('a.txt', file);
       expect(response, isA<String>());
-      expect(response.endsWith('/a.txt'), isTrue);
+      expect(response, endsWith('/a.txt'));
     });
 
     test('should move file', () async {
@@ -187,8 +187,8 @@ void main() {
       () async {
         customHttpClient.response = {'signedURL': null};
 
-        expect(
-          () => client.from('public').createSignedUrl('missing.txt', 60),
+        await expectLater(
+          client.from('public').createSignedUrl('missing.txt', 60),
           throwsA(isA<StorageException>()),
         );
       },
@@ -350,11 +350,6 @@ void main() {
       );
     });
 
-    test('getPublicUrl leaves the URL unchanged when download is null', () {
-      final response = client.from('files').getPublicUrl('b.txt');
-      expect(response, '$objectUrl/public/files/b.txt');
-    });
-
     test('getPublicUrl with empty transform does not use render endpoint', () {
       final response = client
           .from('files')
@@ -470,7 +465,7 @@ void main() {
       final uploadTask = client
           .from('public')
           .upload('a.txt', file, retryAttempts: 1);
-      expect(uploadTask, throwsException);
+      await expectLater(uploadTask, throwsException);
     });
 
     test('should upload file with few network failures', () async {
@@ -479,7 +474,7 @@ void main() {
 
       final response = await client.from('public').upload('a.txt', file);
       expect(response, isA<String>());
-      expect(response.endsWith('/a.txt'), isTrue);
+      expect(response, endsWith('/a.txt'));
     });
 
     test('aborting upload should throw', () async {
@@ -499,7 +494,7 @@ void main() {
       await Future.delayed(Duration(milliseconds: 500));
       retryController.cancel();
 
-      expect(future, throwsException);
+      await expectLater(future, throwsException);
     });
 
     test('should upload binary with few network failures', () async {
@@ -510,7 +505,7 @@ void main() {
           .from('public')
           .uploadBinary('a.txt', file.readAsBytesSync());
       expect(response, isA<String>());
-      expect(response.endsWith('/a.txt'), isTrue);
+      expect(response, endsWith('/a.txt'));
     });
 
     test('should update file with few network failures', () async {
@@ -519,7 +514,7 @@ void main() {
 
       final response = await client.from('public').update('a.txt', file);
       expect(response, isA<String>());
-      expect(response.endsWith('/a.txt'), isTrue);
+      expect(response, endsWith('/a.txt'));
     });
     test('should update binary with few network failures', () async {
       final file = File('a.txt');
@@ -529,7 +524,7 @@ void main() {
           .from('public')
           .updateBinary('a.txt', file.readAsBytesSync());
       expect(response, isA<String>());
-      expect(response.endsWith('/a.txt'), isTrue);
+      expect(response, endsWith('/a.txt'));
     });
   });
 
@@ -546,7 +541,7 @@ void main() {
     });
     test('should list buckets', () async {
       await expectLater(
-        () => client.listBuckets(),
+        client.listBuckets(),
         throwsA(
           isA<StorageException>().having(
             (e) => e.statusCode,

--- a/packages/storage_client/test/client_test.dart
+++ b/packages/storage_client/test/client_test.dart
@@ -76,9 +76,12 @@ void main() {
     final response = await storage.createBucket(newBucketName);
     expect(response, newBucketName);
   });
-  test('createSignedUrls does not throw', () async {
+  test('createSignedUrls completes successfully', () async {
     await storage.from(newBucketName).upload(uploadPath, file);
-    await storage.from(newBucketName).createSignedUrls([uploadPath], 2000);
+    expect(
+      storage.from(newBucketName).createSignedUrls([uploadPath], 2000),
+      completes,
+    );
   });
 
   test('Create new public bucket', () async {
@@ -536,12 +539,15 @@ void main() {
   });
 
   group('file operations', () {
-    test('copy', () async {
+    test('copy completes successfully', () async {
       final client = SupabaseStorageClient(storageUrl, {
         'Authorization': 'Bearer $storageKey',
       });
 
-      await client.from(newBucketName).copy(uploadPath, "$uploadPath 2");
+      expect(
+        client.from(newBucketName).copy(uploadPath, "$uploadPath 2"),
+        completes,
+      );
     });
 
     test('copy to different bucket', () async {

--- a/packages/storage_client/test/client_test.dart
+++ b/packages/storage_client/test/client_test.dart
@@ -67,7 +67,7 @@ void main() {
 
   test('Get bucket with wrong id', () async {
     await expectLater(
-      () => storage.getBucket('not-exist-id'),
+      storage.getBucket('not-exist-id'),
       throwsA(isNotNull),
     );
   });
@@ -96,7 +96,7 @@ void main() {
     final newBucketName = 'my-new-bucket-${DateTime.now()}';
     await storage.createBucket(newBucketName);
 
-    final updateRes = await storage.updateBucket(
+    final updateResult = await storage.updateBucket(
       newBucketName,
       const BucketOptions(
         public: true,
@@ -104,13 +104,13 @@ void main() {
         allowedMimeTypes: ['image/jpeg'],
       ),
     );
-    expect(updateRes, 'Successfully updated');
+    expect(updateResult, 'Successfully updated');
 
-    final getRes = await storage.getBucket(newBucketName);
-    expect(getRes.public, isTrue);
-    expect(getRes.fileSizeLimit, 20000000);
-    expect(getRes.allowedMimeTypes!.length, 1);
-    expect(getRes.allowedMimeTypes!.first, 'image/jpeg');
+    final bucket = await storage.getBucket(newBucketName);
+    expect(bucket.public, isTrue);
+    expect(bucket.fileSizeLimit, 20000000);
+    expect(bucket.allowedMimeTypes, hasLength(1));
+    expect(bucket.allowedMimeTypes!.first, 'image/jpeg');
   });
 
   test('partially update bucket', () async {
@@ -123,16 +123,16 @@ void main() {
         allowedMimeTypes: ['image/jpeg'],
       ),
     );
-    final updateRes = await storage.updateBucket(
+    final updateResult = await storage.updateBucket(
       newBucketName,
       const BucketOptions(public: false),
     );
-    expect(updateRes, 'Successfully updated');
-    final getRes = await storage.getBucket(newBucketName);
-    expect(getRes.public, isFalse);
-    expect(getRes.fileSizeLimit, 20000000);
-    expect(getRes.allowedMimeTypes!.length, 1);
-    expect(getRes.allowedMimeTypes!.first, 'image/jpeg');
+    expect(updateResult, 'Successfully updated');
+    final bucket = await storage.getBucket(newBucketName);
+    expect(bucket.public, isFalse);
+    expect(bucket.fileSizeLimit, 20000000);
+    expect(bucket.allowedMimeTypes, hasLength(1));
+    expect(bucket.allowedMimeTypes!.first, 'image/jpeg');
   });
 
   test('Empty bucket', () async {
@@ -215,7 +215,7 @@ void main() {
 
       expect(uploadedPath, uploadPath);
       await expectLater(
-        () => storage
+        storage
             .from(newBucketName)
             .uploadToSignedUrl(response.path, response.token, file),
         throwsA(
@@ -265,10 +265,8 @@ void main() {
           );
 
       expect(
-        url.contains(
-          '$storageUrl/render/image/sign/$newBucketName/$uploadPath',
-        ),
-        isTrue,
+        url,
+        contains('$storageUrl/render/image/sign/$newBucketName/$uploadPath'),
       );
     });
 
@@ -287,7 +285,7 @@ void main() {
     });
 
     test('will download a public transformed file', () async {
-      final bytesArray = await storage
+      final bytes = await storage
           .from(newBucketName)
           .download(
             uploadPath,
@@ -301,7 +299,7 @@ void main() {
         '${Directory.current.path}/public-image.jpg',
       ).create();
       try {
-        await downloadedFile.writeAsBytes(bytesArray);
+        await downloadedFile.writeAsBytes(bytes);
         final size = await downloadedFile.length();
         final type = lookupMimeType(downloadedFile.path);
         expect(size, isPositive);
@@ -317,7 +315,7 @@ void main() {
 
       await storage.from(privateBucketName).upload(uploadPath, file);
 
-      final bytesArray = await storage
+      final bytes = await storage
           .from(privateBucketName)
           .download(
             uploadPath,
@@ -328,7 +326,7 @@ void main() {
         '${Directory.current.path}/private-image.jpg',
       ).create();
       try {
-        await downloadedFile.writeAsBytes(bytesArray);
+        await downloadedFile.writeAsBytes(bytes);
         final size = await downloadedFile.length();
         final type = lookupMimeType(
           downloadedFile.path,
@@ -348,7 +346,7 @@ void main() {
         'Accept': 'image/webp',
       });
 
-      final bytesArray = await client
+      final bytes = await client
           .from(newBucketName)
           .download(
             uploadPath,
@@ -361,7 +359,7 @@ void main() {
         '${Directory.current.path}/webpimage',
       ).create();
       try {
-        await downloadedFile.writeAsBytes(bytesArray);
+        await downloadedFile.writeAsBytes(bytes);
         final size = await downloadedFile.length();
         final type = lookupMimeType(
           downloadedFile.path,
@@ -383,7 +381,7 @@ void main() {
           'Accept': 'image/webp',
         });
 
-        final bytesArray = await client
+        final bytes = await client
             .from(newBucketName)
             .download(
               uploadPath,
@@ -397,7 +395,7 @@ void main() {
           '${Directory.current.path}/jpegimage',
         ).create();
         try {
-          await downloadedFile.writeAsBytes(bytesArray);
+          await downloadedFile.writeAsBytes(bytes);
           final size = await downloadedFile.length();
           final type = lookupMimeType(
             downloadedFile.path,
@@ -474,8 +472,8 @@ void main() {
         ),
       );
 
-      final res = await storage.from(bucketName).upload(uploadPath, file);
-      expect(res, isA<String>());
+      final response = await storage.from(bucketName).upload(uploadPath, file);
+      expect(response, isA<String>());
     });
 
     test('cannot upload a file that exceed the file size limit', () async {
@@ -502,7 +500,7 @@ void main() {
         ),
       );
 
-      final res = await storage
+      final response = await storage
           .from(bucketName)
           .upload(
             uploadPath,
@@ -511,7 +509,7 @@ void main() {
               contentType: 'image/png',
             ),
           );
-      expect(res, isA<String>());
+      expect(response, isA<String>());
     });
 
     test('cannot upload a file an invalid mime type', () async {
@@ -552,7 +550,7 @@ void main() {
       });
 
       await expectLater(
-        () => client.from('bucket2').download(uploadPath),
+        client.from('bucket2').download(uploadPath),
         throwsA(
           isA<StorageException>().having(
             (e) => e.statusCode,
@@ -577,7 +575,7 @@ void main() {
       });
 
       await expectLater(
-        () => client.from('bucket2').download('$uploadPath 3'),
+        client.from('bucket2').download('$uploadPath 3'),
         throwsA(
           isA<StorageException>().having(
             (e) => e.statusCode,
@@ -595,7 +593,7 @@ void main() {
         fail('File that was moved was not found');
       }
       await expectLater(
-        () => client.from(newBucketName).download(uploadPath),
+        client.from(newBucketName).download(uploadPath),
         throwsA(
           isA<StorageException>().having(
             (e) => e.statusCode,
@@ -624,17 +622,19 @@ void main() {
           ),
         );
 
-    final updateRes = await storage.from(newBucketName).info(path);
-    expect(updateRes.metadata, metadata);
+    final objectInfo = await storage.from(newBucketName).info(path);
+    expect(objectInfo.metadata, metadata);
   });
 
   test('check if object exists', () async {
     await storage.from(newBucketName).upload('$uploadPath-exists', file);
-    final res = await storage.from(newBucketName).exists('$uploadPath-exists');
-    expect(res, isTrue);
+    final exists = await storage
+        .from(newBucketName)
+        .exists('$uploadPath-exists');
+    expect(exists, isTrue);
 
-    final res2 = await storage.from(newBucketName).exists('not-exist');
-    expect(res2, isFalse);
+    final missing = await storage.from(newBucketName).exists('not-exist');
+    expect(missing, isFalse);
   });
 
   group('setHeader', () {
@@ -875,7 +875,7 @@ void main() {
     for (final invalidKey in ['folder/a#b.txt', 'folder/100%done.txt']) {
       test('rejects "$invalidKey" with an InvalidKey error', () async {
         await expectLater(
-          () => storage
+          storage
               .from(bucket)
               .upload(
                 invalidKey,

--- a/packages/storage_client/test/fetch_test.dart
+++ b/packages/storage_client/test/fetch_test.dart
@@ -107,7 +107,7 @@ void main() {
 
         final requestPath = mockClient.receivedRequests.single.url.path;
         expect(requestPath, endsWith('/bucket/folder/image.png'));
-        expect(requestPath.contains('//'), isFalse);
+        expect(requestPath, isNot(contains('//')));
       },
     );
   });

--- a/packages/supabase/test/client_test.dart
+++ b/packages/supabase/test/client_test.dart
@@ -104,7 +104,7 @@ void main() {
         supabaseClient: supabase,
       );
 
-      var realtimeWebsocketURL = request.uri;
+      final realtimeWebsocketURL = request.uri;
 
       expect(
         realtimeWebsocketURL.queryParameters,
@@ -172,9 +172,9 @@ void main() {
       var count = 0;
 
       // Check for every request if the Authorization header is set properly
-      await for (final req in mockServer) {
+      await for (final request in mockServer) {
         expect(
-          req.headers.value('Authorization')?.split(" ").last,
+          request.headers.value('Authorization')?.split(" ").last,
           accessToken,
         );
         count++;
@@ -211,8 +211,8 @@ void main() {
       var secondAccessToken = "to be set";
 
       // Check for every request if the Authorization header is set properly
-      await for (final req in mockServer) {
-        if (req.uri.path == "/auth/v1/token") {
+      await for (final request in mockServer) {
+        if (request.uri.path == "/auth/v1/token") {
           if (gotTokenRefresh) {
             fail("Token was refreshed twice");
           }
@@ -222,14 +222,14 @@ void main() {
             DateTime.now().add(Duration(hours: 1)),
           );
 
-          req.response
+          request.response
             ..statusCode = HttpStatus.ok
             ..headers.contentType = ContentType.json
             ..write(sessionString);
-          await req.response.close();
+          await request.response.close();
         } else {
           expect(
-            req.headers.value('Authorization')?.split(" ").last,
+            request.headers.value('Authorization')?.split(" ").last,
             secondAccessToken,
           );
           count++;

--- a/packages/supabase/test/client_test.dart
+++ b/packages/supabase/test/client_test.dart
@@ -402,7 +402,7 @@ void main() {
           // meaning there is no double-dispose from sub-clients.
           final client = SupabaseClient(supabaseUrl, supabaseKey);
 
-          await client.dispose();
+          expect(client.dispose(), completes);
         },
       );
     });

--- a/packages/supabase/test/mock_test.dart
+++ b/packages/supabase/test/mock_test.dart
@@ -40,7 +40,7 @@ void main() {
 
         // Check that rest api contains the correct filter in the URL
         if (expectedFilter != null) {
-          expect(url.contains(expectedFilter), isTrue);
+          expect(url, contains(expectedFilter));
         }
       }
       if (url == '/rest/v1/todos?select=task%2Cstatus') {
@@ -399,7 +399,7 @@ void main() {
 
     test('test mock server', () async {
       final data = await supabase.from('todos').select('task, status');
-      expect(data.length, 2);
+      expect(data, hasLength(2));
     });
 
     group('Basic client test', () {
@@ -427,10 +427,10 @@ void main() {
     group('stream()', () {
       test("listen, cancel and listen again", () async {
         final stream = supabase.from('todos').stream(primaryKey: ['id']);
-        final sub = stream.listen(expectAsync1((event) {}, count: 5));
+        final subscription = stream.listen(expectAsync1((event) {}, count: 5));
         await Future.delayed(Duration(seconds: 1));
 
-        await sub.cancel();
+        await subscription.cancel();
         await Future.delayed(Duration(seconds: 1));
 
         stream.listen(expectAsync1((event) {}, count: 5));
@@ -844,8 +844,8 @@ void main() {
         );
 
         // Should handle token errors gracefully
-        expect(
-          () async => await clientWithFailingToken.from('test').select(),
+        await expectLater(
+          clientWithFailingToken.from('test').select(),
           throwsA(isA<Exception>()),
         );
 

--- a/packages/supabase/test/mock_test.dart
+++ b/packages/supabase/test/mock_test.dart
@@ -845,7 +845,7 @@ void main() {
 
         // Should handle token errors gracefully
         await expectLater(
-          clientWithFailingToken.from('test').select(),
+          () => clientWithFailingToken.from('test').select(),
           throwsA(isA<Exception>()),
         );
 

--- a/packages/supabase/test/realtime_test.dart
+++ b/packages/supabase/test/realtime_test.dart
@@ -58,11 +58,11 @@ void main() {
             callback: (payload) {},
           )
           .subscribe(
-            (event, [errorMsg]) {},
+            (event, [errorMessage]) {},
           );
       expect(
         () => channel.subscribe(),
-        throwsA(const TypeMatcher<String>()),
+        throwsA(isA<String>()),
       );
     });
 
@@ -79,8 +79,8 @@ void main() {
       final channels = supabase.getChannels();
 
       expect(
-        channels.length,
-        2,
+        channels,
+        hasLength(2),
       );
     });
 
@@ -99,8 +99,8 @@ void main() {
       anotherChannel.subscribe();
 
       expect(
-        supabase.getChannels().length,
-        2,
+        supabase.getChannels(),
+        hasLength(2),
       );
 
       final status = await supabase.removeChannel(anotherChannel);
@@ -108,8 +108,8 @@ void main() {
       expect(status, 'ok');
 
       expect(
-        supabase.getChannels().length,
-        1,
+        supabase.getChannels(),
+        hasLength(1),
       );
     });
 
@@ -141,8 +141,8 @@ void main() {
       );
 
       expect(
-        supabase.getChannels().length,
-        0,
+        supabase.getChannels(),
+        isEmpty,
       );
     });
 
@@ -162,14 +162,10 @@ void main() {
       channel.subscribe();
       anotherChannel.subscribe();
 
-      final result1 = await supabase.removeAllChannels();
+      final result = await supabase.removeAllChannels();
       expect(
-        result1,
-        isNotEmpty,
-      );
-      expect(
-        result1.length,
-        2,
+        result,
+        hasLength(2),
       );
 
       expect(

--- a/packages/supabase_common/test/base64url_test.dart
+++ b/packages/supabase_common/test/base64url_test.dart
@@ -73,7 +73,7 @@ void main() {
         const jwtSignature = 'SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c';
         final decoded = Base64Url.decodeToBytes(jwtSignature);
         expect(decoded, isA<List<int>>());
-        expect(decoded.length, greaterThan(0));
+        expect(decoded, isNotEmpty);
       });
     });
   });

--- a/packages/supabase_common/test/retry_test.dart
+++ b/packages/supabase_common/test/retry_test.dart
@@ -11,7 +11,7 @@ void main() {
         return 'ok';
       },
       delayFactor: const Duration(milliseconds: 1),
-      retryIf: (e) => e is FormatException,
+      retryIf: (error) => error is FormatException,
     );
     expect(result, 'ok');
     expect(attempts, 3);
@@ -42,7 +42,7 @@ void main() {
           throw const FormatException('nope');
         },
         delayFactor: const Duration(milliseconds: 1),
-        retryIf: (e) => false,
+        retryIf: (error) => false,
       ),
       throwsA(isA<FormatException>()),
     );
@@ -60,7 +60,7 @@ void main() {
           attempts++;
           throw const FormatException('x');
         },
-        retryIf: (e) => true,
+        retryIf: (error) => true,
       ),
       throwsA(isA<FormatException>()),
     );

--- a/packages/supabase_common/test/supabase_common_test.dart
+++ b/packages/supabase_common/test/supabase_common_test.dart
@@ -52,7 +52,7 @@ void main() {
     test('verifier is url safe and challenge is deterministic', () {
       final verifier = generatePKCEVerifier();
       expect(verifier, isNot(contains('=')));
-      expect(verifier.length, greaterThan(0));
+      expect(verifier, isNotEmpty);
       // Same verifier always yields the same challenge.
       expect(
         generatePKCEChallenge(verifier),

--- a/packages/supabase_flutter/test/auth_test.dart
+++ b/packages/supabase_flutter/test/auth_test.dart
@@ -25,7 +25,7 @@ void main() {
     setUp(() async {
       try {
         await Supabase.instance.dispose();
-      } catch (e) {
+      } catch (_) {
         // Ignore dispose errors
       }
 
@@ -35,7 +35,7 @@ void main() {
     tearDown(() async {
       try {
         await Supabase.instance.dispose();
-      } catch (e) {
+      } catch (_) {
         // Ignore dispose errors
       }
     });

--- a/packages/supabase_flutter/test/initialization_test.dart
+++ b/packages/supabase_flutter/test/initialization_test.dart
@@ -31,10 +31,13 @@ void main() {
 
     group('Basic initialization', () {
       test('initialize successfully with default options', () async {
-        await Supabase.initialize(
-          url: supabaseUrl,
-          publishableKey: supabaseKey,
-          debug: false,
+        expect(
+          Supabase.initialize(
+            url: supabaseUrl,
+            publishableKey: supabaseKey,
+            debug: false,
+          ),
+          completes,
         );
       });
     });
@@ -42,13 +45,16 @@ void main() {
     group('Custom storage initialization', () {
       test('initialize successfully with custom localStorage', () async {
         const localStorage = MockLocalStorage();
-        await Supabase.initialize(
-          url: supabaseUrl,
-          publishableKey: supabaseKey,
-          debug: false,
-          authOptions: const FlutterAuthClientOptions(
-            localStorage: localStorage,
+        expect(
+          Supabase.initialize(
+            url: supabaseUrl,
+            publishableKey: supabaseKey,
+            debug: false,
+            authOptions: const FlutterAuthClientOptions(
+              localStorage: localStorage,
+            ),
           ),
+          completes,
         );
       });
 
@@ -70,13 +76,16 @@ void main() {
 
     group('Auth options initialization', () {
       test('initialize successfully with PKCE auth flow', () async {
-        await Supabase.initialize(
-          url: supabaseUrl,
-          publishableKey: supabaseKey,
-          debug: false,
-          authOptions: const FlutterAuthClientOptions(
-            authFlowType: AuthFlowType.pkce,
+        expect(
+          Supabase.initialize(
+            url: supabaseUrl,
+            publishableKey: supabaseKey,
+            debug: false,
+            authOptions: const FlutterAuthClientOptions(
+              authFlowType: AuthFlowType.pkce,
+            ),
           ),
+          completes,
         );
       });
     });
@@ -84,11 +93,14 @@ void main() {
     group('Custom client initialization', () {
       test('initialize successfully with custom HTTP client', () async {
         final httpClient = PkceHttpClient();
-        await Supabase.initialize(
-          url: supabaseUrl,
-          publishableKey: supabaseKey,
-          debug: false,
-          httpClient: httpClient,
+        expect(
+          Supabase.initialize(
+            url: supabaseUrl,
+            publishableKey: supabaseKey,
+            debug: false,
+            httpClient: httpClient,
+          ),
+          completes,
         );
       });
 

--- a/packages/supabase_flutter/test/initialization_test.dart
+++ b/packages/supabase_flutter/test/initialization_test.dart
@@ -24,7 +24,7 @@ void main() {
     tearDown(() async {
       try {
         await Supabase.instance.dispose();
-      } catch (e) {
+      } catch (_) {
         // Ignore dispose errors
       }
     });

--- a/packages/supabase_flutter/test/initialization_test.dart
+++ b/packages/supabase_flutter/test/initialization_test.dart
@@ -30,7 +30,7 @@ void main() {
     });
 
     group('Basic initialization', () {
-      test('initialize successfully with default options', () async {
+      test('initialize successfully with default options', () {
         expect(
           Supabase.initialize(
             url: supabaseUrl,
@@ -43,7 +43,7 @@ void main() {
     });
 
     group('Custom storage initialization', () {
-      test('initialize successfully with custom localStorage', () async {
+      test('initialize successfully with custom localStorage', () {
         const localStorage = MockLocalStorage();
         expect(
           Supabase.initialize(
@@ -75,7 +75,7 @@ void main() {
     });
 
     group('Auth options initialization', () {
-      test('initialize successfully with PKCE auth flow', () async {
+      test('initialize successfully with PKCE auth flow', () {
         expect(
           Supabase.initialize(
             url: supabaseUrl,
@@ -91,7 +91,7 @@ void main() {
     });
 
     group('Custom client initialization', () {
-      test('initialize successfully with custom HTTP client', () async {
+      test('initialize successfully with custom HTTP client', () {
         final httpClient = PkceHttpClient();
         expect(
           Supabase.initialize(

--- a/packages/supabase_flutter/test/lifecycle_test.dart
+++ b/packages/supabase_flutter/test/lifecycle_test.dart
@@ -121,8 +121,8 @@ void main() {
       var previousCount = -1;
       while (readyCompleters.length != previousCount) {
         previousCount = readyCompleters.length;
-        for (final c in readyCompleters) {
-          if (!c.isCompleted) c.complete();
+        for (final completer in readyCompleters) {
+          if (!completer.isCompleted) completer.complete();
         }
         await pumpEventQueue();
       }

--- a/packages/supabase_flutter/test/storage_test.dart
+++ b/packages/supabase_flutter/test/storage_test.dart
@@ -41,7 +41,7 @@ void main() {
       test('accessToken returns null when no session exists', () async {
         final localStorage = await createFreshLocalStorage();
         final result = await localStorage.accessToken();
-        expect(result, null);
+        expect(result, isNull);
       });
 
       test('accessToken returns session string when session exists', () async {
@@ -72,7 +72,7 @@ void main() {
         // Then remove it
         await localStorage.removePersistedSession();
         expect(await localStorage.hasAccessToken(), isFalse);
-        expect(await localStorage.accessToken(), null);
+        expect(await localStorage.accessToken(), isNull);
       });
     });
 
@@ -92,14 +92,14 @@ void main() {
 
       test('setItem stores value for key', () async {
         await asyncStorage.setItem(key: testKey, value: testValue);
-        final prefs = await SharedPreferences.getInstance();
-        final storedValue = prefs.getString(testKey);
+        final preferences = await SharedPreferences.getInstance();
+        final storedValue = preferences.getString(testKey);
         expect(storedValue, testValue);
       });
 
       test('getItem returns null when no value exists', () async {
         final result = await asyncStorage.getItem(key: 'non_existent_key');
-        expect(result, null);
+        expect(result, isNull);
       });
 
       test('getItem returns value when value exists', () async {
@@ -115,7 +115,7 @@ void main() {
 
         // Then remove it
         await asyncStorage.removeItem(key: testKey);
-        expect(await asyncStorage.getItem(key: testKey), null);
+        expect(await asyncStorage.getItem(key: testKey), isNull);
       });
     });
   });

--- a/packages/supabase_flutter/test/supabase_flutter_test.dart
+++ b/packages/supabase_flutter/test/supabase_flutter_test.dart
@@ -138,7 +138,7 @@ void main() {
 
       // Get the token (should be null)
       final token = await localStorage.accessToken();
-      expect(token, null);
+      expect(token, isNull);
 
       // Try to persist a session
       await localStorage.persistSession('test-session-data');
@@ -149,7 +149,7 @@ void main() {
 
       // Get the token after persisting (should still be null)
       final tokenAfterPersist = await localStorage.accessToken();
-      expect(tokenAfterPersist, null);
+      expect(tokenAfterPersist, isNull);
 
       // Try to remove the session
       await localStorage.removePersistedSession();

--- a/packages/yet_another_json_isolate/test/yet_another_json_isolate_test.dart
+++ b/packages/yet_another_json_isolate/test/yet_another_json_isolate_test.dart
@@ -22,8 +22,8 @@ void main() {
     });
 
     test('encode', () async {
-      final str = await isolate.encode(_jsonMap);
-      expect(str, _jsonString);
+      final encoded = await isolate.encode(_jsonMap);
+      expect(encoded, _jsonString);
     });
   });
 
@@ -42,8 +42,8 @@ void main() {
     });
 
     test('encode', () async {
-      final str = await isolate.encode(_jsonMap);
-      expect(str, _jsonString);
+      final encoded = await isolate.encode(_jsonMap);
+      expect(encoded, _jsonString);
     });
   });
 }


### PR DESCRIPTION
## What

Cleans up the test suites across every package. No production (`lib/`) changes.

- **Abbreviations removed** in test-local identifiers: `res`/`getRes`/… → `response`/`result`, `req` → `request`, `params` → `parameters`, `msg` → `message`, `e`/`err` → `error`, `conn` → `connection`, `db` → `database`, `at` → `accessToken`, `sig` → `signature`, `sub` → `subscription`, and similar. Public API names, named arguments, JSON/map keys and conventional acronyms (id, url, jwt, otp, pkce, ws, …) are left untouched.
- **Weak assertions strengthened** with proper matchers: `isNotNull`, `isEmpty`, `isTrue`/`isFalse`, `hasLength`, `contains`, `isA<T>()`, `endsWith`, `isNot(contains(...))`. Redundant `.toString()`/casts and a pointless cascade removed.
- **Idiomatic throw assertions**: converted `try { await op } catch (e) { expect(e, isA<X>()) }` and closure-wrapped `expectLater(() => future, throwsA(...))` to `expectLater(future, throwsA(...))` (69 sites). Genuinely synchronous `expect(() => syncCall(), throwsX)` and mockito `when`/`verify` closures were left as-is.
- **Stale phone-auth tests fixed**: the two gotrue "should fail because Twilio is not setup" tests were silently passing as no-ops (a `try/catch` swallowed the non-exception). The test stack deliberately enables phone auth, so they now assert the real success behavior.
- **Useless/duplicate tests removed (7)**:
  - gotrue: four identical `same()` reference-equality tautologies (`session`, `auth_exception`, `user`, `user_identity`).
  - realtime: `socket_test` "calls callback" (incremented a counter unconditionally, asserted nothing real).
  - postgrest: "bulk insert with one row uses default value" (exact duplicate).
  - storage: "getPublicUrl leaves the URL unchanged when download is null" (byte-for-byte duplicate).

## Testing

All package suites pass against a local Supabase stack: gotrue 446, realtime 182, postgrest 177, storage 110, functions 45, supabase 83, supabase_common 33, supabase_flutter 63, yet_another_json_isolate 4. `dart analyze` clean, `dart format` applied.

Resolves SDK-1290.
