### PR TITLE
fix(functions): never send new-format API key as Bearer; warn on unrecognized sb_ key subtype

### DIFF
--- a/packages/supabase/lib/src/api_key.dart
+++ b/packages/supabase/lib/src/api_key.dart
@@ -1,4 +1,5 @@
 import 'package:logging/logging.dart';
+import 'package:meta/meta.dart';
 
 const _publishableKeyPrefix = 'sb_publishable_';
 const _secretKeyPrefix = 'sb_secret_';
@@ -8,6 +9,7 @@ const _secretKeyPrefix = 'sb_secret_';
 ///
 /// These keys are not JWTs and must never be sent as an
 /// `Authorization: Bearer` token.
+@internal
 bool isNewApiKey(String key) =>
     key.startsWith(_publishableKeyPrefix) || key.startsWith(_secretKeyPrefix);
 
@@ -17,6 +19,7 @@ final Set<String> _warnedApiKeySubtypes = {};
 ///
 /// Never throws: the server, not the SDK, decides key validity. The key value
 /// is never logged.
+@internal
 void warnOnUnrecognizedApiKey(String key, Logger log) {
   if (!key.startsWith('sb_') || isNewApiKey(key)) {
     return;

--- a/packages/supabase/lib/src/api_key.dart
+++ b/packages/supabase/lib/src/api_key.dart
@@ -1,0 +1,35 @@
+import 'package:logging/logging.dart';
+
+const _publishableKeyPrefix = 'sb_publishable_';
+const _secretKeyPrefix = 'sb_secret_';
+
+/// Whether [key] uses the new Supabase API key format
+/// (`sb_publishable_...` / `sb_secret_...`).
+///
+/// These keys are not JWTs and must never be sent as an
+/// `Authorization: Bearer` token.
+bool isNewApiKey(String key) =>
+    key.startsWith(_publishableKeyPrefix) || key.startsWith(_secretKeyPrefix);
+
+final Set<String> _warnedApiKeySubtypes = {};
+
+/// Warns once per unrecognized `sb_`-prefixed key subtype.
+///
+/// Never throws: the server, not the SDK, decides key validity. The key value
+/// is never logged.
+void warnOnUnrecognizedApiKey(String key, Logger log) {
+  if (!key.startsWith('sb_') || isNewApiKey(key)) {
+    return;
+  }
+  final rest = key.substring('sb_'.length);
+  final underscoreIndex = rest.indexOf('_');
+  final subtype = underscoreIndex == -1
+      ? rest
+      : rest.substring(0, underscoreIndex);
+  if (_warnedApiKeySubtypes.add(subtype)) {
+    log.warning(
+      'Unrecognized Supabase API key subtype "sb_${subtype}_". '
+      'The key will be sent as-is. If this is unexpected, verify your API key.',
+    );
+  }
+}

--- a/packages/supabase/lib/src/api_key.dart
+++ b/packages/supabase/lib/src/api_key.dart
@@ -24,12 +24,12 @@ void warnOnUnrecognizedApiKey(String key, Logger log) {
   final rest = key.substring('sb_'.length);
   final underscoreIndex = rest.indexOf('_');
   final subtype = underscoreIndex == -1
-      ? rest
+      ? ''
       : rest.substring(0, underscoreIndex);
   if (_warnedApiKeySubtypes.add(subtype)) {
     log.warning(
-      'Unrecognized Supabase API key subtype "sb_${subtype}_". '
-      'The key will be sent as-is. If this is unexpected, verify your API key.',
+      'Unrecognized Supabase API key format. The key will be sent as-is. '
+      'If this is unexpected, verify your API key.',
     );
   }
 }

--- a/packages/supabase/lib/src/auth_http_client.dart
+++ b/packages/supabase/lib/src/auth_http_client.dart
@@ -1,18 +1,36 @@
 import 'package:http/http.dart';
+import 'package:supabase/src/api_key.dart';
 
 class AuthHttpClient extends BaseClient {
   final Client _inner;
 
   final String _supabaseKey;
   final Future<String?> Function() _getAccessToken;
-  AuthHttpClient(this._supabaseKey, this._inner, this._getAccessToken);
+
+  /// When `true`, a new-format API key (`sb_publishable_...` / `sb_secret_...`)
+  /// is never sent as an `Authorization: Bearer` token. A genuine session
+  /// access token is still sent normally.
+  final bool _omitNewApiKeyAsBearer;
+
+  AuthHttpClient(
+    this._supabaseKey,
+    this._inner,
+    this._getAccessToken, {
+    bool omitNewApiKeyAsBearer = false,
+  }) : _omitNewApiKeyAsBearer = omitNewApiKeyAsBearer;
 
   @override
   Future<StreamedResponse> send(BaseRequest request) async {
     final accessToken = await _getAccessToken();
-    final authBearer = accessToken ?? _supabaseKey;
 
-    request.headers.putIfAbsent("Authorization", () => 'Bearer $authBearer');
+    if (accessToken != null) {
+      request.headers.putIfAbsent("Authorization", () => 'Bearer $accessToken');
+    } else if (!(_omitNewApiKeyAsBearer && isNewApiKey(_supabaseKey))) {
+      request.headers.putIfAbsent(
+        "Authorization",
+        () => 'Bearer $_supabaseKey',
+      );
+    }
     request.headers.putIfAbsent("apikey", () => _supabaseKey);
     return _inner.send(request);
   }

--- a/packages/supabase/lib/src/supabase_client.dart
+++ b/packages/supabase/lib/src/supabase_client.dart
@@ -7,6 +7,7 @@ import 'package:supabase/src/version.dart';
 import 'package:supabase/supabase.dart';
 import 'package:yet_another_json_isolate/yet_another_json_isolate.dart';
 
+import 'api_key.dart';
 import 'auth_http_client.dart';
 import 'counter.dart';
 import 'trace_http_client.dart';
@@ -55,6 +56,7 @@ class SupabaseClient {
   final Map<String, String> _headers;
   final Client? _httpClient;
   late final Client _authHttpClient;
+  late final Client _functionsHttpClient;
   late final Client _gotrueHttpClient;
 
   GoTrueClient? _authInstance;
@@ -168,6 +170,13 @@ class SupabaseClient {
       tracedHttpClient,
       _getAccessToken,
     );
+    _functionsHttpClient = AuthHttpClient(
+      _supabaseKey,
+      tracedHttpClient,
+      _getAccessToken,
+      omitNewApiKeyAsBearer: true,
+    );
+    warnOnUnrecognizedApiKey(_supabaseKey, _log);
     rest = _initRestClient();
     functions = _initFunctionsClient();
     storage = _initStorageClient(
@@ -336,7 +345,7 @@ class SupabaseClient {
     return FunctionsClient(
       _functionsUrl,
       {...headers},
-      httpClient: _authHttpClient,
+      httpClient: _functionsHttpClient,
       isolate: _isolate,
       region: _functionsOptions.region,
     );

--- a/packages/supabase/test/api_key_test.dart
+++ b/packages/supabase/test/api_key_test.dart
@@ -34,8 +34,22 @@ void main() {
 
       expect(records, hasLength(1));
       expect(records.first.level, Level.WARNING);
-      expect(records.first.message, contains('sb_weirdtype_'));
+      expect(records.first.message, isNot(contains('weirdtype')));
       expect(records.first.message, isNot(contains('supersecretvalue')));
+    });
+
+    test('does not log the key when there is no second underscore', () {
+      final records = <LogRecord>[];
+      final subscription = Logger.root.onRecord.listen(records.add);
+      final log = Logger('test.api_key');
+
+      warnOnUnrecognizedApiKey('sb_sensitivevalue', log);
+
+      unawaited(subscription.cancel());
+
+      expect(records, hasLength(1));
+      expect(records.first.level, Level.WARNING);
+      expect(records.first.message, isNot(contains('sensitivevalue')));
     });
 
     test('does not warn on recognized or legacy keys', () {

--- a/packages/supabase/test/api_key_test.dart
+++ b/packages/supabase/test/api_key_test.dart
@@ -1,0 +1,125 @@
+import 'dart:async';
+
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:logging/logging.dart';
+import 'package:supabase/src/api_key.dart';
+import 'package:supabase/src/auth_http_client.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('isNewApiKey', () {
+    test('detects publishable and secret keys', () {
+      expect(isNewApiKey('sb_publishable_abc123'), isTrue);
+      expect(isNewApiKey('sb_secret_abc123'), isTrue);
+    });
+
+    test('legacy JWT and anon keys are not new format', () {
+      expect(isNewApiKey('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9'), isFalse);
+      expect(isNewApiKey('anon-key'), isFalse);
+      expect(isNewApiKey('sb_something'), isFalse);
+    });
+  });
+
+  group('warnOnUnrecognizedApiKey', () {
+    test('warns once per unrecognized sb_ subtype without logging the key', () {
+      final records = <LogRecord>[];
+      final subscription = Logger.root.onRecord.listen(records.add);
+      final log = Logger('test.api_key');
+
+      warnOnUnrecognizedApiKey('sb_weirdtype_supersecretvalue', log);
+      warnOnUnrecognizedApiKey('sb_weirdtype_anothersecretvalue', log);
+
+      unawaited(subscription.cancel());
+
+      expect(records, hasLength(1));
+      expect(records.first.level, Level.WARNING);
+      expect(records.first.message, contains('sb_weirdtype_'));
+      expect(records.first.message, isNot(contains('supersecretvalue')));
+    });
+
+    test('does not warn on recognized or legacy keys', () {
+      final records = <LogRecord>[];
+      final subscription = Logger.root.onRecord.listen(records.add);
+      final log = Logger('test.api_key');
+
+      warnOnUnrecognizedApiKey('sb_publishable_abc', log);
+      warnOnUnrecognizedApiKey('sb_secret_abc', log);
+      warnOnUnrecognizedApiKey('eyJhbGciOiJIUzI1NiJ9', log);
+
+      unawaited(subscription.cancel());
+
+      expect(records, isEmpty);
+    });
+  });
+
+  group('AuthHttpClient bearer suppression', () {
+    late Map<String, String> capturedHeaders;
+
+    http.Client buildClient({
+      required String key,
+      required String? session,
+      required bool omitNewApiKeyAsBearer,
+    }) {
+      final mockClient = MockClient((request) async {
+        capturedHeaders = request.headers;
+        return http.Response('', 200);
+      });
+      return AuthHttpClient(
+        key,
+        mockClient,
+        () async => session,
+        omitNewApiKeyAsBearer: omitNewApiKeyAsBearer,
+      );
+    }
+
+    test('omits new-format key as Bearer when there is no session', () async {
+      final client = buildClient(
+        key: 'sb_publishable_abc',
+        session: null,
+        omitNewApiKeyAsBearer: true,
+      );
+      await client.get(Uri.parse('https://example.com'));
+
+      expect(capturedHeaders.containsKey('authorization'), isFalse);
+      expect(capturedHeaders['apikey'], 'sb_publishable_abc');
+    });
+
+    test('sends session JWT as Bearer even with a new-format key', () async {
+      final client = buildClient(
+        key: 'sb_publishable_abc',
+        session: 'jwt-token',
+        omitNewApiKeyAsBearer: true,
+      );
+      await client.get(Uri.parse('https://example.com'));
+
+      expect(capturedHeaders['authorization'], 'Bearer jwt-token');
+      expect(capturedHeaders['apikey'], 'sb_publishable_abc');
+    });
+
+    test('sends legacy key as Bearer when there is no session', () async {
+      final client = buildClient(
+        key: 'legacy-anon-key',
+        session: null,
+        omitNewApiKeyAsBearer: true,
+      );
+      await client.get(Uri.parse('https://example.com'));
+
+      expect(capturedHeaders['authorization'], 'Bearer legacy-anon-key');
+    });
+
+    test(
+      'without the flag, a new-format key is still sent as Bearer',
+      () async {
+        final client = buildClient(
+          key: 'sb_publishable_abc',
+          session: null,
+          omitNewApiKeyAsBearer: false,
+        );
+        await client.get(Uri.parse('https://example.com'));
+
+        expect(capturedHeaders['authorization'], 'Bearer sb_publishable_abc');
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Parity with supabase-js and supabase-swift ([#1130](https://github.com/supabase/supabase-swift/pull/1130)) for the new Supabase API key format (`sb_publishable_…` / `sb_secret_…`). These keys are not JWTs and must never be sent as an `Authorization: Bearer` token.

- **Functions never sends a new-format key as Bearer.** The `Authorization: Bearer` header for Functions (and REST/Storage) is injected per request by the shared `AuthHttpClient`. When no user session exists it previously fell back to the API key, so a `sb_publishable_`/`sb_secret_` key was sent as `Bearer …`, which the Edge Functions runtime rejects. The Functions client now uses a dedicated `AuthHttpClient` that omits the Bearer header for a new-format key when there is no session. A genuine session JWT is still sent normally.
- **Warn on unrecognized `sb_` subtypes.** `SupabaseClient` now warns once per unrecognized `sb_`-prefixed key subtype at construction. It never throws (the server, not the SDK, decides key validity) and never logs the key value.

Scope matches the reference implementations: this affects Functions only. Legacy JWT keys, REST, Storage, Auth, and Realtime are unchanged.

## Implementation notes

Unlike supabase-swift/js, supabase-flutter injects the Bearer token through a **shared** `AuthHttpClient` used by REST, Functions, and Storage, and `FunctionsClient.setAuth` is never wired up from `SupabaseClient`. To keep the fix scoped to Functions, a separate `AuthHttpClient` instance (`omitNewApiKeyAsBearer: true`) is created for the Functions client instead of changing auth-state handling.

## Changes

- `packages/supabase/lib/src/api_key.dart` (new): `isNewApiKey` classification and `warnOnUnrecognizedApiKey` warn-once helper.
- `packages/supabase/lib/src/auth_http_client.dart`: `omitNewApiKeyAsBearer` flag suppressing the Bearer header for new-format keys with no session.
- `packages/supabase/lib/src/supabase_client.dart`: dedicated Functions `AuthHttpClient`; warn at construction.
- `packages/supabase/test/api_key_test.dart` (new): classification, warn-once/no-key-leak, and all Bearer-suppression cases.

## Test plan

- [x] `dart analyze` — clean
- [x] `dart test` (supabase package) — all 91 tests pass, including the 8 new ones
- [x] `dart format` run
