### PR TITLE
test(examples): add end-to-end test for the passkeys example

### DIFF
--- a/examples/passkeys/README.md
+++ b/examples/passkeys/README.md
@@ -77,3 +77,23 @@ Then:
 
 > Passkeys are bound to the domain (relying party) they were created on, so a
 > passkey registered on `localhost` only works on `localhost`.
+
+## Integration test
+
+[`integration_test/passkeys_test.dart`](integration_test/passkeys_test.dart) is
+an end-to-end test that drives the app widgets against the local stack: it
+creates an account, lands on the passkey management screen, signs out, tries a
+wrong password and signs back in.
+
+The WebAuthn ceremony itself (`registerPasskey` / `signInWithPasskey`) drives a
+platform authenticator prompt that cannot be automated headlessly, so it is
+exercised manually with the steps above rather than in this test.
+
+With the local stack running, pass the same defines the app uses and run it on a
+device (integration tests need one, so `-d macos`, an emulator or a real device):
+
+```bash
+flutter test integration_test/passkeys_test.dart -d macos \
+  --dart-define=SUPABASE_URL=http://localhost:54321 \
+  --dart-define=SUPABASE_PUBLISHABLE_KEY=YOUR_LOCAL_PUBLISHABLE_KEY
+```

--- a/examples/passkeys/integration_test/passkeys_test.dart
+++ b/examples/passkeys/integration_test/passkeys_test.dart
@@ -1,0 +1,111 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:passkeys_example/main.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+const supabaseUrl = String.fromEnvironment('SUPABASE_URL');
+const supabasePublishableKey = String.fromEnvironment(
+  'SUPABASE_PUBLISHABLE_KEY',
+);
+
+/// End-to-end test that drives the passkeys app widgets against the local
+/// Supabase stack.
+///
+/// It covers everything around the WebAuthn ceremony: creating an account,
+/// landing on the passkey management screen, signing out, a failed sign in and a
+/// successful password sign in. The ceremony itself (`registerPasskey` /
+/// `signInWithPasskey`) drives a platform authenticator prompt (Face ID, Windows
+/// Hello, a security key, ...) that can't be automated headlessly, so it is
+/// exercised manually per the README rather than here.
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  // A unique account each run so sign up never collides with an existing user.
+  final email =
+      'passkeys-e2e-${DateTime.now().microsecondsSinceEpoch}@example.com';
+  const password = 'password123';
+
+  setUpAll(() async {
+    await Supabase.initialize(
+      url: supabaseUrl,
+      publishableKey: supabasePublishableKey,
+    );
+  });
+
+  tearDownAll(() async {
+    await Supabase.instance.client.auth.signOut();
+    await Supabase.instance.dispose();
+  });
+
+  testWidgets('signs up, manages the session and signs back in', (
+    tester,
+  ) async {
+    await tester.pumpWidget(const PasskeyExampleApp());
+    await tester.pumpAndSettle();
+
+    // Create an account. Email confirmations are disabled in the shared config,
+    // so this returns a session and lands on the passkey management screen.
+    await tester.enterText(find.widgetWithText(TextField, 'Email'), email);
+    await tester.enterText(
+      find.widgetWithText(TextField, 'Password'),
+      password,
+    );
+    await tester.tap(find.widgetWithText(OutlinedButton, 'Create an account'));
+
+    // The signed-in screen lists passkeys; a fresh account has none.
+    await _pumpUntil(tester, find.text('No passkeys yet.'));
+    expect(find.text(email), findsOneWidget);
+    expect(
+      find.widgetWithText(FilledButton, 'Register a passkey'),
+      findsOneWidget,
+    );
+
+    // Sign out returns to the sign-in screen.
+    await tester.tap(find.widgetWithText(OutlinedButton, 'Sign out'));
+    await _pumpUntil(
+      tester,
+      find.widgetWithText(FilledButton, 'Sign in with password'),
+    );
+
+    // A wrong password surfaces an error instead of signing in.
+    await tester.enterText(find.widgetWithText(TextField, 'Email'), email);
+    await tester.enterText(
+      find.widgetWithText(TextField, 'Password'),
+      'wrong-password',
+    );
+    await tester.tap(
+      find.widgetWithText(FilledButton, 'Sign in with password'),
+    );
+    await _pumpUntil(tester, find.byType(SnackBar));
+    expect(find.text('No passkeys yet.'), findsNothing);
+
+    // The correct password signs in again.
+    await tester.enterText(find.widgetWithText(TextField, 'Email'), email);
+    await tester.enterText(
+      find.widgetWithText(TextField, 'Password'),
+      password,
+    );
+    await tester.tap(
+      find.widgetWithText(FilledButton, 'Sign in with password'),
+    );
+    await _pumpUntil(tester, find.text('No passkeys yet.'));
+  });
+}
+
+/// Pumps frames until [finder] matches at least one widget or [timeout] elapses.
+///
+/// Auth calls go over the network, so the UI can't be settled with
+/// `pumpAndSettle`; this polls the widget tree instead.
+Future<void> _pumpUntil(
+  WidgetTester tester,
+  Finder finder, {
+  Duration timeout = const Duration(seconds: 20),
+}) async {
+  final deadline = DateTime.now().add(timeout);
+  while (DateTime.now().isBefore(deadline)) {
+    await tester.pump(const Duration(milliseconds: 100));
+    if (finder.evaluate().isNotEmpty) return;
+  }
+  fail('Timed out waiting for: $finder');
+}

--- a/examples/passkeys/pubspec.yaml
+++ b/examples/passkeys/pubspec.yaml
@@ -21,6 +21,8 @@ dev_dependencies:
   supabase_lints: ^0.1.1
   flutter_test:
     sdk: flutter
+  integration_test:
+    sdk: flutter
 
 flutter:
   uses-material-design: true

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -350,6 +350,11 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_driver:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_lints:
     dependency: transitive
     description:
@@ -376,6 +381,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.0"
+  fuchsia_remote_debug_protocol:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   glob:
     dependency: transitive
     description:
@@ -424,6 +434,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.2"
+  integration_test:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   io:
     dependency: transitive
     description:
@@ -933,6 +948,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.1"
+  sync_http:
+    dependency: transitive
+    description:
+      name: sync_http
+      sha256: "7f0cd72eca000d2e026bcd6f990b81d0ca06022ef4e32fb257b30d3d1014a961"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.1"
   term_glyph:
     dependency: transitive
     description:
@@ -1109,6 +1132,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.3"
+  webdriver:
+    dependency: transitive
+    description:
+      name: webdriver
+      sha256: "2f3a14ca026957870cfd9c635b83507e0e51d8091568e90129fbf805aba7cade"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.0"
   webkit_inspection_protocol:
     dependency: transitive
     description:


### PR DESCRIPTION
## What

Adds an end-to-end integration test for the `passkeys` example, matching the ones added for `realtime_room` and `database_crud`. It drives the actual app widgets against the local Supabase stack.

## The test

`integration_test/passkeys_test.dart` uses `testWidgets` to:

1. Pump `PasskeyExampleApp`, create an account and land on the passkey management screen (a fresh account shows "No passkeys yet." and the "Register a passkey" button).
2. Sign out and assert the sign-in screen returns.
3. Attempt a wrong password and assert an error surfaces instead of signing in.
4. Sign in with the correct password and assert the signed-in screen returns.

### Scope

The WebAuthn ceremony itself (`registerPasskey` / `signInWithPasskey`) drives a platform authenticator prompt (Face ID, Windows Hello, a security key, ...) that cannot be automated headlessly, so it is exercised manually per the README rather than in this test. The test covers everything around the ceremony: account creation, the passkey-list screen, session management and password sign-in error handling.

A small `_pumpUntil` helper polls the widget tree (auth calls are async over the network, so the UI can't be `pumpAndSettle`d). Each run uses a unique email so sign up never collides with an existing user.

Also adds the `integration_test` dev dependency and an "Integration test" section to the example README.

## Testing

- `flutter analyze`: no issues; `dart format`: clean.
- Ran end to end against a local stack, twice, both green. Integration tests need a device, so run it with `-d macos`, an emulator or a real device.
