### PR TITLE
docs(compliance): register backing symbols for all implemented capabilities

### DIFF
--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -22,15 +22,27 @@ sdk: flutter
 
 features:
   # auth — sign in / sign up
-  auth.sign_in.sign_up: implemented
-  auth.sign_in.sign_in_with_password: implemented
-  auth.sign_in.sign_in_with_otp: implemented
+  auth.sign_in.sign_up:
+    status: implemented
+    symbols:
+      - GoTrueClient.signUp
+  auth.sign_in.sign_in_with_password:
+    status: implemented
+    symbols:
+      - GoTrueClient.signInWithPassword
+  auth.sign_in.sign_in_with_otp:
+    status: implemented
+    symbols:
+      - GoTrueClient.signInWithOtp
   auth.sign_in.sign_in_with_oauth:
     status: implemented
     symbols:
       - OAuthProvider
       - OAuthProvider.OAuthProvider
-  auth.sign_in.sign_in_with_id_token: implemented
+  auth.sign_in.sign_in_with_id_token:
+    status: implemented
+    symbols:
+      - GoTrueClient.signInWithIdToken
   auth.sign_in.sign_in_with_sso:
     status: implemented
     note: "Split across two methods: getSSOSignInUrl returns Future<String> (the URL) rather than the structured {url} response used by JS, and supabase_flutter's signInWithSSO launches that URL in the browser and returns Future<bool>."
@@ -42,12 +54,30 @@ features:
     symbols:
       - GoTrueClient.signInWithWeb3
       - Web3Chain
-  auth.sign_in.sign_in_anonymously: implemented
-  auth.sign_in.verify_otp: implemented
-  auth.sign_in.exchange_code_for_session: implemented
-  auth.sign_in.resend_confirmation: implemented
-  auth.sign_in.reauthenticate: implemented
-  auth.sign_in.reset_password: implemented
+  auth.sign_in.sign_in_anonymously:
+    status: implemented
+    symbols:
+      - GoTrueClient.signInAnonymously
+  auth.sign_in.verify_otp:
+    status: implemented
+    symbols:
+      - GoTrueClient.verifyOTP
+  auth.sign_in.exchange_code_for_session:
+    status: implemented
+    symbols:
+      - GoTrueClient.exchangeCodeForSession
+  auth.sign_in.resend_confirmation:
+    status: implemented
+    symbols:
+      - GoTrueClient.resend
+  auth.sign_in.reauthenticate:
+    status: implemented
+    symbols:
+      - GoTrueClient.reauthenticate
+  auth.sign_in.reset_password:
+    status: implemented
+    symbols:
+      - GoTrueClient.resetPasswordForEmail
 
   # auth — session & user
   auth.session.get_session:
@@ -58,16 +88,35 @@ features:
     status: implemented
     symbols:
       - GoTrueClient.setSession
-  auth.session.refresh_session: implemented
-  auth.session.get_user: implemented
+  auth.session.refresh_session:
+    status: implemented
+    symbols:
+      - GoTrueClient.refreshSession
+  auth.session.get_user:
+    status: implemented
+    symbols:
+      - GoTrueClient.getUser
   auth.session.update_user:
     status: implemented
     symbols:
       - UserAttributes.currentPassword
-  auth.session.get_claims: implemented
-  auth.session.sign_out: implemented
-  auth.session.auto_refresh: implemented
-  auth.session.subscribe_auth_events: implemented
+  auth.session.get_claims:
+    status: implemented
+    symbols:
+      - GoTrueClient.getClaims
+  auth.session.sign_out:
+    status: implemented
+    symbols:
+      - GoTrueClient.signOut
+  auth.session.auto_refresh:
+    status: implemented
+    symbols:
+      - GoTrueClient.startAutoRefresh
+      - GoTrueClient.stopAutoRefresh
+  auth.session.subscribe_auth_events:
+    status: implemented
+    symbols:
+      - GoTrueClient.onAuthStateChange
   auth.session.sign_out_reason:
     status: implemented
     symbols:
@@ -78,21 +127,57 @@ features:
   auth.identities.link_identity:
     status: implemented
     note: "Split into getLinkIdentityUrl (OAuth) and linkIdentityWithIdToken (ID token) rather than a single overloaded method."
-  auth.identities.list_identities: implemented
-  auth.identities.unlink_identity: implemented
+    symbols:
+      - GoTrueClient.getLinkIdentityUrl
+      - GoTrueClient.linkIdentityWithIdToken
+  auth.identities.list_identities:
+    status: implemented
+    symbols:
+      - GoTrueClient.getUserIdentities
+  auth.identities.unlink_identity:
+    status: implemented
+    symbols:
+      - GoTrueClient.unlinkIdentity
 
   # auth — MFA
-  auth.mfa.enroll: implemented
-  auth.mfa.challenge: implemented
-  auth.mfa.verify: implemented
-  auth.mfa.challenge_and_verify: implemented
-  auth.mfa.unenroll: implemented
-  auth.mfa.list_factors: implemented
-  auth.mfa.get_authenticator_assurance_level: implemented
+  auth.mfa.enroll:
+    status: implemented
+    symbols:
+      - GoTrueMFAApi.enroll
+  auth.mfa.challenge:
+    status: implemented
+    symbols:
+      - GoTrueMFAApi.challenge
+  auth.mfa.verify:
+    status: implemented
+    symbols:
+      - GoTrueMFAApi.verify
+  auth.mfa.challenge_and_verify:
+    status: implemented
+    symbols:
+      - GoTrueMFAApi.challengeAndVerify
+  auth.mfa.unenroll:
+    status: implemented
+    symbols:
+      - GoTrueMFAApi.unenroll
+  auth.mfa.list_factors:
+    status: implemented
+    symbols:
+      - GoTrueMFAApi.listFactors
+  auth.mfa.get_authenticator_assurance_level:
+    status: implemented
+    symbols:
+      - GoTrueMFAApi.getAuthenticatorAssuranceLevel
 
   # auth — passkeys (experimental)
-  auth.passkey.register_passkey: implemented
-  auth.passkey.sign_in_with_passkey: implemented
+  auth.passkey.register_passkey:
+    status: implemented
+    symbols:
+      - GoTrueClientPasskey.registerPasskey
+  auth.passkey.sign_in_with_passkey:
+    status: implemented
+    symbols:
+      - GoTrueClientPasskey.signInWithPasskey
 
   # auth — OAuth server (Supabase acting as an OAuth provider)
   auth.oauth_server.get_authorization_details:
@@ -152,18 +237,45 @@ features:
       - GoTrueOAuthApi.revokeGrant
 
   # auth — admin
-  auth.admin.create_user: implemented
-  auth.admin.get_user: implemented
-  auth.admin.update_user: implemented
-  auth.admin.delete_user: implemented
+  auth.admin.create_user:
+    status: implemented
+    symbols:
+      - GoTrueAdminApi.createUser
+  auth.admin.get_user:
+    status: implemented
+    symbols:
+      - GoTrueAdminApi.getUserById
+  auth.admin.update_user:
+    status: implemented
+    symbols:
+      - GoTrueAdminApi.updateUserById
+  auth.admin.delete_user:
+    status: implemented
+    symbols:
+      - GoTrueAdminApi.deleteUser
   auth.admin.list_users:
     status: partially_implemented
     note: "Returns the user list only; pagination metadata (total, nextPage, lastPage, aud) is not returned."
-  auth.admin.invite_user: implemented
-  auth.admin.generate_link: implemented
-  auth.admin.sign_out: implemented
-  auth.admin.list_mfa_factors: implemented
-  auth.admin.delete_mfa_factor: implemented
+  auth.admin.invite_user:
+    status: implemented
+    symbols:
+      - GoTrueAdminApi.inviteUserByEmail
+  auth.admin.generate_link:
+    status: implemented
+    symbols:
+      - GoTrueAdminApi.generateLink
+  auth.admin.sign_out:
+    status: implemented
+    symbols:
+      - GoTrueAdminApi.signOut
+  auth.admin.list_mfa_factors:
+    status: implemented
+    symbols:
+      - GoTrueAdminMFAApi.listFactors
+  auth.admin.delete_mfa_factor:
+    status: implemented
+    symbols:
+      - GoTrueAdminMFAApi.deleteFactor
   auth.admin.create_provider:
     status: implemented
     symbols:
@@ -274,75 +386,245 @@ features:
       - GoTrueAdminCustomProvidersApi.listProviders
 
   # auth — admin OAuth clients
-  auth.oauth_admin.create_client: implemented
-  auth.oauth_admin.get_client: implemented
-  auth.oauth_admin.update_client: implemented
-  auth.oauth_admin.delete_client: implemented
-  auth.oauth_admin.list_clients: implemented
-  auth.oauth_admin.regenerate_client_secret: implemented
+  auth.oauth_admin.create_client:
+    status: implemented
+    symbols:
+      - GoTrueAdminOAuthApi.createClient
+  auth.oauth_admin.get_client:
+    status: implemented
+    symbols:
+      - GoTrueAdminOAuthApi.getClient
+  auth.oauth_admin.update_client:
+    status: implemented
+    symbols:
+      - GoTrueAdminOAuthApi.updateClient
+  auth.oauth_admin.delete_client:
+    status: implemented
+    symbols:
+      - GoTrueAdminOAuthApi.deleteClient
+  auth.oauth_admin.list_clients:
+    status: implemented
+    symbols:
+      - GoTrueAdminOAuthApi.listClients
+  auth.oauth_admin.regenerate_client_secret:
+    status: implemented
+    symbols:
+      - GoTrueAdminOAuthApi.regenerateClientSecret
 
   # auth — admin passkeys (experimental)
-  auth.passkey_admin.list_passkeys: implemented
-  auth.passkey_admin.delete_passkey: implemented
+  auth.passkey_admin.list_passkeys:
+    status: implemented
+    symbols:
+      - GoTrueAdminPasskeyApi.listPasskeys
+  auth.passkey_admin.delete_passkey:
+    status: implemented
+    symbols:
+      - GoTrueAdminPasskeyApi.deletePasskey
 
   # database — query
-  database.query.from_table: implemented
-  database.query.select: implemented
+  database.query.from_table:
+    status: implemented
+    symbols:
+      - PostgrestClient.from
+  database.query.select:
+    status: implemented
+    symbols:
+      - PostgrestQueryBuilder.select
   database.query.rpc:
     status: implemented
     note: "head and count are applied via type-safe chaining (.head()/.count()) rather than inline call options, which is the idiomatic Dart builder pattern; inline options cannot preserve the distinct return types."
-  database.query.schema_selection: implemented
+    symbols:
+      - PostgrestClient.rpc
+  database.query.schema_selection:
+    status: implemented
+    symbols:
+      - PostgrestClient.schema
 
   # database — mutate
-  database.mutate.insert: implemented
-  database.mutate.update: implemented
-  database.mutate.upsert: implemented
-  database.mutate.delete: implemented
-  database.mutate.select_after_mutation: implemented
+  database.mutate.insert:
+    status: implemented
+    symbols:
+      - PostgrestQueryBuilder.insert
+  database.mutate.update:
+    status: implemented
+    symbols:
+      - PostgrestQueryBuilder.update
+  database.mutate.upsert:
+    status: implemented
+    symbols:
+      - PostgrestQueryBuilder.upsert
+  database.mutate.delete:
+    status: implemented
+    symbols:
+      - PostgrestQueryBuilder.delete
+  database.mutate.select_after_mutation:
+    status: implemented
+    symbols:
+      - PostgrestTransformBuilder.select
 
   # database — filters
-  database.using_filters.eq: implemented
-  database.using_filters.neq: implemented
-  database.using_filters.gt: implemented
-  database.using_filters.gte: implemented
-  database.using_filters.lt: implemented
-  database.using_filters.lte: implemented
-  database.using_filters.like: implemented
-  database.using_filters.like_all: implemented
-  database.using_filters.like_any: implemented
-  database.using_filters.ilike: implemented
-  database.using_filters.ilike_all: implemented
-  database.using_filters.ilike_any: implemented
-  database.using_filters.is: implemented
-  database.using_filters.is_distinct: implemented
-  database.using_filters.in: implemented
-  database.using_filters.not_in: implemented
-  database.using_filters.contains: implemented
-  database.using_filters.contained_by: implemented
-  database.using_filters.overlaps: implemented
-  database.using_filters.match: implemented
-  database.using_filters.not: implemented
-  database.using_filters.or: implemented
-  database.using_filters.range_gt: implemented
-  database.using_filters.range_gte: implemented
-  database.using_filters.range_lt: implemented
-  database.using_filters.range_lte: implemented
-  database.using_filters.range_adjacent: implemented
-  database.using_filters.text_search: implemented
-  database.using_filters.regex: implemented
-  database.using_filters.regex_icase: implemented
-  database.using_filters.raw: implemented
+  database.using_filters.eq:
+    status: implemented
+    symbols:
+      - PostgrestFilterBuilder.eq
+  database.using_filters.neq:
+    status: implemented
+    symbols:
+      - PostgrestFilterBuilder.neq
+  database.using_filters.gt:
+    status: implemented
+    symbols:
+      - PostgrestFilterBuilder.gt
+  database.using_filters.gte:
+    status: implemented
+    symbols:
+      - PostgrestFilterBuilder.gte
+  database.using_filters.lt:
+    status: implemented
+    symbols:
+      - PostgrestFilterBuilder.lt
+  database.using_filters.lte:
+    status: implemented
+    symbols:
+      - PostgrestFilterBuilder.lte
+  database.using_filters.like:
+    status: implemented
+    symbols:
+      - PostgrestFilterBuilder.like
+  database.using_filters.like_all:
+    status: implemented
+    symbols:
+      - PostgrestFilterBuilder.likeAllOf
+  database.using_filters.like_any:
+    status: implemented
+    symbols:
+      - PostgrestFilterBuilder.likeAnyOf
+  database.using_filters.ilike:
+    status: implemented
+    symbols:
+      - PostgrestFilterBuilder.ilike
+  database.using_filters.ilike_all:
+    status: implemented
+    symbols:
+      - PostgrestFilterBuilder.ilikeAllOf
+  database.using_filters.ilike_any:
+    status: implemented
+    symbols:
+      - PostgrestFilterBuilder.ilikeAnyOf
+  database.using_filters.is:
+    status: implemented
+    symbols:
+      - PostgrestFilterBuilder.isFilter
+  database.using_filters.is_distinct:
+    status: implemented
+    symbols:
+      - PostgrestFilterBuilder.isDistinct
+  database.using_filters.in:
+    status: implemented
+    symbols:
+      - PostgrestFilterBuilder.inFilter
+  database.using_filters.not_in:
+    status: implemented
+    symbols:
+      - PostgrestFilterBuilder.not
+  database.using_filters.contains:
+    status: implemented
+    symbols:
+      - PostgrestFilterBuilder.contains
+  database.using_filters.contained_by:
+    status: implemented
+    symbols:
+      - PostgrestFilterBuilder.containedBy
+  database.using_filters.overlaps:
+    status: implemented
+    symbols:
+      - PostgrestFilterBuilder.overlaps
+  database.using_filters.match:
+    status: implemented
+    symbols:
+      - PostgrestFilterBuilder.match
+  database.using_filters.not:
+    status: implemented
+    symbols:
+      - PostgrestFilterBuilder.not
+  database.using_filters.or:
+    status: implemented
+    symbols:
+      - PostgrestFilterBuilder.or
+  database.using_filters.range_gt:
+    status: implemented
+    symbols:
+      - PostgrestFilterBuilder.rangeGt
+  database.using_filters.range_gte:
+    status: implemented
+    symbols:
+      - PostgrestFilterBuilder.rangeGte
+  database.using_filters.range_lt:
+    status: implemented
+    symbols:
+      - PostgrestFilterBuilder.rangeLt
+  database.using_filters.range_lte:
+    status: implemented
+    symbols:
+      - PostgrestFilterBuilder.rangeLte
+  database.using_filters.range_adjacent:
+    status: implemented
+    symbols:
+      - PostgrestFilterBuilder.rangeAdjacent
+  database.using_filters.text_search:
+    status: implemented
+    symbols:
+      - PostgrestFilterBuilder.textSearch
+  database.using_filters.regex:
+    status: implemented
+    symbols:
+      - PostgrestFilterBuilder.matchRegex
+  database.using_filters.regex_icase:
+    status: implemented
+    symbols:
+      - PostgrestFilterBuilder.imatchRegex
+  database.using_filters.raw:
+    status: implemented
+    symbols:
+      - PostgrestFilterBuilder.filter
 
   # database — modifiers
-  database.using_modifiers.order: implemented
-  database.using_modifiers.limit: implemented
-  database.using_modifiers.range: implemented
-  database.using_modifiers.single_row: implemented
-  database.using_modifiers.maybe_single_row: implemented
-  database.using_modifiers.max_affected_rows: implemented
-  database.using_modifiers.format_csv: implemented
-  database.using_modifiers.format_geojson: implemented
-  database.using_modifiers.relationship_embed: implemented
+  database.using_modifiers.order:
+    status: implemented
+    symbols:
+      - PostgrestTransformBuilder.order
+  database.using_modifiers.limit:
+    status: implemented
+    symbols:
+      - PostgrestTransformBuilder.limit
+  database.using_modifiers.range:
+    status: implemented
+    symbols:
+      - PostgrestTransformBuilder.range
+  database.using_modifiers.single_row:
+    status: implemented
+    symbols:
+      - PostgrestTransformBuilder.single
+  database.using_modifiers.maybe_single_row:
+    status: implemented
+    symbols:
+      - PostgrestTransformBuilder.maybeSingle
+  database.using_modifiers.max_affected_rows:
+    status: implemented
+    symbols:
+      - PostgrestTransformBuilder.maxAffected
+  database.using_modifiers.format_csv:
+    status: implemented
+    symbols:
+      - PostgrestTransformBuilder.csv
+  database.using_modifiers.format_geojson:
+    status: implemented
+    symbols:
+      - PostgrestTransformBuilder.geojson
+  database.using_modifiers.relationship_embed:
+    status: implemented
+    symbols:
+      - PostgrestTransformBuilder.select
   database.using_modifiers.explain:
     status: implemented
     symbols:
@@ -379,19 +661,46 @@ features:
       - PostgrestClientOptions.requestTimeout
 
   # storage — file buckets
-  storage.file_buckets.access_bucket: implemented
-  storage.file_buckets.upload: implemented
-  storage.file_buckets.upload_with_metadata: implemented
-  storage.file_buckets.upload_with_signed_url: implemented
-  storage.file_buckets.update_file: implemented
-  storage.file_buckets.download: implemented
-  storage.file_buckets.download_with_transform: implemented
+  storage.file_buckets.access_bucket:
+    status: implemented
+    symbols:
+      - SupabaseStorageClient.from
+  storage.file_buckets.upload:
+    status: implemented
+    symbols:
+      - StorageFileApi.upload
+      - StorageFileApi.uploadBinary
+  storage.file_buckets.upload_with_metadata:
+    status: implemented
+    symbols:
+      - FileOptions.metadata
+  storage.file_buckets.upload_with_signed_url:
+    status: implemented
+    symbols:
+      - StorageFileApi.uploadToSignedUrl
+      - StorageFileApi.uploadBinaryToSignedUrl
+  storage.file_buckets.update_file:
+    status: implemented
+    symbols:
+      - StorageFileApi.update
+      - StorageFileApi.updateBinary
+  storage.file_buckets.download:
+    status: implemented
+    symbols:
+      - StorageFileApi.download
+  storage.file_buckets.download_with_transform:
+    status: implemented
+    symbols:
+      - TransformOptions
   storage.file_buckets.download_as_stream:
     status: implemented
     note: "Exposed as a dedicated downloadStream method returning a lazy Stream<Uint8List> rather than an asStream() builder off download(); the request is sent on listen and a non-success status surfaces as a StorageException on the stream."
     symbols:
       - StorageFileApi.downloadStream
-  storage.file_buckets.list_files: implemented
+  storage.file_buckets.list_files:
+    status: implemented
+    symbols:
+      - StorageFileApi.list
   storage.file_buckets.list_files_paginated:
     status: implemented
     note: "Exposed as listPaginated (paired with descriptive Dart type names) rather than the supabase-js listV2 name."
@@ -435,11 +744,26 @@ features:
       - FileSortOrder
       - FileSortOrder.FileSortOrder
       - FileSortOrder.value
-  storage.file_buckets.move: implemented
-  storage.file_buckets.move_cross_bucket: implemented
-  storage.file_buckets.copy: implemented
-  storage.file_buckets.copy_cross_bucket: implemented
-  storage.file_buckets.remove: implemented
+  storage.file_buckets.move:
+    status: implemented
+    symbols:
+      - StorageFileApi.move
+  storage.file_buckets.move_cross_bucket:
+    status: implemented
+    symbols:
+      - StorageFileApi.move
+  storage.file_buckets.copy:
+    status: implemented
+    symbols:
+      - StorageFileApi.copy
+  storage.file_buckets.copy_cross_bucket:
+    status: implemented
+    symbols:
+      - StorageFileApi.copy
+  storage.file_buckets.remove:
+    status: implemented
+    symbols:
+      - StorageFileApi.remove
   storage.file_buckets.purge_cache:
     status: implemented
     symbols:
@@ -454,14 +778,38 @@ features:
       - DownloadBehavior
       - DownloadBehavior.named
       - DownloadBehavior.withOriginalName
-  storage.file_buckets.create_signed_urls: implemented
-  storage.file_buckets.create_signed_upload_url: implemented
-  storage.file_buckets.get_public_url: implemented
-  storage.file_buckets.url_cache_nonce: implemented
-  storage.file_buckets.file_exists: implemented
-  storage.file_buckets.file_info: implemented
-  storage.file_buckets.create_file_bucket: implemented
-  storage.file_buckets.get_bucket: implemented
+  storage.file_buckets.create_signed_urls:
+    status: implemented
+    symbols:
+      - StorageFileApi.createSignedUrls
+  storage.file_buckets.create_signed_upload_url:
+    status: implemented
+    symbols:
+      - StorageFileApi.createSignedUploadUrl
+  storage.file_buckets.get_public_url:
+    status: implemented
+    symbols:
+      - StorageFileApi.getPublicUrl
+  storage.file_buckets.url_cache_nonce:
+    status: implemented
+    symbols:
+      - StorageFileApi.getPublicUrl
+  storage.file_buckets.file_exists:
+    status: implemented
+    symbols:
+      - StorageFileApi.exists
+  storage.file_buckets.file_info:
+    status: implemented
+    symbols:
+      - StorageFileApi.info
+  storage.file_buckets.create_file_bucket:
+    status: implemented
+    symbols:
+      - StorageBucketApi.createBucket
+  storage.file_buckets.get_bucket:
+    status: implemented
+    symbols:
+      - StorageBucketApi.getBucket
   storage.file_buckets.list_file_buckets:
     status: implemented
     symbols:
@@ -478,9 +826,18 @@ features:
       - BucketSortOrder
       - BucketSortOrder.BucketSortOrder
       - BucketSortOrder.value
-  storage.file_buckets.update_bucket: implemented
-  storage.file_buckets.delete_file_bucket: implemented
-  storage.file_buckets.empty_bucket: implemented
+  storage.file_buckets.update_bucket:
+    status: implemented
+    symbols:
+      - StorageBucketApi.updateBucket
+  storage.file_buckets.delete_file_bucket:
+    status: implemented
+    symbols:
+      - StorageBucketApi.deleteBucket
+  storage.file_buckets.empty_bucket:
+    status: implemented
+    symbols:
+      - StorageBucketApi.emptyBucket
 
   # storage — vector buckets
   storage.vector_buckets.create_vector_bucket:
@@ -607,7 +964,8 @@ features:
   storage.vector_buckets.parallel_scan:
     status: implemented
     note: "Exposed through listVectors' segmentCount/segmentIndex parameters rather than a separate method; both are validated client-side."
-
+    symbols:
+      - StorageVectorIndexApi.listVectors
   # storage — analytics (Iceberg) buckets
   storage.analytics.create_analytics_bucket:
     status: implemented
@@ -993,35 +1351,70 @@ features:
       - UpgradeFormatVersionUpdate.toJson
 
   # realtime — channel
-  realtime.channel.subscribe: implemented
-  realtime.channel.unsubscribe: implemented
-  realtime.channel.send: implemented
+  realtime.channel.subscribe:
+    status: implemented
+    symbols:
+      - RealtimeChannel.subscribe
+  realtime.channel.unsubscribe:
+    status: implemented
+    symbols:
+      - RealtimeChannel.unsubscribe
+  realtime.channel.send:
+    status: implemented
+    symbols:
+      - RealtimeChannel.sendBroadcastMessage
   realtime.channel.broadcast_http:
     status: implemented
     note: "httpSend posts to the legacy /api/broadcast endpoint with a messages array and returns Future<void>, not the newer per-channel endpoint returning {success}."
 
+    symbols:
+      - RealtimeChannel.httpSend
   # realtime — client
-  realtime.client.channel: implemented
-  realtime.client.connect: implemented
+  realtime.client.channel:
+    status: implemented
+    symbols:
+      - RealtimeClient.channel
+  realtime.client.connect:
+    status: implemented
+    symbols:
+      - RealtimeChannel.subscribe
   realtime.client.disconnect:
     status: implemented
     symbols:
       - Constants.defaultConnectionCloseTimeout
       - RealtimeClient.connectionCloseTimeout
       - RealtimeClientOptions.connectionCloseTimeout
-  realtime.client.connection_state: implemented
-  realtime.client.get_channels: implemented
-  realtime.client.remove_channel: implemented
-  realtime.client.remove_all_channels: implemented
+  realtime.client.connection_state:
+    status: implemented
+    symbols:
+      - RealtimeClient.connectionState
+  realtime.client.get_channels:
+    status: implemented
+    symbols:
+      - RealtimeClient.getChannels
+  realtime.client.remove_channel:
+    status: implemented
+    symbols:
+      - RealtimeClient.removeChannel
+  realtime.client.remove_all_channels:
+    status: implemented
+    symbols:
+      - RealtimeClient.removeAllChannels
   realtime.client.listen_heartbeats:
     status: implemented
     symbols:
       - RealtimeClient.onHeartbeat
       - RealtimeHeartbeatStatus
-  realtime.client.set_auth_token: implemented
+  realtime.client.set_auth_token:
+    status: implemented
+    symbols:
+      - RealtimeClient.setAuth
 
   # realtime — subscriptions
-  realtime.subscriptions.broadcast: implemented
+  realtime.subscriptions.broadcast:
+    status: implemented
+    symbols:
+      - RealtimeChannel.onBroadcast
   realtime.subscriptions.postgres_changes:
     status: implemented
     symbols:
@@ -1040,27 +1433,74 @@ features:
     symbols:
       - PostgresChangeFilter.negate
       - PostgresChangeFilterType.token
-  realtime.subscriptions.subscribe_presence: implemented
-  realtime.subscriptions.private_channel: implemented
-  realtime.subscriptions.broadcast_self: implemented
-  realtime.subscriptions.broadcast_ack: implemented
-  realtime.subscriptions.broadcast_replay: implemented
+  realtime.subscriptions.subscribe_presence:
+    status: implemented
+    symbols:
+      - RealtimeChannel.onPresenceSync
+      - RealtimeChannel.onPresenceJoin
+      - RealtimeChannel.onPresenceLeave
+  realtime.subscriptions.private_channel:
+    status: implemented
+    symbols:
+      - RealtimeChannelConfig.private
+  realtime.subscriptions.broadcast_self:
+    status: implemented
+    symbols:
+      - RealtimeChannelConfig.self
+  realtime.subscriptions.broadcast_ack:
+    status: implemented
+    symbols:
+      - RealtimeChannelConfig.ack
+  realtime.subscriptions.broadcast_replay:
+    status: implemented
+    symbols:
+      - RealtimeChannelConfig.replay
 
   # realtime — presence
-  realtime.presence.track: implemented
-  realtime.presence.untrack: implemented
-  realtime.presence.presence_state: implemented
-  realtime.presence.presence_key: implemented
+  realtime.presence.track:
+    status: implemented
+    symbols:
+      - RealtimeChannel.track
+  realtime.presence.untrack:
+    status: implemented
+    symbols:
+      - RealtimeChannel.untrack
+  realtime.presence.presence_state:
+    status: implemented
+    symbols:
+      - RealtimeChannel.presenceState
+  realtime.presence.presence_key:
+    status: implemented
+    symbols:
+      - RealtimeChannelConfig.key
 
   # realtime — configuration
-  realtime.configuration.custom_websocket_transport: implemented
-  realtime.configuration.reconnect_backoff: implemented
-  realtime.configuration.heartbeat_interval: implemented
+  realtime.configuration.custom_websocket_transport:
+    status: implemented
+    symbols:
+      - RealtimeClientOptions.transport
+  realtime.configuration.reconnect_backoff:
+    status: implemented
+    symbols:
+      - RealtimeClient.reconnectAfterMs
+  realtime.configuration.heartbeat_interval:
+    status: implemented
+    symbols:
+      - RealtimeClient.heartbeatIntervalMs
   realtime.configuration.access_token_callback:
     status: implemented
     note: "On connect the access token is resolved before the send buffer is flushed; buffered channel join payloads are patched with the token and re-sent so subscriptions authenticate correctly when the token resolves asynchronously (e.g. read from async storage)."
-  realtime.configuration.custom_logger: implemented
-  realtime.configuration.binary_protocol: implemented
+    symbols:
+      - RealtimeClient.customAccessToken
+  realtime.configuration.custom_logger:
+    status: implemented
+    symbols:
+      - RealtimeClient.logger
+  realtime.configuration.binary_protocol:
+    status: implemented
+    symbols:
+      - RealtimeClient.encode
+      - RealtimeClient.decode
   realtime.configuration.deferred_disconnect:
     status: implemented
     symbols:
@@ -1076,10 +1516,22 @@ features:
       - FunctionsRelayException.FunctionsRelayException
       - FunctionsHttpException
       - FunctionsHttpException.FunctionsHttpException
-  functions.invocation.set_auth_token: implemented
-  functions.invocation.method_override: implemented
-  functions.invocation.streaming_response: implemented
-  functions.invocation.region_selection: implemented
+  functions.invocation.set_auth_token:
+    status: implemented
+    symbols:
+      - FunctionsClient.setAuth
+  functions.invocation.method_override:
+    status: implemented
+    symbols:
+      - HttpMethod
+  functions.invocation.streaming_response:
+    status: implemented
+    symbols:
+      - FunctionResponse.data
+  functions.invocation.region_selection:
+    status: implemented
+    symbols:
+      - FunctionsClientOptions.region
   functions.invocation.timeout:
     status: not_applicable
     note: "A genuine timeout that aborts the in-flight request is already expressible as `invoke(..., abortSignal: Future.delayed(duration))` via functions.invocation.request_cancellation, so a dedicated timeout option would add no capability over that."
@@ -1089,21 +1541,45 @@ features:
       - FunctionsClient.invoke
 
   # client
-  client.authentication_integration.third_party_auth: implemented
-  client.authentication_integration.cross_client_token_sync: implemented
-  client.authentication_integration.oauth_flow_type: implemented
+  client.authentication_integration.third_party_auth:
+    status: implemented
+    symbols:
+      - SupabaseClient.accessToken
+  client.authentication_integration.cross_client_token_sync:
+    status: implemented
+    symbols:
+      - PostgrestClient.setAuth
+      - RealtimeClient.setAuth
+      - SupabaseStorageClient.setAuth
+      - FunctionsClient.setAuth
+  client.authentication_integration.oauth_flow_type:
+    status: implemented
+    symbols:
+      - AuthFlowType
+      - AuthClientOptions.authFlowType
   client.authentication_integration.session_url_detection:
     status: implemented
     symbols:
       - FlutterAuthClientOptions.detectSessionInUri
       - FlutterAuthClientOptions.detectSessionInUriPredicate
-  client.session_management.custom_storage: implemented
+  client.session_management.custom_storage:
+    status: implemented
+    symbols:
+      - GotrueAsyncStorage
+      - LocalStorage
   client.session_management.persist_session:
     status: implemented
     symbols:
       - FlutterAuthClientOptions.persistSession
-  client.request_configuration.custom_http_client: implemented
-  client.request_configuration.global_headers: implemented
+  client.request_configuration.custom_http_client:
+    status: implemented
+    symbols:
+      - PostgrestClient.httpClient
+      - RealtimeClient.httpClient
+  client.request_configuration.global_headers:
+    status: implemented
+    symbols:
+      - SupabaseClient.headers
   client.observability.trace_propagation:
     status: implemented
     note: "Opt-in W3C trace context propagation (traceparent/tracestate/baggage) to Supabase hosts only, with sampling-decision respect. The active context is supplied through a traceContextProvider callback, the idiomatic Dart equivalent of supabase-js's automatic extraction from the OpenTelemetry global API, since Dart has no ubiquitous ambient trace context."


### PR DESCRIPTION
## What

Adds a `symbols:` list to every capability in `sdk-compliance.yaml` that was marked `implemented` but had no registered symbols (156 capabilities across auth, database, storage, realtime, functions, and client).

> **Stacked on #1613.** This PR targets `chore/sso-compliance-symbol` and inherits the `sign_in_with_sso` symbol registered there; review/merge #1613 first, then this.

## Why

The reusable **SDK Compliance** workflow runs a capability-matrix drift check on every PR (see the drift comment on #1613). For each `implemented` capability it expects a `symbols:` list so the Dart symbol extractor can confirm the backing public API actually exists. Capabilities without a list are reported as unverifiable, which is why every PR got a ~150-line drift warning. This registers the backing symbol(s) for each remaining one, clearing the drift.

## How

- Ran the same `dart_symbol_extractor` the CI uses (from `supabase/sdk`) against this repo to produce the ground-truth public symbol dump, then mapped each capability to the public Dart symbol(s) that implement it (e.g. `auth.sign_in.sign_up` → `GoTrueClient.signUp`, `database.using_filters.eq` → `PostgrestFilterBuilder.eq`).
- Every registered symbol was validated to exist in the extractor output, and the drift-check logic was replicated locally: it now reports **0 findings**.
- Symbols that are intentionally `@internal` (e.g. `RealtimeClient.connect`, which is not part of the public parity surface since Dart connects lazily on subscribe) were not registered; those capabilities point at the public symbol that actually drives them.

## Notes

- No source or public API changed, this only touches the compliance matrix, so the "new public symbols" check is unaffected.
