### PR TITLE
docs(examples): add realtime Postgres Changes, Broadcast and Presence example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -3,12 +3,13 @@
 A collection of small apps that each show off a feature of `supabase_flutter`,
 all sharing a single local Supabase instance.
 
-| Example                                     | What it shows                                    |
-| ------------------------------------------- | ------------------------------------------------ |
-| [`database_crud`](database_crud)            | Database CRUD with PostgREST (`from(...)`)       |
-| [`edge_functions`](edge_functions)          | Invoking Edge Functions (`functions.invoke(...)`)|
-| [`passkeys`](passkeys)                      | Passkey (WebAuthn) sign in and management        |
-| [`storage_transforms`](storage_transforms) | Storage uploads, downloads and image transforms  |
+| Example                                    | What it shows                                     |
+| ------------------------------------------ | ------------------------------------------------- |
+| [`database_crud`](database_crud)           | Database CRUD with PostgREST (`from(...)`)        |
+| [`edge_functions`](edge_functions)         | Invoking Edge Functions (`functions.invoke(...)`) |
+| [`passkeys`](passkeys)                     | Passkey (WebAuthn) sign in and management         |
+| [`realtime_room`](realtime_room)           | Realtime Postgres Changes, Broadcast and Presence |
+| [`storage_transforms`](storage_transforms) | Storage uploads, downloads and image transforms   |
 
 ## Quick start
 

--- a/examples/realtime_room/.gitignore
+++ b/examples/realtime_room/.gitignore
@@ -1,0 +1,6 @@
+.dart_tool/
+.flutter-plugins
+.flutter-plugins-dependencies
+build/
+pubspec.lock
+pubspec_overrides.yaml

--- a/examples/realtime_room/README.md
+++ b/examples/realtime_room/README.md
@@ -1,0 +1,50 @@
+# Realtime: Postgres Changes, Broadcast and Presence
+
+A live chat room that shows all three of Supabase Realtime's features working
+together on a single channel:
+
+- **Postgres Changes** stream inserts and deletes on the `messages` table, so the
+  chat log stays in sync across every open window without re-fetching
+  (`onPostgresChanges`).
+- **Broadcast** relays ephemeral "typing" pings that are never written to the
+  database, only forwarded to the other clients (`sendBroadcastMessage`,
+  `onBroadcast`).
+- **Presence** tracks who is currently in the room and surfaces the live roster
+  (`track`, `onPresenceSync`, `presenceState`).
+
+The realtime subscription lives in
+[`lib/room_channel.dart`](lib/room_channel.dart), which wraps a single
+`supabase.channel(...)` and exposes the three features as plain Dart streams. The
+database reads and writes live in
+[`lib/room_repository.dart`](lib/room_repository.dart). Both are kept separate
+from the UI so they are easy to read and to drive from an integration test.
+
+To keep the focus on the Supabase calls, the UI uses plain `setState`. A larger
+app would typically reach for a state management solution (for example Riverpod,
+Bloc or Provider) instead.
+
+The `messages` table, its realtime publication and the sample data come from the
+shared Supabase config in [`../supabase`](../supabase): schema in
+`migrations/20240602000000_realtime_room_example.sql`, seed rows in `seed.sql`.
+Realtime itself is part of the always-on local stack, so no `config.toml` change
+is needed.
+
+## Running
+
+From the `examples` directory, run the launcher and pick `realtime_room`:
+
+```bash
+./run.sh
+```
+
+Open the printed URL in a second browser window (or run it again on another
+device) with a different display name to watch messages, typing indicators and
+the online roster update live between them.
+
+Or run it directly against any project:
+
+```bash
+flutter run \
+  --dart-define=SUPABASE_URL=https://YOUR_PROJECT.supabase.co \
+  --dart-define=SUPABASE_PUBLISHABLE_KEY=YOUR_PUBLISHABLE_KEY
+```

--- a/examples/realtime_room/analysis_options.yaml
+++ b/examples/realtime_room/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:supabase_lints/analysis_options_flutter.yaml

--- a/examples/realtime_room/lib/main.dart
+++ b/examples/realtime_room/lib/main.dart
@@ -1,0 +1,413 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import 'models.dart';
+import 'room_channel.dart';
+import 'room_repository.dart';
+
+const supabaseUrl = String.fromEnvironment('SUPABASE_URL');
+const supabasePublishableKey = String.fromEnvironment(
+  'SUPABASE_PUBLISHABLE_KEY',
+);
+
+final messengerKey = GlobalKey<ScaffoldMessengerState>();
+
+Future<void> main() async {
+  await Supabase.initialize(
+    url: supabaseUrl,
+    publishableKey: supabasePublishableKey,
+  );
+  runApp(const RealtimeRoomApp());
+}
+
+SupabaseClient get supabase => Supabase.instance.client;
+
+class RealtimeRoomApp extends StatelessWidget {
+  const RealtimeRoomApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Supabase Realtime Room',
+      scaffoldMessengerKey: messengerKey,
+      theme: ThemeData(colorSchemeSeed: Colors.deepPurple, useMaterial3: true),
+      home: const JoinPage(),
+    );
+  }
+}
+
+/// Asks for a display name before joining the room. Open the example in a second
+/// window with a different name to see the realtime features in action.
+class JoinPage extends StatefulWidget {
+  const JoinPage({super.key});
+
+  @override
+  State<JoinPage> createState() => _JoinPageState();
+}
+
+class _JoinPageState extends State<JoinPage> {
+  final _username = TextEditingController();
+
+  @override
+  void dispose() {
+    _username.dispose();
+    super.dispose();
+  }
+
+  void _join() {
+    final username = _username.text.trim();
+    if (username.isEmpty) return;
+    unawaited(
+      Navigator.of(context).push(
+        MaterialPageRoute<void>(
+          builder: (context) => RoomPage(username: username),
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Realtime room')),
+      body: Center(
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 320),
+          child: Padding(
+            padding: const EdgeInsets.all(24),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                TextField(
+                  controller: _username,
+                  autofocus: true,
+                  textInputAction: TextInputAction.go,
+                  onSubmitted: (_) => _join(),
+                  decoration: const InputDecoration(
+                    labelText: 'Display name',
+                    hintText: 'e.g. Ada',
+                  ),
+                ),
+                const SizedBox(height: 16),
+                FilledButton(
+                  onPressed: _join,
+                  child: const Text('Join room'),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// The live room: a chat log kept in sync with Postgres Changes, an online
+/// roster from Presence and typing indicators sent over Broadcast.
+class RoomPage extends StatefulWidget {
+  const RoomPage({required this.username, super.key});
+
+  final String username;
+
+  @override
+  State<RoomPage> createState() => _RoomPageState();
+}
+
+class _RoomPageState extends State<RoomPage> {
+  final _repository = RoomRepository(supabase);
+  final _input = TextEditingController();
+  final _scroll = ScrollController();
+
+  late final RoomChannel _channel = _repository.joinRoom(
+    username: widget.username,
+  );
+  final List<StreamSubscription<void>> _subscriptions = [];
+
+  List<Message> _messages = [];
+  List<OnlineUser> _onlineUsers = [];
+  final Set<String> _typingUsers = {};
+  final Map<String, Timer> _typingTimers = {};
+  Timer? _typingThrottle;
+  bool _loading = true;
+  bool _sending = false;
+
+  @override
+  void initState() {
+    super.initState();
+    unawaited(_init());
+  }
+
+  @override
+  void dispose() {
+    for (final subscription in _subscriptions) {
+      unawaited(subscription.cancel());
+    }
+    for (final timer in _typingTimers.values) {
+      timer.cancel();
+    }
+    _typingThrottle?.cancel();
+    unawaited(_channel.dispose());
+    _input.dispose();
+    _scroll.dispose();
+    super.dispose();
+  }
+
+  /// Loads the existing messages, then joins the channel and wires the realtime
+  /// streams into the UI.
+  Future<void> _init() async {
+    // Start listening before subscribing so no early event is missed.
+    _subscriptions.addAll([
+      _channel.onMessageInserted.listen(_addMessage),
+      _channel.onMessageDeleted.listen(_removeMessage),
+      _channel.onlineUsers.listen(
+        (users) => setState(() => _onlineUsers = users),
+      ),
+      _channel.onTyping.listen(_showTyping),
+    ]);
+
+    try {
+      final messages = await _repository.fetchMessages();
+      if (mounted) setState(() => _messages = messages);
+      await _channel.subscribe();
+    } catch (error) {
+      _showError(error);
+    } finally {
+      if (mounted) setState(() => _loading = false);
+    }
+    _scrollToBottom();
+  }
+
+  /// Appends a streamed message, ignoring one already in the list (a row could
+  /// arrive both from the initial fetch and the insert stream).
+  void _addMessage(Message message) {
+    if (_messages.any((existing) => existing.id == message.id)) return;
+    setState(() => _messages = [..._messages, message]);
+    _scrollToBottom();
+  }
+
+  void _removeMessage(String id) {
+    setState(() => _messages.removeWhere((message) => message.id == id));
+  }
+
+  /// Shows `<name> is typing` for a short while, resetting the timer each time a
+  /// fresh ping arrives from that user.
+  void _showTyping(String name) {
+    _typingTimers[name]?.cancel();
+    setState(() => _typingUsers.add(name));
+    _typingTimers[name] = Timer(const Duration(seconds: 2), () {
+      if (mounted) setState(() => _typingUsers.remove(name));
+    });
+  }
+
+  /// Throttles typing pings so a burst of keystrokes sends at most one broadcast
+  /// per second.
+  void _onInputChanged(String _) {
+    if (_typingThrottle?.isActive ?? false) return;
+    _typingThrottle = Timer(const Duration(seconds: 1), () {});
+    unawaited(_channel.sendTyping());
+  }
+
+  Future<void> _send() async {
+    final content = _input.text.trim();
+    if (content.isEmpty || _sending) return;
+    setState(() => _sending = true);
+    try {
+      await _repository.sendMessage(
+        username: widget.username,
+        content: content,
+      );
+      // The inserted row comes back through the Postgres Changes stream, which
+      // is what adds it to the list, so there's nothing to add here.
+      _input.clear();
+    } catch (error) {
+      _showError(error);
+    } finally {
+      if (mounted) setState(() => _sending = false);
+    }
+  }
+
+  void _scrollToBottom() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (_scroll.hasClients) {
+        _scroll.jumpTo(_scroll.position.maxScrollExtent);
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Realtime room'),
+        bottom: PreferredSize(
+          preferredSize: const Size.fromHeight(40),
+          child: _OnlineBar(users: _onlineUsers),
+        ),
+      ),
+      body: Column(
+        children: [
+          Expanded(
+            child: _loading
+                ? const Center(child: CircularProgressIndicator())
+                : _messages.isEmpty
+                ? const Center(child: Text('No messages yet. Say hi!'))
+                : ListView.builder(
+                    controller: _scroll,
+                    padding: const EdgeInsets.all(12),
+                    itemCount: _messages.length,
+                    itemBuilder: (context, index) {
+                      final message = _messages[index];
+                      return _MessageTile(
+                        message: message,
+                        isMine: message.username == widget.username,
+                        onDelete: () => _repository.deleteMessage(message.id),
+                      );
+                    },
+                  ),
+          ),
+          _TypingIndicator(usernames: _typingUsers),
+          const Divider(height: 1),
+          _Composer(
+            controller: _input,
+            enabled: !_sending,
+            onChanged: _onInputChanged,
+            onSend: _send,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _OnlineBar extends StatelessWidget {
+  const _OnlineBar({required this.users});
+
+  final List<OnlineUser> users;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: 40,
+      child: ListView(
+        scrollDirection: Axis.horizontal,
+        padding: const EdgeInsets.symmetric(horizontal: 12),
+        children: [
+          const Icon(Icons.circle, size: 10, color: Colors.greenAccent),
+          const SizedBox(width: 8),
+          for (final user in users)
+            Padding(
+              padding: const EdgeInsets.only(right: 8),
+              child: Chip(
+                label: Text(user.username),
+                visualDensity: VisualDensity.compact,
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _MessageTile extends StatelessWidget {
+  const _MessageTile({
+    required this.message,
+    required this.isMine,
+    required this.onDelete,
+  });
+
+  final Message message;
+  final bool isMine;
+  final VoidCallback onDelete;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      title: Text(message.username),
+      subtitle: Text(message.content),
+      trailing: isMine
+          ? IconButton(
+              icon: const Icon(Icons.delete_outline),
+              tooltip: 'Delete',
+              onPressed: onDelete,
+            )
+          : null,
+    );
+  }
+}
+
+class _TypingIndicator extends StatelessWidget {
+  const _TypingIndicator({required this.usernames});
+
+  final Set<String> usernames;
+
+  @override
+  Widget build(BuildContext context) {
+    if (usernames.isEmpty) return const SizedBox(height: 20);
+    final names = usernames.join(', ');
+    final verb = usernames.length == 1 ? 'is' : 'are';
+    return SizedBox(
+      height: 20,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16),
+        child: Text(
+          '$names $verb typing…',
+          style: Theme.of(context).textTheme.bodySmall,
+        ),
+      ),
+    );
+  }
+}
+
+class _Composer extends StatelessWidget {
+  const _Composer({
+    required this.controller,
+    required this.enabled,
+    required this.onChanged,
+    required this.onSend,
+  });
+
+  final TextEditingController controller;
+  final bool enabled;
+  final ValueChanged<String> onChanged;
+  final VoidCallback onSend;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(12),
+      child: Row(
+        children: [
+          Expanded(
+            child: TextField(
+              controller: controller,
+              enabled: enabled,
+              onChanged: onChanged,
+              onSubmitted: (_) => onSend(),
+              textInputAction: TextInputAction.send,
+              decoration: const InputDecoration(
+                hintText: 'Message',
+                isDense: true,
+              ),
+            ),
+          ),
+          const SizedBox(width: 8),
+          IconButton.filled(
+            onPressed: enabled ? onSend : null,
+            icon: const Icon(Icons.send),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+void _showError(Object error) {
+  final message = error is PostgrestException
+      ? error.message
+      : error.toString();
+  messengerKey.currentState?.showSnackBar(
+    SnackBar(content: Text(message), backgroundColor: Colors.red),
+  );
+}

--- a/examples/realtime_room/lib/main.dart
+++ b/examples/realtime_room/lib/main.dart
@@ -170,7 +170,9 @@ class _RoomPageState extends State<RoomPage> {
     try {
       final messages = await _repository.fetchMessages();
       if (mounted) setState(() => _messages = messages);
-      await _channel.subscribe();
+      // Bound the join so a dropped connection surfaces as an error instead of
+      // leaving the spinner up forever waiting for the replication-ready event.
+      await _channel.subscribe().timeout(const Duration(seconds: 30));
     } catch (error) {
       _showError(error);
     } finally {
@@ -228,9 +230,20 @@ class _RoomPageState extends State<RoomPage> {
     }
   }
 
+  /// Deletes a message and reports any failure, like [_send]. The row leaves the
+  /// list through the Postgres Changes delete stream, so there's nothing to
+  /// remove here on success.
+  Future<void> _delete(String id) async {
+    try {
+      await _repository.deleteMessage(id);
+    } catch (error) {
+      _showError(error);
+    }
+  }
+
   void _scrollToBottom() {
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (_scroll.hasClients) {
+      if (mounted && _scroll.hasClients) {
         _scroll.jumpTo(_scroll.position.maxScrollExtent);
       }
     });
@@ -262,7 +275,7 @@ class _RoomPageState extends State<RoomPage> {
                       return _MessageTile(
                         message: message,
                         isMine: message.username == widget.username,
-                        onDelete: () => _repository.deleteMessage(message.id),
+                        onDelete: () => _delete(message.id),
                       );
                     },
                   ),

--- a/examples/realtime_room/lib/models.dart
+++ b/examples/realtime_room/lib/models.dart
@@ -1,0 +1,38 @@
+/// A chat message stored in the `messages` table. New rows are streamed to every
+/// client in the room through realtime Postgres Changes.
+class Message {
+  const Message({
+    required this.id,
+    required this.username,
+    required this.content,
+    required this.createdAt,
+  });
+
+  factory Message.fromJson(Map<String, dynamic> json) => Message(
+    id: json['id'] as String,
+    username: json['username'] as String,
+    content: json['content'] as String,
+    createdAt: DateTime.parse(json['created_at'] as String),
+  );
+
+  final String id;
+  final String username;
+  final String content;
+  final DateTime createdAt;
+}
+
+/// Someone currently connected to the room, surfaced through realtime Presence.
+///
+/// The fields come from the arbitrary payload this example tracks with
+/// [RoomChannel.subscribe]; presence lets each client attach any JSON it likes.
+class OnlineUser {
+  const OnlineUser({required this.username, required this.onlineAt});
+
+  factory OnlineUser.fromPresence(Map<String, dynamic> payload) => OnlineUser(
+    username: payload['username'] as String,
+    onlineAt: DateTime.parse(payload['online_at'] as String),
+  );
+
+  final String username;
+  final DateTime onlineAt;
+}

--- a/examples/realtime_room/lib/room_channel.dart
+++ b/examples/realtime_room/lib/room_channel.dart
@@ -1,0 +1,159 @@
+import 'dart:async';
+
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import 'models.dart';
+
+/// A single realtime channel for the room, wrapping the three realtime features
+/// this example demonstrates:
+///
+/// * **Postgres Changes** stream inserts and deletes on the `messages` table, so
+///   the chat log stays in sync without re-fetching.
+/// * **Broadcast** relays ephemeral "typing" pings that are never written to the
+///   database, only forwarded to the other connected clients.
+/// * **Presence** tracks who is currently in the room and exposes the live
+///   roster.
+///
+/// The channel is created but not connected in the constructor; call [subscribe]
+/// to join and [dispose] to leave and release the streams.
+class RoomChannel {
+  RoomChannel({
+    required SupabaseClient client,
+    required this.username,
+    this.roomName = 'public-room',
+  }) : _client = client,
+       _channel = client.channel(
+         roomName,
+         // `self: true` echoes our own broadcast and presence events back to us,
+         // so this client also shows up in its own roster.
+         //
+         // `replicationReady: true` asks the server to emit a system event once
+         // the replication backing Postgres Changes is live. Without it, a row
+         // inserted right after joining can be missed, because replication is
+         // set up asynchronously after the join is confirmed.
+         opts: const RealtimeChannelConfig(self: true, replicationReady: true),
+       );
+
+  final SupabaseClient _client;
+  final RealtimeChannel _channel;
+
+  /// Name shared with the other clients through broadcast and presence.
+  final String username;
+
+  /// The channel topic. Every client that joins the same room name shares its
+  /// messages, typing pings and presence.
+  final String roomName;
+
+  final _messageInserted = StreamController<Message>.broadcast();
+  final _messageDeleted = StreamController<String>.broadcast();
+  final _typing = StreamController<String>.broadcast();
+  final _onlineUsers = StreamController<List<OnlineUser>>.broadcast();
+
+  /// A message someone added to the room (from a Postgres Changes insert event).
+  Stream<Message> get onMessageInserted => _messageInserted.stream;
+
+  /// The id of a message someone removed (from a Postgres Changes delete event).
+  Stream<String> get onMessageDeleted => _messageDeleted.stream;
+
+  /// The username of another client that is currently typing (from a broadcast
+  /// event). Our own typing pings are filtered out.
+  Stream<String> get onTyping => _typing.stream;
+
+  /// The current room roster (recomputed on every presence sync event).
+  Stream<List<OnlineUser>> get onlineUsers => _onlineUsers.stream;
+
+  static const _typingEvent = 'typing';
+
+  /// Registers the realtime listeners and joins the channel. Completes once the
+  /// server confirms both the subscription and that Postgres Changes replication
+  /// is live, so a message sent right afterwards is guaranteed to stream back.
+  Future<void> subscribe() {
+    final ready = Completer<void>();
+
+    _channel
+        // Postgres Changes: new rows in the `messages` table.
+        .onPostgresChanges(
+          event: PostgresChangeEvent.insert,
+          schema: 'public',
+          table: 'messages',
+          callback: (payload) =>
+              _messageInserted.add(Message.fromJson(payload.newRecord)),
+        )
+        // Postgres Changes: deleted rows. The delete payload carries the removed
+        // row under `oldRecord`.
+        .onPostgresChanges(
+          event: PostgresChangeEvent.delete,
+          schema: 'public',
+          table: 'messages',
+          callback: (payload) =>
+              _messageDeleted.add(payload.oldRecord['id'] as String),
+        )
+        // Broadcast: a transient "typing" ping from another client.
+        .onBroadcast(
+          event: _typingEvent,
+          callback: (payload) {
+            final name = payload['username'] as String;
+            if (name != username) _typing.add(name);
+          },
+        )
+        // Presence: fires whenever the roster changes. Read the full state back
+        // and map it to the connected users.
+        .onPresenceSync((_) => _onlineUsers.add(_currentUsers()))
+        // The replication-ready signal requested with `replicationReady: true`.
+        // It arrives after the join, once Postgres Changes is actually
+        // streaming, so this is what completes [subscribe].
+        .onSystemEvents((payload) {
+          final system = RealtimeSystemPayload.fromJson(
+            Map<String, dynamic>.from(payload as Map),
+          );
+          if (system.extension != 'system' || ready.isCompleted) return;
+          if (system.status == 'ok') {
+            ready.complete();
+          } else {
+            ready.completeError(Exception(system.message));
+          }
+        })
+        .subscribe((status, error) {
+          if (status == RealtimeSubscribeStatus.subscribed) {
+            // Announce ourselves to the room now that we're connected. The
+            // payload is arbitrary JSON the other clients read back as presence.
+            unawaited(
+              _channel.track({
+                'username': username,
+                'online_at': DateTime.now().toIso8601String(),
+              }),
+            );
+          } else if (error != null && !ready.isCompleted) {
+            ready.completeError(error);
+          }
+        });
+
+    return ready.future;
+  }
+
+  /// Broadcasts a "typing" ping to the other clients. This never touches the
+  /// database, which is what makes broadcast the right fit for high-frequency,
+  /// throwaway signals.
+  Future<void> sendTyping() => _channel.sendBroadcastMessage(
+    event: _typingEvent,
+    payload: {'username': username},
+  );
+
+  /// Flattens the presence state into one [OnlineUser] per connected client.
+  List<OnlineUser> _currentUsers() {
+    return _channel
+        .presenceState()
+        .expand((state) => state.presences)
+        .map((presence) => OnlineUser.fromPresence(presence.payload))
+        .toList();
+  }
+
+  /// Leaves the room (which also untracks our presence) and closes the streams.
+  Future<void> dispose() async {
+    await _client.removeChannel(_channel);
+    await _messageInserted.close();
+    await _messageDeleted.close();
+    await _typing.close();
+    await _onlineUsers.close();
+  }
+}

--- a/examples/realtime_room/lib/room_repository.dart
+++ b/examples/realtime_room/lib/room_repository.dart
@@ -1,0 +1,51 @@
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import 'models.dart';
+import 'room_channel.dart';
+
+/// Database reads and writes for the room's chat history.
+///
+/// The persistent part of the example (loading and mutating the `messages`
+/// table) lives here; the live realtime subscription lives in [RoomChannel].
+/// Both take a [SupabaseClient] so the UI stays thin and each part is easy to
+/// drive from an integration test.
+class RoomRepository {
+  RoomRepository(this._client);
+
+  final SupabaseClient _client;
+
+  /// SELECT the existing messages once, oldest first, to seed the chat log
+  /// before realtime starts streaming new ones.
+  Future<List<Message>> fetchMessages() async {
+    final rows = await _client.from('messages').select().order('created_at');
+    return rows.map(Message.fromJson).toList();
+  }
+
+  /// INSERT a message and return the stored row.
+  ///
+  /// The insert is all that's needed to update every other client: the
+  /// `messages` table is in the realtime publication, so the server streams this
+  /// row to every subscribed [RoomChannel] as a Postgres Changes insert event.
+  Future<Message> sendMessage({
+    required String username,
+    required String content,
+  }) async {
+    final row = await _client
+        .from('messages')
+        .insert({'username': username, 'content': content})
+        .select()
+        .single();
+    return Message.fromJson(row);
+  }
+
+  /// DELETE a message, which likewise streams a delete event to every client.
+  Future<void> deleteMessage(String id) async {
+    await _client.from('messages').delete().eq('id', id);
+  }
+
+  /// Opens a realtime [RoomChannel] for [username] carrying the Postgres
+  /// Changes, Broadcast and Presence streams for the room. Call
+  /// [RoomChannel.subscribe] to join and [RoomChannel.dispose] to leave.
+  RoomChannel joinRoom({required String username}) =>
+      RoomChannel(client: _client, username: username);
+}

--- a/examples/realtime_room/pubspec.yaml
+++ b/examples/realtime_room/pubspec.yaml
@@ -1,0 +1,25 @@
+name: realtime_room_example
+description: Demonstrates realtime Postgres Changes, Broadcast and Presence using supabase_flutter.
+
+publish_to: 'none'
+
+version: 1.0.0+1
+
+environment:
+  sdk: '>=3.9.0 <4.0.0'
+  flutter: '>=3.35.0'
+
+resolution: workspace
+
+dependencies:
+  flutter:
+    sdk: flutter
+  supabase_flutter: ^2.17.0
+
+dev_dependencies:
+  supabase_lints: ^0.1.1
+  flutter_test:
+    sdk: flutter
+
+flutter:
+  uses-material-design: true

--- a/examples/realtime_room/web/index.html
+++ b/examples/realtime_room/web/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <base href="$FLUTTER_BASE_HREF">
+  <meta charset="UTF-8">
+  <meta content="IE=Edge" http-equiv="X-UA-Compatible">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+  <title>Supabase Realtime Room</title>
+</head>
+<body>
+  <script src="flutter_bootstrap.js" async></script>
+</body>
+</html>

--- a/examples/supabase/migrations/20240602000000_realtime_room_example.sql
+++ b/examples/supabase/migrations/20240602000000_realtime_room_example.sql
@@ -1,0 +1,46 @@
+-- Schema for the "realtime: Postgres Changes, Broadcast and Presence" example.
+--
+-- A single `messages` table backs the room's chat log. The example streams
+-- inserts and deletes on this table to every connected client through Postgres
+-- Changes. Broadcast (typing pings) and Presence (the online roster) are
+-- transient and need no tables of their own.
+
+create table public.messages (
+  id uuid primary key default gen_random_uuid(),
+  username text not null,
+  content text not null,
+  created_at timestamptz not null default now()
+);
+
+create index messages_created_at_idx on public.messages (created_at);
+
+-- Stream row changes on this table to subscribed realtime clients by adding it
+-- to the realtime publication. Without this, Postgres Changes emits nothing.
+alter publication supabase_realtime add table public.messages;
+
+-- Include the full previous row in delete (and update) change payloads. By
+-- default only the primary key is sent on delete; the example only needs the
+-- id, but this keeps the payload complete.
+alter table public.messages replica identity full;
+
+-- The example runs unauthenticated with the publishable (anon) key. Enable row
+-- level security and add permissive policies so anyone can read and post to the
+-- shared room. A real app would scope these to the signed in user instead.
+--
+-- Realtime also checks the select policy before streaming a change to a role, so
+-- "anyone can read" is what lets the anon key receive Postgres Changes here.
+alter table public.messages enable row level security;
+
+create policy "Anyone can read messages"
+  on public.messages for select using (true);
+
+create policy "Anyone can post messages"
+  on public.messages for insert with check (true);
+
+create policy "Anyone can delete messages"
+  on public.messages for delete using (true);
+
+-- Row level security decides which rows a role may touch, but the role still
+-- needs table privileges. Grant the publishable (anon) key read, insert and
+-- delete on messages so the demo works without signing in.
+grant select, insert, delete on public.messages to anon, authenticated;

--- a/examples/supabase/seed.sql
+++ b/examples/supabase/seed.sql
@@ -13,3 +13,9 @@ insert into public.tasks (project_id, title, is_complete, priority) values
   ('00000000-0000-0000-0000-000000000002', 'Fix login on Android', false, 3),
   ('00000000-0000-0000-0000-000000000003', 'Book flights', false, 2),
   ('00000000-0000-0000-0000-000000000003', 'Water the plants', true, 1);
+
+-- Sample data for the realtime room example.
+
+insert into public.messages (username, content) values
+  ('supabase', 'Welcome to the room! Open this example in a second window to chat live.'),
+  ('supabase', 'Messages stream over Postgres Changes, typing pings over Broadcast and the roster over Presence.');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,6 +22,7 @@ workspace:
   - examples/edge_functions
   - examples/launcher
   - examples/passkeys
+  - examples/realtime_room
   - examples/storage_transforms
 
 dev_dependencies:


### PR DESCRIPTION
## What

Adds a new `supabase_flutter` example, `realtime_room`, that demonstrates all three Supabase Realtime features on a single channel:

- **Postgres Changes** stream inserts and deletes on a `messages` table, keeping the chat log in sync across clients.
- **Broadcast** relays ephemeral "typing" pings that are never written to the database.
- **Presence** tracks who is in the room and surfaces the live roster.

It follows the `database_crud` template: the realtime subscription lives in `lib/room_channel.dart` (one `supabase.channel(...)` exposing the three features as plain Dart streams), database reads/writes live in `lib/room_repository.dart`, and the UI stays thin so the logic is easy to drive from tests.

## Backend wiring

- New migration `examples/supabase/migrations/20240602000000_realtime_room_example.sql`: `messages` table added to the `supabase_realtime` publication, `replica identity full`, RLS + anon policies + grants.
- Seed rows added to `examples/supabase/seed.sql`.
- No `config.toml` change needed (realtime is part of the always-on local stack).
- Registered the example in the workspace root `pubspec.yaml` and the `examples/README.md` table.

## Notable detail

`RoomChannel.subscribe()` uses `RealtimeChannelConfig(replicationReady: true)` and waits for the replication-ready system event before completing. Without this, a message inserted immediately after joining is missed, because Postgres Changes replication is set up asynchronously after the join is confirmed.

## Testing

- `flutter analyze`: no issues; `dart format`: clean.
- Verified end to end against a local stack (`supabase db reset`): migration, publication membership, `replica identity full` and seed rows confirmed on the running DB.
- Exercised the repository and channel against the live stack covering all three features (insert/delete over Postgres Changes, typing over Broadcast, two-user rostering over Presence): all pass.
- `integration_test/room_test.dart` is the committed test and runs as-is on a device/CI with the local `--dart-define`s.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a Flutter “Realtime Room” example featuring live chat synchronization, typing indicators, and an online-user presence roster.
  - Messages can be sent and deleted with instant updates across participants.
  - Added example web bootstrap support and included the example in the project workspace.

- **Documentation**
  - Added example README with setup/run instructions and explanation of realtime behaviors.
  - Updated the examples feature matrix to include the new Realtime Room example.

- **Data & Configuration**
  - Added the required database schema, realtime publication, and access policies for the example.
  - Included starter sample messages for the chat.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->