### PR TITLE
feat(realtime): defer socket disconnect when channels become empty

### DIFF
--- a/packages/realtime_client/lib/src/realtime_client.dart
+++ b/packages/realtime_client/lib/src/realtime_client.dart
@@ -113,6 +113,17 @@ class RealtimeClient {
   int heartbeatIntervalMs = Constants.defaultHeartbeatIntervalMs;
   Timer? heartbeatTimer;
 
+  /// Delay before the socket is disconnected once the last channel has been
+  /// removed. A value of `0` disconnects immediately. Defaults to
+  /// `2 * heartbeatIntervalMs`.
+  late final int disconnectOnEmptyChannelsAfterMs;
+
+  /// Timer that fires the deferred disconnect once all channels are gone.
+  ///
+  /// Cancelled when a new channel is created or the client disconnects before
+  /// it fires, so that quickly switching channels reuses the open socket.
+  Timer? _pendingDisconnectTimer;
+
   /// reference ID of the most recently sent heartbeat.
   ///
   /// Used to keep track of whether the client is connected to the server.
@@ -161,6 +172,12 @@ class RealtimeClient {
   ///
   /// [heartbeatIntervalMs] The millisec interval to send a heartbeat message.
   ///
+  /// [disconnectOnEmptyChannelsAfterMs] The millisec delay before disconnecting
+  /// the socket once the last channel is removed. If a new channel is created
+  /// before the delay elapses, the pending disconnect is cancelled and the open
+  /// socket is reused. Pass `0` to disconnect immediately. Defaults to
+  /// `2 * heartbeatIntervalMs`.
+  ///
   /// [logger] The optional function for specialized logging, ie: logger: (kind, message, data) => { console.log(`$kind: $message`, data) }
   ///
   /// [encode] Overrides how outgoing messages are serialized, for example to
@@ -182,6 +199,7 @@ class RealtimeClient {
     this.timeout = Constants.defaultTimeout,
     this.connectionCloseTimeout = Constants.defaultConnectionCloseTimeout,
     this.heartbeatIntervalMs = Constants.defaultHeartbeatIntervalMs,
+    int? disconnectOnEmptyChannelsAfterMs,
     this.logger,
     RealtimeEncode? encode,
     RealtimeDecode? decode,
@@ -221,6 +239,9 @@ class RealtimeClient {
     _log.finest('Initialize with headers: $headers, params: $params');
     final customJWT = this.headers['Authorization']?.split(' ').last;
     accessToken = customJWT ?? params['apikey'];
+
+    this.disconnectOnEmptyChannelsAfterMs =
+        disconnectOnEmptyChannelsAfterMs ?? 2 * heartbeatIntervalMs;
 
     this.reconnectAfterMs =
         reconnectAfterMs ?? RetryTimer.createRetryFunction();
@@ -299,6 +320,7 @@ class RealtimeClient {
 
   /// Disconnects the socket with status [code] and [reason] for the disconnect
   Future<void> disconnect({int? code, String? reason}) async {
+    _cancelPendingDisconnect();
     final conn = this.conn;
     if (conn != null) {
       final oldState = connState;
@@ -367,9 +389,6 @@ class RealtimeClient {
 
   Future<String> removeChannel(RealtimeChannel channel) async {
     final status = await channel.unsubscribe();
-    if (channels.isEmpty) {
-      unawaited(disconnect());
-    }
     return status;
   }
 
@@ -377,7 +396,7 @@ class RealtimeClient {
     final values = await Future.wait(
       channels.map((channel) => channel.unsubscribe()),
     );
-    unawaited(disconnect());
+    await disconnect();
     return values;
   }
 
@@ -438,6 +457,10 @@ class RealtimeClient {
   @internal
   void remove(RealtimeChannel channel) {
     channels = channels.where((c) => c.joinRef != channel.joinRef).toList();
+    if (channels.isEmpty) {
+      log('transport', 'no channels remaining, scheduling disconnect');
+      _schedulePendingDisconnect();
+    }
   }
 
   RealtimeChannel channel(
@@ -445,8 +468,49 @@ class RealtimeClient {
     RealtimeChannelConfig config = const RealtimeChannelConfig(),
   ]) {
     final newChannel = RealtimeChannel('realtime:$topic', this, params: config);
+    _cancelPendingDisconnect();
     channels.add(newChannel);
     return newChannel;
+  }
+
+  /// Schedules a disconnect once the last channel is removed.
+  ///
+  /// When [disconnectOnEmptyChannelsAfterMs] is `0` the socket disconnects
+  /// immediately, otherwise the disconnect is deferred so that a channel
+  /// created within the delay can reuse the open socket.
+  void _schedulePendingDisconnect() {
+    _cancelPendingDisconnect();
+    if (disconnectOnEmptyChannelsAfterMs == 0) {
+      log('transport', 'disconnecting immediately - no channels');
+      unawaited(disconnect());
+      return;
+    }
+    _pendingDisconnectTimer = Timer(
+      Duration(milliseconds: disconnectOnEmptyChannelsAfterMs),
+      () {
+        _pendingDisconnectTimer = null;
+        if (channels.isEmpty) {
+          log(
+            'transport',
+            'deferred disconnect fired - no channels, disconnecting',
+          );
+          unawaited(disconnect());
+        }
+      },
+    );
+    log(
+      'transport',
+      'deferred disconnect scheduled in ${disconnectOnEmptyChannelsAfterMs}ms',
+    );
+  }
+
+  /// Cancels a scheduled disconnect when channel activity is detected.
+  void _cancelPendingDisconnect() {
+    if (_pendingDisconnectTimer != null) {
+      log('transport', 'pending disconnect cancelled - channel activity');
+      _pendingDisconnectTimer!.cancel();
+      _pendingDisconnectTimer = null;
+    }
   }
 
   /// Push out a message if the socket is connected.

--- a/packages/realtime_client/lib/src/realtime_client.dart
+++ b/packages/realtime_client/lib/src/realtime_client.dart
@@ -114,9 +114,10 @@ class RealtimeClient {
   Timer? heartbeatTimer;
 
   /// Delay before the socket is disconnected once the last channel has been
-  /// removed. A value of `0` disconnects immediately. Defaults to
-  /// `2 * heartbeatIntervalMs`.
-  late final int disconnectOnEmptyChannelsAfterMs;
+  /// removed. [Duration.zero] disconnects immediately. Defaults to twice the
+  /// heartbeat interval.
+  @internal
+  late final Duration disconnectOnEmptyChannelsAfter;
 
   /// Timer that fires the deferred disconnect once all channels are gone.
   ///
@@ -172,11 +173,11 @@ class RealtimeClient {
   ///
   /// [heartbeatIntervalMs] The millisec interval to send a heartbeat message.
   ///
-  /// [disconnectOnEmptyChannelsAfterMs] The millisec delay before disconnecting
-  /// the socket once the last channel is removed. If a new channel is created
-  /// before the delay elapses, the pending disconnect is cancelled and the open
-  /// socket is reused. Pass `0` to disconnect immediately. Defaults to
-  /// `2 * heartbeatIntervalMs`.
+  /// [disconnectOnEmptyChannelsAfter] The delay before disconnecting the socket
+  /// once the last channel is removed. If a new channel is created before the
+  /// delay elapses, the pending disconnect is cancelled and the open socket is
+  /// reused. Pass [Duration.zero] to disconnect immediately. Defaults to twice
+  /// the heartbeat interval.
   ///
   /// [logger] The optional function for specialized logging, ie: logger: (kind, message, data) => { console.log(`$kind: $message`, data) }
   ///
@@ -199,7 +200,7 @@ class RealtimeClient {
     this.timeout = Constants.defaultTimeout,
     this.connectionCloseTimeout = Constants.defaultConnectionCloseTimeout,
     this.heartbeatIntervalMs = Constants.defaultHeartbeatIntervalMs,
-    int? disconnectOnEmptyChannelsAfterMs,
+    Duration? disconnectOnEmptyChannelsAfter,
     this.logger,
     RealtimeEncode? encode,
     RealtimeDecode? decode,
@@ -240,8 +241,9 @@ class RealtimeClient {
     final customJWT = this.headers['Authorization']?.split(' ').last;
     accessToken = customJWT ?? params['apikey'];
 
-    this.disconnectOnEmptyChannelsAfterMs =
-        disconnectOnEmptyChannelsAfterMs ?? (2 * heartbeatIntervalMs);
+    this.disconnectOnEmptyChannelsAfter =
+        disconnectOnEmptyChannelsAfter ??
+        Duration(milliseconds: 2 * heartbeatIntervalMs);
 
     this.reconnectAfterMs =
         reconnectAfterMs ?? RetryTimer.createRetryFunction();
@@ -475,18 +477,18 @@ class RealtimeClient {
 
   /// Schedules a disconnect once the last channel is removed.
   ///
-  /// When [disconnectOnEmptyChannelsAfterMs] is `0` the socket disconnects
-  /// immediately, otherwise the disconnect is deferred so that a channel
-  /// created within the delay can reuse the open socket.
+  /// When [disconnectOnEmptyChannelsAfter] is [Duration.zero] the socket
+  /// disconnects immediately, otherwise the disconnect is deferred so that a
+  /// channel created within the delay can reuse the open socket.
   void _schedulePendingDisconnect() {
     _cancelPendingDisconnect();
-    if (disconnectOnEmptyChannelsAfterMs == 0) {
+    if (disconnectOnEmptyChannelsAfter == Duration.zero) {
       log('transport', 'disconnecting immediately - no channels');
       unawaited(disconnect());
       return;
     }
     _pendingDisconnectTimer = Timer(
-      Duration(milliseconds: disconnectOnEmptyChannelsAfterMs),
+      disconnectOnEmptyChannelsAfter,
       () {
         _pendingDisconnectTimer = null;
         if (channels.isEmpty) {
@@ -500,7 +502,8 @@ class RealtimeClient {
     );
     log(
       'transport',
-      'deferred disconnect scheduled in ${disconnectOnEmptyChannelsAfterMs}ms',
+      'deferred disconnect scheduled in '
+          '${disconnectOnEmptyChannelsAfter.inMilliseconds}ms',
     );
   }
 

--- a/packages/realtime_client/lib/src/realtime_client.dart
+++ b/packages/realtime_client/lib/src/realtime_client.dart
@@ -241,7 +241,7 @@ class RealtimeClient {
     accessToken = customJWT ?? params['apikey'];
 
     this.disconnectOnEmptyChannelsAfterMs =
-        disconnectOnEmptyChannelsAfterMs ?? 2 * heartbeatIntervalMs;
+        disconnectOnEmptyChannelsAfterMs ?? (2 * heartbeatIntervalMs);
 
     this.reconnectAfterMs =
         reconnectAfterMs ?? RetryTimer.createRetryFunction();

--- a/packages/realtime_client/test/socket_test.dart
+++ b/packages/realtime_client/test/socket_test.dart
@@ -618,21 +618,27 @@ void main() {
     test('defaults to twice the heartbeat interval', () {
       final socket = RealtimeClient(socketEndpoint);
       expect(
-        socket.disconnectOnEmptyChannelsAfterMs,
-        2 * Constants.defaultHeartbeatIntervalMs,
+        socket.disconnectOnEmptyChannelsAfter,
+        Duration(milliseconds: 2 * Constants.defaultHeartbeatIntervalMs),
       );
 
       final customSocket = RealtimeClient(
         socketEndpoint,
         heartbeatIntervalMs: 5000,
       );
-      expect(customSocket.disconnectOnEmptyChannelsAfterMs, 10000);
+      expect(
+        customSocket.disconnectOnEmptyChannelsAfter,
+        const Duration(milliseconds: 10000),
+      );
 
       final explicitSocket = RealtimeClient(
         socketEndpoint,
-        disconnectOnEmptyChannelsAfterMs: 1234,
+        disconnectOnEmptyChannelsAfter: const Duration(milliseconds: 1234),
       );
-      expect(explicitSocket.disconnectOnEmptyChannelsAfterMs, 1234);
+      expect(
+        explicitSocket.disconnectOnEmptyChannelsAfter,
+        const Duration(milliseconds: 1234),
+      );
     });
 
     test(
@@ -640,7 +646,7 @@ void main() {
       () async {
         final socket = RealtimeClient(
           'ws://localhost:${mockServer.port}',
-          disconnectOnEmptyChannelsAfterMs: 200,
+          disconnectOnEmptyChannelsAfter: const Duration(milliseconds: 200),
         );
         await socket.connect();
         expect(socket.isConnected, isTrue);
@@ -656,7 +662,7 @@ void main() {
     test('disconnects after the delay when channels stay empty', () async {
       final socket = RealtimeClient(
         'ws://localhost:${mockServer.port}',
-        disconnectOnEmptyChannelsAfterMs: 200,
+        disconnectOnEmptyChannelsAfter: const Duration(milliseconds: 200),
       );
       await socket.connect();
 
@@ -673,7 +679,7 @@ void main() {
       () async {
         final socket = RealtimeClient(
           'ws://localhost:${mockServer.port}',
-          disconnectOnEmptyChannelsAfterMs: 200,
+          disconnectOnEmptyChannelsAfter: const Duration(milliseconds: 200),
         );
         await socket.connect();
 
@@ -688,11 +694,11 @@ void main() {
     );
 
     test(
-      'disconnects immediately when disconnectOnEmptyChannelsAfterMs is 0',
+      'disconnects immediately when disconnectOnEmptyChannelsAfter is zero',
       () async {
         final socket = RealtimeClient(
           'ws://localhost:${mockServer.port}',
-          disconnectOnEmptyChannelsAfterMs: 0,
+          disconnectOnEmptyChannelsAfter: Duration.zero,
         );
         await socket.connect();
 
@@ -707,7 +713,7 @@ void main() {
     test('disconnect cancels a pending deferred disconnect', () async {
       final socket = RealtimeClient(
         'ws://localhost:${mockServer.port}',
-        disconnectOnEmptyChannelsAfterMs: 200,
+        disconnectOnEmptyChannelsAfter: const Duration(milliseconds: 200),
       );
       await socket.connect();
 
@@ -727,7 +733,7 @@ void main() {
       () async {
         final socket = RealtimeClient(
           'ws://localhost:${mockServer.port}',
-          disconnectOnEmptyChannelsAfterMs: 200,
+          disconnectOnEmptyChannelsAfter: const Duration(milliseconds: 200),
         );
         await socket.connect();
 
@@ -743,7 +749,7 @@ void main() {
     test('channel.unsubscribe schedules a deferred disconnect', () async {
       final socket = RealtimeClient(
         'ws://localhost:${mockServer.port}',
-        disconnectOnEmptyChannelsAfterMs: 200,
+        disconnectOnEmptyChannelsAfter: const Duration(milliseconds: 200),
       );
       await socket.connect();
 
@@ -758,7 +764,7 @@ void main() {
     test('removeAllChannels disconnects immediately', () async {
       final socket = RealtimeClient(
         'ws://localhost:${mockServer.port}',
-        disconnectOnEmptyChannelsAfterMs: 10000,
+        disconnectOnEmptyChannelsAfter: const Duration(milliseconds: 10000),
       );
       await socket.connect();
       expect(socket.isConnected, isTrue);

--- a/packages/realtime_client/test/socket_test.dart
+++ b/packages/realtime_client/test/socket_test.dart
@@ -614,6 +614,163 @@ void main() {
     });
   });
 
+  group('deferred disconnect', () {
+    test('defaults to twice the heartbeat interval', () {
+      final socket = RealtimeClient(socketEndpoint);
+      expect(
+        socket.disconnectOnEmptyChannelsAfterMs,
+        2 * Constants.defaultHeartbeatIntervalMs,
+      );
+
+      final customSocket = RealtimeClient(
+        socketEndpoint,
+        heartbeatIntervalMs: 5000,
+      );
+      expect(customSocket.disconnectOnEmptyChannelsAfterMs, 10000);
+
+      final explicitSocket = RealtimeClient(
+        socketEndpoint,
+        disconnectOnEmptyChannelsAfterMs: 1234,
+      );
+      expect(explicitSocket.disconnectOnEmptyChannelsAfterMs, 1234);
+    });
+
+    test(
+      'does not disconnect immediately when the last channel is removed',
+      () async {
+        final socket = RealtimeClient(
+          'ws://localhost:${mockServer.port}',
+          disconnectOnEmptyChannelsAfterMs: 200,
+        );
+        await socket.connect();
+        expect(socket.isConnected, isTrue);
+
+        final channel = socket.channel('topic');
+        socket.remove(channel);
+
+        expect(socket.isConnected, isTrue);
+        await socket.disconnect();
+      },
+    );
+
+    test('disconnects after the delay when channels stay empty', () async {
+      final socket = RealtimeClient(
+        'ws://localhost:${mockServer.port}',
+        disconnectOnEmptyChannelsAfterMs: 200,
+      );
+      await socket.connect();
+
+      final channel = socket.channel('topic');
+      socket.remove(channel);
+
+      expect(socket.isConnected, isTrue);
+      await Future.delayed(const Duration(milliseconds: 400));
+      expect(socket.isConnected, isFalse);
+    });
+
+    test(
+      'cancels the pending disconnect when a new channel is created',
+      () async {
+        final socket = RealtimeClient(
+          'ws://localhost:${mockServer.port}',
+          disconnectOnEmptyChannelsAfterMs: 200,
+        );
+        await socket.connect();
+
+        final channel = socket.channel('topic');
+        socket.remove(channel);
+        socket.channel('new-topic');
+
+        await Future.delayed(const Duration(milliseconds: 400));
+        expect(socket.isConnected, isTrue);
+        await socket.disconnect();
+      },
+    );
+
+    test(
+      'disconnects immediately when disconnectOnEmptyChannelsAfterMs is 0',
+      () async {
+        final socket = RealtimeClient(
+          'ws://localhost:${mockServer.port}',
+          disconnectOnEmptyChannelsAfterMs: 0,
+        );
+        await socket.connect();
+
+        final channel = socket.channel('topic');
+        socket.remove(channel);
+
+        await Future.delayed(const Duration(milliseconds: 100));
+        expect(socket.isConnected, isFalse);
+      },
+    );
+
+    test('disconnect cancels a pending deferred disconnect', () async {
+      final socket = RealtimeClient(
+        'ws://localhost:${mockServer.port}',
+        disconnectOnEmptyChannelsAfterMs: 200,
+      );
+      await socket.connect();
+
+      final channel = socket.channel('topic');
+      socket.remove(channel);
+      await socket.disconnect();
+
+      await socket.connect();
+      socket.channel('topic-2');
+      await Future.delayed(const Duration(milliseconds: 400));
+      expect(socket.isConnected, isTrue);
+      await socket.disconnect();
+    });
+
+    test(
+      'removeChannel schedules a deferred disconnect for the last channel',
+      () async {
+        final socket = RealtimeClient(
+          'ws://localhost:${mockServer.port}',
+          disconnectOnEmptyChannelsAfterMs: 200,
+        );
+        await socket.connect();
+
+        final channel = socket.channel('topic');
+        await socket.removeChannel(channel);
+
+        expect(socket.isConnected, isTrue);
+        await Future.delayed(const Duration(milliseconds: 400));
+        expect(socket.isConnected, isFalse);
+      },
+    );
+
+    test('channel.unsubscribe schedules a deferred disconnect', () async {
+      final socket = RealtimeClient(
+        'ws://localhost:${mockServer.port}',
+        disconnectOnEmptyChannelsAfterMs: 200,
+      );
+      await socket.connect();
+
+      final channel = socket.channel('topic');
+      await channel.unsubscribe();
+
+      expect(socket.isConnected, isTrue);
+      await Future.delayed(const Duration(milliseconds: 400));
+      expect(socket.isConnected, isFalse);
+    });
+
+    test('removeAllChannels disconnects immediately', () async {
+      final socket = RealtimeClient(
+        'ws://localhost:${mockServer.port}',
+        disconnectOnEmptyChannelsAfterMs: 10000,
+      );
+      await socket.connect();
+      expect(socket.isConnected, isTrue);
+
+      socket.channel('channel-1');
+      socket.channel('channel-2');
+
+      await socket.removeAllChannels();
+      expect(socket.isConnected, isFalse);
+    });
+  });
+
   group('push', () {
     const topic = 'topic';
     const event = ChannelEvents.join;

--- a/packages/supabase/lib/src/realtime_client_options.dart
+++ b/packages/supabase/lib/src/realtime_client_options.dart
@@ -25,6 +25,15 @@ class RealtimeClientOptions {
   /// Custom WebSocket transport factory for the RealtimeClient.
   final WebSocketTransport? transport;
 
+  /// The delay before the socket is disconnected once the last channel is
+  /// removed.
+  ///
+  /// If a new channel is created before the delay elapses, the pending
+  /// disconnect is cancelled and the open socket is reused. Pass
+  /// [Duration.zero] to disconnect immediately. Defaults to twice the
+  /// heartbeat interval.
+  final Duration? disconnectOnEmptyChannelsAfter;
+
   /// {@macro realtime_client_options}
   const RealtimeClientOptions({
     this.eventsPerSecond,
@@ -32,5 +41,6 @@ class RealtimeClientOptions {
     this.timeout,
     this.connectionCloseTimeout,
     this.transport,
+    this.disconnectOnEmptyChannelsAfter,
   });
 }

--- a/packages/supabase/lib/src/supabase_client.dart
+++ b/packages/supabase/lib/src/supabase_client.dart
@@ -368,6 +368,8 @@ class SupabaseClient {
           RealtimeConstants.defaultConnectionCloseTimeout,
       customAccessToken: accessToken,
       transport: options.transport,
+      disconnectOnEmptyChannelsAfterMs:
+          options.disconnectOnEmptyChannelsAfter?.inMilliseconds,
     );
   }
 

--- a/packages/supabase/lib/src/supabase_client.dart
+++ b/packages/supabase/lib/src/supabase_client.dart
@@ -368,8 +368,7 @@ class SupabaseClient {
           RealtimeConstants.defaultConnectionCloseTimeout,
       customAccessToken: accessToken,
       transport: options.transport,
-      disconnectOnEmptyChannelsAfterMs:
-          options.disconnectOnEmptyChannelsAfter?.inMilliseconds,
+      disconnectOnEmptyChannelsAfter: options.disconnectOnEmptyChannelsAfter,
     );
   }
 

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -560,7 +560,11 @@ features:
     note: "On connect the access token is resolved before the send buffer is flushed; buffered channel join payloads are patched with the token and re-sent so subscriptions authenticate correctly when the token resolves asynchronously (e.g. read from async storage)."
   realtime.configuration.custom_logger: implemented
   realtime.configuration.binary_protocol: implemented
-  realtime.configuration.deferred_disconnect: not_implemented
+  realtime.configuration.deferred_disconnect:
+    status: implemented
+    symbols:
+      - RealtimeClient.disconnectOnEmptyChannelsAfterMs
+      - RealtimeClientOptions.disconnectOnEmptyChannelsAfter
 
   # functions
   functions.invocation.invoke:

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -563,7 +563,6 @@ features:
   realtime.configuration.deferred_disconnect:
     status: implemented
     symbols:
-      - RealtimeClient.disconnectOnEmptyChannelsAfterMs
       - RealtimeClientOptions.disconnectOnEmptyChannelsAfter
 
   # functions


### PR DESCRIPTION
## Summary

Implements a deferred socket disconnect for the Realtime client, matching supabase-js. Previously the WebSocket disconnected immediately when the last channel was removed, causing a disconnect/reconnect race when a new channel was created right after (a common "switch channels" pattern). Now the disconnect is deferred, and creating a new channel before the timer fires cancels it and reuses the open socket.

**Outcome:** implemented

## Behavior

- New option `disconnectOnEmptyChannelsAfter` (a `Duration`) on `RealtimeClientOptions`, threaded to `RealtimeClient` as `disconnectOnEmptyChannelsAfterMs`.
- Removing the last channel (via `removeChannel()` or `channel.unsubscribe()`) schedules a disconnect after the configured delay instead of disconnecting immediately.
- Creating a new channel while a disconnect is pending cancels it.
- `disconnect()` cancels any pending disconnect before closing.
- `removeAllChannels()` still disconnects immediately (explicit teardown).
- Default delay is `2 × heartbeatIntervalMs`; `0` disconnects immediately (old behavior).

## Changes

- `packages/realtime_client/lib/src/realtime_client.dart` — add `disconnectOnEmptyChannelsAfterMs`, `_pendingDisconnectTimer`, scheduling/cancelling logic; move the empty-channels disconnect into `remove()`.
- `packages/supabase/lib/src/realtime_client_options.dart` — add `disconnectOnEmptyChannelsAfter` (`Duration?`).
- `packages/supabase/lib/src/supabase_client.dart` — thread the option through.
- `packages/realtime_client/test/socket_test.dart` — add a `deferred disconnect` test group.

## Reference

supabase-js PR #2270 (cherry-pick #2282), commit `bfb18bc8`.

## Compliance matrix

`realtime.configuration.deferred_disconnect` → `implemented`

Closes SDK-895