### PR TITLE
fix(supabase_common): align platform stats casing with other SDKs

### DIFF
--- a/packages/supabase/test/client_test.dart
+++ b/packages/supabase/test/client_test.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:supabase/supabase.dart';
+import 'package:supabase_common/supabase_common.dart';
 import 'package:test/test.dart';
 import 'package:yet_another_json_isolate/yet_another_json_isolate.dart';
 
@@ -40,21 +41,36 @@ void main() {
     test('X-Client-Info includes structured platform metadata', () {
       final clientInfo = supabase.headers['X-Client-Info']!;
       expect(clientInfo, startsWith('supabase-dart/'));
-      expect(clientInfo, contains('; platform=${Platform.operatingSystem}'));
+      expect(
+        clientInfo,
+        contains(
+          '; platform=${normalizePlatformName(Platform.operatingSystem)}',
+        ),
+      );
       expect(clientInfo, contains('; runtime=dart'));
     });
 
     test('X-Client-Info includes structured platform metadata on auth', () {
       final clientInfo = supabase.auth.headers['X-Client-Info']!;
       expect(clientInfo, startsWith('supabase-dart/'));
-      expect(clientInfo, contains('; platform=${Platform.operatingSystem}'));
+      expect(
+        clientInfo,
+        contains(
+          '; platform=${normalizePlatformName(Platform.operatingSystem)}',
+        ),
+      );
       expect(clientInfo, contains('; runtime=dart'));
     });
 
     test('X-Client-Info includes structured platform metadata on storage', () {
       final clientInfo = supabase.storage.headers['X-Client-Info']!;
       expect(clientInfo, startsWith('supabase-dart/'));
-      expect(clientInfo, contains('; platform=${Platform.operatingSystem}'));
+      expect(
+        clientInfo,
+        contains(
+          '; platform=${normalizePlatformName(Platform.operatingSystem)}',
+        ),
+      );
       expect(clientInfo, contains('; runtime=dart'));
     });
 
@@ -63,7 +79,12 @@ void main() {
       () {
         final clientInfo = supabase.functions.headers['X-Client-Info']!;
         expect(clientInfo, startsWith('supabase-dart/'));
-        expect(clientInfo, contains('; platform=${Platform.operatingSystem}'));
+        expect(
+          clientInfo,
+          contains(
+            '; platform=${normalizePlatformName(Platform.operatingSystem)}',
+          ),
+        );
         expect(clientInfo, contains('; runtime=dart'));
       },
     );
@@ -71,7 +92,12 @@ void main() {
     test('X-Client-Info includes structured platform metadata on rest', () {
       final clientInfo = supabase.rest.headers['X-Client-Info']!;
       expect(clientInfo, startsWith('supabase-dart/'));
-      expect(clientInfo, contains('; platform=${Platform.operatingSystem}'));
+      expect(
+        clientInfo,
+        contains(
+          '; platform=${normalizePlatformName(Platform.operatingSystem)}',
+        ),
+      );
       expect(clientInfo, contains('; runtime=dart'));
     });
 
@@ -84,7 +110,12 @@ void main() {
         );
         final clientInfo = request.headers['X-Client-Info']?.first;
         expect(clientInfo, startsWith('supabase-dart/'));
-        expect(clientInfo, contains('; platform=${Platform.operatingSystem}'));
+        expect(
+          clientInfo,
+          contains(
+            '; platform=${normalizePlatformName(Platform.operatingSystem)}',
+          ),
+        );
         expect(clientInfo, contains('; runtime=dart'));
       },
     );

--- a/packages/supabase_common/lib/src/client_info.dart
+++ b/packages/supabase_common/lib/src/client_info.dart
@@ -12,6 +12,24 @@ class PlatformInfo {
   });
 }
 
+/// Platform names shared across the Supabase SDKs so per-platform stats can be
+/// aggregated regardless of language or framework. The casing matches the
+/// Swift SDK.
+const _platformNames = <String, String>{
+  'android': 'Android',
+  'ios': 'iOS',
+  'linux': 'Linux',
+  'macos': 'macOS',
+  'windows': 'Windows',
+  'fuchsia': 'Fuchsia',
+};
+
+/// Normalizes a `dart:io` `Platform.operatingSystem` value to the platform name
+/// shared across the Supabase SDKs. Unknown values are returned unchanged so
+/// they stay visible in stats.
+String normalizePlatformName(String operatingSystem) =>
+    _platformNames[operatingSystem] ?? operatingSystem;
+
 /// Builds the value of the `X-Client-Info` header.
 ///
 /// When [platformInfo] is `null` the minimal `'$clientName/$version'` form is

--- a/packages/supabase_common/lib/src/platform/platform_io.dart
+++ b/packages/supabase_common/lib/src/platform/platform_io.dart
@@ -1,6 +1,9 @@
 import 'dart:io';
 
-String get conditionalPlatform => Platform.operatingSystem;
+import '../client_info.dart';
+
+String get conditionalPlatform =>
+    normalizePlatformName(Platform.operatingSystem);
 
 String get conditionalPlatformVersion => Platform.operatingSystemVersion;
 

--- a/packages/supabase_common/test/supabase_common_test.dart
+++ b/packages/supabase_common/test/supabase_common_test.dart
@@ -17,14 +17,14 @@ void main() {
         'supabase-dart',
         '2.0.0',
         platformInfo: const PlatformInfo(
-          platform: 'macos',
+          platform: 'macOS',
           platformVersion: 'Version 14.0',
           runtimeVersion: '3.9.0',
         ),
       );
       expect(
         header,
-        'supabase-dart/2.0.0; platform=macos; '
+        'supabase-dart/2.0.0; platform=macOS; '
         'platform-version=Version 14.0; runtime=dart; runtime-version=3.9.0',
       );
     });
@@ -36,6 +36,21 @@ void main() {
         platformInfo: const PlatformInfo(),
       );
       expect(header, 'supabase-dart/2.0.0; runtime=dart');
+    });
+  });
+
+  group('normalizePlatformName', () {
+    test('aligns casing with the other Supabase SDKs', () {
+      expect(normalizePlatformName('android'), 'Android');
+      expect(normalizePlatformName('ios'), 'iOS');
+      expect(normalizePlatformName('linux'), 'Linux');
+      expect(normalizePlatformName('macos'), 'macOS');
+      expect(normalizePlatformName('windows'), 'Windows');
+      expect(normalizePlatformName('fuchsia'), 'Fuchsia');
+    });
+
+    test('returns unknown values unchanged', () {
+      expect(normalizePlatformName('someNewPlatform'), 'someNewPlatform');
     });
   });
 


### PR DESCRIPTION
## What

Normalizes the platform name reported in the `platform=` segment of the `X-Client-Info` header so it uses the same casing across all Supabase SDKs.

Previously the Flutter SDK sent the raw `Platform.operatingSystem` value, which is always lowercase (`macos`, `ios`, `android`, `linux`, `windows`). Swift reports properly cased names (`macOS`, `iOS`, `Android`, `Linux`, `Windows`). This mismatch made it harder to aggregate stats per platform independently of framework/language.

## Changes

- Added `normalizePlatformName` in `supabase_common` backed by a lookup map that maps each `Platform.operatingSystem` value to the shared, Swift-aligned casing. Unknown values pass through unchanged so any new platform still shows up in stats.
- `conditionalPlatform` (the `dart:io` implementation) now runs `Platform.operatingSystem` through `normalizePlatformName`. This is the single source used by both the `supabase` (pure Dart) and `supabase_flutter` packages, so both are covered.
- Updated tests accordingly.

Only the platforms `dart:io` can actually report are mapped. visionOS, watchOS, and tvOS aren't Flutter targets, and the alignment discussion concluded those three aren't valuable to track.

## Context

Follows the casing agreement in supabase-community/core-csharp#2 ([discussion](https://github.com/supabase-community/core-csharp/pull/2#discussion_r3571537527)).