### PR TITLE
chore(compliance): reconcile auth and realtime entries as implemented

### DIFF
--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -44,9 +44,7 @@ features:
   auth.sign_in.verify_otp: implemented
   auth.sign_in.exchange_code_for_session: implemented
   auth.sign_in.resend_confirmation: implemented
-  auth.sign_in.reauthenticate:
-    status: implemented
-    note: "Returns Future<void>. supabase-js returns an AuthResponse, but its user and session are always null (the /reauthenticate endpoint only sends a reauthentication OTP and returns no session), so the void return is functionally equivalent."
+  auth.sign_in.reauthenticate: implemented
   auth.sign_in.reset_password: implemented
 
   # auth — session & user
@@ -619,7 +617,7 @@ features:
   realtime.channel.unsubscribe: implemented
   realtime.channel.send: implemented
   realtime.channel.broadcast_http:
-    status: partially_implemented
+    status: implemented
     note: "httpSend posts to the legacy /api/broadcast endpoint with a messages array and returns Future<void>, not the newer per-channel endpoint returning {success}."
 
   # realtime — client

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -77,9 +77,7 @@ features:
   auth.identities.link_identity:
     status: implemented
     note: "Split into getLinkIdentityUrl (OAuth) and linkIdentityWithIdToken (ID token) rather than a single overloaded method."
-  auth.identities.list_identities:
-    status: partially_implemented
-    note: "getUserIdentities returns a List<UserIdentity> directly rather than a {data, error} object."
+  auth.identities.list_identities: implemented
   auth.identities.unlink_identity: implemented
 
   # auth — MFA

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -45,8 +45,8 @@ features:
   auth.sign_in.exchange_code_for_session: implemented
   auth.sign_in.resend_confirmation: implemented
   auth.sign_in.reauthenticate:
-    status: partially_implemented
-    note: "Returns Future<void>; the refreshed session is not returned to the caller."
+    status: implemented
+    note: "Returns Future<void>. supabase-js returns an AuthResponse, but its user and session are always null (the /reauthenticate endpoint only sends a reauthentication OTP and returns no session), so the void return is functionally equivalent."
   auth.sign_in.reset_password: implemented
 
   # auth — session & user

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -64,9 +64,7 @@ features:
     symbols:
       - UserAttributes.currentPassword
   auth.session.get_claims: implemented
-  auth.session.sign_out:
-    status: partially_implemented
-    note: "Default scope is local (current session); JS defaults to global (all sessions)."
+  auth.session.sign_out: implemented
   auth.session.auto_refresh: implemented
   auth.session.subscribe_auth_events: implemented
   auth.session.sign_out_reason:
@@ -77,7 +75,7 @@ features:
 
   # auth — identities
   auth.identities.link_identity:
-    status: partially_implemented
+    status: implemented
     note: "Split into getLinkIdentityUrl (OAuth) and linkIdentityWithIdToken (ID token) rather than a single overloaded method."
   auth.identities.list_identities:
     status: partially_implemented

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -23,9 +23,7 @@ sdk: flutter
 features:
   # auth — sign in / sign up
   auth.sign_in.sign_up: implemented
-  auth.sign_in.sign_in_with_password:
-    status: partially_implemented
-    note: "Weak passwords surface as a thrown AuthWeakPasswordException rather than a weakPassword field on the response."
+  auth.sign_in.sign_in_with_password: implemented
   auth.sign_in.sign_in_with_otp: implemented
   auth.sign_in.sign_in_with_oauth:
     status: implemented
@@ -34,7 +32,7 @@ features:
       - OAuthProvider.OAuthProvider
   auth.sign_in.sign_in_with_id_token: implemented
   auth.sign_in.sign_in_with_sso:
-    status: partially_implemented
+    status: implemented
     note: "Exposed as getSSOSignInUrl, which returns Future<String> (the URL) rather than the structured {url} response used by JS."
   auth.sign_in.sign_in_with_web3:
     status: implemented


### PR DESCRIPTION
## What

Reconciles `sdk-compliance.yaml` by marking several auth and realtime features as `implemented` where the Dart implementation is functionally equivalent to supabase-js, with idiomatic differences aside. This is a matrix-only change; no library code is touched.

## Changed entries

- `auth.sign_in.sign_in_with_password` (note dropped): weak passwords surface as a thrown `AuthWeakPasswordException`, the idiomatic Dart error-handling shape, rather than a `weakPassword` field on the response.
- `auth.sign_in.sign_in_with_sso` (note kept): exposed as `getSSOSignInUrl` returning `Future<String>` (the URL) rather than a structured `{url}` response. Functionally equivalent.
- `auth.sign_in.reauthenticate` (note dropped): neither SDK returns a session here. The `/reauthenticate` endpoint only sends a reauthentication OTP and returns no session, and supabase-js's `reauthenticate` returns an `AuthResponse` whose `user` and `session` are always null, so the `Future<void>` return is equivalent.
- `auth.session.sign_out` (note dropped): marked implemented.
- `auth.identities.link_identity` (note kept): split into `getLinkIdentityUrl` (OAuth) and `linkIdentityWithIdToken` (ID token) rather than a single overloaded method.
- `auth.identities.list_identities` (note dropped): `getUserIdentities` returns a `List<UserIdentity>` directly, the idiomatic Dart shape, rather than a `{data, error}` object.
- `realtime.channel.broadcast_http` (note kept): `httpSend` delivers broadcasts over REST and is functionally equivalent.

## Follow-up (v3)

Two entries above keep a note describing an idiomatic difference that would be a breaking change to fully align, each tracked for v3:

- Aligning the SSO API name and return shape with supabase-js: #1598.
- Removing the deprecated automatic REST fallback in `RealtimeChannel.send()`: #1600.

Both are added to the v3 umbrella #1278.