### PR TITLE
feat(realtime): block adding postgres_changes listener after subscribe

### DIFF
--- a/packages/realtime_client/lib/src/realtime_channel.dart
+++ b/packages/realtime_client/lib/src/realtime_channel.dart
@@ -593,6 +593,13 @@ class RealtimeChannel {
   ) {
     final typeLower = type.toLowerCase();
 
+    if ((isJoined || isJoining) && typeLower == 'postgres_changes') {
+      final message =
+          'cannot add `$typeLower` callbacks for $topic after `subscribe()`.';
+      socket.log('channel', message);
+      throw message;
+    }
+
     final binding = Binding(typeLower, filter.toMap(), callback);
 
     if (_bindings[typeLower] != null) {

--- a/packages/realtime_client/test/channel_test.dart
+++ b/packages/realtime_client/test/channel_test.dart
@@ -487,6 +487,80 @@ void main() {
     });
   });
 
+  group('blocking listeners after subscribe', () {
+    setUp(() {
+      socket = RealtimeClient('wss://example.com/socket');
+      channel = socket.channel('topic');
+    });
+
+    test('throws when adding postgres_changes listener while joining', () {
+      channel.subscribe();
+      expect(channel.isJoining, isTrue);
+
+      expect(
+        () => channel.onPostgresChanges(
+          event: PostgresChangeEvent.all,
+          callback: (_) {},
+        ),
+        throwsA(
+          allOf(
+            isA<String>(),
+            contains('cannot add `postgres_changes` callbacks'),
+          ),
+        ),
+      );
+    });
+
+    test('throws when adding postgres_changes listener after join', () {
+      channel.subscribe();
+      channel.joinPush.trigger('ok', {});
+      expect(channel.isJoined, isTrue);
+
+      expect(
+        () => channel.onPostgresChanges(
+          event: PostgresChangeEvent.all,
+          callback: (_) {},
+        ),
+        throwsA(
+          allOf(
+            isA<String>(),
+            contains('cannot add `postgres_changes` callbacks'),
+          ),
+        ),
+      );
+    });
+
+    test('allows adding postgres_changes listener before subscribe', () {
+      expect(
+        () => channel.onPostgresChanges(
+          event: PostgresChangeEvent.all,
+          callback: (_) {},
+        ),
+        returnsNormally,
+      );
+    });
+
+    test('does not block presence listeners after subscribe', () {
+      channel.subscribe();
+      expect(channel.isJoining, isTrue);
+
+      expect(
+        () => channel.onPresenceSync((_) {}),
+        returnsNormally,
+      );
+    });
+
+    test('does not block broadcast listeners after subscribe', () {
+      channel.subscribe();
+      expect(channel.isJoining, isTrue);
+
+      expect(
+        () => channel.onBroadcast(event: 'test', callback: (_) {}),
+        returnsNormally,
+      );
+    });
+  });
+
   group('off', () {
     setUp(() {
       socket = RealtimeClient('/socket');


### PR DESCRIPTION
## Summary

Blocks adding a `postgres_changes` listener after `subscribe()` has been called, matching the behavior introduced in supabase-js. Calling `onPostgresChanges(...)` while the channel is `joining` or `joined` now throws a clear error instead of silently registering a binding that would never be applied to the join payload.

**Outcome:** implemented

## Details

- `RealtimeChannel.onEvents` now throws when a `postgres_changes` binding is added while the channel is joining or joined, with the message `cannot add \`postgres_changes\` callbacks for <topic> after \`subscribe()\`.`
- Presence listeners are intentionally **not** blocked: the Dart SDK deliberately supports adding presence callbacks after join and resubscribes with presence enabled (`_handlePresenceUpdate`). Blocking presence would regress that established Dart idiom, so this differs from supabase-js by design.

## Reference

- supabase-js commit `219c0c16`, PR supabase/supabase-js#2201

## Compliance matrix

`realtime.subscriptions.postgres_changes` was already `implemented`; this change makes the behavior equivalent for the post-subscribe case. No new public symbols, so no matrix edit was required.

Linear: SDK-827
