### PR TITLE
chore(supabase_common): drop inferrable type arguments on platform names

### DIFF
--- a/packages/supabase_common/lib/src/client_info.dart
+++ b/packages/supabase_common/lib/src/client_info.dart
@@ -15,7 +15,7 @@ class PlatformInfo {
 /// Platform names shared across the Supabase SDKs so per-platform stats can be
 /// aggregated regardless of language or framework. The casing matches the
 /// Swift SDK.
-const _platformNames = <String, String>{
+const _platformNames = {
   'android': 'Android',
   'ios': 'iOS',
   'linux': 'Linux',


### PR DESCRIPTION
## Summary

Removes the explicit `<String, String>` type arguments from the `_platformNames` const map in `packages/supabase_common/lib/src/client_info.dart`. The type is inferred identically from the string literals, so this is a no-op at runtime.

## Why

The DCM check (`CQLabs/setup-dcm` installs the latest DCM at runtime) now flags this as `avoid-inferrable-type-arguments`. Because the DCM version is not pinned, the rule surfaces intermittently and can turn the DCM job red on unrelated PRs. This removes the finding at the source.

No behavior change.