### PR TITLE
docs(examples): add database CRUD with PostgREST example

### DIFF
--- a/.sdk-parse-ignore
+++ b/.sdk-parse-ignore
@@ -13,3 +13,7 @@
 # @internal (that would trigger invalid_use_of_internal_member in the
 # consumers). Exclude the whole package from the public-API scan instead.
 packages/supabase_common/
+
+# The examples are standalone demo apps, not part of the published SDK, so their
+# public classes are not capability-matrix symbols.
+examples/

--- a/examples/README.md
+++ b/examples/README.md
@@ -3,9 +3,10 @@
 A collection of small apps that each show off a feature of `supabase_flutter`,
 all sharing a single local Supabase instance.
 
-| Example                | What it shows                             |
-| ---------------------- | ----------------------------------------- |
-| [`passkeys`](passkeys) | Passkey (WebAuthn) sign in and management |
+| Example                          | What it shows                              |
+| -------------------------------- | ------------------------------------------ |
+| [`database_crud`](database_crud) | Database CRUD with PostgREST (`from(...)`) |
+| [`passkeys`](passkeys)           | Passkey (WebAuthn) sign in and management  |
 
 ## Quick start
 

--- a/examples/database_crud/.gitignore
+++ b/examples/database_crud/.gitignore
@@ -1,0 +1,6 @@
+.dart_tool/
+.flutter-plugins
+.flutter-plugins-dependencies
+build/
+pubspec.lock
+pubspec_overrides.yaml

--- a/examples/database_crud/README.md
+++ b/examples/database_crud/README.md
@@ -14,6 +14,11 @@ All database access is in
 [`lib/tasks_repository.dart`](lib/tasks_repository.dart), kept separate from the
 UI so the queries are easy to read and to drive from an integration test.
 
+To keep the focus on the Supabase calls, the screen uses plain `setState` and
+reloads the list after each write rather than pulling in a state management
+package or applying optimistic updates. A larger app would typically reach for a
+state management solution (for example Riverpod, Bloc or Provider) instead.
+
 The tables and sample data come from the shared Supabase config in
 [`../supabase`](../supabase): schema in
 `migrations/20240601000000_crud_example.sql`, seed rows in `seed.sql`.

--- a/examples/database_crud/README.md
+++ b/examples/database_crud/README.md
@@ -1,0 +1,35 @@
+# Database CRUD with PostgREST
+
+A small task manager that shows how to read and write data with
+`supabase.from(...)`:
+
+- **Select** tasks joined to their project (`select('*, projects(name)')`).
+- **Filter** by project (`eq`), title (`ilike`) and completion state (`eq`).
+- **Order** by priority then creation time (`order`).
+- **Insert** a new task and read the created row back (`insert().select()`).
+- **Update** a task's title and completion state (`update().eq()`).
+- **Delete** a task (`delete().eq()`).
+
+All database access is in
+[`lib/tasks_repository.dart`](lib/tasks_repository.dart), kept separate from the
+UI so the queries are easy to read and to drive from an integration test.
+
+The tables and sample data come from the shared Supabase config in
+[`../supabase`](../supabase): schema in
+`migrations/20240601000000_crud_example.sql`, seed rows in `seed.sql`.
+
+## Running
+
+From the `examples` directory, run the launcher and pick `database_crud`:
+
+```bash
+./run.sh
+```
+
+Or run it directly against any project:
+
+```bash
+flutter run \
+  --dart-define=SUPABASE_URL=https://YOUR_PROJECT.supabase.co \
+  --dart-define=SUPABASE_PUBLISHABLE_KEY=YOUR_PUBLISHABLE_KEY
+```

--- a/examples/database_crud/analysis_options.yaml
+++ b/examples/database_crud/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:supabase_lints/analysis_options_flutter.yaml

--- a/examples/database_crud/lib/main.dart
+++ b/examples/database_crud/lib/main.dart
@@ -57,38 +57,55 @@ class _TasksPageState extends State<TasksPage> {
   String? _projectFilter;
   bool _onlyIncomplete = false;
   bool _loading = true;
+  Timer? _debounce;
 
   @override
   void initState() {
     super.initState();
-    unawaited(_load());
+    unawaited(_init());
   }
 
   @override
   void dispose() {
+    _debounce?.cancel();
     _search.dispose();
     super.dispose();
   }
 
-  /// Loads the projects (once) and the tasks matching the current filters.
-  Future<void> _load() async {
-    setState(() => _loading = true);
+  /// Loads the projects once, then the tasks for the current filters.
+  Future<void> _init() async {
     try {
       final projects = await _repository.fetchProjects();
+      if (mounted) setState(() => _projects = projects);
+    } catch (error) {
+      _showError(error);
+    }
+    await _loadTasks();
+  }
+
+  /// Reloads the task list for the current filters. Leaves the previous list on
+  /// screen while it runs, so changing a filter or toggling a task doesn't flash
+  /// a spinner over the whole list.
+  Future<void> _loadTasks() async {
+    try {
       final tasks = await _repository.fetchTasks(
         projectId: _projectFilter,
         search: _search.text.trim(),
         onlyIncomplete: _onlyIncomplete,
       );
-      setState(() {
-        _projects = projects;
-        _tasks = tasks;
-      });
+      if (mounted) setState(() => _tasks = tasks);
     } catch (error) {
       _showError(error);
     } finally {
       if (mounted) setState(() => _loading = false);
     }
+  }
+
+  /// Debounces the search field so typing doesn't fire a query per keystroke
+  /// and race the responses back out of order.
+  void _onSearchChanged(String _) {
+    _debounce?.cancel();
+    _debounce = Timer(const Duration(milliseconds: 300), _loadTasks);
   }
 
   Future<void> _toggle(Task task) async {
@@ -97,7 +114,7 @@ class _TasksPageState extends State<TasksPage> {
         id: task.id,
         isComplete: !task.isComplete,
       );
-      await _load();
+      await _loadTasks();
     } catch (error) {
       _showError(error);
     }
@@ -106,7 +123,7 @@ class _TasksPageState extends State<TasksPage> {
   Future<void> _delete(Task task) async {
     try {
       await _repository.deleteTask(task.id);
-      await _load();
+      await _loadTasks();
     } catch (error) {
       _showError(error);
     }
@@ -124,7 +141,7 @@ class _TasksPageState extends State<TasksPage> {
         title: result.title,
         priority: result.priority,
       );
-      await _load();
+      await _loadTasks();
     } catch (error) {
       _showError(error);
     }
@@ -156,7 +173,7 @@ class _TasksPageState extends State<TasksPage> {
     if (title == null || title.isEmpty) return;
     try {
       await _repository.renameTask(id: task.id, title: title);
-      await _load();
+      await _loadTasks();
     } catch (error) {
       _showError(error);
     }
@@ -180,12 +197,12 @@ class _TasksPageState extends State<TasksPage> {
             onlyIncomplete: _onlyIncomplete,
             onProjectChanged: (value) {
               setState(() => _projectFilter = value);
-              unawaited(_load());
+              unawaited(_loadTasks());
             },
-            onSearchChanged: (_) => unawaited(_load()),
+            onSearchChanged: _onSearchChanged,
             onOnlyIncompleteChanged: (value) {
               setState(() => _onlyIncomplete = value);
-              unawaited(_load());
+              unawaited(_loadTasks());
             },
           ),
           const Divider(height: 1),
@@ -195,7 +212,7 @@ class _TasksPageState extends State<TasksPage> {
                 : _tasks.isEmpty
                 ? const Center(child: Text('No tasks match these filters.'))
                 : RefreshIndicator(
-                    onRefresh: _load,
+                    onRefresh: _loadTasks,
                     child: ListView.builder(
                       itemCount: _tasks.length,
                       itemBuilder: (context, index) {

--- a/examples/database_crud/lib/main.dart
+++ b/examples/database_crud/lib/main.dart
@@ -23,8 +23,6 @@ Future<void> main() async {
 
 SupabaseClient get supabase => Supabase.instance.client;
 
-const _priorityLabels = {1: 'Low', 2: 'Medium', 3: 'High'};
-
 class CrudExampleApp extends StatelessWidget {
   const CrudExampleApp({super.key});
 
@@ -57,6 +55,7 @@ class _TasksPageState extends State<TasksPage> {
   String? _projectFilter;
   bool _onlyIncomplete = false;
   bool _loading = true;
+  bool _mutating = false;
   Timer? _debounce;
 
   /// Bumped on every task reload so a slower earlier request can't overwrite the
@@ -118,26 +117,30 @@ class _TasksPageState extends State<TasksPage> {
     _debounce = Timer(const Duration(milliseconds: 300), _loadTasks);
   }
 
-  Future<void> _toggle(Task task) async {
+  /// Runs a single write, then reloads the list. Ignores the call if another
+  /// write is already in flight, so a double tap can't fire duplicate requests.
+  Future<void> _mutate(Future<void> Function() write) async {
+    if (_mutating) return;
+    setState(() => _mutating = true);
     try {
-      await _repository.setTaskComplete(
-        id: task.id,
-        isComplete: !task.isComplete,
-      );
+      await write();
       await _loadTasks();
     } catch (error) {
       _showError(error);
+    } finally {
+      if (mounted) setState(() => _mutating = false);
     }
   }
 
-  Future<void> _delete(Task task) async {
-    try {
-      await _repository.deleteTask(task.id);
-      await _loadTasks();
-    } catch (error) {
-      _showError(error);
-    }
-  }
+  Future<void> _toggle(Task task) => _mutate(
+    () => _repository.setTaskComplete(
+      id: task.id,
+      isComplete: !task.isComplete,
+    ),
+  );
+
+  Future<void> _delete(Task task) =>
+      _mutate(() => _repository.deleteTask(task.id));
 
   Future<void> _create() async {
     final result = await showDialog<_TaskFormResult>(
@@ -145,16 +148,13 @@ class _TasksPageState extends State<TasksPage> {
       builder: (context) => _TaskDialog(projects: _projects),
     );
     if (result == null) return;
-    try {
-      await _repository.createTask(
+    await _mutate(
+      () => _repository.createTask(
         projectId: result.projectId,
         title: result.title,
         priority: result.priority,
-      );
-      await _loadTasks();
-    } catch (error) {
-      _showError(error);
-    }
+      ),
+    );
   }
 
   Future<void> _rename(Task task) async {
@@ -181,12 +181,7 @@ class _TasksPageState extends State<TasksPage> {
       ),
     );
     if (title == null || title.isEmpty) return;
-    try {
-      await _repository.renameTask(id: task.id, title: title);
-      await _loadTasks();
-    } catch (error) {
-      _showError(error);
-    }
+    await _mutate(() => _repository.renameTask(id: task.id, title: title));
   }
 
   @override
@@ -194,7 +189,7 @@ class _TasksPageState extends State<TasksPage> {
     return Scaffold(
       appBar: AppBar(title: const Text('Tasks')),
       floatingActionButton: FloatingActionButton.extended(
-        onPressed: _projects.isEmpty ? null : _create,
+        onPressed: _projects.isEmpty || _mutating ? null : _create,
         icon: const Icon(Icons.add),
         label: const Text('New task'),
       ),
@@ -229,6 +224,7 @@ class _TasksPageState extends State<TasksPage> {
                         final task = _tasks[index];
                         return _TaskTile(
                           task: task,
+                          enabled: !_mutating,
                           onToggle: () => _toggle(task),
                           onRename: () => _rename(task),
                           onDelete: () => _delete(task),
@@ -303,14 +299,12 @@ class _Filters extends StatelessWidget {
               ),
             ],
           ),
-          Row(
-            children: [
-              Checkbox(
-                value: onlyIncomplete,
-                onChanged: (value) => onOnlyIncompleteChanged(value ?? false),
-              ),
-              const Text('Only incomplete'),
-            ],
+          CheckboxListTile(
+            value: onlyIncomplete,
+            onChanged: (value) => onOnlyIncompleteChanged(value ?? false),
+            title: const Text('Only incomplete'),
+            controlAffinity: ListTileControlAffinity.leading,
+            contentPadding: EdgeInsets.zero,
           ),
         ],
       ),
@@ -321,23 +315,24 @@ class _Filters extends StatelessWidget {
 class _TaskTile extends StatelessWidget {
   const _TaskTile({
     required this.task,
+    required this.enabled,
     required this.onToggle,
     required this.onRename,
     required this.onDelete,
   });
 
   final Task task;
+  final bool enabled;
   final VoidCallback onToggle;
   final VoidCallback onRename;
   final VoidCallback onDelete;
 
   @override
   Widget build(BuildContext context) {
-    final priority = _priorityLabels[task.priority] ?? '${task.priority}';
     return ListTile(
       leading: Checkbox(
         value: task.isComplete,
-        onChanged: (_) => onToggle(),
+        onChanged: enabled ? (_) => onToggle() : null,
       ),
       title: Text(
         task.title,
@@ -345,12 +340,22 @@ class _TaskTile extends StatelessWidget {
             ? const TextStyle(decoration: TextDecoration.lineThrough)
             : null,
       ),
-      subtitle: Text('${task.projectName ?? 'Unknown'}  ·  $priority priority'),
+      subtitle: Text(
+        '${task.projectName ?? 'Unknown'}  ·  ${task.priority.label} priority',
+      ),
       trailing: Row(
         mainAxisSize: MainAxisSize.min,
         children: [
-          IconButton(icon: const Icon(Icons.edit), onPressed: onRename),
-          IconButton(icon: const Icon(Icons.delete), onPressed: onDelete),
+          IconButton(
+            icon: const Icon(Icons.edit),
+            tooltip: 'Rename',
+            onPressed: enabled ? onRename : null,
+          ),
+          IconButton(
+            icon: const Icon(Icons.delete),
+            tooltip: 'Delete',
+            onPressed: enabled ? onDelete : null,
+          ),
         ],
       ),
     );
@@ -366,7 +371,7 @@ class _TaskFormResult {
 
   final String projectId;
   final String title;
-  final int priority;
+  final Priority priority;
 }
 
 class _TaskDialog extends StatefulWidget {
@@ -381,7 +386,7 @@ class _TaskDialog extends StatefulWidget {
 class _TaskDialogState extends State<_TaskDialog> {
   final _title = TextEditingController();
   late String _projectId = widget.projects.first.id;
-  int _priority = 1;
+  Priority _priority = Priority.low;
 
   @override
   void dispose() {
@@ -429,13 +434,13 @@ class _TaskDialogState extends State<_TaskDialog> {
             onChanged: (value) => setState(() => _projectId = value!),
           ),
           const SizedBox(height: 12),
-          DropdownButtonFormField<int>(
+          DropdownButtonFormField<Priority>(
             initialValue: _priority,
             isExpanded: true,
             decoration: const InputDecoration(labelText: 'Priority'),
             items: [
-              for (final entry in _priorityLabels.entries)
-                DropdownMenuItem(value: entry.key, child: Text(entry.value)),
+              for (final priority in Priority.values)
+                DropdownMenuItem(value: priority, child: Text(priority.label)),
             ],
             onChanged: (value) => setState(() => _priority = value!),
           ),

--- a/examples/database_crud/lib/main.dart
+++ b/examples/database_crud/lib/main.dart
@@ -59,6 +59,10 @@ class _TasksPageState extends State<TasksPage> {
   bool _loading = true;
   Timer? _debounce;
 
+  /// Bumped on every task reload so a slower earlier request can't overwrite the
+  /// results of a later one.
+  int _requestId = 0;
+
   @override
   void initState() {
     super.initState();
@@ -87,17 +91,23 @@ class _TasksPageState extends State<TasksPage> {
   /// screen while it runs, so changing a filter or toggling a task doesn't flash
   /// a spinner over the whole list.
   Future<void> _loadTasks() async {
+    final requestId = ++_requestId;
+    // Ignore a response if a newer reload started or the widget went away while
+    // this request was in flight.
+    bool isStale() => !mounted || requestId != _requestId;
     try {
       final tasks = await _repository.fetchTasks(
         projectId: _projectFilter,
         search: _search.text.trim(),
         onlyIncomplete: _onlyIncomplete,
       );
-      if (mounted) setState(() => _tasks = tasks);
+      if (isStale()) return;
+      setState(() => _tasks = tasks);
     } catch (error) {
+      if (isStale()) return;
       _showError(error);
     } finally {
-      if (mounted) setState(() => _loading = false);
+      if (!isStale()) setState(() => _loading = false);
     }
   }
 

--- a/examples/database_crud/lib/main.dart
+++ b/examples/database_crud/lib/main.dart
@@ -1,0 +1,435 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import 'models.dart';
+import 'tasks_repository.dart';
+
+const supabaseUrl = String.fromEnvironment('SUPABASE_URL');
+const supabasePublishableKey = String.fromEnvironment(
+  'SUPABASE_PUBLISHABLE_KEY',
+);
+
+final messengerKey = GlobalKey<ScaffoldMessengerState>();
+
+Future<void> main() async {
+  await Supabase.initialize(
+    url: supabaseUrl,
+    publishableKey: supabasePublishableKey,
+  );
+  runApp(const CrudExampleApp());
+}
+
+SupabaseClient get supabase => Supabase.instance.client;
+
+const _priorityLabels = {1: 'Low', 2: 'Medium', 3: 'High'};
+
+class CrudExampleApp extends StatelessWidget {
+  const CrudExampleApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Supabase Database CRUD',
+      scaffoldMessengerKey: messengerKey,
+      theme: ThemeData(colorSchemeSeed: Colors.green, useMaterial3: true),
+      home: const TasksPage(),
+    );
+  }
+}
+
+/// Lists tasks with filtering, ordering and a join to their project, and lets
+/// you create, update and delete them.
+class TasksPage extends StatefulWidget {
+  const TasksPage({super.key});
+
+  @override
+  State<TasksPage> createState() => _TasksPageState();
+}
+
+class _TasksPageState extends State<TasksPage> {
+  final _repository = TasksRepository(supabase);
+  final _search = TextEditingController();
+
+  List<Project> _projects = [];
+  List<Task> _tasks = [];
+  String? _projectFilter;
+  bool _onlyIncomplete = false;
+  bool _loading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    unawaited(_load());
+  }
+
+  @override
+  void dispose() {
+    _search.dispose();
+    super.dispose();
+  }
+
+  /// Loads the projects (once) and the tasks matching the current filters.
+  Future<void> _load() async {
+    setState(() => _loading = true);
+    try {
+      final projects = await _repository.fetchProjects();
+      final tasks = await _repository.fetchTasks(
+        projectId: _projectFilter,
+        search: _search.text.trim(),
+        onlyIncomplete: _onlyIncomplete,
+      );
+      setState(() {
+        _projects = projects;
+        _tasks = tasks;
+      });
+    } catch (error) {
+      _showError(error);
+    } finally {
+      if (mounted) setState(() => _loading = false);
+    }
+  }
+
+  Future<void> _toggle(Task task) async {
+    try {
+      await _repository.setTaskComplete(
+        id: task.id,
+        isComplete: !task.isComplete,
+      );
+      await _load();
+    } catch (error) {
+      _showError(error);
+    }
+  }
+
+  Future<void> _delete(Task task) async {
+    try {
+      await _repository.deleteTask(task.id);
+      await _load();
+    } catch (error) {
+      _showError(error);
+    }
+  }
+
+  Future<void> _create() async {
+    final result = await showDialog<_TaskFormResult>(
+      context: context,
+      builder: (context) => _TaskDialog(projects: _projects),
+    );
+    if (result == null) return;
+    try {
+      await _repository.createTask(
+        projectId: result.projectId,
+        title: result.title,
+        priority: result.priority,
+      );
+      await _load();
+    } catch (error) {
+      _showError(error);
+    }
+  }
+
+  Future<void> _rename(Task task) async {
+    final controller = TextEditingController(text: task.title);
+    final title = await showDialog<String>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Rename task'),
+        content: TextField(
+          controller: controller,
+          autofocus: true,
+          decoration: const InputDecoration(labelText: 'Title'),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.pop(context, controller.text.trim()),
+            child: const Text('Save'),
+          ),
+        ],
+      ),
+    );
+    if (title == null || title.isEmpty) return;
+    try {
+      await _repository.renameTask(id: task.id, title: title);
+      await _load();
+    } catch (error) {
+      _showError(error);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Tasks')),
+      floatingActionButton: FloatingActionButton.extended(
+        onPressed: _projects.isEmpty ? null : _create,
+        icon: const Icon(Icons.add),
+        label: const Text('New task'),
+      ),
+      body: Column(
+        children: [
+          _Filters(
+            projects: _projects,
+            projectFilter: _projectFilter,
+            search: _search,
+            onlyIncomplete: _onlyIncomplete,
+            onProjectChanged: (value) {
+              setState(() => _projectFilter = value);
+              unawaited(_load());
+            },
+            onSearchChanged: (_) => unawaited(_load()),
+            onOnlyIncompleteChanged: (value) {
+              setState(() => _onlyIncomplete = value);
+              unawaited(_load());
+            },
+          ),
+          const Divider(height: 1),
+          Expanded(
+            child: _loading
+                ? const Center(child: CircularProgressIndicator())
+                : _tasks.isEmpty
+                ? const Center(child: Text('No tasks match these filters.'))
+                : RefreshIndicator(
+                    onRefresh: _load,
+                    child: ListView.builder(
+                      itemCount: _tasks.length,
+                      itemBuilder: (context, index) {
+                        final task = _tasks[index];
+                        return _TaskTile(
+                          task: task,
+                          onToggle: () => _toggle(task),
+                          onRename: () => _rename(task),
+                          onDelete: () => _delete(task),
+                        );
+                      },
+                    ),
+                  ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _Filters extends StatelessWidget {
+  const _Filters({
+    required this.projects,
+    required this.projectFilter,
+    required this.search,
+    required this.onlyIncomplete,
+    required this.onProjectChanged,
+    required this.onSearchChanged,
+    required this.onOnlyIncompleteChanged,
+  });
+
+  final List<Project> projects;
+  final String? projectFilter;
+  final TextEditingController search;
+  final bool onlyIncomplete;
+  final ValueChanged<String?> onProjectChanged;
+  final ValueChanged<String> onSearchChanged;
+  final ValueChanged<bool> onOnlyIncompleteChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        children: [
+          Row(
+            children: [
+              Expanded(
+                child: TextField(
+                  controller: search,
+                  onChanged: onSearchChanged,
+                  decoration: const InputDecoration(
+                    labelText: 'Search title',
+                    prefixIcon: Icon(Icons.search),
+                    isDense: true,
+                  ),
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: DropdownButtonFormField<String?>(
+                  initialValue: projectFilter,
+                  isExpanded: true,
+                  decoration: const InputDecoration(
+                    labelText: 'Project',
+                    isDense: true,
+                  ),
+                  items: [
+                    const DropdownMenuItem(child: Text('All projects')),
+                    for (final project in projects)
+                      DropdownMenuItem(
+                        value: project.id,
+                        child: Text(project.name),
+                      ),
+                  ],
+                  onChanged: onProjectChanged,
+                ),
+              ),
+            ],
+          ),
+          Row(
+            children: [
+              Checkbox(
+                value: onlyIncomplete,
+                onChanged: (value) => onOnlyIncompleteChanged(value ?? false),
+              ),
+              const Text('Only incomplete'),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _TaskTile extends StatelessWidget {
+  const _TaskTile({
+    required this.task,
+    required this.onToggle,
+    required this.onRename,
+    required this.onDelete,
+  });
+
+  final Task task;
+  final VoidCallback onToggle;
+  final VoidCallback onRename;
+  final VoidCallback onDelete;
+
+  @override
+  Widget build(BuildContext context) {
+    final priority = _priorityLabels[task.priority] ?? '${task.priority}';
+    return ListTile(
+      leading: Checkbox(
+        value: task.isComplete,
+        onChanged: (_) => onToggle(),
+      ),
+      title: Text(
+        task.title,
+        style: task.isComplete
+            ? const TextStyle(decoration: TextDecoration.lineThrough)
+            : null,
+      ),
+      subtitle: Text('${task.projectName ?? 'Unknown'}  ·  $priority priority'),
+      trailing: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          IconButton(icon: const Icon(Icons.edit), onPressed: onRename),
+          IconButton(icon: const Icon(Icons.delete), onPressed: onDelete),
+        ],
+      ),
+    );
+  }
+}
+
+class _TaskFormResult {
+  const _TaskFormResult({
+    required this.projectId,
+    required this.title,
+    required this.priority,
+  });
+
+  final String projectId;
+  final String title;
+  final int priority;
+}
+
+class _TaskDialog extends StatefulWidget {
+  const _TaskDialog({required this.projects});
+
+  final List<Project> projects;
+
+  @override
+  State<_TaskDialog> createState() => _TaskDialogState();
+}
+
+class _TaskDialogState extends State<_TaskDialog> {
+  final _title = TextEditingController();
+  late String _projectId = widget.projects.first.id;
+  int _priority = 1;
+
+  @override
+  void dispose() {
+    _title.dispose();
+    super.dispose();
+  }
+
+  void _submit() {
+    final title = _title.text.trim();
+    if (title.isEmpty) return;
+    Navigator.pop(
+      context,
+      _TaskFormResult(
+        projectId: _projectId,
+        title: title,
+        priority: _priority,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('New task'),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          TextField(
+            controller: _title,
+            autofocus: true,
+            decoration: const InputDecoration(labelText: 'Title'),
+          ),
+          const SizedBox(height: 12),
+          DropdownButtonFormField<String>(
+            initialValue: _projectId,
+            isExpanded: true,
+            decoration: const InputDecoration(labelText: 'Project'),
+            items: [
+              for (final project in widget.projects)
+                DropdownMenuItem(
+                  value: project.id,
+                  child: Text(project.name),
+                ),
+            ],
+            onChanged: (value) => setState(() => _projectId = value!),
+          ),
+          const SizedBox(height: 12),
+          DropdownButtonFormField<int>(
+            initialValue: _priority,
+            isExpanded: true,
+            decoration: const InputDecoration(labelText: 'Priority'),
+            items: [
+              for (final entry in _priorityLabels.entries)
+                DropdownMenuItem(value: entry.key, child: Text(entry.value)),
+            ],
+            onChanged: (value) => setState(() => _priority = value!),
+          ),
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(onPressed: _submit, child: const Text('Create')),
+      ],
+    );
+  }
+}
+
+void _showError(Object error) {
+  final message = error is PostgrestException
+      ? error.message
+      : error.toString();
+  messengerKey.currentState?.showSnackBar(
+    SnackBar(content: Text(message), backgroundColor: Colors.red),
+  );
+}

--- a/examples/database_crud/lib/models.dart
+++ b/examples/database_crud/lib/models.dart
@@ -1,3 +1,18 @@
+/// How urgent a [Task] is. Stored in the database as the integer [value].
+enum Priority {
+  low(1, 'Low'),
+  medium(2, 'Medium'),
+  high(3, 'High');
+
+  const Priority(this.value, this.label);
+
+  factory Priority.fromValue(int value) =>
+      values.firstWhere((priority) => priority.value == value);
+
+  final int value;
+  final String label;
+}
+
 /// A project that groups tasks together.
 class Project {
   const Project({required this.id, required this.name});
@@ -32,7 +47,7 @@ class Task {
       projectId: json['project_id'] as String,
       title: json['title'] as String,
       isComplete: json['is_complete'] as bool,
-      priority: json['priority'] as int,
+      priority: Priority.fromValue(json['priority'] as int),
       createdAt: DateTime.parse(json['created_at'] as String),
       projectName: project?['name'] as String?,
     );
@@ -42,7 +57,7 @@ class Task {
   final String projectId;
   final String title;
   final bool isComplete;
-  final int priority;
+  final Priority priority;
   final DateTime createdAt;
 
   /// Name of the task's project, populated from the embedded `projects` row when

--- a/examples/database_crud/lib/models.dart
+++ b/examples/database_crud/lib/models.dart
@@ -1,0 +1,51 @@
+/// A project that groups tasks together.
+class Project {
+  const Project({required this.id, required this.name});
+
+  factory Project.fromJson(Map<String, dynamic> json) => Project(
+    id: json['id'] as String,
+    name: json['name'] as String,
+  );
+
+  final String id;
+  final String name;
+}
+
+/// A single task belonging to a [Project].
+class Task {
+  const Task({
+    required this.id,
+    required this.projectId,
+    required this.title,
+    required this.isComplete,
+    required this.priority,
+    required this.createdAt,
+    this.projectName,
+  });
+
+  factory Task.fromJson(Map<String, dynamic> json) {
+    // When the task is fetched with a join, the related project is nested under
+    // the `projects` key.
+    final project = json['projects'] as Map<String, dynamic>?;
+    return Task(
+      id: json['id'] as String,
+      projectId: json['project_id'] as String,
+      title: json['title'] as String,
+      isComplete: json['is_complete'] as bool,
+      priority: json['priority'] as int,
+      createdAt: DateTime.parse(json['created_at'] as String),
+      projectName: project?['name'] as String?,
+    );
+  }
+
+  final String id;
+  final String projectId;
+  final String title;
+  final bool isComplete;
+  final int priority;
+  final DateTime createdAt;
+
+  /// Name of the task's project, populated from the embedded `projects` row when
+  /// the task is fetched with a join.
+  final String? projectName;
+}

--- a/examples/database_crud/lib/tasks_repository.dart
+++ b/examples/database_crud/lib/tasks_repository.dart
@@ -1,0 +1,101 @@
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import 'models.dart';
+
+/// All database access for the CRUD example lives here, so the UI stays thin and
+/// every `supabase.from(...)` call is easy to read and to exercise from an
+/// integration test.
+class TasksRepository {
+  TasksRepository(this._client);
+
+  final SupabaseClient _client;
+
+  /// Columns for a task plus its related project, used everywhere a task is
+  /// returned so the join is consistent.
+  static const _taskColumns = '*, projects(name)';
+
+  /// SELECT every project, ordered alphabetically by name.
+  Future<List<Project>> fetchProjects() async {
+    final rows = await _client.from('projects').select().order('name');
+    return rows.map(Project.fromJson).toList();
+  }
+
+  /// SELECT tasks joined to their project, with optional filters and ordering.
+  ///
+  /// * [projectId] restricts to a single project (`eq`).
+  /// * [search] matches the title case-insensitively (`ilike`).
+  /// * [onlyIncomplete] hides finished tasks (`eq`).
+  ///
+  /// Results are ordered by priority (highest first) then creation time.
+  Future<List<Task>> fetchTasks({
+    String? projectId,
+    String? search,
+    bool onlyIncomplete = false,
+  }) async {
+    // Embed the related project row (`projects(name)`) to demonstrate a join.
+    var query = _client.from('tasks').select(_taskColumns);
+
+    if (projectId != null) {
+      query = query.eq('project_id', projectId);
+    }
+    if (search != null && search.isNotEmpty) {
+      query = query.ilike('title', '%$search%');
+    }
+    if (onlyIncomplete) {
+      query = query.eq('is_complete', false);
+    }
+
+    final rows = await query
+        .order('priority', ascending: false)
+        .order('created_at');
+    return rows.map(Task.fromJson).toList();
+  }
+
+  /// INSERT a task and return the created row (joined to its project).
+  Future<Task> createTask({
+    required String projectId,
+    required String title,
+    int priority = 1,
+  }) async {
+    final row = await _client
+        .from('tasks')
+        .insert({
+          'project_id': projectId,
+          'title': title,
+          'priority': priority,
+        })
+        .select(_taskColumns)
+        .single();
+    return Task.fromJson(row);
+  }
+
+  /// UPDATE a task's completion state and return the updated row.
+  Future<Task> setTaskComplete({
+    required String id,
+    required bool isComplete,
+  }) async {
+    final row = await _client
+        .from('tasks')
+        .update({'is_complete': isComplete})
+        .eq('id', id)
+        .select(_taskColumns)
+        .single();
+    return Task.fromJson(row);
+  }
+
+  /// UPDATE a task's title and return the updated row.
+  Future<Task> renameTask({required String id, required String title}) async {
+    final row = await _client
+        .from('tasks')
+        .update({'title': title})
+        .eq('id', id)
+        .select(_taskColumns)
+        .single();
+    return Task.fromJson(row);
+  }
+
+  /// DELETE a task.
+  Future<void> deleteTask(String id) async {
+    await _client.from('tasks').delete().eq('id', id);
+  }
+}

--- a/examples/database_crud/lib/tasks_repository.dart
+++ b/examples/database_crud/lib/tasks_repository.dart
@@ -55,14 +55,14 @@ class TasksRepository {
   Future<Task> createTask({
     required String projectId,
     required String title,
-    int priority = 1,
+    Priority priority = Priority.low,
   }) async {
     final row = await _client
         .from('tasks')
         .insert({
           'project_id': projectId,
           'title': title,
-          'priority': priority,
+          'priority': priority.value,
         })
         .select(_taskColumns)
         .single();

--- a/examples/database_crud/pubspec.yaml
+++ b/examples/database_crud/pubspec.yaml
@@ -1,0 +1,25 @@
+name: database_crud_example
+description: Demonstrates database CRUD with PostgREST using supabase_flutter.
+
+publish_to: 'none'
+
+version: 1.0.0+1
+
+environment:
+  sdk: '>=3.9.0 <4.0.0'
+  flutter: '>=3.35.0'
+
+resolution: workspace
+
+dependencies:
+  flutter:
+    sdk: flutter
+  supabase_flutter: ^2.17.0
+
+dev_dependencies:
+  supabase_lints: ^0.1.1
+  flutter_test:
+    sdk: flutter
+
+flutter:
+  uses-material-design: true

--- a/examples/database_crud/web/index.html
+++ b/examples/database_crud/web/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <base href="$FLUTTER_BASE_HREF">
+  <meta charset="UTF-8">
+  <meta content="IE=Edge" http-equiv="X-UA-Compatible">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+  <title>Supabase Database CRUD</title>
+</head>
+<body>
+  <script src="flutter_bootstrap.js" async></script>
+</body>
+</html>

--- a/examples/supabase/migrations/20240601000000_crud_example.sql
+++ b/examples/supabase/migrations/20240601000000_crud_example.sql
@@ -1,0 +1,41 @@
+-- Schema for the "database CRUD with PostgREST" example.
+--
+-- Two related tables (projects 1:N tasks) so the example can show selects with
+-- filters and ordering, inserts, updates, deletes and a join from a task to its
+-- project.
+
+create table public.projects (
+  id uuid primary key default gen_random_uuid(),
+  name text not null,
+  created_at timestamptz not null default now()
+);
+
+create table public.tasks (
+  id uuid primary key default gen_random_uuid(),
+  project_id uuid not null references public.projects (id) on delete cascade,
+  title text not null,
+  is_complete boolean not null default false,
+  priority int not null default 1,
+  created_at timestamptz not null default now()
+);
+
+create index tasks_project_id_idx on public.tasks (project_id);
+
+-- The example runs unauthenticated with the publishable (anon) key. Enable row
+-- level security and add permissive policies so the demo can read and write
+-- without signing in. A real app would scope these policies to the signed in
+-- user instead.
+alter table public.projects enable row level security;
+alter table public.tasks enable row level security;
+
+create policy "Anyone can read projects"
+  on public.projects for select using (true);
+
+create policy "Anyone can manage tasks"
+  on public.tasks for all using (true) with check (true);
+
+-- Row level security decides which rows a role may touch, but the role still
+-- needs table privileges. Grant the publishable (anon) key read access to
+-- projects and full access to tasks so the demo works without signing in.
+grant select on public.projects to anon, authenticated;
+grant all on public.tasks to anon, authenticated;

--- a/examples/supabase/seed.sql
+++ b/examples/supabase/seed.sql
@@ -1,0 +1,15 @@
+-- Sample data for the database CRUD example. Runs when the local stack is first
+-- created (`supabase start`) or reset (`supabase db reset`).
+
+insert into public.projects (id, name) values
+  ('00000000-0000-0000-0000-000000000001', 'Website redesign'),
+  ('00000000-0000-0000-0000-000000000002', 'Mobile app'),
+  ('00000000-0000-0000-0000-000000000003', 'Personal');
+
+insert into public.tasks (project_id, title, is_complete, priority) values
+  ('00000000-0000-0000-0000-000000000001', 'Draft the landing page copy', false, 3),
+  ('00000000-0000-0000-0000-000000000001', 'Pick a color palette', true, 1),
+  ('00000000-0000-0000-0000-000000000002', 'Set up push notifications', false, 2),
+  ('00000000-0000-0000-0000-000000000002', 'Fix login on Android', false, 3),
+  ('00000000-0000-0000-0000-000000000003', 'Book flights', false, 2),
+  ('00000000-0000-0000-0000-000000000003', 'Water the plants', true, 1);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,6 +18,7 @@ workspace:
   - packages/supabase_common
   - packages/supabase_lints
   - packages/yet_another_json_isolate
+  - examples/database_crud
   - examples/launcher
   - examples/passkeys
 


### PR DESCRIPTION
## What

Adds a runnable **Database CRUD with PostgREST** example under `examples/database_crud`, plus the shared schema and seed data it runs against. Closes SDK-1065.

The example is a small task manager that covers everything `supabase.from(...)` offers for CRUD:

- **Select** tasks joined to their project (`select('*, projects(name)')`)
- **Filters**: `eq` (project, completion), `ilike` (title search)
- **Ordering**: `order('priority', ascending: false).order('created_at')`
- **Insert** returning the created joined row (`insert().select().single()`)
- **Update** title and completion state (`update().eq()`)
- **Delete** (`delete().eq()`)

All database access lives in `lib/tasks_repository.dart`, kept separate from the UI so the queries are easy to read and can later be driven from a full end-to-end integration test.

## Shared config

- `examples/supabase/migrations/20240601000000_crud_example.sql` — `projects` 1:N `tasks` with a foreign key and index, RLS enabled with permissive demo policies, and grants so the publishable (anon) key can read projects and manage tasks without signing in.
- `examples/supabase/seed.sql` — sample projects and tasks.

## Wiring

- Registered `examples/database_crud` in the root workspace `pubspec.yaml` and the `examples/README.md` table. The launcher auto-discovers it.

## Verification

- `flutter analyze examples` → no issues; `dart format` clean.
- `supabase db reset` against `examples/` applies the migration and seed cleanly.
- Exercised the full flow over PostgREST with the publishable key: joined + ordered + `ilike` select, insert returning the joined row, update, filtered select, and delete (204) with confirmation.