### PR TITLE
fix(realtime_client): stop throwing internally when converting null cell values

### DIFF
--- a/packages/realtime_client/lib/src/transformers.dart
+++ b/packages/realtime_client/lib/src/transformers.dart
@@ -129,6 +129,10 @@ dynamic convertColumn(
 /// => [1,2,3,4]
 /// ```
 dynamic convertCell(String type, dynamic value) {
+  if (value == null) {
+    return null;
+  }
+
   // if data type is an array
   if (type[0] == '_') {
     final dataType = type.substring(1);
@@ -197,24 +201,20 @@ double? toDouble(dynamic value) {
   if (value is double) {
     return value;
   }
-  try {
-    final temp = value.toString();
-    return double.parse(temp);
-  } catch (_) {
+  if (value == null) {
     return null;
   }
+  return double.tryParse(value.toString());
 }
 
 int? toInt(dynamic value) {
   if (value is int) {
     return value;
   }
-  try {
-    final temp = value.toString();
-    return int.parse(temp);
-  } catch (_) {
+  if (value == null) {
     return null;
   }
+  return int.tryParse(value.toString());
 }
 
 dynamic toJson(dynamic value) {

--- a/packages/realtime_client/test/transformers_test.dart
+++ b/packages/realtime_client/test/transformers_test.dart
@@ -20,6 +20,23 @@ void main() {
     expect(toBoolean(null), isNull);
   });
 
+  test('transformers toInt', () {
+    expect(toInt(10), equals(10));
+    expect(toInt('10'), equals(10));
+    expect(toInt(null), isNull);
+    expect(toInt(''), isNull);
+    expect(toInt('not a number'), isNull);
+  });
+
+  test('transformers toDouble', () {
+    expect(toDouble(1.23), equals(1.23));
+    expect(toDouble('1.23'), equals(1.23));
+    expect(toDouble(1), equals(1.0));
+    expect(toDouble(null), isNull);
+    expect(toDouble(''), isNull);
+    expect(toDouble('not a number'), isNull);
+  });
+
   test('transformers noop', () {
     expect(noop(null), equals(null));
     expect(noop(''), equals(''));


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (internal exception noise; no observable behavior change).

## What is the current behavior?

`convertCell`'s doc comment says *"If the value of the cell is `null`, returns null"* — but the code never checks for null. A null value in an `int2/int4/int8/oid` (or `float4/float8/numeric`) column falls through to `toInt`/`toDouble`, which do:

```dart
try {
  return int.parse(value.toString()); // null → "null" → FormatException
} catch (_) {
  return null;
}
```

So every `postgres_changes` payload containing a null numeric column throws (and immediately catches) `FormatException: Invalid radix-10 number (at character 1) null` inside the library.

The converted result is correct, but the exception-as-control-flow fires on **every CDC frame** for any subscribed table with nullable numeric columns. In practice this means anyone debugging a realtime Flutter app with "break on all exceptions" enabled gets stopped in `integers_patch.dart` constantly, with no way to silence it from app code.

For reference, realtime-js doesn't have this problem: its `toNumber` only parses `typeof value === 'string'` and passes null through untouched.

## What is the new behavior?

- `convertCell` short-circuits `null` → `null`, matching its own documented behavior and realtime-js
- `toInt`/`toDouble` use `tryParse` instead of `parse` inside try/catch, so unparseable strings also no longer throw internally

Output is unchanged for every input — existing tests already pin `convertCell('int8', null) => null` and `convertCell('float8', null) => null`, and they still pass. Added direct unit tests for `toInt`/`toDouble` covering null, empty, and non-numeric inputs.

## Additional context

Repro: subscribe to `postgres_changes` on any table with a nullable `integer` column, update a row while the column is null, run with a debugger set to break on all exceptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)