### PR TITLE
feat(auth): add signInWithWeb3 for Web3 wallet authentication

### DIFF
--- a/packages/gotrue/lib/src/constants.dart
+++ b/packages/gotrue/lib/src/constants.dart
@@ -99,6 +99,12 @@ enum OtpChannel {
   whatsapp,
 }
 
+/// The blockchain used to sign in with a Web3 wallet.
+enum Web3Chain {
+  ethereum,
+  solana,
+}
+
 /// Determines which sessions should be logged out.
 enum SignOutScope {
   /// All sessions by this account will be signed out.

--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -535,6 +535,54 @@ class GoTrueClient {
     return authResponse;
   }
 
+  /// Signs in a user by verifying a message signed with their Web3 wallet.
+  ///
+  /// Supports Ethereum (Sign-In with Ethereum) and Solana (Sign-In with
+  /// Solana), both of which derive from the EIP-4361 standard.
+  ///
+  /// Wallet interaction and message signing are performed by the caller using
+  /// their wallet library of choice. Provide the signed [message] together with
+  /// its [signature]. For [Web3Chain.ethereum] the signature is a hex encoded
+  /// string, for [Web3Chain.solana] it is a base64url encoded string.
+  ///
+  /// [captchaToken] is the verification token received when the user
+  /// completes the captcha on the app.
+  ///
+  /// See also https://eips.ethereum.org/EIPS/eip-4361
+  Future<AuthResponse> signInWithWeb3({
+    required Web3Chain chain,
+    required String message,
+    required String signature,
+    String? captchaToken,
+  }) async {
+    final response = await _fetch.request(
+      '$_url/token',
+      RequestMethodType.post,
+      options: GotrueRequestOptions(
+        headers: _headers,
+        body: {
+          'chain': chain.name,
+          'message': message,
+          'signature': signature,
+          if (captchaToken != null)
+            'gotrue_meta_security': {'captcha_token': captchaToken},
+        },
+        query: {'grant_type': 'web3'},
+      ),
+    );
+
+    final authResponse = AuthResponse.fromJson(response);
+
+    if (authResponse.session == null) {
+      throw AuthException('An error occurred on token verification.');
+    }
+
+    _saveSession(authResponse.session!);
+    notifyAllSubscribers(AuthChangeEvent.signedIn);
+
+    return authResponse;
+  }
+
   /// Log in a user using magiclink or a one-time password (OTP).
   ///
   /// If the `{{ .ConfirmationURL }}` variable is specified in the email template, a magiclink will be sent.

--- a/packages/gotrue/pubspec.yaml
+++ b/packages/gotrue/pubspec.yaml
@@ -28,7 +28,7 @@ dependencies:
   dart_jsonwebtoken: ">=3.0.0 <4.0.0"
 
 dev_dependencies:
-  cryptography: ^2.7.0
+  cryptography: ^2.9.0
   dotenv: ^4.2.0
   supabase_lints: ^0.1.0
   test: ^1.25.0

--- a/packages/gotrue/pubspec.yaml
+++ b/packages/gotrue/pubspec.yaml
@@ -28,6 +28,7 @@ dependencies:
   dart_jsonwebtoken: ">=3.0.0 <4.0.0"
 
 dev_dependencies:
+  cryptography: ^2.7.0
   dotenv: ^4.2.0
   supabase_lints: ^0.1.0
   test: ^1.25.0

--- a/packages/gotrue/test/mocks/web3_mock_client.dart
+++ b/packages/gotrue/test/mocks/web3_mock_client.dart
@@ -1,0 +1,117 @@
+import 'dart:convert';
+
+import 'package:http/http.dart';
+
+/// A mock HTTP client that simulates the `POST /token?grant_type=web3`
+/// endpoint used for Web3 wallet authentication.
+class Web3MockClient extends BaseClient {
+  final String userId;
+  final String accessToken;
+  final String refreshToken;
+
+  Uri? lastUri;
+  Map<String, dynamic>? lastRequestBody;
+  Map<String, String>? lastHeaders;
+
+  Web3MockClient({
+    this.userId = 'mock-user-id-web3',
+    this.accessToken = 'mock-access-token',
+    this.refreshToken = 'mock-refresh-token',
+  });
+
+  @override
+  Future<StreamedResponse> send(BaseRequest request) async {
+    lastUri = request.url;
+    lastHeaders = request.headers;
+
+    if (request is Request) {
+      try {
+        lastRequestBody = json.decode(request.body) as Map<String, dynamic>;
+      } catch (_) {
+        // Ignore non-JSON bodies.
+      }
+    }
+
+    final now = DateTime.now().toIso8601String();
+
+    return StreamedResponse(
+      Stream.value(
+        utf8.encode(
+          jsonEncode({
+            'access_token': accessToken,
+            'token_type': 'bearer',
+            'expires_in': 3600,
+            'refresh_token': refreshToken,
+            'user': {
+              'id': userId,
+              'aud': 'authenticated',
+              'role': 'authenticated',
+              'email': null,
+              'phone': null,
+              'confirmed_at': now,
+              'last_sign_in_at': now,
+              'created_at': now,
+              'updated_at': now,
+              'app_metadata': {
+                'provider': 'web3',
+                'providers': ['web3'],
+              },
+              'user_metadata': {
+                'custom_claims': {
+                  'address': lastRequestBody?['message'],
+                },
+              },
+              'identities': [
+                {
+                  'id': userId,
+                  'user_id': userId,
+                  'identity_data': {'sub': userId},
+                  'provider': 'web3',
+                  'last_sign_in_at': now,
+                  'created_at': now,
+                  'updated_at': now,
+                },
+              ],
+            },
+          }),
+        ),
+      ),
+      200,
+      request: request,
+    );
+  }
+}
+
+/// A mock client that always fails the Web3 token exchange with the given
+/// [statusCode] and [errorResponse], simulating an expired nonce or a bad
+/// signature.
+class Web3ErrorMockClient extends BaseClient {
+  final int statusCode;
+  final Map<String, dynamic> errorResponse;
+
+  Web3ErrorMockClient({
+    this.statusCode = 403,
+    this.errorResponse = const {
+      'code': 'bad_json',
+      'message': 'Signature verification failed',
+    },
+  });
+
+  @override
+  Future<StreamedResponse> send(BaseRequest request) async {
+    return StreamedResponse(
+      Stream.value(utf8.encode(jsonEncode(errorResponse))),
+      statusCode,
+      request: request,
+    );
+  }
+}
+
+/// A mock client that fails every request with a transport error, simulating a
+/// dropped connection.
+class Web3NetworkErrorMockClient extends BaseClient {
+  @override
+  Future<StreamedResponse> send(BaseRequest request) async {
+    throw ClientException('Connection failed', request.url);
+  }
+}

--- a/packages/gotrue/test/web3_auth_integration_test.dart
+++ b/packages/gotrue/test/web3_auth_integration_test.dart
@@ -1,0 +1,115 @@
+import 'dart:convert';
+
+import 'package:cryptography/cryptography.dart';
+import 'package:dotenv/dotenv.dart';
+import 'package:gotrue/gotrue.dart';
+import 'package:test/test.dart';
+
+import 'utils.dart';
+
+const _base58Alphabet =
+    '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+
+String _base58Encode(List<int> bytes) {
+  var value = BigInt.zero;
+  for (final byte in bytes) {
+    value = (value << 8) | BigInt.from(byte);
+  }
+
+  final result = StringBuffer();
+  final radix = BigInt.from(58);
+  while (value > BigInt.zero) {
+    result.write(_base58Alphabet[(value % radix).toInt()]);
+    value = value ~/ radix;
+  }
+
+  for (final byte in bytes) {
+    if (byte != 0) break;
+    result.write('1');
+  }
+
+  return String.fromCharCodes(result.toString().codeUnits.reversed);
+}
+
+void main() {
+  final env = DotEnv()..load();
+  final gotrueUrl = env['GOTRUE_URL'] ?? 'http://127.0.0.1:54421/auth/v1';
+  final anonToken = env['GOTRUE_TOKEN'] ?? getAnonToken(env);
+  final ed25519 = Ed25519();
+
+  late GoTrueClient client;
+
+  setUp(() {
+    client = GoTrueClient(
+      url: gotrueUrl,
+      headers: {'Authorization': 'Bearer $anonToken', 'apikey': anonToken},
+      asyncStorage: TestAsyncStorage(),
+    );
+  });
+
+  tearDown(() {
+    client.dispose();
+  });
+
+  Future<({String message, String signature})> signSolanaMessage() async {
+    final keyPair = await ed25519.newKeyPair();
+    final publicKey = await keyPair.extractPublicKey();
+    final address = _base58Encode(publicKey.bytes);
+    final issuedAt = DateTime.now().toUtc().toIso8601String();
+
+    final message =
+        'localhost:9999 wants you to sign in with your Solana account:\n'
+        '$address\n'
+        '\n'
+        'Version: 1\n'
+        'URI: http://localhost:9999/welcome\n'
+        'Issued At: $issuedAt';
+
+    final signature = await ed25519.sign(
+      utf8.encode(message),
+      keyPair: keyPair,
+    );
+
+    return (message: message, signature: base64Url.encode(signature.bytes));
+  }
+
+  group('signInWithWeb3 against a live GoTrue', () {
+    test('signs in with a valid Solana signature', () async {
+      final signed = await signSolanaMessage();
+
+      final events = <AuthChangeEvent>[];
+      client.onAuthStateChange.listen(
+        (state) => events.add(state.event),
+        onError: (_) {},
+      );
+
+      final response = await client.signInWithWeb3(
+        chain: Web3Chain.solana,
+        message: signed.message,
+        signature: signed.signature,
+      );
+
+      expect(response.session, isNotNull);
+      expect(response.session?.accessToken, isNotEmpty);
+      expect(response.user?.appMetadata['provider'], 'web3');
+      expect(client.currentSession?.accessToken, response.session?.accessToken);
+
+      await Future<void>.delayed(Duration.zero);
+      expect(events, contains(AuthChangeEvent.signedIn));
+    });
+
+    test('rejects a signature that does not match the message', () async {
+      final signed = await signSolanaMessage();
+      final other = await signSolanaMessage();
+
+      await expectLater(
+        client.signInWithWeb3(
+          chain: Web3Chain.solana,
+          message: signed.message,
+          signature: other.signature,
+        ),
+        throwsA(isA<AuthApiException>()),
+      );
+    });
+  });
+}

--- a/packages/gotrue/test/web3_auth_test.dart
+++ b/packages/gotrue/test/web3_auth_test.dart
@@ -1,0 +1,162 @@
+import 'package:gotrue/gotrue.dart';
+import 'package:test/test.dart';
+
+import 'mocks/web3_mock_client.dart';
+import 'utils.dart';
+
+void main() {
+  group('signInWithWeb3', () {
+    late Web3MockClient mockClient;
+    late GoTrueClient client;
+
+    setUp(() {
+      mockClient = Web3MockClient();
+      client = GoTrueClient(
+        url: 'http://localhost:9999',
+        httpClient: mockClient,
+        autoRefreshToken: false,
+        asyncStorage: TestAsyncStorage(),
+      );
+    });
+
+    tearDown(() {
+      client.dispose();
+    });
+
+    test('exchanges an Ethereum signature for a session', () async {
+      final events = <AuthChangeEvent>[];
+      client.onAuthStateChange.listen(
+        (state) => events.add(state.event),
+        onError: (_) {},
+      );
+
+      final response = await client.signInWithWeb3(
+        chain: Web3Chain.ethereum,
+        message: 'example.com wants you to sign in',
+        signature: '0xdeadbeef',
+      );
+
+      expect(mockClient.lastUri?.path, '/token');
+      expect(mockClient.lastUri?.queryParameters['grant_type'], 'web3');
+      expect(mockClient.lastRequestBody?['chain'], 'ethereum');
+      expect(
+        mockClient.lastRequestBody?['message'],
+        'example.com wants you to sign in',
+      );
+      expect(mockClient.lastRequestBody?['signature'], '0xdeadbeef');
+      expect(
+        mockClient.lastRequestBody?.containsKey('gotrue_meta_security'),
+        isFalse,
+      );
+
+      expect(response.session, isNotNull);
+      expect(response.session?.accessToken, 'mock-access-token');
+      expect(response.user?.id, 'mock-user-id-web3');
+      expect(client.currentSession?.accessToken, 'mock-access-token');
+
+      await Future<void>.delayed(Duration.zero);
+      expect(events, contains(AuthChangeEvent.signedIn));
+    });
+
+    test('exchanges a Solana signature for a session', () async {
+      final response = await client.signInWithWeb3(
+        chain: Web3Chain.solana,
+        message: 'example.com wants you to sign in',
+        signature: 'base64url-signature',
+      );
+
+      expect(mockClient.lastRequestBody?['chain'], 'solana');
+      expect(mockClient.lastRequestBody?['signature'], 'base64url-signature');
+      expect(response.session, isNotNull);
+    });
+
+    test('includes the captcha token when provided', () async {
+      await client.signInWithWeb3(
+        chain: Web3Chain.ethereum,
+        message: 'message',
+        signature: 'signature',
+        captchaToken: 'captcha-token',
+      );
+
+      expect(
+        mockClient.lastRequestBody?['gotrue_meta_security'],
+        {'captcha_token': 'captcha-token'},
+      );
+    });
+
+    test('throws AuthApiException for a bad signature', () async {
+      final errorClient = GoTrueClient(
+        url: 'http://localhost:9999',
+        httpClient: Web3ErrorMockClient(),
+        autoRefreshToken: false,
+        asyncStorage: TestAsyncStorage(),
+      );
+      addTearDown(errorClient.dispose);
+
+      await expectLater(
+        errorClient.signInWithWeb3(
+          chain: Web3Chain.ethereum,
+          message: 'message',
+          signature: 'bad-signature',
+        ),
+        throwsA(
+          isA<AuthApiException>().having(
+            (e) => e.statusCode,
+            'statusCode',
+            '403',
+          ),
+        ),
+      );
+    });
+
+    test('throws AuthApiException for an expired nonce', () async {
+      final errorClient = GoTrueClient(
+        url: 'http://localhost:9999',
+        httpClient: Web3ErrorMockClient(
+          statusCode: 403,
+          errorResponse: const {
+            'error_code': 'validation_failed',
+            'message': 'Message is expired',
+          },
+        ),
+        autoRefreshToken: false,
+        asyncStorage: TestAsyncStorage(),
+      );
+      addTearDown(errorClient.dispose);
+
+      await expectLater(
+        errorClient.signInWithWeb3(
+          chain: Web3Chain.ethereum,
+          message: 'expired message',
+          signature: 'signature',
+        ),
+        throwsA(
+          isA<AuthApiException>().having(
+            (e) => e.code,
+            'code',
+            'validation_failed',
+          ),
+        ),
+      );
+    });
+
+    test('throws AuthRetryableFetchException on a network error', () async {
+      final networkErrorClient = GoTrueClient(
+        url: 'http://localhost:9999',
+        httpClient: Web3NetworkErrorMockClient(),
+        autoRefreshToken: false,
+        asyncStorage: TestAsyncStorage(),
+      );
+      addTearDown(networkErrorClient.dispose);
+
+      await expectLater(
+        networkErrorClient.signInWithWeb3(
+          chain: Web3Chain.solana,
+          message: 'message',
+          signature: 'signature',
+        ),
+        throwsA(isA<AuthRetryableFetchException>()),
+      );
+    });
+  });
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -205,10 +205,10 @@ packages:
     dependency: transitive
     description:
       name: cli_launcher
-      sha256: "35cf15a3ffaeb9c11849eaa0afba761bb76dceb42d050532bfd3e1299c9748cd"
+      sha256: "96883f87648524292e24e2cc6a369fbdf64883473fe3e3ddadd3d857bf16a484"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.3+1"
+    version: "0.3.3+2"
   cli_util:
     dependency: transitive
     description:
@@ -265,6 +265,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.7"
+  cryptography:
+    dependency: transitive
+    description:
+      name: cryptography
+      sha256: "3eda3029d34ec9095a27a198ac9785630fe525c0eb6a49f3d575272f8e792ef0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.9.0"
   dart_jsonwebtoken:
     dependency: transitive
     description:

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -36,7 +36,12 @@ features:
   auth.sign_in.sign_in_with_sso:
     status: partially_implemented
     note: "Exposed as getSSOSignInUrl, which returns Future<String> (the URL) rather than the structured {url} response used by JS."
-  auth.sign_in.sign_in_with_web3: not_implemented
+  auth.sign_in.sign_in_with_web3:
+    status: implemented
+    note: "Callers sign the SIWE/SIWS message with their own wallet library and pass the message and signature; the SDK does not auto-detect browser wallets or build the message, since window.ethereum/window.solana have no Flutter equivalent."
+    symbols:
+      - GoTrueClient.signInWithWeb3
+      - Web3Chain
   auth.sign_in.sign_in_anonymously: implemented
   auth.sign_in.verify_otp: implemented
   auth.sign_in.exchange_code_for_session: implemented

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -367,7 +367,7 @@ email_optional = false
 # Allow Solana wallet holders to sign in to your project via the Sign in with Solana (SIWS, EIP-4361) standard.
 # You can configure "web3" rate limit in the [auth.rate_limit] section and set up [auth.captcha] if self-hosting.
 [auth.web3.solana]
-enabled = false
+enabled = true
 
 # Use Firebase Auth as a third-party provider alongside Supabase Auth.
 [auth.third_party.firebase]


### PR DESCRIPTION
## Summary

Adds `signInWithWeb3` support to `gotrue`, wrapping the GoTrue `POST /token?grant_type=web3` endpoint used for Web3 wallet authentication (Sign-In with Ethereum and Sign-In with Solana, both derived from EIP-4361).

- `GoTrueClient.signInWithWeb3({required Web3Chain chain, required String message, required String signature, String? captchaToken})` exchanges a signed message for a session, saves it, and emits `AuthChangeEvent.signedIn`.
- New `Web3Chain` enum (`ethereum`, `solana`).
- Exposed through `supabase` / `supabase_flutter` automatically via the existing `auth` getter.

Message signing and wallet interaction are delegated to the caller (using `web3dart`, `walletconnect_dart`, or a Solana wallet library). This matches the platform-agnostic path in supabase-js: `window.ethereum` / `window.solana` auto-detection has no Flutter equivalent, so the SDK does not build the message or auto-detect a browser wallet.

## Outcome

**implemented** — for `Web3Chain.ethereum` the signature is a hex string, for `Web3Chain.solana` it is a base64url string, matching the wire format supabase-js sends.

## Tests

`packages/gotrue/test/web3_auth_test.dart` (mocked, 6 tests, all passing): Ethereum happy path, Solana happy path, captcha token, bad signature, expired nonce, and network error.

## Reference

supabase-js / auth-js `GoTrueClient.signInWithWeb3` (`POST /token?grant_type=web3`).

## Compliance matrix

`auth.sign_in.sign_in_with_web3`: `not_implemented` → `implemented` (symbols: `GoTrueClient.signInWithWeb3`, `Web3Chain`).

Linear: SDK-836
