### PR TITLE
fix(realtime): UTF-8 encode broadcast header fields in serializer

### DIFF
--- a/packages/realtime_client/lib/src/serializer.dart
+++ b/packages/realtime_client/lib/src/serializer.dart
@@ -90,16 +90,22 @@ class Serializer {
     Map<String, dynamic> message,
     Map<dynamic, dynamic> payload,
   ) {
-    final topic = (message['topic'] ?? '') as String;
-    final ref = (message['ref'] ?? '') as String;
-    final joinRef = (message['join_ref'] ?? '') as String;
-    final userEvent = payload['event'] as String;
     final encodedPayload = _asBytes(payload['payload'])!;
 
     final rest = allowedMetadataKeys.isEmpty
         ? const <String, dynamic>{}
         : _pick(payload, allowedMetadataKeys);
-    final metadata = rest.isEmpty ? '' : jsonEncode(rest);
+    final metadataString = rest.isEmpty ? '' : jsonEncode(rest);
+
+    // Encode each header field as UTF-8. The length prefixes are byte counts
+    // and the decode side uses utf8.decode, so measuring with String.length
+    // (UTF-16 code units) and writing one byte per unit would corrupt any
+    // multi-byte character (e.g. accents or emoji) and desynchronize the frame.
+    final topic = utf8.encode((message['topic'] ?? '') as String);
+    final ref = utf8.encode((message['ref'] ?? '') as String);
+    final joinRef = utf8.encode((message['join_ref'] ?? '') as String);
+    final userEvent = utf8.encode(payload['event'] as String);
+    final metadata = utf8.encode(metadataString);
 
     _checkLength('joinRef', joinRef.length);
     _checkLength('ref', ref.length);
@@ -124,11 +130,11 @@ class Serializer {
     frame[offset++] = userEvent.length;
     frame[offset++] = metadata.length;
     frame[offset++] = binaryEncoding;
-    offset = _writeString(frame, offset, joinRef);
-    offset = _writeString(frame, offset, ref);
-    offset = _writeString(frame, offset, topic);
-    offset = _writeString(frame, offset, userEvent);
-    offset = _writeString(frame, offset, metadata);
+    offset = _writeBytes(frame, offset, joinRef);
+    offset = _writeBytes(frame, offset, ref);
+    offset = _writeBytes(frame, offset, topic);
+    offset = _writeBytes(frame, offset, userEvent);
+    offset = _writeBytes(frame, offset, metadata);
 
     frame.setAll(offset, encodedPayload);
     return frame;
@@ -194,15 +200,9 @@ class Serializer {
     }
   }
 
-  // Writes one byte per UTF-16 code unit, matching the size byte (which is the
-  // code-unit count). Frame string fields (joinRef, ref, topic, userEvent,
-  // metadata) are therefore assumed to be ASCII; non-ASCII characters would be
-  // truncated and not round-trip through the utf8 decode on the other side.
-  int _writeString(Uint8List buffer, int offset, String value) {
-    for (final unit in value.codeUnits) {
-      buffer[offset++] = unit & 0xFF;
-    }
-    return offset;
+  int _writeBytes(Uint8List buffer, int offset, List<int> bytes) {
+    buffer.setAll(offset, bytes);
+    return offset + bytes.length;
   }
 
   bool _isBinary(dynamic value) {

--- a/packages/realtime_client/test/serializer_test.dart
+++ b/packages/realtime_client/test/serializer_test.dart
@@ -233,6 +233,63 @@ void main() {
       expect(jsonDecode(metadata), {'trace_id': 'abc'});
     });
 
+    test('encodes multi-byte header fields as UTF-8 byte lengths', () {
+      final serializerWithMeta = Serializer(allowedMetadataKeys: ['label']);
+      final topic = 'realtime:café';
+      final userEvent = 'café-🎉';
+      final payload = Uint8List.fromList([1, 2, 3]);
+      final result = serializerWithMeta.encode({
+        'join_ref': '10',
+        'ref': '1',
+        'topic': topic,
+        'event': 'broadcast',
+        'payload': {
+          'type': 'broadcast',
+          'event': userEvent,
+          'label': 'naïve',
+          'payload': payload,
+        },
+      });
+
+      final bytes = result as Uint8List;
+      final joinRefBytes = utf8.encode('10');
+      final refBytes = utf8.encode('1');
+      final topicBytes = utf8.encode(topic);
+      final userEventBytes = utf8.encode(userEvent);
+      final metadataBytes = utf8.encode(jsonEncode({'label': 'naïve'}));
+
+      // Length prefixes must be UTF-8 byte lengths, not UTF-16 code-unit counts.
+      expect(bytes[1], joinRefBytes.length);
+      expect(bytes[2], refBytes.length);
+      expect(bytes[3], topicBytes.length);
+      expect(bytes[4], userEventBytes.length);
+      expect(bytes[5], metadataBytes.length);
+      expect(bytes[4], greaterThan(userEvent.length));
+
+      // The written bytes must round-trip through utf8.decode, as decode does.
+      var offset =
+          Serializer.headerLength + Serializer.userBroadcastPushMetaLength;
+      offset += joinRefBytes.length + refBytes.length;
+      expect(
+        utf8.decode(bytes.sublist(offset, offset + topicBytes.length)),
+        topic,
+      );
+      offset += topicBytes.length;
+      expect(
+        utf8.decode(bytes.sublist(offset, offset + userEventBytes.length)),
+        userEvent,
+      );
+      offset += userEventBytes.length;
+      expect(
+        jsonDecode(
+          utf8.decode(bytes.sublist(offset, offset + metadataBytes.length)),
+        ),
+        {'label': 'naïve'},
+      );
+      offset += metadataBytes.length;
+      expect(bytes.sublist(offset), payload);
+    });
+
     test('throws when a frame field exceeds 255 bytes', () {
       final longTopic = 'a' * 256;
       expect(


### PR DESCRIPTION
## Summary

The binary broadcast serializer measured header field lengths with `String.length` (UTF-16 code units) and wrote one byte per code unit. Any multi-byte character (accents, emoji, non-Latin scripts) in the topic, ref, join-ref, event name, or metadata corrupted the length prefixes and desynchronized the binary frame. Each header field is now encoded to UTF-8 bytes first, and the byte length is used for both the length prefixes and the write offsets, matching the `utf8.decode` on the decode side.

**Outcome:** implemented (bug fix)

## Changes
- `packages/realtime_client/lib/src/serializer.dart` — UTF-8 encode `topic`, `ref`, `joinRef`, `userEvent`, and `metadata` before measuring/writing; replaced the code-unit `_writeString` helper with a byte-copying `_writeBytes`.
- `packages/realtime_client/test/serializer_test.dart` — added a test covering multi-byte header fields (accented text and emoji) round-tripping correctly.

## Reference
supabase-js PR #2516 / commit `b4ddbd5` (fix(realtime): encode broadcast header fields as UTF-8)

## Compliance matrix
`realtime.configuration.binary_protocol` remains `implemented` (no new public symbols; the change is internal to the non-exported serializer).

Closes SDK-1322