### PR TITLE
ci: run WASM tests in a separate workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -296,11 +296,6 @@ jobs:
         if: ${{ matrix.os == 'ubuntu-latest' && matrix.flutter-version == 'latest'}}
         run: flutter test --platform chrome
 
-      - name: Build example for web (WASM)
-        if: ${{ matrix.os == 'ubuntu-latest' && matrix.flutter-version == 'latest'}}
-        working-directory: packages/supabase_flutter/example
-        run: flutter build web --wasm
-
   dcm:
     name: DCM
     needs: changes

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -1,0 +1,124 @@
+name: WASM
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  changes:
+    name: Detect affected packages
+    runs-on: ubuntu-latest
+    outputs:
+      flutter: ${{ steps.detect.outputs.flutter }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Setup Dart
+        uses: dart-lang/setup-dart@e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c # v1.7.1
+        with:
+          sdk: stable
+
+      - name: Detect affected packages
+        id: detect
+        run: |
+          set -euo pipefail
+
+          dart pub global activate melos
+
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE="${{ github.event.pull_request.base.sha }}"
+          else
+            BASE="${{ github.event.before }}"
+          fi
+
+          FORCE_ALL=false
+          if [ -z "$BASE" ] || [ "$BASE" = "0000000000000000000000000000000000000000" ]; then
+            FORCE_ALL=true
+          elif git diff --name-only "$BASE...HEAD" \
+              | grep -qE '^(\.github/workflows/wasm\.yml|pubspec\.yaml|pubspec\.lock|supabase/)'; then
+            FORCE_ALL=true
+          fi
+
+          if [ "$FORCE_ALL" = "true" ]; then
+            echo "Running all packages."
+            CHANGED=$(melos list --json | jq -r '.[].name')
+          else
+            CHANGED=$(melos list --json --diff="$BASE...HEAD" --include-dependents | jq -r '.[].name')
+          fi
+
+          echo "Affected packages:"
+          echo "$CHANGED"
+
+          if echo "$CHANGED" | grep -qx "supabase_flutter"; then
+            echo "flutter=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "flutter=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  test-wasm:
+    name: Test and build WASM
+    needs: changes
+    if: ${{ needs.changes.outputs.flutter == 'true' }}
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: packages/supabase_flutter
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
+        with:
+          channel: 'stable'
+          # Caching the latest stable is flaky: the cached SDK contains
+          # runner-image-specific binaries that break silently when the runner
+          # image is updated.
+          cache: false
+
+      - name: Show Flutter version
+        run: flutter --version
+
+      - name: Bootstrap workspace
+        run: |
+          cd ../../
+          dart pub global activate melos
+          melos bootstrap
+
+      - name: Test web (WASM)
+        # Serial compilation avoids the memory pressure from parallel dart2wasm
+        # runs that previously caused suite loading timeouts in CI.
+        run: flutter test --platform chrome --wasm --concurrency=1
+
+      - name: Build example for web (WASM)
+        working-directory: packages/supabase_flutter/example
+        run: flutter build web --wasm
+
+  wasm-result:
+    name: WASM result
+    needs: [changes, test-wasm]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify all jobs succeeded
+        run: |
+          if ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}; then
+            echo "One or more jobs failed or were cancelled."
+            exit 1
+          fi
+          echo "All required jobs passed or were skipped."


### PR DESCRIPTION
## What

Fixes [SDK-670](https://linear.app/supabase/issue/SDK-670/fix-wasm-tests-failing-in-ci-for-supabase-flutter).

Re-enables the previously disabled `flutter test --platform chrome --wasm` step for `supabase_flutter` and moves all WASM work into a dedicated `wasm.yml` workflow so it no longer slows down the main `Test` workflow.

## Root cause

The WASM tests were disabled in #1341 due to "12min+ loading timeouts" in CI. Running the tests locally passes in ~10 seconds even with a cleared test cache, so the tests themselves are fine. The historical failure was CI resource contention: `flutter test` compiles multiple test suites in parallel, and parallel `dart2wasm` runs are memory-heavy enough to make the Dart test runner's suite-loading step hit its 12-minute timeout on the runner.

## Changes

- **New `.github/workflows/wasm.yml`** (separate workflow):
  - Same affected-package detection as `test.yml`/`build.yml` (only runs when `supabase_flutter` is affected).
  - Runs `flutter test --platform chrome --wasm --concurrency=1`. Serial compilation avoids the memory pressure that caused the timeouts.
  - Runs the example `flutter build web --wasm`.
  - `wasm-result` gate job mirroring the existing pattern.
- **`.github/workflows/test.yml`**: removed the `Build example for web (WASM)` step (moved into `wasm.yml`); the JS web test stays in place.

## Verification

- `flutter test --platform chrome --wasm --concurrency=1` locally: all tests pass.
- `flutter build web --wasm` for the example: builds successfully.