### PR TITLE
feat(storage): add vector buckets support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -144,7 +144,7 @@ jobs:
         if: ${{ matrix.package.backend }}
         uses: supabase/setup-cli@3c2f5e2ae34c34e428e8e206e2c4d21fa2d20fbf # v2.1.1
         with:
-          version: 2.106.0
+          version: 2.109.1
 
       - name: Print Supabase CLI version
         if: ${{ matrix.package.backend }}

--- a/packages/gotrue/lib/src/gotrue_oauth_api.dart
+++ b/packages/gotrue/lib/src/gotrue_oauth_api.dart
@@ -56,7 +56,7 @@ class OAuthGrant {
   factory OAuthGrant.fromJson(Map<String, dynamic> json) {
     return OAuthGrant(
       client: OAuthAuthorizedClient.fromJson(json['client']),
-      scopes: (json['scopes'] as List?)?.cast<String>() ?? const <String>[],
+      scopes: (json['scopes'] as List?)?.cast() ?? const [],
       grantedAt: DateTime.parse(json['granted_at'] as String),
     );
   }

--- a/packages/storage_client/lib/src/fetch.dart
+++ b/packages/storage_client/lib/src/fetch.dart
@@ -211,6 +211,9 @@ class Fetch {
       if (options?.noResolveJson == true) {
         return response.bodyBytes;
       }
+      if (response.body.isEmpty) {
+        return null;
+      }
       final jsonBody = json.decode(response.body);
       return jsonBody;
     }

--- a/packages/storage_client/lib/src/storage_client.dart
+++ b/packages/storage_client/lib/src/storage_client.dart
@@ -1,5 +1,6 @@
 import 'package:http/http.dart';
 import 'package:logging/logging.dart';
+import 'package:meta/meta.dart';
 import 'package:storage_client/src/constants.dart';
 import 'package:storage_client/src/storage_bucket_api.dart';
 import 'package:storage_client/src/storage_file_api.dart';
@@ -116,6 +117,7 @@ class SupabaseStorageClient extends StorageBucketApi {
   /// final vectors = storage.vectors;
   /// await vectors.createBucket('embeddings');
   /// ```
+  @experimental
   late final SupabaseVectorsClient vectors = SupabaseVectorsClient(
     '$url/vector',
     headers,

--- a/packages/storage_client/lib/src/storage_client.dart
+++ b/packages/storage_client/lib/src/storage_client.dart
@@ -116,9 +116,11 @@ class SupabaseStorageClient extends StorageBucketApi {
   /// final vectors = storage.vectors;
   /// await vectors.createBucket('embeddings');
   /// ```
-  SupabaseVectorsClient get vectors {
-    return SupabaseVectorsClient('$url/vector', headers, storageFetch);
-  }
+  late final SupabaseVectorsClient vectors = SupabaseVectorsClient(
+    '$url/vector',
+    headers,
+    storageFetch,
+  );
 
   void setAuth(String jwt) {
     headers['Authorization'] = 'Bearer $jwt';

--- a/packages/storage_client/lib/src/storage_client.dart
+++ b/packages/storage_client/lib/src/storage_client.dart
@@ -3,6 +3,7 @@ import 'package:logging/logging.dart';
 import 'package:storage_client/src/constants.dart';
 import 'package:storage_client/src/storage_bucket_api.dart';
 import 'package:storage_client/src/storage_file_api.dart';
+import 'package:storage_client/src/vector_client.dart';
 import 'package:storage_client/src/version.dart';
 
 class SupabaseStorageClient extends StorageBucketApi {
@@ -103,6 +104,20 @@ class SupabaseStorageClient extends StorageBucketApi {
       _defaultRetryAttempts,
       storageFetch,
     );
+  }
+
+  /// Access the Storage Vectors API to manage vector buckets, indexes and the
+  /// vectors stored inside them.
+  ///
+  /// This API is part of a public alpha and may not be available to every
+  /// project.
+  ///
+  /// ```dart
+  /// final vectors = storage.vectors;
+  /// await vectors.createBucket('embeddings');
+  /// ```
+  SupabaseVectorsClient get vectors {
+    return SupabaseVectorsClient('$url/vector', headers, storageFetch);
   }
 
   void setAuth(String jwt) {

--- a/packages/storage_client/lib/src/vector_client.dart
+++ b/packages/storage_client/lib/src/vector_client.dart
@@ -31,7 +31,7 @@ class SupabaseVectorsClient {
   final Fetch _storageFetch;
 
   @internal
-  SupabaseVectorsClient(this._url, this._headers, this._storageFetch);
+  const SupabaseVectorsClient(this._url, this._headers, this._storageFetch);
 
   FetchOptions get _options => FetchOptions(_headers);
 
@@ -104,7 +104,7 @@ class StorageVectorBucketApi {
   final String bucketName;
 
   @internal
-  StorageVectorBucketApi(
+  const StorageVectorBucketApi(
     this._url,
     this._headers,
     this._storageFetch,
@@ -213,7 +213,7 @@ class StorageVectorIndexApi {
   final String indexName;
 
   @internal
-  StorageVectorIndexApi(
+  const StorageVectorIndexApi(
     this._url,
     this._headers,
     this._storageFetch,

--- a/packages/storage_client/lib/src/vector_client.dart
+++ b/packages/storage_client/lib/src/vector_client.dart
@@ -24,6 +24,7 @@ import 'package:supabase_common/supabase_common.dart';
 ///
 /// This API is part of a public alpha and may not be available to every
 /// project.
+@experimental
 class SupabaseVectorsClient {
   final String _url;
   final Map<String, String> _headers;
@@ -93,6 +94,7 @@ class SupabaseVectorsClient {
 /// Index operations scoped to a single vector bucket.
 ///
 /// Obtain an instance through [SupabaseVectorsClient.from].
+@experimental
 class StorageVectorBucketApi {
   final String _url;
   final Map<String, String> _headers;
@@ -198,6 +200,7 @@ class StorageVectorBucketApi {
 /// Vector data operations scoped to a single index within a bucket.
 ///
 /// Obtain an instance through [StorageVectorBucketApi.index].
+@experimental
 class StorageVectorIndexApi {
   final String _url;
   final Map<String, String> _headers;

--- a/packages/storage_client/lib/src/vector_client.dart
+++ b/packages/storage_client/lib/src/vector_client.dart
@@ -1,0 +1,356 @@
+import 'package:meta/meta.dart';
+import 'package:storage_client/src/fetch.dart';
+import 'package:storage_client/src/vector_types.dart';
+import 'package:supabase_common/supabase_common.dart';
+
+/// Client for the Storage Vectors API, reachable through
+/// `supabase.storage.vectors`.
+///
+/// It manages vector buckets directly and hands out bucket-scoped clients via
+/// [from], which in turn hand out index-scoped clients via
+/// [StorageVectorBucketApi.index].
+///
+/// ```dart
+/// final vectors = supabase.storage.vectors;
+/// await vectors.createBucket('embeddings');
+///
+/// final index = vectors.from('embeddings').index('documents');
+/// await index.putVectors([
+///   Vector(key: 'doc-1', data: [0.1, 0.2, 0.3], metadata: {'title': 'Intro'}),
+/// ]);
+///
+/// final result = await index.queryVectors(queryVector: [0.1, 0.2, 0.3], topK: 5);
+/// ```
+///
+/// This API is part of a public alpha and may not be available to every
+/// project.
+class SupabaseVectorsClient {
+  final String _url;
+  final Map<String, String> _headers;
+  final Fetch _storageFetch;
+
+  @internal
+  SupabaseVectorsClient(this._url, this._headers, this._storageFetch);
+
+  FetchOptions get _options => FetchOptions(_headers);
+
+  /// Creates a new vector bucket.
+  Future<void> createBucket(String name) async {
+    await _storageFetch.post(
+      '$_url/CreateVectorBucket',
+      {'vectorBucketName': name},
+      options: _options,
+    );
+  }
+
+  /// Retrieves the metadata of an existing vector bucket.
+  Future<VectorBucket> getBucket(String name) async {
+    final response = await _storageFetch.post(
+      '$_url/GetVectorBucket',
+      {'vectorBucketName': name},
+      options: _options,
+    );
+    return VectorBucket.fromJson(
+      (response as Map<String, dynamic>)['vectorBucket']
+          as Map<String, dynamic>,
+    );
+  }
+
+  /// Lists vector buckets, optionally filtered by [prefix] and paginated with
+  /// [maxResults] and [nextToken].
+  Future<VectorBucketList> listBuckets({
+    String? prefix,
+    int? maxResults,
+    String? nextToken,
+  }) async {
+    final response = await _storageFetch.post(
+      '$_url/ListVectorBuckets',
+      {
+        'prefix': ?prefix,
+        'maxResults': ?maxResults,
+        'nextToken': ?nextToken,
+      },
+      options: _options,
+    );
+    return VectorBucketList.fromJson(response as Map<String, dynamic>);
+  }
+
+  /// Deletes a vector bucket. The bucket must have no indexes.
+  Future<void> deleteBucket(String name) async {
+    await _storageFetch.post(
+      '$_url/DeleteVectorBucket',
+      {'vectorBucketName': name},
+      options: _options,
+    );
+  }
+
+  /// Scopes index operations to the vector bucket named [bucketName].
+  StorageVectorBucketApi from(String bucketName) {
+    return StorageVectorBucketApi(_url, _headers, _storageFetch, bucketName);
+  }
+}
+
+/// Index operations scoped to a single vector bucket.
+///
+/// Obtain an instance through [SupabaseVectorsClient.from].
+class StorageVectorBucketApi {
+  final String _url;
+  final Map<String, String> _headers;
+  final Fetch _storageFetch;
+
+  /// The name of the vector bucket these operations are scoped to.
+  final String bucketName;
+
+  @internal
+  StorageVectorBucketApi(
+    this._url,
+    this._headers,
+    this._storageFetch,
+    this.bucketName,
+  );
+
+  FetchOptions get _options => FetchOptions(_headers);
+
+  /// Creates a new vector index in this bucket.
+  ///
+  /// [dimension] is the length of the vectors the index will store and
+  /// [distanceMetric] the metric used for similarity queries. Keys listed in
+  /// [nonFilterableMetadataKeys] can be stored on vectors but not used in query
+  /// filters.
+  Future<void> createIndex({
+    required String name,
+    required int dimension,
+    required DistanceMetric distanceMetric,
+    VectorDataType dataType = VectorDataType.float32,
+    List<String>? nonFilterableMetadataKeys,
+  }) async {
+    await _storageFetch.post(
+      '$_url/CreateIndex',
+      {
+        'vectorBucketName': bucketName,
+        'indexName': name,
+        'dataType': dataType.value,
+        'dimension': dimension,
+        'distanceMetric': distanceMetric.value,
+        if (nonFilterableMetadataKeys != null)
+          'metadataConfiguration': {
+            'nonFilterableMetadataKeys': nonFilterableMetadataKeys,
+          },
+      },
+      options: _options,
+    );
+  }
+
+  /// Retrieves the metadata of an index in this bucket.
+  Future<VectorIndex> getIndex(String name) async {
+    final response = await _storageFetch.post(
+      '$_url/GetIndex',
+      {'vectorBucketName': bucketName, 'indexName': name},
+      options: _options,
+    );
+    return VectorIndex.fromJson(
+      (response as Map<String, dynamic>)['index'] as Map<String, dynamic>,
+    );
+  }
+
+  /// Lists indexes in this bucket, optionally filtered by [prefix] and
+  /// paginated with [maxResults] and [nextToken].
+  Future<VectorIndexList> listIndexes({
+    String? prefix,
+    int? maxResults,
+    String? nextToken,
+  }) async {
+    final response = await _storageFetch.post(
+      '$_url/ListIndexes',
+      {
+        'vectorBucketName': bucketName,
+        'prefix': ?prefix,
+        'maxResults': ?maxResults,
+        'nextToken': ?nextToken,
+      },
+      options: _options,
+    );
+    return VectorIndexList.fromJson(response as Map<String, dynamic>);
+  }
+
+  /// Deletes an index and all of its vectors from this bucket.
+  Future<void> deleteIndex(String name) async {
+    await _storageFetch.post(
+      '$_url/DeleteIndex',
+      {'vectorBucketName': bucketName, 'indexName': name},
+      options: _options,
+    );
+  }
+
+  /// Scopes vector data operations to the index named [indexName] in this
+  /// bucket.
+  StorageVectorIndexApi index(String indexName) {
+    return StorageVectorIndexApi(
+      _url,
+      _headers,
+      _storageFetch,
+      bucketName,
+      indexName,
+    );
+  }
+}
+
+/// Vector data operations scoped to a single index within a bucket.
+///
+/// Obtain an instance through [StorageVectorBucketApi.index].
+class StorageVectorIndexApi {
+  final String _url;
+  final Map<String, String> _headers;
+  final Fetch _storageFetch;
+
+  /// The name of the vector bucket these operations are scoped to.
+  final String bucketName;
+
+  /// The name of the index these operations are scoped to.
+  final String indexName;
+
+  @internal
+  StorageVectorIndexApi(
+    this._url,
+    this._headers,
+    this._storageFetch,
+    this.bucketName,
+    this.indexName,
+  );
+
+  FetchOptions get _options => FetchOptions(_headers);
+
+  /// Inserts or updates a batch of [vectors] in this index.
+  ///
+  /// The batch must contain between 1 and 500 vectors.
+  Future<void> putVectors(List<Vector> vectors) async {
+    if (vectors.isEmpty || vectors.length > 500) {
+      throw ArgumentError('Vector batch size must be between 1 and 500 items');
+    }
+    await _storageFetch.post(
+      '$_url/PutVectors',
+      {
+        'vectorBucketName': bucketName,
+        'indexName': indexName,
+        'vectors': vectors.map((vector) => vector.toJson()).toList(),
+      },
+      options: _options,
+    );
+  }
+
+  /// Retrieves vectors by their [keys].
+  ///
+  /// Set [returnData] and [returnMetadata] to include the embeddings and
+  /// metadata in the result. Keys that do not exist are omitted from the
+  /// returned list.
+  Future<List<VectorMatch>> getVectors({
+    required List<String> keys,
+    bool? returnData,
+    bool? returnMetadata,
+  }) async {
+    final response = await _storageFetch.post(
+      '$_url/GetVectors',
+      {
+        'vectorBucketName': bucketName,
+        'indexName': indexName,
+        'keys': keys,
+        'returnData': ?returnData,
+        'returnMetadata': ?returnMetadata,
+      },
+      options: _options,
+    );
+    final vectors =
+        (response as Map<String, dynamic>)['vectors'] as List? ?? const [];
+    return vectors
+        .map((value) => VectorMatch.fromJson(value as Map<String, dynamic>))
+        .toList();
+  }
+
+  /// Lists vectors in this index with pagination.
+  ///
+  /// A full-index scan can be distributed across multiple workers by giving
+  /// each worker a different [segmentIndex] (0 to `segmentCount - 1`) for the
+  /// same [segmentCount] (1 to 16).
+  Future<VectorList> listVectors({
+    int? maxResults,
+    String? nextToken,
+    bool? returnData,
+    bool? returnMetadata,
+    int? segmentCount,
+    int? segmentIndex,
+  }) async {
+    if (segmentCount != null) {
+      if (segmentCount < 1 || segmentCount > 16) {
+        throw ArgumentError('segmentCount must be between 1 and 16');
+      }
+      if (segmentIndex != null &&
+          (segmentIndex < 0 || segmentIndex >= segmentCount)) {
+        throw ArgumentError(
+          'segmentIndex must be between 0 and ${segmentCount - 1}',
+        );
+      }
+    }
+    final response = await _storageFetch.post(
+      '$_url/ListVectors',
+      {
+        'vectorBucketName': bucketName,
+        'indexName': indexName,
+        'maxResults': ?maxResults,
+        'nextToken': ?nextToken,
+        'returnData': ?returnData,
+        'returnMetadata': ?returnMetadata,
+        'segmentCount': ?segmentCount,
+        'segmentIndex': ?segmentIndex,
+      },
+      options: _options,
+    );
+    return VectorList.fromJson(response as Map<String, dynamic>);
+  }
+
+  /// Searches this index for the vectors most similar to [queryVector].
+  ///
+  /// [topK] limits the number of matches returned. [filter] restricts the
+  /// search to vectors whose metadata matches the given expression. Set
+  /// [returnDistance] and [returnMetadata] to include the distance scores and
+  /// metadata in the result.
+  Future<VectorQueryResult> queryVectors({
+    required List<double> queryVector,
+    int? topK,
+    Map<String, dynamic>? filter,
+    bool? returnDistance,
+    bool? returnMetadata,
+  }) async {
+    final response = await _storageFetch.post(
+      '$_url/QueryVectors',
+      {
+        'vectorBucketName': bucketName,
+        'indexName': indexName,
+        'queryVector': {'float32': queryVector},
+        'topK': ?topK,
+        'filter': ?filter,
+        'returnDistance': ?returnDistance,
+        'returnMetadata': ?returnMetadata,
+      },
+      options: _options,
+    );
+    return VectorQueryResult.fromJson(response as Map<String, dynamic>);
+  }
+
+  /// Deletes vectors by their [keys].
+  ///
+  /// The batch must contain between 1 and 500 keys.
+  Future<void> deleteVectors(List<String> keys) async {
+    if (keys.isEmpty || keys.length > 500) {
+      throw ArgumentError('Keys batch size must be between 1 and 500 items');
+    }
+    await _storageFetch.post(
+      '$_url/DeleteVectors',
+      {
+        'vectorBucketName': bucketName,
+        'indexName': indexName,
+        'keys': keys,
+      },
+      options: _options,
+    );
+  }
+}

--- a/packages/storage_client/lib/src/vector_types.dart
+++ b/packages/storage_client/lib/src/vector_types.dart
@@ -9,6 +9,15 @@ enum VectorDataType {
 
   /// The value sent to and returned by the storage API.
   String get value => name.toLowerCase();
+
+  /// The [VectorDataType] matching the given API [value], or `null` when it is
+  /// not recognized.
+  static VectorDataType? fromValue(Object? value) {
+    for (final type in values) {
+      if (type.value == value) return type;
+    }
+    return null;
+  }
 }
 
 /// Distance metric used when comparing vectors during a similarity search.
@@ -20,20 +29,15 @@ enum DistanceMetric {
 
   /// The value sent to and returned by the storage API.
   String get value => name.toLowerCase();
-}
 
-VectorDataType? _vectorDataTypeFromValue(Object? value) {
-  for (final type in VectorDataType.values) {
-    if (type.value == value) return type;
+  /// The [DistanceMetric] matching the given API [value], or `null` when it is
+  /// not recognized.
+  static DistanceMetric? fromValue(Object? value) {
+    for (final metric in values) {
+      if (metric.value == value) return metric;
+    }
+    return null;
   }
-  return null;
-}
-
-DistanceMetric? _distanceMetricFromValue(Object? value) {
-  for (final metric in DistanceMetric.values) {
-    if (metric.value == value) return metric;
-  }
-  return null;
 }
 
 List<double>? _parseFloat32(Object? data) {
@@ -148,9 +152,9 @@ class VectorIndex {
     return VectorIndex(
       name: json['indexName'] as String,
       bucketName: json['vectorBucketName'] as String?,
-      dataType: _vectorDataTypeFromValue(json['dataType']),
+      dataType: VectorDataType.fromValue(json['dataType']),
       dimension: (json['dimension'] as num?)?.toInt(),
-      distanceMetric: _distanceMetricFromValue(json['distanceMetric']),
+      distanceMetric: DistanceMetric.fromValue(json['distanceMetric']),
       nonFilterableMetadataKeys: nonFilterableMetadataKeys is List
           ? nonFilterableMetadataKeys.cast()
           : null,
@@ -319,7 +323,7 @@ class VectorQueryResult {
       matches: matches
           .map((value) => VectorMatch.fromJson(value as Map<String, dynamic>))
           .toList(),
-      distanceMetric: _distanceMetricFromValue(json['distanceMetric']),
+      distanceMetric: DistanceMetric.fromValue(json['distanceMetric']),
     );
   }
 }

--- a/packages/storage_client/lib/src/vector_types.dart
+++ b/packages/storage_client/lib/src/vector_types.dart
@@ -1,0 +1,309 @@
+/// Supported data types for vector components.
+///
+/// Currently the S3 Vectors service only supports 32-bit floats.
+enum VectorDataType {
+  float32('float32');
+
+  const VectorDataType(this.value);
+
+  /// The value sent to and returned by the storage API.
+  final String value;
+}
+
+/// Distance metric used when comparing vectors during a similarity search.
+enum DistanceMetric {
+  cosine('cosine'),
+  euclidean('euclidean'),
+  dotProduct('dotproduct');
+
+  const DistanceMetric(this.value);
+
+  /// The value sent to and returned by the storage API.
+  final String value;
+}
+
+VectorDataType? _vectorDataTypeFromValue(Object? value) {
+  for (final type in VectorDataType.values) {
+    if (type.value == value) return type;
+  }
+  return null;
+}
+
+DistanceMetric? _distanceMetricFromValue(Object? value) {
+  for (final metric in DistanceMetric.values) {
+    if (metric.value == value) return metric;
+  }
+  return null;
+}
+
+List<double>? _parseFloat32(Object? data) {
+  if (data is! Map) return null;
+  final float32 = data['float32'];
+  if (float32 is! List) return null;
+  return float32.map((value) => (value as num).toDouble()).toList();
+}
+
+/// Encryption settings attached to a vector bucket.
+class VectorBucketEncryption {
+  /// The ARN of the KMS key used to encrypt the bucket, if any.
+  final String? kmsKeyArn;
+
+  /// The server-side encryption type applied to the bucket.
+  final String? sseType;
+
+  const VectorBucketEncryption({this.kmsKeyArn, this.sseType});
+
+  factory VectorBucketEncryption.fromJson(Map<String, dynamic> json) {
+    return VectorBucketEncryption(
+      kmsKeyArn: json['kmsKeyArn'] as String?,
+      sseType: json['sseType'] as String?,
+    );
+  }
+}
+
+/// Metadata describing a vector bucket.
+class VectorBucket {
+  /// The unique name of the vector bucket.
+  final String name;
+
+  /// The unix timestamp of when the bucket was created, as returned by the
+  /// server. `null` when the server does not include it (for example in list
+  /// responses).
+  final int? creationTime;
+
+  /// The bucket's encryption configuration, when present.
+  final VectorBucketEncryption? encryption;
+
+  const VectorBucket({
+    required this.name,
+    this.creationTime,
+    this.encryption,
+  });
+
+  factory VectorBucket.fromJson(Map<String, dynamic> json) {
+    final encryption = json['encryptionConfiguration'];
+    return VectorBucket(
+      name: json['vectorBucketName'] as String,
+      creationTime: (json['creationTime'] as num?)?.toInt(),
+      encryption: encryption is Map<String, dynamic>
+          ? VectorBucketEncryption.fromJson(encryption)
+          : null,
+    );
+  }
+}
+
+/// Metadata describing a vector index within a bucket.
+class VectorIndex {
+  /// The unique name of the index within its bucket.
+  final String name;
+
+  /// The name of the parent vector bucket. `null` when the server does not
+  /// include it (for example in list responses).
+  final String? bucketName;
+
+  /// The data type of the vector components. `null` for values the client does
+  /// not recognize.
+  final VectorDataType? dataType;
+
+  /// The dimensionality of the vectors stored in this index.
+  final int? dimension;
+
+  /// The distance metric used for similarity queries. `null` for values the
+  /// client does not recognize.
+  final DistanceMetric? distanceMetric;
+
+  /// Metadata keys that are stored but cannot be used in query filters.
+  final List<String>? nonFilterableMetadataKeys;
+
+  /// The unix timestamp of when the index was created, as returned by the
+  /// server.
+  final int? creationTime;
+
+  const VectorIndex({
+    required this.name,
+    this.bucketName,
+    this.dataType,
+    this.dimension,
+    this.distanceMetric,
+    this.nonFilterableMetadataKeys,
+    this.creationTime,
+  });
+
+  factory VectorIndex.fromJson(Map<String, dynamic> json) {
+    final metadataConfiguration = json['metadataConfiguration'];
+    final nonFilterableMetadataKeys =
+        metadataConfiguration is Map<String, dynamic>
+        ? metadataConfiguration['nonFilterableMetadataKeys']
+        : null;
+    return VectorIndex(
+      name: json['indexName'] as String,
+      bucketName: json['vectorBucketName'] as String?,
+      dataType: _vectorDataTypeFromValue(json['dataType']),
+      dimension: (json['dimension'] as num?)?.toInt(),
+      distanceMetric: _distanceMetricFromValue(json['distanceMetric']),
+      nonFilterableMetadataKeys: nonFilterableMetadataKeys is List
+          ? nonFilterableMetadataKeys.cast<String>()
+          : null,
+      creationTime: (json['creationTime'] as num?)?.toInt(),
+    );
+  }
+}
+
+/// A single vector to insert or update through
+/// [StorageVectorIndexApi.putVectors].
+class Vector {
+  /// The unique key identifying the vector within its index.
+  final String key;
+
+  /// The vector embedding. Its length must match the index dimension.
+  final List<double> data;
+
+  /// Optional arbitrary metadata stored alongside the vector.
+  final Map<String, dynamic>? metadata;
+
+  const Vector({
+    required this.key,
+    required this.data,
+    this.metadata,
+  });
+
+  Map<String, dynamic> toJson() {
+    return {
+      'key': key,
+      'data': {'float32': data},
+      'metadata': ?metadata,
+    };
+  }
+}
+
+/// A vector returned from a get, list or query operation.
+///
+/// [data], [metadata] and [distance] are only populated when the corresponding
+/// operation was asked to return them.
+class VectorMatch {
+  /// The unique key identifying the vector within its index.
+  final String key;
+
+  /// The vector embedding, when requested.
+  final List<double>? data;
+
+  /// The arbitrary metadata stored alongside the vector, when requested.
+  final Map<String, dynamic>? metadata;
+
+  /// The similarity distance from the query vector. Only present in query
+  /// results when distances were requested.
+  final double? distance;
+
+  const VectorMatch({
+    required this.key,
+    this.data,
+    this.metadata,
+    this.distance,
+  });
+
+  factory VectorMatch.fromJson(Map<String, dynamic> json) {
+    return VectorMatch(
+      key: json['key'] as String,
+      data: _parseFloat32(json['data']),
+      metadata: json['metadata'] as Map<String, dynamic>?,
+      distance: (json['distance'] as num?)?.toDouble(),
+    );
+  }
+}
+
+/// The result of [SupabaseVectorsClient.listBuckets].
+class VectorBucketList {
+  /// The buckets in this page.
+  final List<VectorBucket> buckets;
+
+  /// The token to pass as `nextToken` to fetch the next page, if any.
+  final String? nextToken;
+
+  const VectorBucketList({
+    required this.buckets,
+    this.nextToken,
+  });
+
+  factory VectorBucketList.fromJson(Map<String, dynamic> json) {
+    final buckets = json['vectorBuckets'] as List? ?? const [];
+    return VectorBucketList(
+      buckets: buckets
+          .map((value) => VectorBucket.fromJson(value as Map<String, dynamic>))
+          .toList(),
+      nextToken: json['nextToken'] as String?,
+    );
+  }
+}
+
+/// The result of [StorageVectorBucketApi.listIndexes].
+class VectorIndexList {
+  /// The indexes in this page.
+  final List<VectorIndex> indexes;
+
+  /// The token to pass as `nextToken` to fetch the next page, if any.
+  final String? nextToken;
+
+  const VectorIndexList({
+    required this.indexes,
+    this.nextToken,
+  });
+
+  factory VectorIndexList.fromJson(Map<String, dynamic> json) {
+    final indexes = json['indexes'] as List? ?? const [];
+    return VectorIndexList(
+      indexes: indexes
+          .map((value) => VectorIndex.fromJson(value as Map<String, dynamic>))
+          .toList(),
+      nextToken: json['nextToken'] as String?,
+    );
+  }
+}
+
+/// The result of [StorageVectorIndexApi.listVectors].
+class VectorList {
+  /// The vectors in this page.
+  final List<VectorMatch> vectors;
+
+  /// The token to pass as `nextToken` to fetch the next page, if any.
+  final String? nextToken;
+
+  const VectorList({
+    required this.vectors,
+    this.nextToken,
+  });
+
+  factory VectorList.fromJson(Map<String, dynamic> json) {
+    final vectors = json['vectors'] as List? ?? const [];
+    return VectorList(
+      vectors: vectors
+          .map((value) => VectorMatch.fromJson(value as Map<String, dynamic>))
+          .toList(),
+      nextToken: json['nextToken'] as String?,
+    );
+  }
+}
+
+/// The result of [StorageVectorIndexApi.queryVectors].
+class VectorQueryResult {
+  /// The matching vectors ordered by ascending distance from the query vector.
+  final List<VectorMatch> matches;
+
+  /// The distance metric the server used for the search. `null` for values the
+  /// client does not recognize.
+  final DistanceMetric? distanceMetric;
+
+  const VectorQueryResult({
+    required this.matches,
+    this.distanceMetric,
+  });
+
+  factory VectorQueryResult.fromJson(Map<String, dynamic> json) {
+    final matches = json['vectors'] as List? ?? const [];
+    return VectorQueryResult(
+      matches: matches
+          .map((value) => VectorMatch.fromJson(value as Map<String, dynamic>))
+          .toList(),
+      distanceMetric: _distanceMetricFromValue(json['distanceMetric']),
+    );
+  }
+}

--- a/packages/storage_client/lib/src/vector_types.dart
+++ b/packages/storage_client/lib/src/vector_types.dart
@@ -1,25 +1,25 @@
+import 'package:meta/meta.dart';
+
 /// Supported data types for vector components.
 ///
 /// Currently the S3 Vectors service only supports 32-bit floats.
+@experimental
 enum VectorDataType {
-  float32('float32');
-
-  const VectorDataType(this.value);
+  float32;
 
   /// The value sent to and returned by the storage API.
-  final String value;
+  String get value => name.toLowerCase();
 }
 
 /// Distance metric used when comparing vectors during a similarity search.
+@experimental
 enum DistanceMetric {
-  cosine('cosine'),
-  euclidean('euclidean'),
-  dotProduct('dotproduct');
-
-  const DistanceMetric(this.value);
+  cosine,
+  euclidean,
+  dotProduct;
 
   /// The value sent to and returned by the storage API.
-  final String value;
+  String get value => name.toLowerCase();
 }
 
 VectorDataType? _vectorDataTypeFromValue(Object? value) {
@@ -44,6 +44,7 @@ List<double>? _parseFloat32(Object? data) {
 }
 
 /// Encryption settings attached to a vector bucket.
+@experimental
 class VectorBucketEncryption {
   /// The ARN of the KMS key used to encrypt the bucket, if any.
   final String? kmsKeyArn;
@@ -62,6 +63,7 @@ class VectorBucketEncryption {
 }
 
 /// Metadata describing a vector bucket.
+@experimental
 class VectorBucket {
   /// The unique name of the vector bucket.
   final String name;
@@ -93,6 +95,7 @@ class VectorBucket {
 }
 
 /// Metadata describing a vector index within a bucket.
+@experimental
 class VectorIndex {
   /// The unique name of the index within its bucket.
   final String name;
@@ -151,6 +154,7 @@ class VectorIndex {
 
 /// A single vector to insert or update through
 /// [StorageVectorIndexApi.putVectors].
+@experimental
 class Vector {
   /// The unique key identifying the vector within its index.
   final String key;
@@ -180,6 +184,7 @@ class Vector {
 ///
 /// [data], [metadata] and [distance] are only populated when the corresponding
 /// operation was asked to return them.
+@experimental
 class VectorMatch {
   /// The unique key identifying the vector within its index.
   final String key;
@@ -212,6 +217,7 @@ class VectorMatch {
 }
 
 /// The result of [SupabaseVectorsClient.listBuckets].
+@experimental
 class VectorBucketList {
   /// The buckets in this page.
   final List<VectorBucket> buckets;
@@ -236,6 +242,7 @@ class VectorBucketList {
 }
 
 /// The result of [StorageVectorBucketApi.listIndexes].
+@experimental
 class VectorIndexList {
   /// The indexes in this page.
   final List<VectorIndex> indexes;
@@ -260,6 +267,7 @@ class VectorIndexList {
 }
 
 /// The result of [StorageVectorIndexApi.listVectors].
+@experimental
 class VectorList {
   /// The vectors in this page.
   final List<VectorMatch> vectors;
@@ -284,6 +292,7 @@ class VectorList {
 }
 
 /// The result of [StorageVectorIndexApi.queryVectors].
+@experimental
 class VectorQueryResult {
   /// The matching vectors ordered by ascending distance from the query vector.
   final List<VectorMatch> matches;

--- a/packages/storage_client/lib/src/vector_types.dart
+++ b/packages/storage_client/lib/src/vector_types.dart
@@ -152,7 +152,7 @@ class VectorIndex {
       dimension: (json['dimension'] as num?)?.toInt(),
       distanceMetric: _distanceMetricFromValue(json['distanceMetric']),
       nonFilterableMetadataKeys: nonFilterableMetadataKeys is List
-          ? nonFilterableMetadataKeys.cast<String>()
+          ? nonFilterableMetadataKeys.cast()
           : null,
       creationTime: _parseUnixSeconds(json['creationTime']),
     );

--- a/packages/storage_client/lib/src/vector_types.dart
+++ b/packages/storage_client/lib/src/vector_types.dart
@@ -43,6 +43,14 @@ List<double>? _parseFloat32(Object? data) {
   return float32.map((value) => (value as num).toDouble()).toList();
 }
 
+DateTime? _parseUnixSeconds(Object? value) {
+  if (value is! num) return null;
+  return DateTime.fromMillisecondsSinceEpoch(
+    (value * 1000).round(),
+    isUtc: true,
+  );
+}
+
 /// Encryption settings attached to a vector bucket.
 @experimental
 class VectorBucketEncryption {
@@ -68,10 +76,9 @@ class VectorBucket {
   /// The unique name of the vector bucket.
   final String name;
 
-  /// The unix timestamp of when the bucket was created, as returned by the
-  /// server. `null` when the server does not include it (for example in list
-  /// responses).
-  final int? creationTime;
+  /// When the bucket was created, in UTC. `null` when the server does not
+  /// include it (for example in list responses).
+  final DateTime? creationTime;
 
   /// The bucket's encryption configuration, when present.
   final VectorBucketEncryption? encryption;
@@ -86,7 +93,7 @@ class VectorBucket {
     final encryption = json['encryptionConfiguration'];
     return VectorBucket(
       name: json['vectorBucketName'] as String,
-      creationTime: (json['creationTime'] as num?)?.toInt(),
+      creationTime: _parseUnixSeconds(json['creationTime']),
       encryption: encryption is Map<String, dynamic>
           ? VectorBucketEncryption.fromJson(encryption)
           : null,
@@ -118,9 +125,9 @@ class VectorIndex {
   /// Metadata keys that are stored but cannot be used in query filters.
   final List<String>? nonFilterableMetadataKeys;
 
-  /// The unix timestamp of when the index was created, as returned by the
-  /// server.
-  final int? creationTime;
+  /// When the index was created, in UTC. `null` when the server does not
+  /// include it.
+  final DateTime? creationTime;
 
   const VectorIndex({
     required this.name,
@@ -147,7 +154,7 @@ class VectorIndex {
       nonFilterableMetadataKeys: nonFilterableMetadataKeys is List
           ? nonFilterableMetadataKeys.cast<String>()
           : null,
-      creationTime: (json['creationTime'] as num?)?.toInt(),
+      creationTime: _parseUnixSeconds(json['creationTime']),
     );
   }
 }

--- a/packages/storage_client/lib/storage_client.dart
+++ b/packages/storage_client/lib/storage_client.dart
@@ -4,3 +4,5 @@ library;
 export 'src/storage_client.dart';
 export 'src/storage_file_api.dart';
 export 'src/types.dart' hide ToQueryParams;
+export 'src/vector_client.dart';
+export 'src/vector_types.dart';

--- a/packages/storage_client/test/vector_integration_test.dart
+++ b/packages/storage_client/test/vector_integration_test.dart
@@ -1,0 +1,157 @@
+import 'package:storage_client/storage_client.dart';
+import 'package:test/test.dart';
+
+const storageUrl = 'http://127.0.0.1:54421/storage/v1';
+// service_role key of the local Supabase CLI stack (RS256, signed by the
+// committed supabase/signing_keys.json). It bypasses RLS so the tests have
+// unrestricted access.
+const storageKey =
+    'eyJhbGciOiJSUzI1NiIsImtpZCI6IjNkZjU5YWIxLWI4ZWMtNDlkMy05YzkyLThiOWQ0MmNhYzFmZSIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MjA5Njg5NTE5Mn0.jO5vwkRNFZTiVHNjFzaypvWV4aJkKm6TvFsdl0W5x9g7LttQMWMopC7HanUpeFLmg4E9gMb-v1e6f6oZ9e0PHYpsRwEdSOxKfYwKhzFI9DsDGLrX4ueArZuKgaV_bulWpwGKI3xwLugeuCp6N0hYFkXvMmUjaKx9nClWckJ33cchSpgjVQ5YxL8PGrUj2Sjhw-5IyGiwrdPfWjTQmpWnCjePoVrRf2jEMF_VGoxDAEqt72w_HGOrdXRFU5BW9-LkvpfzkrTENrj555JtYP4mkZgvUlrkXFRSh010o3n2UehN5WonfDRzwOeTC56QEbPVS6ubvWGR9luykdMNlXawZA';
+
+// These tests exercise the Storage Vectors API against a live Supabase stack
+// with `[storage.vector] enabled = true`. Each test provisions and tears down
+// its own bucket/index, so they are self-contained and can run in any order.
+void main() {
+  late SupabaseVectorsClient vectors;
+  final runId = DateTime.now().millisecondsSinceEpoch;
+  var counter = 0;
+
+  setUpAll(() {
+    vectors = SupabaseStorageClient(storageUrl, {
+      'Authorization': 'Bearer $storageKey',
+    }).vectors;
+  });
+
+  String uniqueName(String prefix) => '$prefix-$runId-${counter++}';
+
+  group('bucket lifecycle', () {
+    test('create, get, list and delete a vector bucket', () async {
+      final name = uniqueName('vec-bucket');
+
+      await vectors.createBucket(name);
+
+      final bucket = await vectors.getBucket(name);
+      expect(bucket.name, name);
+      expect(bucket.creationTime, isA<DateTime>());
+
+      final list = await vectors.listBuckets(prefix: name);
+      expect(list.buckets.map((bucket) => bucket.name), contains(name));
+
+      await vectors.deleteBucket(name);
+      await expectLater(
+        vectors.getBucket(name),
+        throwsA(isA<StorageException>()),
+      );
+    });
+  });
+
+  group('index and vector operations', () {
+    late String bucketName;
+    late StorageVectorBucketApi bucket;
+    late StorageVectorIndexApi index;
+
+    setUp(() async {
+      bucketName = uniqueName('vec-idx');
+      await vectors.createBucket(bucketName);
+      bucket = vectors.from(bucketName);
+      await bucket.createIndex(
+        name: 'idx',
+        dimension: 3,
+        distanceMetric: DistanceMetric.cosine,
+      );
+      index = bucket.index('idx');
+    });
+
+    tearDown(() async {
+      try {
+        await bucket.deleteIndex('idx');
+      } catch (_) {}
+      try {
+        await vectors.deleteBucket(bucketName);
+      } catch (_) {}
+    });
+
+    test('get and list indexes', () async {
+      final fetched = await bucket.getIndex('idx');
+      expect(fetched.name, 'idx');
+      expect(fetched.bucketName, bucketName);
+      expect(fetched.dataType, VectorDataType.float32);
+      expect(fetched.dimension, 3);
+      expect(fetched.distanceMetric, DistanceMetric.cosine);
+      expect(fetched.creationTime, isA<DateTime>());
+
+      final list = await bucket.listIndexes();
+      expect(list.indexes.map((index) => index.name), contains('idx'));
+    });
+
+    test('put, get and list vectors', () async {
+      await index.putVectors([
+        Vector(key: 'a', data: [0.1, 0.2, 0.3], metadata: {'label': 'first'}),
+        Vector(key: 'b', data: [0.4, 0.5, 0.6]),
+      ]);
+
+      final fetched = await index.getVectors(
+        keys: ['a'],
+        returnData: true,
+        returnMetadata: true,
+      );
+      expect(fetched.single.key, 'a');
+      expect(fetched.single.data, hasLength(3));
+      expect(fetched.single.metadata?['label'], 'first');
+
+      final listed = await index.listVectors();
+      expect(
+        listed.vectors.map((vector) => vector.key),
+        containsAll(['a', 'b']),
+      );
+    });
+
+    test('query returns the nearest vector first', () async {
+      await index.putVectors([
+        Vector(key: 'near', data: [0.1, 0.2, 0.3]),
+        Vector(key: 'far', data: [0.9, 0.1, 0.05]),
+      ]);
+
+      final result = await index.queryVectors(
+        queryVector: [0.1, 0.2, 0.3],
+        topK: 2,
+        returnDistance: true,
+      );
+
+      expect(result.distanceMetric, DistanceMetric.cosine);
+      expect(result.matches.first.key, 'near');
+      expect(result.matches.first.distance, isNotNull);
+    });
+
+    test('delete removes vectors', () async {
+      await index.putVectors([
+        Vector(key: 'a', data: [0.1, 0.2, 0.3]),
+        Vector(key: 'b', data: [0.4, 0.5, 0.6]),
+      ]);
+
+      await index.deleteVectors(['a']);
+
+      final remaining = await index.getVectors(keys: ['a', 'b']);
+      expect(remaining.map((vector) => vector.key), ['b']);
+    });
+
+    test('parallel scan segments cover every vector', () async {
+      await index.putVectors([
+        Vector(key: 'a', data: [0.1, 0.2, 0.3]),
+        Vector(key: 'b', data: [0.4, 0.5, 0.6]),
+        Vector(key: 'c', data: [0.7, 0.8, 0.9]),
+      ]);
+
+      final keys = <String>{};
+      for (var segment = 0; segment < 2; segment++) {
+        final page = await index.listVectors(
+          segmentCount: 2,
+          segmentIndex: segment,
+        );
+        keys.addAll(page.vectors.map((vector) => vector.key));
+      }
+
+      expect(keys, {'a', 'b', 'c'});
+    });
+  });
+}

--- a/packages/storage_client/test/vector_integration_test.dart
+++ b/packages/storage_client/test/vector_integration_test.dart
@@ -35,7 +35,7 @@ void main() {
       expect(bucket.creationTime, isA<DateTime>());
 
       final list = await vectors.listBuckets(prefix: name);
-      expect(list.buckets.map((bucket) => bucket.name), contains(name));
+      expect(list.buckets.map((entry) => entry.name), contains(name));
 
       await vectors.deleteBucket(name);
       await expectLater(
@@ -81,7 +81,7 @@ void main() {
       expect(fetched.creationTime, isA<DateTime>());
 
       final list = await bucket.listIndexes();
-      expect(list.indexes.map((index) => index.name), contains('idx'));
+      expect(list.indexes.map((entry) => entry.name), contains('idx'));
     });
 
     test('put, get and list vectors', () async {

--- a/packages/storage_client/test/vector_test.dart
+++ b/packages/storage_client/test/vector_test.dart
@@ -57,7 +57,10 @@ void main() {
         'http://localhost/storage/v1/vector/GetVectorBucket',
       );
       expect(bucket.name, 'embeddings');
-      expect(bucket.creationTime, 1700000000);
+      expect(
+        bucket.creationTime,
+        DateTime.fromMillisecondsSinceEpoch(1700000000 * 1000, isUtc: true),
+      );
       expect(bucket.encryption?.sseType, 'AES256');
     });
 

--- a/packages/storage_client/test/vector_test.dart
+++ b/packages/storage_client/test/vector_test.dart
@@ -1,0 +1,366 @@
+import 'dart:convert';
+
+import 'package:http/http.dart';
+import 'package:storage_client/storage_client.dart';
+import 'package:test/test.dart';
+
+import 'custom_http_client.dart';
+
+const storageUrl = 'http://localhost/storage/v1';
+const headers = {'Authorization': 'Bearer token'};
+
+void main() {
+  late CustomHttpClient mockClient;
+  late SupabaseVectorsClient vectors;
+
+  setUp(() {
+    mockClient = CustomHttpClient();
+    mockClient.statusCode = 200;
+    mockClient.response = <String, dynamic>{};
+    vectors = SupabaseStorageClient(
+      storageUrl,
+      headers,
+      httpClient: mockClient,
+    ).vectors;
+  });
+
+  Request lastRequest() => mockClient.receivedRequests.single as Request;
+
+  Map<String, dynamic> lastBody() =>
+      jsonDecode(lastRequest().body) as Map<String, dynamic>;
+
+  group('vector buckets', () {
+    test('createBucket posts the bucket name', () async {
+      await vectors.createBucket('embeddings');
+
+      expect(
+        lastRequest().url.toString(),
+        'http://localhost/storage/v1/vector/CreateVectorBucket',
+      );
+      expect(lastRequest().method, 'POST');
+      expect(lastBody(), {'vectorBucketName': 'embeddings'});
+    });
+
+    test('getBucket parses the bucket metadata', () async {
+      mockClient.response = {
+        'vectorBucket': {
+          'vectorBucketName': 'embeddings',
+          'creationTime': 1700000000,
+          'encryptionConfiguration': {'sseType': 'AES256'},
+        },
+      };
+
+      final bucket = await vectors.getBucket('embeddings');
+
+      expect(
+        lastRequest().url.toString(),
+        'http://localhost/storage/v1/vector/GetVectorBucket',
+      );
+      expect(bucket.name, 'embeddings');
+      expect(bucket.creationTime, 1700000000);
+      expect(bucket.encryption?.sseType, 'AES256');
+    });
+
+    test('listBuckets sends filters and parses buckets and cursor', () async {
+      mockClient.response = {
+        'vectorBuckets': [
+          {'vectorBucketName': 'embeddings-a'},
+          {'vectorBucketName': 'embeddings-b'},
+        ],
+        'nextToken': 'cursor-1',
+      };
+
+      final result = await vectors.listBuckets(
+        prefix: 'embeddings-',
+        maxResults: 10,
+      );
+
+      expect(lastBody(), {'prefix': 'embeddings-', 'maxResults': 10});
+      expect(result.buckets.map((bucket) => bucket.name), [
+        'embeddings-a',
+        'embeddings-b',
+      ]);
+      expect(result.nextToken, 'cursor-1');
+    });
+
+    test('deleteBucket posts the bucket name', () async {
+      await vectors.deleteBucket('embeddings');
+
+      expect(
+        lastRequest().url.toString(),
+        'http://localhost/storage/v1/vector/DeleteVectorBucket',
+      );
+      expect(lastBody(), {'vectorBucketName': 'embeddings'});
+    });
+  });
+
+  group('vector indexes', () {
+    test('createIndex sends the full configuration', () async {
+      await vectors
+          .from('embeddings')
+          .createIndex(
+            name: 'documents',
+            dimension: 1536,
+            distanceMetric: DistanceMetric.cosine,
+            nonFilterableMetadataKeys: ['raw_text'],
+          );
+
+      expect(
+        lastRequest().url.toString(),
+        'http://localhost/storage/v1/vector/CreateIndex',
+      );
+      expect(lastBody(), {
+        'vectorBucketName': 'embeddings',
+        'indexName': 'documents',
+        'dataType': 'float32',
+        'dimension': 1536,
+        'distanceMetric': 'cosine',
+        'metadataConfiguration': {
+          'nonFilterableMetadataKeys': ['raw_text'],
+        },
+      });
+    });
+
+    test('getIndex parses the index metadata', () async {
+      mockClient.response = {
+        'index': {
+          'indexName': 'documents',
+          'vectorBucketName': 'embeddings',
+          'dataType': 'float32',
+          'dimension': 1536,
+          'distanceMetric': 'euclidean',
+          'metadataConfiguration': {
+            'nonFilterableMetadataKeys': ['raw_text'],
+          },
+        },
+      };
+
+      final index = await vectors.from('embeddings').getIndex('documents');
+
+      expect(index.name, 'documents');
+      expect(index.bucketName, 'embeddings');
+      expect(index.dataType, VectorDataType.float32);
+      expect(index.dimension, 1536);
+      expect(index.distanceMetric, DistanceMetric.euclidean);
+      expect(index.nonFilterableMetadataKeys, ['raw_text']);
+    });
+
+    test('getIndex leaves unknown enum values null', () async {
+      mockClient.response = {
+        'index': {
+          'indexName': 'documents',
+          'distanceMetric': 'manhattan',
+        },
+      };
+
+      final index = await vectors.from('embeddings').getIndex('documents');
+
+      expect(index.distanceMetric, isNull);
+    });
+
+    test('listIndexes parses indexes and cursor', () async {
+      mockClient.response = {
+        'indexes': [
+          {'indexName': 'documents'},
+          {'indexName': 'images'},
+        ],
+        'nextToken': 'cursor-2',
+      };
+
+      final result = await vectors.from('embeddings').listIndexes();
+
+      expect(result.indexes.map((index) => index.name), [
+        'documents',
+        'images',
+      ]);
+      expect(result.nextToken, 'cursor-2');
+    });
+
+    test('deleteIndex posts the bucket and index names', () async {
+      await vectors.from('embeddings').deleteIndex('documents');
+
+      expect(lastBody(), {
+        'vectorBucketName': 'embeddings',
+        'indexName': 'documents',
+      });
+    });
+  });
+
+  group('vector data', () {
+    StorageVectorIndexApi index() =>
+        vectors.from('embeddings').index('documents');
+
+    test('putVectors serializes the batch', () async {
+      await index().putVectors([
+        Vector(key: 'doc-1', data: [0.1, 0.2, 0.3], metadata: {'page': 1}),
+        Vector(key: 'doc-2', data: [0.4, 0.5, 0.6]),
+      ]);
+
+      expect(
+        lastRequest().url.toString(),
+        'http://localhost/storage/v1/vector/PutVectors',
+      );
+      expect(lastBody(), {
+        'vectorBucketName': 'embeddings',
+        'indexName': 'documents',
+        'vectors': [
+          {
+            'key': 'doc-1',
+            'data': {
+              'float32': [0.1, 0.2, 0.3],
+            },
+            'metadata': {'page': 1},
+          },
+          {
+            'key': 'doc-2',
+            'data': {
+              'float32': [0.4, 0.5, 0.6],
+            },
+          },
+        ],
+      });
+    });
+
+    test('putVectors rejects an empty batch', () {
+      expect(
+        index().putVectors([]),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('putVectors rejects a batch larger than 500', () {
+      final batch = List.generate(
+        501,
+        (i) => Vector(key: 'doc-$i', data: const [0.1]),
+      );
+      expect(
+        index().putVectors(batch),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('getVectors parses the returned vectors', () async {
+      mockClient.response = {
+        'vectors': [
+          {
+            'key': 'doc-1',
+            'data': {
+              'float32': [0.1, 0.2, 0.3],
+            },
+            'metadata': {'title': 'Intro'},
+          },
+        ],
+      };
+
+      final result = await index().getVectors(
+        keys: ['doc-1'],
+        returnData: true,
+        returnMetadata: true,
+      );
+
+      expect(lastBody(), {
+        'vectorBucketName': 'embeddings',
+        'indexName': 'documents',
+        'keys': ['doc-1'],
+        'returnData': true,
+        'returnMetadata': true,
+      });
+      expect(result.single.key, 'doc-1');
+      expect(result.single.data, [0.1, 0.2, 0.3]);
+      expect(result.single.metadata, {'title': 'Intro'});
+    });
+
+    test('listVectors parses vectors and cursor', () async {
+      mockClient.response = {
+        'vectors': [
+          {'key': 'doc-1'},
+          {'key': 'doc-2'},
+        ],
+        'nextToken': 'cursor-3',
+      };
+
+      final result = await index().listVectors(maxResults: 2);
+
+      expect(result.vectors.map((vector) => vector.key), ['doc-1', 'doc-2']);
+      expect(result.nextToken, 'cursor-3');
+    });
+
+    test('listVectors sends parallel scan segments', () async {
+      await index().listVectors(segmentCount: 4, segmentIndex: 2);
+
+      expect(lastBody(), {
+        'vectorBucketName': 'embeddings',
+        'indexName': 'documents',
+        'segmentCount': 4,
+        'segmentIndex': 2,
+      });
+    });
+
+    test('listVectors rejects an out-of-range segmentCount', () {
+      expect(
+        index().listVectors(segmentCount: 17),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('listVectors rejects a segmentIndex outside the segment count', () {
+      expect(
+        index().listVectors(segmentCount: 4, segmentIndex: 4),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('queryVectors sends the query vector and parses matches', () async {
+      mockClient.response = {
+        'vectors': [
+          {
+            'key': 'doc-1',
+            'distance': 0.02,
+            'metadata': {'title': 'Intro'},
+          },
+        ],
+        'distanceMetric': 'cosine',
+      };
+
+      final result = await index().queryVectors(
+        queryVector: [0.1, 0.2, 0.3],
+        topK: 5,
+        filter: {'category': 'technical'},
+        returnDistance: true,
+        returnMetadata: true,
+      );
+
+      expect(lastBody(), {
+        'vectorBucketName': 'embeddings',
+        'indexName': 'documents',
+        'queryVector': {
+          'float32': [0.1, 0.2, 0.3],
+        },
+        'topK': 5,
+        'filter': {'category': 'technical'},
+        'returnDistance': true,
+        'returnMetadata': true,
+      });
+      expect(result.matches.single.key, 'doc-1');
+      expect(result.matches.single.distance, 0.02);
+      expect(result.distanceMetric, DistanceMetric.cosine);
+    });
+
+    test('deleteVectors posts the keys', () async {
+      await index().deleteVectors(['doc-1', 'doc-2']);
+
+      expect(lastBody(), {
+        'vectorBucketName': 'embeddings',
+        'indexName': 'documents',
+        'keys': ['doc-1', 'doc-2'],
+      });
+    });
+
+    test('deleteVectors rejects an empty batch', () {
+      expect(
+        index().deleteVectors([]),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+  });
+}

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -469,20 +469,135 @@ features:
   storage.file_buckets.empty_bucket: implemented
 
   # storage — vector buckets
-  storage.vector_buckets.create_vector_bucket: not_implemented
-  storage.vector_buckets.list_vector_buckets: not_implemented
-  storage.vector_buckets.delete_vector_bucket: not_implemented
-  storage.vector_buckets.access_vector_index: not_implemented
-  storage.vector_buckets.create_index: not_implemented
-  storage.vector_buckets.get_index: not_implemented
-  storage.vector_buckets.list_indexes: not_implemented
-  storage.vector_buckets.delete_index: not_implemented
-  storage.vector_buckets.put_vectors: not_implemented
-  storage.vector_buckets.get_vectors: not_implemented
-  storage.vector_buckets.list_vectors: not_implemented
-  storage.vector_buckets.delete_vectors: not_implemented
-  storage.vector_buckets.query_vectors: not_implemented
-  storage.vector_buckets.parallel_scan: not_implemented
+  storage.vector_buckets.create_vector_bucket:
+    status: implemented
+    note: "Reached through storage.vectors (SupabaseVectorsClient). Operations return the parsed data directly and throw a StorageException on failure, matching the rest of the Dart storage client rather than the {data, error} envelope used by supabase-js."
+    symbols:
+      - SupabaseStorageClient.vectors
+      - SupabaseVectorsClient
+      - SupabaseVectorsClient.createBucket
+  storage.vector_buckets.list_vector_buckets:
+    status: implemented
+    symbols:
+      - SupabaseVectorsClient.listBuckets
+      - SupabaseVectorsClient.getBucket
+      - VectorBucket
+      - VectorBucket.VectorBucket
+      - VectorBucket.name
+      - VectorBucket.creationTime
+      - VectorBucket.encryption
+      - VectorBucket.fromJson
+      - VectorBucketEncryption
+      - VectorBucketEncryption.VectorBucketEncryption
+      - VectorBucketEncryption.kmsKeyArn
+      - VectorBucketEncryption.sseType
+      - VectorBucketEncryption.fromJson
+      - VectorBucketList
+      - VectorBucketList.VectorBucketList
+      - VectorBucketList.buckets
+      - VectorBucketList.nextToken
+      - VectorBucketList.fromJson
+  storage.vector_buckets.delete_vector_bucket:
+    status: implemented
+    symbols:
+      - SupabaseVectorsClient.deleteBucket
+  storage.vector_buckets.access_vector_index:
+    status: implemented
+    note: "Scoping mirrors supabase-js: vectors.from(bucket) returns a bucket-scoped client and .index(name) an index-scoped client."
+    symbols:
+      - SupabaseVectorsClient.from
+      - StorageVectorBucketApi
+      - StorageVectorBucketApi.bucketName
+      - StorageVectorBucketApi.index
+      - StorageVectorIndexApi
+      - StorageVectorIndexApi.bucketName
+      - StorageVectorIndexApi.indexName
+  storage.vector_buckets.create_index:
+    status: implemented
+    note: "metadataConfiguration is flattened to a nonFilterableMetadataKeys parameter, and dataType/distanceMetric are Dart enums rather than open strings."
+    symbols:
+      - StorageVectorBucketApi.createIndex
+      - VectorDataType
+      - VectorDataType.VectorDataType
+      - VectorDataType.value
+      - DistanceMetric
+      - DistanceMetric.DistanceMetric
+      - DistanceMetric.value
+  storage.vector_buckets.get_index:
+    status: implemented
+    symbols:
+      - StorageVectorBucketApi.getIndex
+      - VectorIndex
+      - VectorIndex.VectorIndex
+      - VectorIndex.name
+      - VectorIndex.bucketName
+      - VectorIndex.dataType
+      - VectorIndex.dimension
+      - VectorIndex.distanceMetric
+      - VectorIndex.nonFilterableMetadataKeys
+      - VectorIndex.creationTime
+      - VectorIndex.fromJson
+  storage.vector_buckets.list_indexes:
+    status: implemented
+    symbols:
+      - StorageVectorBucketApi.listIndexes
+      - VectorIndexList
+      - VectorIndexList.VectorIndexList
+      - VectorIndexList.indexes
+      - VectorIndexList.nextToken
+      - VectorIndexList.fromJson
+  storage.vector_buckets.delete_index:
+    status: implemented
+    symbols:
+      - StorageVectorBucketApi.deleteIndex
+  storage.vector_buckets.put_vectors:
+    status: implemented
+    note: "Batch size (1-500) is validated client-side and an ArgumentError is thrown when out of range."
+    symbols:
+      - StorageVectorIndexApi.putVectors
+      - Vector
+      - Vector.Vector
+      - Vector.key
+      - Vector.data
+      - Vector.metadata
+      - Vector.toJson
+  storage.vector_buckets.get_vectors:
+    status: implemented
+    symbols:
+      - StorageVectorIndexApi.getVectors
+      - VectorMatch
+      - VectorMatch.VectorMatch
+      - VectorMatch.key
+      - VectorMatch.data
+      - VectorMatch.metadata
+      - VectorMatch.distance
+      - VectorMatch.fromJson
+  storage.vector_buckets.list_vectors:
+    status: implemented
+    symbols:
+      - StorageVectorIndexApi.listVectors
+      - VectorList
+      - VectorList.VectorList
+      - VectorList.vectors
+      - VectorList.nextToken
+      - VectorList.fromJson
+  storage.vector_buckets.delete_vectors:
+    status: implemented
+    note: "Batch size (1-500) is validated client-side and an ArgumentError is thrown when out of range."
+    symbols:
+      - StorageVectorIndexApi.deleteVectors
+  storage.vector_buckets.query_vectors:
+    status: implemented
+    symbols:
+      - StorageVectorIndexApi.queryVectors
+      - VectorQueryResult
+      - VectorQueryResult.VectorQueryResult
+      - VectorQueryResult.matches
+      - VectorQueryResult.distanceMetric
+      - VectorQueryResult.fromJson
+  storage.vector_buckets.parallel_scan:
+    status: implemented
+    note: "Exposed through listVectors' segmentCount/segmentIndex parameters rather than a separate method; both are validated client-side."
 
   # storage — analytics (Iceberg) buckets
   storage.analytics.create_analytics_bucket: not_implemented

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -518,10 +518,8 @@ features:
     symbols:
       - StorageVectorBucketApi.createIndex
       - VectorDataType
-      - VectorDataType.VectorDataType
       - VectorDataType.value
       - DistanceMetric
-      - DistanceMetric.DistanceMetric
       - DistanceMetric.value
   storage.vector_buckets.get_index:
     status: implemented

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -516,8 +516,10 @@ features:
       - StorageVectorBucketApi.createIndex
       - VectorDataType
       - VectorDataType.value
+      - VectorDataType.fromValue
       - DistanceMetric
       - DistanceMetric.value
+      - DistanceMetric.fromValue
   storage.vector_buckets.get_index:
     status: implemented
     symbols:

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -471,7 +471,6 @@ features:
   # storage — vector buckets
   storage.vector_buckets.create_vector_bucket:
     status: implemented
-    note: "Reached through storage.vectors (SupabaseVectorsClient). Operations return the parsed data directly and throw a StorageException on failure, matching the rest of the Dart storage client rather than the {data, error} envelope used by supabase-js."
     symbols:
       - SupabaseStorageClient.vectors
       - SupabaseVectorsClient
@@ -503,7 +502,6 @@ features:
       - SupabaseVectorsClient.deleteBucket
   storage.vector_buckets.access_vector_index:
     status: implemented
-    note: "Scoping mirrors supabase-js: vectors.from(bucket) returns a bucket-scoped client and .index(name) an index-scoped client."
     symbols:
       - SupabaseVectorsClient.from
       - StorageVectorBucketApi
@@ -514,7 +512,6 @@ features:
       - StorageVectorIndexApi.indexName
   storage.vector_buckets.create_index:
     status: implemented
-    note: "metadataConfiguration is flattened to a nonFilterableMetadataKeys parameter, and dataType/distanceMetric are Dart enums rather than open strings."
     symbols:
       - StorageVectorBucketApi.createIndex
       - VectorDataType
@@ -550,7 +547,6 @@ features:
       - StorageVectorBucketApi.deleteIndex
   storage.vector_buckets.put_vectors:
     status: implemented
-    note: "Batch size (1-500) is validated client-side and an ArgumentError is thrown when out of range."
     symbols:
       - StorageVectorIndexApi.putVectors
       - Vector
@@ -581,7 +577,6 @@ features:
       - VectorList.fromJson
   storage.vector_buckets.delete_vectors:
     status: implemented
-    note: "Batch size (1-500) is validated client-side and an ArgumentError is thrown when out of range."
     symbols:
       - StorageVectorIndexApi.deleteVectors
   storage.vector_buckets.query_vectors:

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -149,7 +149,7 @@ max_catalogs = 2
 
 # Store vector embeddings in S3 for large and durable datasets
 [storage.vector]
-enabled = false
+enabled = true
 max_buckets = 10
 max_indexes = 5
 


### PR DESCRIPTION
## What

Implements the Storage **Vector Buckets** subsystem in `storage_client`, closing all 14 `storage.vector_buckets.*` gaps in the compliance matrix.

Reachable through `supabase.storage.vectors`, mirroring the supabase-js `StorageVectorsClient` structure while staying idiomatic to the Dart storage client (operations return parsed data directly and throw `StorageException` on failure instead of a `{data, error}` envelope).

```dart
final vectors = supabase.storage.vectors;
await vectors.createBucket('embeddings');

final bucket = vectors.from('embeddings');
await bucket.createIndex(
  name: 'documents',
  dimension: 1536,
  distanceMetric: DistanceMetric.cosine,
);

final index = bucket.index('documents');
await index.putVectors([
  Vector(key: 'doc-1', data: [0.1, 0.2, 0.3], metadata: {'title': 'Intro'}),
]);

final result = await index.queryVectors(queryVector: [0.1, 0.2, 0.3], topK: 5);
```

## Capabilities

Bucket & index management (`SupabaseVectorsClient`, `StorageVectorBucketApi`):
- create / list / delete vector bucket, get bucket metadata
- scope to a bucket via `.from(name)` and to an index via `.index(name)`
- create / get / list / delete index

Vector data operations (`StorageVectorIndexApi`):
- put / get / list / query / delete vectors
- parallel scan via `listVectors`' `segmentCount` / `segmentIndex`

## Idiomatic Dart choices

- `dataType` and `distanceMetric` are enums (`VectorDataType`, `DistanceMetric`), parsed leniently (unknown values decode to `null` for forward compatibility).
- `metadataConfiguration` is flattened to a `nonFilterableMetadataKeys` parameter.
- Batch sizes (put/delete 1-500) and parallel-scan segments (1-16) are validated client-side with `ArgumentError`.

## Tests

- 20 self-contained unit tests using the mock HTTP client, verifying request URLs/bodies and response parsing for every operation, plus the validation paths.

## Compliance matrix

- All 14 `storage.vector_buckets.*` features set to `implemented` with every new public symbol registered. The symbol check and compliance-file validator both pass locally.

Closes SDK-1307.
