### PR TITLE
docs(compliance): register getSSOSignInUrl symbol for sign_in_with_sso

### DIFF
--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -33,7 +33,7 @@ features:
   auth.sign_in.sign_in_with_id_token: implemented
   auth.sign_in.sign_in_with_sso:
     status: implemented
-    note: "Exposed as getSSOSignInUrl, which returns Future<String> (the URL) rather than the structured {url} response used by JS."
+    note: "Split across two methods: getSSOSignInUrl returns Future<String> (the URL) rather than the structured {url} response used by JS, and supabase_flutter's signInWithSSO launches that URL in the browser and returns Future<bool>."
     symbols:
       - GoTrueClient.getSSOSignInUrl
   auth.sign_in.sign_in_with_web3:

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -34,6 +34,8 @@ features:
   auth.sign_in.sign_in_with_sso:
     status: implemented
     note: "Exposed as getSSOSignInUrl, which returns Future<String> (the URL) rather than the structured {url} response used by JS."
+    symbols:
+      - GoTrueClient.getSSOSignInUrl
   auth.sign_in.sign_in_with_web3:
     status: implemented
     note: "Callers sign the SIWE/SIWS message with their own wallet library and pass the message and signature; the SDK does not auto-detect browser wallets or build the message, since window.ethereum/window.solana have no Flutter equivalent."


### PR DESCRIPTION
## What

Adds the backing public symbol `GoTrueClient.getSSOSignInUrl` to the `auth.sign_in.sign_in_with_sso` entry in `sdk-compliance.yaml`.

## Why

SSO sign-in is already functionally complete in the Dart SDK: the redirect URL is obtained via the public `getSSOSignInUrl`, which is re-exported all the way up so end users can call `supabase.auth.getSSOSignInUrl(...)` directly. The matrix already documented the deviation from supabase-js (returns `Future<String>` instead of the structured `{ url }` response); this change records the concrete symbol that backs the capability, matching how other entries (e.g. `auth.session.get_session` → `GoTrueClient.getSession`) list theirs.

Follow-up to the discussion on #1598, which was closed as not planned since the capability is already reachable and the name/return-shape alignment is a v3 concern.