### PR TITLE
feat: support more realtime filters and multiple filters for stream

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,7 +72,7 @@ jobs:
               continue
             fi
             case "$package" in
-              gotrue|postgrest|realtime_client|storage_client) backend=true ;;
+              gotrue|postgrest|realtime_client|storage_client|supabase) backend=true ;;
               *) backend=false ;;
             esac
             case "$package" in

--- a/packages/supabase/dart_test.yaml
+++ b/packages/supabase/dart_test.yaml
@@ -1,0 +1,5 @@
+tags:
+  integration:
+    # Integration tests talk to a Dockerized Realtime server, which can be
+    # slower than the default timeout allows.
+    timeout: 2x

--- a/packages/supabase/lib/src/supabase_query_builder.dart
+++ b/packages/supabase/lib/src/supabase_query_builder.dart
@@ -23,24 +23,42 @@ class SupabaseQueryBuilder extends PostgrestQueryBuilder<dynamic> {
          url: Uri.parse(url),
        );
 
-  /// Combines the current state of your table from PostgREST with changes from the realtime server to return real-time data from your table as a [Stream].
+  /// Combines the current state of your table from PostgREST with changes from
+  /// the realtime server to return real-time data from your table as a [Stream].
   ///
-  /// Realtime is disabled by default for new tables. You can turn it on by [managing replication](https://supabase.com/docs/guides/realtime/subscribing-to-database-changes#enable-postgres-changes).
+  /// Realtime is disabled by default for new tables. You can turn it on by
+  /// [managing replication](https://supabase.com/docs/guides/realtime/subscribing-to-database-changes#enable-postgres-changes).
   ///
-  /// Pass the list of primary key column names to [primaryKey], which will be used to update and delete the proper records internally as the stream receives real-time updates.
+  /// Pass the list of primary key column names to [primaryKey], which will be
+  /// used to update and delete the proper records internally as the stream
+  /// receives realtime updates.
   ///
-  /// The underlying [RealtimeChannel] is public by default. Set [private] to `true` to make it private, which requires additional RLS policies to be set up. See https://supabase.com/docs/guides/realtime/authorization for more details.
+  /// The underlying [RealtimeChannel] is public by default. Set [private] to
+  /// true` to make it private, which requires additional RLS policies to be
+  /// set up. See https://supabase.com/docs/guides/realtime/authorization for
+  /// more details.
   ///
-  /// It handles the lifecycle of the realtime connection and automatically refetches data from PostgREST when needed.
+  /// It handles the life cycle of the realtime connection and automatically
+  /// refetches data from PostgREST when needed.
   ///
-  /// Make sure to provide `onError` and `onDone` callbacks to [Stream.listen] to handle errors and completion of the stream.
+  /// Make sure to provide `onError` and `onDone` callbacks to [Stream.listen]
+  /// to handle errors and completion of the stream.
   /// The stream gets closed when the realtime connection is closed.
+  ///
+  /// Be aware of the following limitations when using streams:
+  /// - When using filters like `eq` only realtime updates matching the filter
+  ///   will be received. Therefore, an update that changes a record to no
+  ///   longer match the filter will not be received, and the record will remain
+  ///   in the stream.
+  /// - By default, for DELETE events only the primary key columns can be used.
+  ///   Refer to the documentation about [receiving old records](https://supabase.com/docs/guides/realtime/postgres-changes?queryGroups=language&language=dart#receiving-old-records).
   ///
   /// ```dart
   /// supabase.from('chats').stream(primaryKey: ['id']).listen(_onChatsReceived);
   /// ```
   ///
-  /// `eq`, `neq`, `lt`, `lte`, `gt` or `gte` and `order`, `limit` filter are available to limit the data being queried.
+  /// `eq`, `neq`, `lt`, `lte`, `gt` or `gte` and `order`, `limit` filter are
+  /// available to limit the data being queried.
   ///
   /// ```dart
   /// supabase.from('chats').stream(primaryKey: ['id']).eq('room_id','123').order('created_at').limit(20).listen(_onChatsReceived);

--- a/packages/supabase/lib/src/supabase_query_builder.dart
+++ b/packages/supabase/lib/src/supabase_query_builder.dart
@@ -57,8 +57,9 @@ class SupabaseQueryBuilder extends PostgrestQueryBuilder<dynamic> {
   /// supabase.from('chats').stream(primaryKey: ['id']).listen(_onChatsReceived);
   /// ```
   ///
-  /// `eq`, `neq`, `lt`, `lte`, `gt` or `gte` and `order`, `limit` filter are
-  /// available to limit the data being queried.
+  /// `eq`, `neq`, `lt`, `lte`, `gt` `gte`, `like`, `ilike`, `match`, `imatch`,
+  /// or `isDistinct` and `order`, `limit` filter are available to limit the
+  /// data being queried.
   ///
   /// ```dart
   /// supabase.from('chats').stream(primaryKey: ['id']).eq('room_id','123').order('created_at').limit(20).listen(_onChatsReceived);

--- a/packages/supabase/lib/src/supabase_query_builder.dart
+++ b/packages/supabase/lib/src/supabase_query_builder.dart
@@ -34,7 +34,7 @@ class SupabaseQueryBuilder extends PostgrestQueryBuilder<dynamic> {
   /// receives realtime updates.
   ///
   /// The underlying [RealtimeChannel] is public by default. Set [private] to
-  /// true` to make it private, which requires additional RLS policies to be
+  /// `true` to make it private, which requires additional RLS policies to be
   /// set up. See https://supabase.com/docs/guides/realtime/authorization for
   /// more details.
   ///

--- a/packages/supabase/lib/src/supabase_query_builder.dart
+++ b/packages/supabase/lib/src/supabase_query_builder.dart
@@ -58,7 +58,7 @@ class SupabaseQueryBuilder extends PostgrestQueryBuilder<dynamic> {
   /// ```
   ///
   /// `eq`, `neq`, `lt`, `lte`, `gt` `gte`, `like`, `ilike`, `match`, `imatch`,
-  /// or `isDistinct` and `order`, `limit` filter are available to limit the
+  /// `isDistinct`, `isFilter` or `inFilter` and `order`, `limit` filter are available to limit the
   /// data being queried.
   ///
   /// ```dart

--- a/packages/supabase/lib/src/supabase_stream_builder.dart
+++ b/packages/supabase/lib/src/supabase_stream_builder.dart
@@ -256,18 +256,29 @@ class SupabaseStreamBuilder extends Stream<SupabaseStreamEvent> {
           _streamFilter!.column,
           _streamFilter!.value,
         ),
-        // These operators are only reachable through the realtime
-        // `onPostgresChanges` API, not through `.stream()`'s filter builder,
-        // so they can never be set on `_streamFilter`. Guard the exhaustive
-        // switch defensively in case that ever changes.
-        PostgresChangeFilterType.like ||
-        PostgresChangeFilterType.ilike ||
-        PostgresChangeFilterType.isFilter ||
-        PostgresChangeFilterType.match ||
-        PostgresChangeFilterType.imatch ||
-        PostgresChangeFilterType.isDistinct => throw UnsupportedError(
-          'The "${_streamFilter!.type.name}" filter is not supported by '
-          '`.stream()`. Use one of eq, neq, lt, lte, gt, gte or inFilter.',
+        PostgresChangeFilterType.like => query.like(
+          _streamFilter!.column,
+          _streamFilter!.value,
+        ),
+        PostgresChangeFilterType.ilike => query.ilike(
+          _streamFilter!.column,
+          _streamFilter!.value,
+        ),
+        PostgresChangeFilterType.match => query.matchRegex(
+          _streamFilter!.column,
+          _streamFilter!.value,
+        ),
+        PostgresChangeFilterType.imatch => query.imatchRegex(
+          _streamFilter!.column,
+          _streamFilter!.value,
+        ),
+        PostgresChangeFilterType.isFilter => query.isFilter(
+          _streamFilter!.column,
+          _streamFilter!.value,
+        ),
+        PostgresChangeFilterType.isDistinct => query.isDistinct(
+          _streamFilter!.column,
+          _streamFilter!.value,
         ),
       };
     }

--- a/packages/supabase/lib/src/supabase_stream_builder.dart
+++ b/packages/supabase/lib/src/supabase_stream_builder.dart
@@ -58,9 +58,8 @@ class SupabaseStreamBuilder extends Stream<SupabaseStreamEvent> {
   /// Contains the combined data of postgrest and realtime to emit as stream.
   SupabaseStreamEvent _streamData = [];
 
-  /// `eq` filter used for both postgrest and realtime
-  // ignore: avoid-unassigned-fields
-  _StreamPostgrestFilter? _streamFilter;
+  /// Filters to be applied to the stream
+  List<_StreamPostgrestFilter> _streamFilter = [];
 
   /// Which column to order by and whether it's ascending
   _Order? _orderBy;
@@ -147,16 +146,16 @@ class SupabaseStreamBuilder extends Stream<SupabaseStreamEvent> {
   }
 
   void _getStreamData() {
-    final currentStreamFilter = _streamFilter;
     _streamData = [];
-    PostgresChangeFilter? realtimeFilter;
-    if (currentStreamFilter != null) {
-      realtimeFilter = PostgresChangeFilter(
-        type: currentStreamFilter.type,
-        column: currentStreamFilter.column,
-        value: currentStreamFilter.value,
-      );
-    }
+    List<PostgresChangeFilter> realtimeFilter = _streamFilter
+        .map(
+          (filter) => PostgresChangeFilter(
+            column: filter.column,
+            type: filter.type,
+            value: filter.value,
+          ),
+        )
+        .toList();
 
     _channel = _realtimeClient.channel(
       _realtimeTopic,
@@ -170,7 +169,7 @@ class SupabaseStreamBuilder extends Stream<SupabaseStreamEvent> {
           event: PostgresChangeEvent.all,
           schema: _schema,
           table: _table,
-          filter: realtimeFilter,
+          filters: realtimeFilter,
           callback: (payload) {
             switch (payload.eventType) {
               case PostgresChangeEvent.insert:
@@ -226,59 +225,59 @@ class SupabaseStreamBuilder extends Stream<SupabaseStreamEvent> {
 
   Future<void> _getPostgrestData() async {
     PostgrestFilterBuilder<PostgrestList> query = _queryBuilder.select();
-    if (_streamFilter != null) {
-      query = switch (_streamFilter!.type) {
+    for (final filter in _streamFilter) {
+      query = switch (filter.type) {
         PostgresChangeFilterType.eq => query.eq(
-          _streamFilter!.column,
-          _streamFilter!.value,
+          filter.column,
+          filter.value,
         ),
         PostgresChangeFilterType.neq => query.neq(
-          _streamFilter!.column,
-          _streamFilter!.value,
+          filter.column,
+          filter.value,
         ),
         PostgresChangeFilterType.lt => query.lt(
-          _streamFilter!.column,
-          _streamFilter!.value,
+          filter.column,
+          filter.value,
         ),
         PostgresChangeFilterType.lte => query.lte(
-          _streamFilter!.column,
-          _streamFilter!.value,
+          filter.column,
+          filter.value,
         ),
         PostgresChangeFilterType.gt => query.gt(
-          _streamFilter!.column,
-          _streamFilter!.value,
+          filter.column,
+          filter.value,
         ),
         PostgresChangeFilterType.gte => query.gte(
-          _streamFilter!.column,
-          _streamFilter!.value,
+          filter.column,
+          filter.value,
         ),
         PostgresChangeFilterType.inFilter => query.inFilter(
-          _streamFilter!.column,
-          _streamFilter!.value,
+          filter.column,
+          filter.value,
         ),
         PostgresChangeFilterType.like => query.like(
-          _streamFilter!.column,
-          _streamFilter!.value,
+          filter.column,
+          filter.value,
         ),
         PostgresChangeFilterType.ilike => query.ilike(
-          _streamFilter!.column,
-          _streamFilter!.value,
+          filter.column,
+          filter.value,
         ),
         PostgresChangeFilterType.match => query.matchRegex(
-          _streamFilter!.column,
-          _streamFilter!.value,
+          filter.column,
+          filter.value,
         ),
         PostgresChangeFilterType.imatch => query.imatchRegex(
-          _streamFilter!.column,
-          _streamFilter!.value,
+          filter.column,
+          filter.value,
         ),
         PostgresChangeFilterType.isFilter => query.isFilter(
-          _streamFilter!.column,
-          _streamFilter!.value,
+          filter.column,
+          filter.value,
         ),
         PostgresChangeFilterType.isDistinct => query.isDistinct(
-          _streamFilter!.column,
-          _streamFilter!.value,
+          filter.column,
+          filter.value,
         ),
       };
     }

--- a/packages/supabase/lib/src/supabase_stream_builder.dart
+++ b/packages/supabase/lib/src/supabase_stream_builder.dart
@@ -59,7 +59,7 @@ class SupabaseStreamBuilder extends Stream<SupabaseStreamEvent> {
   SupabaseStreamEvent _streamData = [];
 
   /// Filters to be applied to the stream
-  List<_StreamPostgrestFilter> _streamFilter = [];
+  final List<_StreamPostgrestFilter> _streamFilter = [];
 
   /// Which column to order by and whether it's ascending
   _Order? _orderBy;

--- a/packages/supabase/lib/src/supabase_stream_filter_builder.dart
+++ b/packages/supabase/lib/src/supabase_stream_filter_builder.dart
@@ -107,7 +107,7 @@ class SupabaseStreamFilterBuilder extends SupabaseStreamBuilder {
     return this;
   }
 
-  /// Filters the results where [column] is included in [value].
+  /// Filters the results where [column] is included in [values].
   ///
   /// Only one filter can be applied to `.stream()`.
   ///
@@ -119,6 +119,103 @@ class SupabaseStreamFilterBuilder extends SupabaseStreamBuilder {
       type: PostgresChangeFilterType.inFilter,
       column: column,
       value: values,
+    );
+    return this;
+  }
+
+  /// Filters the results where [column] matches the [pattern] case-sensitive.
+  ///
+  /// Only one filter can be applied to `.stream()`.
+  ///
+  /// ```dart
+  /// supabase.from('users').stream(primaryKey: ['id']).like('title', '%foo%');
+  /// ```
+  SupabaseStreamBuilder like(String column, String pattern) {
+    _streamFilter = (
+      type: PostgresChangeFilterType.like,
+      column: column,
+      value: pattern,
+    );
+    return this;
+  }
+
+  /// Filters the results where [column] matches the [pattern] case-insensitive.
+  ///
+  /// Only one filter can be applied to `.stream()`.
+  ///
+  /// ```dart
+  /// supabase.from('users').stream(primaryKey: ['id']).ilike('title', '%foo%');
+  /// ```
+  SupabaseStreamBuilder ilike(String column, String pattern) {
+    _streamFilter = (
+      type: PostgresChangeFilterType.ilike,
+      column: column,
+      value: pattern,
+    );
+    return this;
+  }
+
+  /// Filters the results where [column] matches the POSIX [regex] case-sensitive.
+  ///
+  /// Only one filter can be applied to `.stream()`.
+  ///
+  /// ```dart
+  /// supabase.from('users').stream(primaryKey: ['id']).match('slug', r'^post-\d+$');
+  /// ```
+  SupabaseStreamBuilder match(String column, String regex) {
+    _streamFilter = (
+      type: PostgresChangeFilterType.match,
+      column: column,
+      value: regex,
+    );
+    return this;
+  }
+
+  /// Filters the results where [column] matches the POSIX [regex] case-insensitive.
+  ///
+  /// Only one filter can be applied to `.stream()`.
+  ///
+  /// ```dart
+  /// supabase.from('users').stream(primaryKey: ['id']).imatch('slug', r'^post-\d+$');
+  /// ```
+  SupabaseStreamBuilder imatch(String column, String regex) {
+    _streamFilter = (
+      type: PostgresChangeFilterType.imatch,
+      column: column,
+      value: regex,
+    );
+    return this;
+  }
+
+  /// Filters the results where [column] is `null`, `true` or `false`.
+  ///
+  /// Only one filter can be applied to `.stream()`.
+  ///
+  /// ```dart
+  /// supabase.from('users').stream(primaryKey: ['id']).isFilter('data', null);
+  /// ```
+  SupabaseStreamBuilder isFilter(String column, bool? value) {
+    _streamFilter = (
+      type: PostgresChangeFilterType.isFilter,
+      column: column,
+      value: value,
+    );
+    return this;
+  }
+
+  /// Filters the results where [column] is not equal to [value] treating `null
+  /// as a distinct value.
+  ///
+  /// Only one filter can be applied to `.stream()`.
+  ///
+  /// ```dart
+  /// supabase.from('users').stream(primaryKey: ['id']).isDistinct('age', null);
+  /// ```
+  SupabaseStreamBuilder isDistinct(String column, Object? value) {
+    _streamFilter = (
+      type: PostgresChangeFilterType.isDistinct,
+      column: column,
+      value: value,
     );
     return this;
   }

--- a/packages/supabase/lib/src/supabase_stream_filter_builder.dart
+++ b/packages/supabase/lib/src/supabase_stream_filter_builder.dart
@@ -13,210 +13,184 @@ class SupabaseStreamFilterBuilder extends SupabaseStreamBuilder {
 
   /// Filters the results where [column] equals [value].
   ///
-  /// Only one filter can be applied to `.stream()`.
-  ///
   /// ```dart
   /// supabase.from('users').stream(primaryKey: ['id']).eq('name', 'Supabase');
   /// ```
-  SupabaseStreamBuilder eq(String column, Object value) {
-    _streamFilter = (
+  SupabaseStreamFilterBuilder eq(String column, Object value) {
+    _streamFilter.add((
       type: PostgresChangeFilterType.eq,
       column: column,
       value: value,
-    );
+    ));
     return this;
   }
 
   /// Filters the results where [column] does not equal [value].
   ///
-  /// Only one filter can be applied to `.stream()`.
-  ///
   /// ```dart
   /// supabase.from('users').stream(primaryKey: ['id']).neq('name', 'Supabase');
   /// ```
-  SupabaseStreamBuilder neq(String column, Object value) {
-    _streamFilter = (
+  SupabaseStreamFilterBuilder neq(String column, Object value) {
+    _streamFilter.add((
       type: PostgresChangeFilterType.neq,
       column: column,
       value: value,
-    );
+    ));
     return this;
   }
 
   /// Filters the results where [column] is less than [value].
   ///
-  /// Only one filter can be applied to `.stream()`.
-  ///
   /// ```dart
   /// supabase.from('users').stream(primaryKey: ['id']).lt('likes', 100);
   /// ```
-  SupabaseStreamBuilder lt(String column, Object value) {
-    _streamFilter = (
+  SupabaseStreamFilterBuilder lt(String column, Object value) {
+    _streamFilter.add((
       type: PostgresChangeFilterType.lt,
       column: column,
       value: value,
-    );
+    ));
     return this;
   }
 
   /// Filters the results where [column] is less than or equal to [value].
   ///
-  /// Only one filter can be applied to `.stream()`.
-  ///
   /// ```dart
   /// supabase.from('users').stream(primaryKey: ['id']).lte('likes', 100);
   /// ```
-  SupabaseStreamBuilder lte(String column, Object value) {
-    _streamFilter = (
+  SupabaseStreamFilterBuilder lte(String column, Object value) {
+    _streamFilter.add((
       type: PostgresChangeFilterType.lte,
       column: column,
       value: value,
-    );
+    ));
     return this;
   }
 
   /// Filters the results where [column] is greater than [value].
   ///
-  /// Only one filter can be applied to `.stream()`.
-  ///
   /// ```dart
   /// supabase.from('users').stream(primaryKey: ['id']).gt('likes', '100');
   /// ```
-  SupabaseStreamBuilder gt(String column, Object value) {
-    _streamFilter = (
+  SupabaseStreamFilterBuilder gt(String column, Object value) {
+    _streamFilter.add((
       type: PostgresChangeFilterType.gt,
       column: column,
       value: value,
-    );
+    ));
     return this;
   }
 
   /// Filters the results where [column] is greater than or equal to [value].
   ///
-  /// Only one filter can be applied to `.stream()`.
-  ///
   /// ```dart
   /// supabase.from('users').stream(primaryKey: ['id']).gte('likes', 100);
   /// ```
-  SupabaseStreamBuilder gte(String column, Object value) {
-    _streamFilter = (
+  SupabaseStreamFilterBuilder gte(String column, Object value) {
+    _streamFilter.add((
       type: PostgresChangeFilterType.gte,
       column: column,
       value: value,
-    );
+    ));
     return this;
   }
 
   /// Filters the results where [column] is included in [values].
   ///
-  /// Only one filter can be applied to `.stream()`.
-  ///
   /// ```dart
   /// supabase.from('users').stream(primaryKey: ['id']).inFilter('name', ['Andy', 'Amy', 'Terry']);
   /// ```
-  SupabaseStreamBuilder inFilter(String column, List<Object> values) {
-    _streamFilter = (
+  SupabaseStreamFilterBuilder inFilter(String column, List<Object> values) {
+    _streamFilter.add((
       type: PostgresChangeFilterType.inFilter,
       column: column,
       value: values,
-    );
+    ));
     return this;
   }
 
   /// Filters the results where [column] matches the [pattern] case-sensitive.
   ///
-  /// Only one filter can be applied to `.stream()`.
-  ///
   /// ```dart
   /// supabase.from('users').stream(primaryKey: ['id']).like('title', '%foo%');
   /// ```
-  SupabaseStreamBuilder like(String column, String pattern) {
-    _streamFilter = (
+  SupabaseStreamFilterBuilder like(String column, String pattern) {
+    _streamFilter.add((
       type: PostgresChangeFilterType.like,
       column: column,
       value: pattern,
-    );
+    ));
     return this;
   }
 
   /// Filters the results where [column] matches the [pattern] case-insensitive.
   ///
-  /// Only one filter can be applied to `.stream()`.
-  ///
   /// ```dart
   /// supabase.from('users').stream(primaryKey: ['id']).ilike('title', '%foo%');
   /// ```
-  SupabaseStreamBuilder ilike(String column, String pattern) {
-    _streamFilter = (
+  SupabaseStreamFilterBuilder ilike(String column, String pattern) {
+    _streamFilter.add((
       type: PostgresChangeFilterType.ilike,
       column: column,
       value: pattern,
-    );
+    ));
     return this;
   }
 
   /// Filters the results where [column] matches the POSIX [regex] case-sensitive.
   ///
-  /// Only one filter can be applied to `.stream()`.
-  ///
   /// ```dart
   /// supabase.from('users').stream(primaryKey: ['id']).match('slug', r'^post-\d+$');
   /// ```
-  SupabaseStreamBuilder match(String column, String regex) {
-    _streamFilter = (
+  SupabaseStreamFilterBuilder match(String column, String regex) {
+    _streamFilter.add((
       type: PostgresChangeFilterType.match,
       column: column,
       value: regex,
-    );
+    ));
     return this;
   }
 
   /// Filters the results where [column] matches the POSIX [regex] case-insensitive.
   ///
-  /// Only one filter can be applied to `.stream()`.
-  ///
   /// ```dart
   /// supabase.from('users').stream(primaryKey: ['id']).imatch('slug', r'^post-\d+$');
   /// ```
-  SupabaseStreamBuilder imatch(String column, String regex) {
-    _streamFilter = (
+  SupabaseStreamFilterBuilder imatch(String column, String regex) {
+    _streamFilter.add((
       type: PostgresChangeFilterType.imatch,
       column: column,
       value: regex,
-    );
+    ));
     return this;
   }
 
   /// Filters the results where [column] is `null`, `true` or `false`.
   ///
-  /// Only one filter can be applied to `.stream()`.
-  ///
   /// ```dart
   /// supabase.from('users').stream(primaryKey: ['id']).isFilter('data', null);
   /// ```
-  SupabaseStreamBuilder isFilter(String column, bool? value) {
-    _streamFilter = (
+  SupabaseStreamFilterBuilder isFilter(String column, bool? value) {
+    _streamFilter.add((
       type: PostgresChangeFilterType.isFilter,
       column: column,
       value: value,
-    );
+    ));
     return this;
   }
 
   /// Filters the results where [column] is not equal to [value] treating `null
   /// as a distinct value.
   ///
-  /// Only one filter can be applied to `.stream()`.
-  ///
   /// ```dart
   /// supabase.from('users').stream(primaryKey: ['id']).isDistinct('age', null);
   /// ```
-  SupabaseStreamBuilder isDistinct(String column, Object? value) {
-    _streamFilter = (
+  SupabaseStreamFilterBuilder isDistinct(String column, Object? value) {
+    _streamFilter.add((
       type: PostgresChangeFilterType.isDistinct,
       column: column,
       value: value,
-    );
+    ));
     return this;
   }
 }

--- a/packages/supabase/lib/src/supabase_stream_filter_builder.dart
+++ b/packages/supabase/lib/src/supabase_stream_filter_builder.dart
@@ -179,7 +179,7 @@ class SupabaseStreamFilterBuilder extends SupabaseStreamBuilder {
     return this;
   }
 
-  /// Filters the results where [column] is not equal to [value] treating `null
+  /// Filters the results where [column] is not equal to [value] treating `null`
   /// as a distinct value.
   ///
   /// ```dart

--- a/packages/supabase/test/stream_integration_test.dart
+++ b/packages/supabase/test/stream_integration_test.dart
@@ -10,6 +10,10 @@ import '../../postgrest/test/test_utils.dart' show serviceRoleKey;
 
 late SupabaseClient _supabase;
 
+/// Track if this is the first connection to the stream. This is used to wait a
+/// bit longer for the first connection to get the replication working properly.
+bool _firstConnection = true;
+
 void main() {
   setUpAll(() async {
     final client = SupabaseClient(
@@ -39,16 +43,6 @@ void main() {
   tearDown(() async {
     await _supabase.removeAllChannels();
     await _supabase.dispose();
-  });
-
-  test('stream lifecycle smoke test', () async {
-    await _expectSnapshots(
-      stream: _supabase.from('users').stream(primaryKey: ['username']),
-      expectedSnapshots: [
-        {'awailas', 'dragarcia', 'kiwicopple', 'supabot'},
-      ],
-      inserts: const [],
-    );
   });
 
   group('stream() filters', () {
@@ -430,6 +424,16 @@ Future<void> _expectSnapshots({
   final bStream = stream.asBroadcastStream();
   unawaited(
     bStream.first.then((_) async {
+      if (_firstConnection) {
+        _firstConnection = false;
+        // We need to wait a bit longer for the first connection to get the replication working properly
+        await Future.delayed(
+          const Duration(seconds: 3),
+        ); // wait for replication
+      }
+      await Future.delayed(
+        const Duration(milliseconds: 500),
+      ); // wait for replication
       for (final user in inserts) {
         await _supabase.from('users').insert({
           'username': user.username,
@@ -450,6 +454,9 @@ Future<void> _resetUsers(SupabaseClient client) async {
       .from('users')
       .delete()
       .not('username', 'in', _seedUsers.map((u) => u.username).toList());
+  await Future.delayed(
+    const Duration(milliseconds: 500),
+  ); // wait for replication
 }
 
 Set<String> _usernamesFromRows(List<Map<String, dynamic>> rows) {

--- a/packages/supabase/test/stream_integration_test.dart
+++ b/packages/supabase/test/stream_integration_test.dart
@@ -1,0 +1,481 @@
+@Tags(['integration'])
+library;
+
+import 'dart:async';
+
+import 'package:supabase/supabase.dart';
+import 'package:test/test.dart';
+
+import '../../postgrest/test/test_utils.dart' show serviceRoleKey;
+
+late SupabaseClient _supabase;
+
+void main() {
+  setUpAll(() async {
+    final client = SupabaseClient(
+      _apiUrl,
+      serviceRoleKey,
+    );
+
+    for (final user in _seedUsers) {
+      await client.from('users').upsert({
+        'username': user.username,
+        'status': user.status,
+      });
+    }
+    await Future.delayed(
+      const Duration(milliseconds: 500),
+    ); // wait for replication
+  });
+
+  setUp(() async {
+    _supabase = SupabaseClient(
+      _apiUrl,
+      serviceRoleKey,
+    );
+    await _resetUsers(_supabase);
+  });
+
+  tearDown(() async {
+    await _supabase.removeAllChannels();
+    await _supabase.dispose();
+  });
+
+  test('stream lifecycle smoke test', () async {
+    await _expectSnapshots(
+      stream: _supabase.from('users').stream(primaryKey: ['username']),
+      expectedSnapshots: [
+        {'awailas', 'dragarcia', 'kiwicopple', 'supabot'},
+      ],
+      inserts: const [],
+    );
+  });
+
+  group('stream() filters', () {
+    test('eq', () async {
+      await _expectSnapshots(
+        stream: _supabase
+            .from('users')
+            .stream(primaryKey: ['username'])
+            .eq('status', 'ONLINE'),
+        expectedSnapshots: [
+          {'awailas', 'dragarcia', 'supabot'},
+          {'awailas', 'dragarcia', 'new_online', 'supabot'},
+        ],
+        inserts: [
+          (
+            username: 'new_offline',
+            status: 'OFFLINE',
+          ),
+          (
+            username: 'new_online',
+            status: 'ONLINE',
+          ),
+        ],
+      );
+    });
+
+    test('neq', () async {
+      await _expectSnapshots(
+        stream: _supabase
+            .from('users')
+            .stream(primaryKey: ['username'])
+            .neq('status', 'ONLINE'),
+        expectedSnapshots: [
+          {'kiwicopple'},
+          {'kiwicopple', 'new_offline'},
+        ],
+        inserts: [
+          (
+            username: 'new_online',
+            status: 'ONLINE',
+          ),
+          (
+            username: 'new_offline',
+            status: 'OFFLINE',
+          ),
+        ],
+      );
+    });
+
+    test('gt', () async {
+      await _expectSnapshots(
+        stream: _supabase
+            .from('users')
+            .stream(primaryKey: ['username'])
+            .gt('username', 'kiwicopple'),
+        expectedSnapshots: [
+          {'supabot'},
+          {'supabot', 'zeta_match'},
+        ],
+        inserts: [
+          (
+            username: 'alpha_miss',
+            status: 'ONLINE',
+          ),
+          (
+            username: 'zeta_match',
+            status: 'ONLINE',
+          ),
+        ],
+      );
+    });
+
+    test('gte', () async {
+      await _expectSnapshots(
+        stream: _supabase
+            .from('users')
+            .stream(primaryKey: ['username'])
+            .gte('username', 'kiwicopple'),
+        expectedSnapshots: [
+          {'kiwicopple', 'supabot'},
+          {'kiwicopple', 'supabot', 'zeta_match'},
+        ],
+        inserts: [
+          (
+            username: 'alpha_miss',
+            status: 'ONLINE',
+          ),
+          (
+            username: 'zeta_match',
+            status: 'ONLINE',
+          ),
+        ],
+      );
+    });
+
+    test('lt', () async {
+      await _expectSnapshots(
+        stream: _supabase
+            .from('users')
+            .stream(primaryKey: ['username'])
+            .lt('username', 'kiwicopple'),
+        expectedSnapshots: [
+          {'awailas', 'dragarcia'},
+          {'alpha_match', 'awailas', 'dragarcia'},
+        ],
+        inserts: [
+          (
+            username: 'zeta_miss',
+            status: 'ONLINE',
+          ),
+          (
+            username: 'alpha_match',
+            status: 'ONLINE',
+          ),
+        ],
+      );
+    });
+
+    test('lte', () async {
+      await _expectSnapshots(
+        stream: _supabase
+            .from('users')
+            .stream(primaryKey: ['username'])
+            .lte('username', 'kiwicopple'),
+        expectedSnapshots: [
+          {'awailas', 'dragarcia', 'kiwicopple'},
+          {'alpha_match', 'awailas', 'dragarcia', 'kiwicopple'},
+        ],
+        inserts: [
+          (
+            username: 'zeta_miss',
+            status: 'ONLINE',
+          ),
+          (
+            username: 'alpha_match',
+            status: 'ONLINE',
+          ),
+        ],
+      );
+    });
+
+    test('inFilter', () async {
+      await _expectSnapshots(
+        stream: _supabase
+            .from('users')
+            .stream(primaryKey: ['username'])
+            .inFilter('status', ['ONLINE']),
+        expectedSnapshots: [
+          {'awailas', 'dragarcia', 'supabot'},
+          {'awailas', 'dragarcia', 'in_online', 'supabot'},
+        ],
+        inserts: [
+          (
+            username: 'in_offline',
+            status: 'OFFLINE',
+          ),
+          (
+            username: 'in_online',
+            status: 'ONLINE',
+          ),
+        ],
+      );
+    });
+
+    test('like', () async {
+      await _expectSnapshots(
+        stream: _supabase
+            .from('users')
+            .stream(primaryKey: ['username'])
+            .like('username', '%supa%'),
+        expectedSnapshots: [
+          {'supabot'},
+          {'supabot', 'super-supa'},
+        ],
+        inserts: [
+          (
+            username: 'kiwi-extra',
+            status: 'ONLINE',
+          ),
+          (
+            username: 'super-supa',
+            status: 'ONLINE',
+          ),
+        ],
+      );
+    });
+
+    test('ilike', () async {
+      await _expectSnapshots(
+        stream: _supabase
+            .from('users')
+            .stream(primaryKey: ['username'])
+            .ilike('username', '%SUPA%'),
+        expectedSnapshots: [
+          {'supabot'},
+          {'SUPAfriend', 'supabot'},
+        ],
+        inserts: [
+          (
+            username: 'kiwi-extra',
+            status: 'ONLINE',
+          ),
+          (
+            username: 'SUPAfriend',
+            status: 'ONLINE',
+          ),
+        ],
+      );
+    });
+
+    test('match', () async {
+      await _expectSnapshots(
+        stream: _supabase
+            .from('users')
+            .stream(primaryKey: ['username'])
+            .match('username', '^supa.*'),
+        expectedSnapshots: [
+          {'supabot'},
+          {'supa_friend', 'supabot'},
+        ],
+        inserts: [
+          (
+            username: 'bot_supa',
+            status: 'ONLINE',
+          ),
+          (
+            username: 'supa_friend',
+            status: 'ONLINE',
+          ),
+        ],
+      );
+    });
+
+    test('imatch', () async {
+      await _expectSnapshots(
+        stream: _supabase
+            .from('users')
+            .stream(primaryKey: ['username'])
+            .imatch('username', '^SUPA.*'),
+        expectedSnapshots: [
+          {'supabot'},
+          {'SUPA_friend', 'supabot'},
+        ],
+        inserts: [
+          (
+            username: 'bot_supa',
+            status: 'ONLINE',
+          ),
+          (
+            username: 'SUPA_friend',
+            status: 'ONLINE',
+          ),
+        ],
+      );
+    });
+
+    test('isFilter', () async {
+      await _expectSnapshots(
+        stream: _supabase
+            .from('users')
+            .stream(primaryKey: ['username'])
+            .isFilter('data', null),
+        expectedSnapshots: [
+          {'awailas', 'dragarcia', 'kiwicopple', 'supabot'},
+          {'awailas', 'dragarcia', 'kiwicopple', 'null_view', 'supabot'},
+        ],
+        inserts: [
+          (
+            username: 'null_view',
+            status: 'ONLINE',
+          ),
+        ],
+      );
+    });
+
+    test('isDistinct', () async {
+      await _expectSnapshots(
+        stream: _supabase
+            .from('users')
+            .stream(primaryKey: ['username'])
+            .isDistinct('status', 'ONLINE'),
+        expectedSnapshots: [
+          {'kiwicopple'},
+          {'distinct_null', 'kiwicopple'},
+        ],
+        inserts: [
+          (
+            username: 'distinct_null',
+            status: null,
+          ),
+        ],
+      );
+    });
+  });
+
+  group('stream() multiple filters', () {
+    test('eq + like uses AND semantics', () async {
+      await _expectSnapshots(
+        stream: _supabase
+            .from('users')
+            .stream(primaryKey: ['username'])
+            .eq('status', 'ONLINE')
+            .like('username', '%supa%'),
+        expectedSnapshots: [
+          {'supabot'},
+          {'supa_online', 'supabot'},
+        ],
+        inserts: [
+          (
+            username: 'supa_offline',
+            status: 'OFFLINE',
+          ),
+          (
+            username: 'supa_online',
+            status: 'ONLINE',
+          ),
+        ],
+      );
+    });
+
+    test('isFilter + ilike uses AND semantics', () async {
+      await _expectSnapshots(
+        stream: _supabase
+            .from('users')
+            .stream(primaryKey: ['username'])
+            .isFilter('data', null)
+            .ilike('username', '%gar%'),
+        expectedSnapshots: [
+          {'dragarcia'},
+          {'GAR_user', 'dragarcia'},
+        ],
+        inserts: [
+          (
+            username: 'other_null',
+            status: 'ONLINE',
+          ),
+          (
+            username: 'GAR_user',
+            status: 'ONLINE',
+          ),
+        ],
+      );
+    });
+
+    test('eq + gt uses AND semantics', () async {
+      await _expectSnapshots(
+        stream: _supabase
+            .from('users')
+            .stream(primaryKey: ['username'])
+            .eq('status', 'ONLINE')
+            .gt('username', 'b'),
+        expectedSnapshots: [
+          {'dragarcia', 'supabot'},
+          {'charlie_online', 'dragarcia', 'supabot'},
+        ],
+        inserts: [
+          (
+            username: 'alpha_online',
+            status: 'ONLINE',
+          ),
+          (
+            username: 'charlie_online',
+            status: 'ONLINE',
+          ),
+        ],
+      );
+    });
+  });
+}
+
+const _apiUrl = 'http://127.0.0.1:54421';
+const _streamTimeout = Duration(seconds: 10);
+
+Future<void> _expectSnapshots({
+  required Stream<List<Map<String, dynamic>>> stream,
+  required List<Set<String>> expectedSnapshots,
+  required List<_UserSeed> inserts,
+}) async {
+  final bStream = stream.asBroadcastStream();
+  unawaited(
+    bStream.first.then((_) async {
+      for (final user in inserts) {
+        await _supabase.from('users').insert({
+          'username': user.username,
+          'status': user.status,
+        });
+      }
+    }),
+  );
+
+  await expectLater(
+    bStream.map(_usernamesFromRows).timeout(_streamTimeout),
+    emitsInOrder(expectedSnapshots),
+  );
+}
+
+Future<void> _resetUsers(SupabaseClient client) async {
+  await client
+      .from('users')
+      .delete()
+      .not('username', 'in', _seedUsers.map((u) => u.username).toList());
+}
+
+Set<String> _usernamesFromRows(List<Map<String, dynamic>> rows) {
+  return rows.map((row) => row['username']).whereType<String>().toSet();
+}
+
+final _seedUsers = <_UserSeed>[
+  (
+    username: 'supabot',
+    status: 'ONLINE',
+  ),
+  (
+    username: 'kiwicopple',
+    status: 'OFFLINE',
+  ),
+  (
+    username: 'awailas',
+    status: 'ONLINE',
+  ),
+  (
+    username: 'dragarcia',
+    status: 'ONLINE',
+  ),
+];
+
+typedef _UserSeed = ({
+  String? status,
+  String username,
+});

--- a/packages/supabase/test/stream_integration_test.dart
+++ b/packages/supabase/test/stream_integration_test.dart
@@ -27,6 +27,7 @@ void main() {
         'status': user.status,
       });
     }
+    await client.dispose();
     await Future.delayed(
       const Duration(milliseconds: 500),
     ); // wait for replication

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -467,6 +467,7 @@ features:
     status: implemented
     symbols:
       - PostgrestFilterBuilder.eq
+      - SupabaseStreamFilterBuilder.eq
   database.using_filters.neq:
     status: implemented
     symbols:
@@ -491,6 +492,7 @@ features:
     status: implemented
     symbols:
       - PostgrestFilterBuilder.like
+      - SupabaseStreamFilterBuilder.like
   database.using_filters.like_all:
     status: implemented
     symbols:
@@ -503,6 +505,7 @@ features:
     status: implemented
     symbols:
       - PostgrestFilterBuilder.ilike
+      - SupabaseStreamFilterBuilder.ilike
   database.using_filters.ilike_all:
     status: implemented
     symbols:
@@ -515,10 +518,12 @@ features:
     status: implemented
     symbols:
       - PostgrestFilterBuilder.isFilter
+      - SupabaseStreamFilterBuilder.isFilter
   database.using_filters.is_distinct:
     status: implemented
     symbols:
       - PostgrestFilterBuilder.isDistinct
+      - SupabaseStreamFilterBuilder.isDistinct
   database.using_filters.in:
     status: implemented
     symbols:
@@ -579,10 +584,12 @@ features:
     status: implemented
     symbols:
       - PostgrestFilterBuilder.matchRegex
+      - SupabaseStreamFilterBuilder.match
   database.using_filters.regex_icase:
     status: implemented
     symbols:
       - PostgrestFilterBuilder.imatchRegex
+      - SupabaseStreamFilterBuilder.imatch
   database.using_filters.raw:
     status: implemented
     symbols:

--- a/supabase/migrations/20240101000000_postgrest_schema.sql
+++ b/supabase/migrations/20240101000000_postgrest_schema.sql
@@ -16,6 +16,7 @@ create table public.users (
 );
 alter table public.users replica identity full;
 comment on column public.users.data is 'For unstructured data and prototyping.';
+alter publication supabase_realtime add table public.users;
 
 -- CHANNELS
 create table public.channels (


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature; catching up with newer capabilities of the realtime client for the stream method.

## What is the current behavior?

- The `stream` did not catch up with newly supported realtime filters like `like`, `ilike`, `match`, `imatch`, `isDistinct`
- Previously realtime did only allow one filter, but that has changed and is not yet reflected in the stream method.

## What is the new behavior?

- Allow the new filters as well
- Allow any count of filters
- Improve documentation of the `stream` method by mentioning two realtime caveats affecting the behavior of the stream method

I've also added the first integration tests for the stream method. Ensuring the values are all properly serialized as well.

## Additional context

- realtime filters documentation: https://supabase.com/docs/guides/realtime/postgres-changes?queryGroups=language&language=dart#available-filters

This pr does not yet cover adding negated stream filters. Will add that in a future pr.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added support for combining multiple filters in real-time `stream()` calls using AND semantics.
  * Added stream filters including `like`, `ilike`, `match`, `imatch`, `isFilter`, and `isDistinct`.
* **Bug Fixes**
  * Improved reliability of Docker-based real-time integration tests with longer timeouts.
* **Documentation**
  * Expanded streaming guidance covering filtering, behavior, supported operators, and event handling.
* **Chores**
  * Enabled real-time streaming updates for the `public.users` table.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->