### PR TITLE
test(examples): add end-to-end test for the database CRUD example

### DIFF
--- a/examples/database_crud/README.md
+++ b/examples/database_crud/README.md
@@ -38,3 +38,19 @@ flutter run \
   --dart-define=SUPABASE_URL=https://YOUR_PROJECT.supabase.co \
   --dart-define=SUPABASE_PUBLISHABLE_KEY=YOUR_PUBLISHABLE_KEY
 ```
+
+## Integration test
+
+[`integration_test/tasks_test.dart`](integration_test/tasks_test.dart) is an
+end-to-end test that drives the app widgets against the local stack: it reads the
+seeded tasks, filters them by title, then creates, completes, renames and deletes
+a task, asserting on the UI after each step.
+
+With the local stack running, pass the same defines the app uses and run it on a
+device (integration tests need one, so `-d macos`, an emulator or a real device):
+
+```bash
+flutter test integration_test/tasks_test.dart -d macos \
+  --dart-define=SUPABASE_URL=http://localhost:54321 \
+  --dart-define=SUPABASE_PUBLISHABLE_KEY=YOUR_LOCAL_PUBLISHABLE_KEY
+```

--- a/examples/database_crud/integration_test/tasks_test.dart
+++ b/examples/database_crud/integration_test/tasks_test.dart
@@ -1,0 +1,139 @@
+import 'package:database_crud_example/main.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+const supabaseUrl = String.fromEnvironment('SUPABASE_URL');
+const supabasePublishableKey = String.fromEnvironment(
+  'SUPABASE_PUBLISHABLE_KEY',
+);
+
+/// End-to-end test that drives the real app widgets against the local Supabase
+/// stack, exercising the CRUD flow through the UI: reading the seeded tasks,
+/// filtering them, then creating, completing, renaming and deleting a task.
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  // A unique title so the test's own task never clashes with a leftover from a
+  // previous run.
+  final createdTitle = 'E2E task ${DateTime.now().microsecondsSinceEpoch}';
+  final renamedTitle = 'E2E renamed ${DateTime.now().microsecondsSinceEpoch}';
+
+  setUpAll(() async {
+    await Supabase.initialize(
+      url: supabaseUrl,
+      publishableKey: supabasePublishableKey,
+    );
+  });
+
+  tearDownAll(() async {
+    await Supabase.instance.dispose();
+  });
+
+  tearDown(() async {
+    // Remove anything the test created so it can run repeatedly.
+    await Supabase.instance.client
+        .from('tasks')
+        .delete()
+        .like('title', 'E2E %');
+  });
+
+  testWidgets('reads, filters and manages tasks through the UI', (
+    tester,
+  ) async {
+    await tester.pumpWidget(const CrudExampleApp());
+
+    // The seed tasks load on start.
+    await _pumpUntilGone(tester, find.byType(CircularProgressIndicator));
+    expect(find.text('Book flights'), findsOneWidget);
+    expect(find.text('Draft the landing page copy'), findsOneWidget);
+
+    // Filter by title (ilike): searching narrows the list to the match.
+    await tester.enterText(
+      find.widgetWithText(TextField, 'Search title'),
+      'Book',
+    );
+    await _pumpUntilGone(tester, find.text('Draft the landing page copy'));
+    expect(find.text('Book flights'), findsOneWidget);
+
+    // Clearing the filter brings the other tasks back.
+    await tester.enterText(find.widgetWithText(TextField, 'Search title'), '');
+    await _pumpUntil(tester, find.text('Draft the landing page copy'));
+
+    // Create a task through the new-task dialog (insert).
+    await tester.tap(find.byType(FloatingActionButton));
+    await tester.pumpAndSettle();
+    await tester.enterText(
+      find.widgetWithText(TextField, 'Title'),
+      createdTitle,
+    );
+    await tester.tap(find.widgetWithText(FilledButton, 'Create'));
+    await _pumpUntil(tester, find.text(createdTitle));
+
+    // Complete it by ticking the checkbox in its tile (update).
+    await tester.tap(_inTile(createdTitle, find.byType(Checkbox)));
+    await _pumpUntil(
+      tester,
+      _inTile(
+        createdTitle,
+        find.byWidgetPredicate((widget) => widget is Checkbox && widget.value!),
+      ),
+    );
+
+    // Rename it through the edit dialog (update).
+    await tester.tap(_inTile(createdTitle, find.byIcon(Icons.edit)));
+    await tester.pumpAndSettle();
+    await tester.enterText(
+      find.descendant(
+        of: find.byType(AlertDialog),
+        matching: find.byType(TextField),
+      ),
+      renamedTitle,
+    );
+    await tester.tap(find.widgetWithText(FilledButton, 'Save'));
+    await _pumpUntil(tester, find.text(renamedTitle));
+    expect(find.text(createdTitle), findsNothing);
+
+    // Delete it (delete).
+    await tester.tap(_inTile(renamedTitle, find.byIcon(Icons.delete)));
+    await _pumpUntilGone(tester, find.text(renamedTitle));
+  });
+}
+
+/// Finds [target] within the [ListTile] that contains [title].
+Finder _inTile(String title, Finder target) => find.descendant(
+  of: find.ancestor(of: find.text(title), matching: find.byType(ListTile)),
+  matching: target,
+);
+
+/// Pumps frames until [finder] matches at least one widget or [timeout] elapses.
+///
+/// Reads and writes go over the network, so the UI can't be settled with
+/// `pumpAndSettle`; this polls the widget tree instead.
+Future<void> _pumpUntil(
+  WidgetTester tester,
+  Finder finder, {
+  Duration timeout = const Duration(seconds: 20),
+}) async {
+  final deadline = DateTime.now().add(timeout);
+  while (DateTime.now().isBefore(deadline)) {
+    await tester.pump(const Duration(milliseconds: 100));
+    if (finder.evaluate().isNotEmpty) return;
+  }
+  fail('Timed out waiting for: $finder');
+}
+
+/// The inverse of [_pumpUntil]: pumps until [finder] matches nothing.
+Future<void> _pumpUntilGone(
+  WidgetTester tester,
+  Finder finder, {
+  Duration timeout = const Duration(seconds: 20),
+}) async {
+  final deadline = DateTime.now().add(timeout);
+  while (DateTime.now().isBefore(deadline)) {
+    await tester.pump(const Duration(milliseconds: 100));
+    if (finder.evaluate().isEmpty) return;
+  }
+  fail('Timed out waiting for it to disappear: $finder');
+}

--- a/examples/database_crud/pubspec.yaml
+++ b/examples/database_crud/pubspec.yaml
@@ -20,6 +20,8 @@ dev_dependencies:
   supabase_lints: ^0.1.1
   flutter_test:
     sdk: flutter
+  integration_test:
+    sdk: flutter
 
 flutter:
   uses-material-design: true

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -350,6 +350,11 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_driver:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_lints:
     dependency: transitive
     description:
@@ -376,6 +381,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.0"
+  fuchsia_remote_debug_protocol:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   glob:
     dependency: transitive
     description:
@@ -424,6 +434,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.2"
+  integration_test:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   io:
     dependency: transitive
     description:
@@ -933,6 +948,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.1"
+  sync_http:
+    dependency: transitive
+    description:
+      name: sync_http
+      sha256: "7f0cd72eca000d2e026bcd6f990b81d0ca06022ef4e32fb257b30d3d1014a961"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.1"
   term_glyph:
     dependency: transitive
     description:
@@ -1109,6 +1132,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.3"
+  webdriver:
+    dependency: transitive
+    description:
+      name: webdriver
+      sha256: "2f3a14ca026957870cfd9c635b83507e0e51d8091568e90129fbf805aba7cade"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.0"
   webkit_inspection_protocol:
     dependency: transitive
     description:


### PR DESCRIPTION
## What

Adds a full end-to-end integration test for the `database_crud` example, matching the one added for `realtime_room`. It drives the actual app widgets against the local Supabase stack rather than calling the repository directly.

## The test

`integration_test/tasks_test.dart` uses `testWidgets` to:

1. Pump `CrudExampleApp` and wait for the seeded tasks to load (select).
2. **Filter** by title through the search field and assert the list narrows, then clears (ilike).
3. **Create** a task through the new-task dialog and assert it appears (insert).
4. **Complete** it by ticking the checkbox in its tile and assert the checkbox becomes checked (update).
5. **Rename** it through the edit dialog and assert the new title replaces the old (update).
6. **Delete** it and assert it leaves the list (delete).

Because reads and writes go over the network, the UI can't be settled with `pumpAndSettle`; a small `_pumpUntil` helper polls the widget tree with a timeout instead. The test uses a unique task title and a `tearDown` that removes any `E2E %` rows, so it runs repeatably and leaves the seed data untouched.

Also adds the `integration_test` dev dependency and an "Integration test" section to the example README.

## Testing

- `flutter analyze`: no issues; `dart format`: clean.
- Ran end to end against a local stack, twice, both green. Integration tests need a device, so run it with `-d macos`, an emulator or a real device.
