### PR TITLE
docs(examples): add Storage uploads and image transformations example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -3,10 +3,11 @@
 A collection of small apps that each show off a feature of `supabase_flutter`,
 all sharing a single local Supabase instance.
 
-| Example                          | What it shows                              |
-| -------------------------------- | ------------------------------------------ |
-| [`database_crud`](database_crud) | Database CRUD with PostgREST (`from(...)`) |
-| [`passkeys`](passkeys)           | Passkey (WebAuthn) sign in and management  |
+| Example                                     | What it shows                                    |
+| ------------------------------------------- | ------------------------------------------------ |
+| [`database_crud`](database_crud)            | Database CRUD with PostgREST (`from(...)`)       |
+| [`passkeys`](passkeys)                      | Passkey (WebAuthn) sign in and management        |
+| [`storage_transforms`](storage_transforms) | Storage uploads, downloads and image transforms  |
 
 ## Quick start
 

--- a/examples/storage_transforms/.gitignore
+++ b/examples/storage_transforms/.gitignore
@@ -1,0 +1,6 @@
+.dart_tool/
+.flutter-plugins
+.flutter-plugins-dependencies
+build/
+pubspec.lock
+pubspec_overrides.yaml

--- a/examples/storage_transforms/README.md
+++ b/examples/storage_transforms/README.md
@@ -1,0 +1,47 @@
+# Storage: uploads and image transformations
+
+A small image gallery that shows how to store and serve files with
+`supabase.storage`:
+
+- **Upload** generated PNG bytes to a bucket (`uploadBinary`).
+- **List** the objects in the bucket, newest first (`list`).
+- **Transform** images on the fly by passing `TransformOptions` (width, height,
+  resize mode, quality) to `getPublicUrl`, so the gallery loads a small cropped
+  thumbnail and the detail view renders several resized variants.
+- **Download** the transformed bytes of an image (`download`).
+- **Delete** an object (`remove`).
+
+All Storage access is in
+[`lib/storage_repository.dart`](lib/storage_repository.dart), kept separate from
+the UI so the calls are easy to read and to drive from an integration test. The
+sample images are drawn in memory in
+[`lib/sample_image.dart`](lib/sample_image.dart), so the example uploads real
+image bytes without bundling asset files or depending on an image picker.
+
+To keep the focus on the Supabase calls, the screen uses plain `setState` and
+reloads the gallery after each write rather than pulling in a state management
+package. A larger app would typically reach for a state management solution (for
+example Riverpod, Bloc or Provider) instead.
+
+The `images` bucket and its access policies come from the shared Supabase config
+in [`../supabase`](../supabase): schema in
+`migrations/20240603000000_storage_transforms_example.sql`. Image
+transformations are enabled in `config.toml`
+(`[storage.image_transformation]`). The bucket starts empty; the app uploads its
+own images, so there are no seed rows.
+
+## Running
+
+From the `examples` directory, run the launcher and pick `storage_transforms`:
+
+```bash
+./run.sh
+```
+
+Or run it directly against any project:
+
+```bash
+flutter run \
+  --dart-define=SUPABASE_URL=https://YOUR_PROJECT.supabase.co \
+  --dart-define=SUPABASE_PUBLISHABLE_KEY=YOUR_PUBLISHABLE_KEY
+```

--- a/examples/storage_transforms/analysis_options.yaml
+++ b/examples/storage_transforms/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:supabase_lints/analysis_options_flutter.yaml

--- a/examples/storage_transforms/lib/main.dart
+++ b/examples/storage_transforms/lib/main.dart
@@ -1,0 +1,262 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import 'models.dart';
+import 'sample_image.dart';
+import 'storage_repository.dart';
+
+const supabaseUrl = String.fromEnvironment('SUPABASE_URL');
+const supabasePublishableKey = String.fromEnvironment(
+  'SUPABASE_PUBLISHABLE_KEY',
+);
+
+final messengerKey = GlobalKey<ScaffoldMessengerState>();
+
+Future<void> main() async {
+  await Supabase.initialize(
+    url: supabaseUrl,
+    publishableKey: supabasePublishableKey,
+  );
+  runApp(const StorageExampleApp());
+}
+
+SupabaseClient get supabase => Supabase.instance.client;
+
+class StorageExampleApp extends StatelessWidget {
+  const StorageExampleApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Supabase Storage transformations',
+      scaffoldMessengerKey: messengerKey,
+      theme: ThemeData(colorSchemeSeed: Colors.indigo, useMaterial3: true),
+      home: const GalleryPage(),
+    );
+  }
+}
+
+/// Uploads generated images to a public bucket and shows them in a gallery.
+/// Tapping an image opens the transformations view.
+class GalleryPage extends StatefulWidget {
+  const GalleryPage({super.key});
+
+  @override
+  State<GalleryPage> createState() => _GalleryPageState();
+}
+
+class _GalleryPageState extends State<GalleryPage> {
+  final _repository = StorageRepository(supabase);
+
+  /// Seed colors cycled through for each uploaded image, so successive uploads
+  /// look different.
+  static const _palette = [
+    Colors.indigo,
+    Colors.teal,
+    Colors.deepOrange,
+    Colors.pink,
+    Colors.green,
+  ];
+
+  List<StoredImage> _images = [];
+  bool _loading = true;
+  bool _mutating = false;
+
+  @override
+  void initState() {
+    super.initState();
+    unawaited(_load());
+  }
+
+  /// Reloads the gallery. Leaves the previous list on screen while it runs so a
+  /// refresh doesn't flash a spinner over the whole grid.
+  Future<void> _load() async {
+    try {
+      final images = await _repository.listImages();
+      if (mounted) setState(() => _images = images);
+    } catch (error) {
+      _showError(error);
+    } finally {
+      if (mounted) setState(() => _loading = false);
+    }
+  }
+
+  /// Generates a fresh PNG and uploads it, then reloads the gallery. Ignores the
+  /// call while another upload is in flight so a double tap can't fire twice.
+  Future<void> _upload() async {
+    if (_mutating) return;
+    setState(() => _mutating = true);
+    try {
+      final color = _palette[_images.length % _palette.length];
+      final bytes = await generateSampleImagePng(color: color);
+      final name = 'sample-${DateTime.now().microsecondsSinceEpoch}.png';
+      await _repository.uploadImage(name: name, bytes: bytes);
+      await _load();
+    } catch (error) {
+      _showError(error);
+    } finally {
+      if (mounted) setState(() => _mutating = false);
+    }
+  }
+
+  Future<void> _openDetail(StoredImage image) async {
+    final deleted = await Navigator.of(context).push<bool>(
+      MaterialPageRoute(
+        builder: (_) => ImageDetailPage(repository: _repository, image: image),
+      ),
+    );
+    if (deleted ?? false) await _load();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Images')),
+      floatingActionButton: FloatingActionButton.extended(
+        onPressed: _mutating ? null : _upload,
+        icon: const Icon(Icons.add_photo_alternate),
+        label: const Text('Upload'),
+      ),
+      body: _loading
+          ? const Center(child: CircularProgressIndicator())
+          : _images.isEmpty
+          ? const Center(child: Text('No images yet. Upload one to start.'))
+          : RefreshIndicator(
+              onRefresh: _load,
+              child: GridView.builder(
+                padding: const EdgeInsets.all(12),
+                gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(
+                  maxCrossAxisExtent: 180,
+                  mainAxisSpacing: 12,
+                  crossAxisSpacing: 12,
+                ),
+                itemCount: _images.length,
+                itemBuilder: (context, index) {
+                  final image = _images[index];
+                  return _GalleryTile(
+                    // A downscaled, cropped thumbnail keeps the grid light: the
+                    // resize happens server-side, so the app never downloads the
+                    // full-size image here.
+                    url: _repository.imageUrl(
+                      image.path,
+                      transform: TransformPreset.thumbnail.options,
+                    ),
+                    onTap: () => _openDetail(image),
+                  );
+                },
+              ),
+            ),
+    );
+  }
+}
+
+class _GalleryTile extends StatelessWidget {
+  const _GalleryTile({required this.url, required this.onTap});
+
+  final String url;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      clipBehavior: Clip.antiAlias,
+      child: InkWell(
+        onTap: onTap,
+        child: Image.network(
+          url,
+          fit: BoxFit.cover,
+          errorBuilder: (context, error, stackTrace) =>
+              const Center(child: Icon(Icons.broken_image_outlined)),
+        ),
+      ),
+    );
+  }
+}
+
+/// Shows a single stored image rendered through every [TransformPreset], each
+/// one a public URL built with different [TransformOptions].
+class ImageDetailPage extends StatelessWidget {
+  const ImageDetailPage({
+    required this.repository,
+    required this.image,
+    super.key,
+  });
+
+  final StorageRepository repository;
+  final StoredImage image;
+
+  Future<void> _delete(BuildContext context) async {
+    try {
+      await repository.deleteImage(image.path);
+      if (context.mounted) Navigator.of(context).pop(true);
+    } catch (error) {
+      _showError(error);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(image.path),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.delete),
+            tooltip: 'Delete',
+            onPressed: () => _delete(context),
+          ),
+        ],
+      ),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          for (final preset in TransformPreset.values)
+            _TransformCard(
+              label: preset.label,
+              url: repository.imageUrl(image.path, transform: preset.options),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _TransformCard extends StatelessWidget {
+  const _TransformCard({required this.label, required this.url});
+
+  final String label;
+  final String url;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      margin: const EdgeInsets.only(bottom: 16),
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(label, style: Theme.of(context).textTheme.titleMedium),
+            const SizedBox(height: 8),
+            Image.network(
+              url,
+              errorBuilder: (context, error, stackTrace) => const Padding(
+                padding: EdgeInsets.all(24),
+                child: Icon(Icons.broken_image_outlined),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+void _showError(Object error) {
+  final message = error is StorageException ? error.message : error.toString();
+  messengerKey.currentState?.showSnackBar(
+    SnackBar(content: Text(message), backgroundColor: Colors.red),
+  );
+}

--- a/examples/storage_transforms/lib/models.dart
+++ b/examples/storage_transforms/lib/models.dart
@@ -1,0 +1,44 @@
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+/// A single image stored in the bucket, built from the Storage [FileObject]
+/// returned by `list()`.
+class StoredImage {
+  const StoredImage({required this.path, this.createdAt});
+
+  factory StoredImage.fromFileObject(FileObject file) => StoredImage(
+    path: file.name,
+    createdAt: file.createdAt == null
+        ? null
+        : DateTime.tryParse(file.createdAt!),
+  );
+
+  /// Path within the bucket, which is also the object's file name here.
+  final String path;
+  final DateTime? createdAt;
+}
+
+/// A named image transformation shown in the detail view.
+///
+/// Each preset maps to the Storage [TransformOptions] passed to `getPublicUrl`
+/// and `download`. The [original] preset carries no options, so it requests the
+/// untransformed image.
+enum TransformPreset {
+  original('Original', null),
+  thumbnail(
+    '120×120 cover',
+    TransformOptions(width: 120, height: 120, resize: ResizeMode.cover),
+  ),
+  fit(
+    '300×160 contain',
+    TransformOptions(width: 300, height: 160, resize: ResizeMode.contain),
+  ),
+  lowQuality(
+    '320 wide · quality 20',
+    TransformOptions(width: 320, quality: 20),
+  );
+
+  const TransformPreset(this.label, this.options);
+
+  final String label;
+  final TransformOptions? options;
+}

--- a/examples/storage_transforms/lib/sample_image.dart
+++ b/examples/storage_transforms/lib/sample_image.dart
@@ -1,0 +1,41 @@
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:flutter/material.dart';
+
+/// Draws a colorful [size]×[size] PNG entirely in memory.
+///
+/// This lets the example upload real image bytes without bundling asset files
+/// or depending on an image picker. The returned bytes are what get sent to
+/// Storage, and the image is large enough that the transformations in the
+/// detail view visibly resize it.
+Future<Uint8List> generateSampleImagePng({
+  required Color color,
+  int size = 640,
+}) async {
+  final recorder = ui.PictureRecorder();
+  final canvas = Canvas(recorder);
+  final bounds = Rect.fromLTWH(0, 0, size.toDouble(), size.toDouble());
+
+  // A diagonal gradient background derived from the seed color.
+  final background = Paint()
+    ..shader = ui.Gradient.linear(bounds.topLeft, bounds.bottomRight, [
+      color,
+      Color.lerp(color, Colors.black, 0.6)!,
+    ]);
+  canvas.drawRect(bounds, background);
+
+  // A few translucent circles for some visual texture.
+  final circle = Paint()..color = Colors.white.withValues(alpha: 0.15);
+  for (var i = 0; i < 6; i++) {
+    final t = (i + 1) / 7;
+    canvas.drawCircle(Offset(size * t, size * (1 - t)), size * 0.18, circle);
+  }
+
+  final picture = recorder.endRecording();
+  final image = await picture.toImage(size, size);
+  final data = await image.toByteData(format: ui.ImageByteFormat.png);
+  image.dispose();
+  picture.dispose();
+  return data!.buffer.asUint8List();
+}

--- a/examples/storage_transforms/lib/storage_repository.dart
+++ b/examples/storage_transforms/lib/storage_repository.dart
@@ -1,0 +1,68 @@
+import 'dart:typed_data';
+
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import 'models.dart';
+
+/// All Storage access for the example lives here, so the UI stays thin and every
+/// `supabase.storage` call is easy to read and to exercise from an integration
+/// test.
+class StorageRepository {
+  StorageRepository(this._client);
+
+  final SupabaseClient _client;
+
+  /// Public bucket created by the example migration. Being public lets the
+  /// gallery load images straight from their public URL without a signed URL.
+  static const bucket = 'images';
+
+  StorageFileApi get _files => _client.storage.from(bucket);
+
+  /// Uploads [bytes] under [name] and returns the stored path.
+  ///
+  /// `upsert: true` overwrites an object that already has the same name instead
+  /// of failing, and `contentType` tells Storage the bytes are a PNG.
+  Future<String> uploadImage({
+    required String name,
+    required Uint8List bytes,
+  }) {
+    return _files.uploadBinary(
+      name,
+      bytes,
+      fileOptions: const FileOptions(contentType: 'image/png', upsert: true),
+    );
+  }
+
+  /// Lists the images in the bucket, newest first.
+  ///
+  /// `list()` also returns folder placeholders, which have no `id`, so those are
+  /// filtered out before mapping to [StoredImage].
+  Future<List<StoredImage>> listImages() async {
+    final files = await _files.list(
+      searchOptions: const SearchOptions(
+        sortBy: SortBy(column: 'created_at', order: 'desc'),
+      ),
+    );
+    return files
+        .where((file) => file.id != null)
+        .map(StoredImage.fromFileObject)
+        .toList();
+  }
+
+  /// Builds a public URL for [path], optionally applying an image
+  /// [transform] server-side. `Image.network` can render the result directly.
+  String imageUrl(String path, {TransformOptions? transform}) {
+    return _files.getPublicUrl(path, transform: transform);
+  }
+
+  /// Downloads the bytes for [path], optionally applying an image [transform]
+  /// server-side before the bytes are returned.
+  Future<Uint8List> downloadImage(String path, {TransformOptions? transform}) {
+    return _files.download(path, transform: transform);
+  }
+
+  /// Deletes [path] from the bucket.
+  Future<void> deleteImage(String path) async {
+    await _files.remove([path]);
+  }
+}

--- a/examples/storage_transforms/pubspec.yaml
+++ b/examples/storage_transforms/pubspec.yaml
@@ -1,0 +1,25 @@
+name: storage_transforms_example
+description: Demonstrates Storage uploads, downloads and image transformations using supabase_flutter.
+
+publish_to: 'none'
+
+version: 1.0.0+1
+
+environment:
+  sdk: '>=3.9.0 <4.0.0'
+  flutter: '>=3.35.0'
+
+resolution: workspace
+
+dependencies:
+  flutter:
+    sdk: flutter
+  supabase_flutter: ^2.17.0
+
+dev_dependencies:
+  supabase_lints: ^0.1.1
+  flutter_test:
+    sdk: flutter
+
+flutter:
+  uses-material-design: true

--- a/examples/storage_transforms/web/index.html
+++ b/examples/storage_transforms/web/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <base href="$FLUTTER_BASE_HREF">
+  <meta charset="UTF-8">
+  <meta content="IE=Edge" http-equiv="X-UA-Compatible">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+  <title>Supabase Storage transformations</title>
+</head>
+<body>
+  <script src="flutter_bootstrap.js" async></script>
+</body>
+</html>

--- a/examples/supabase/config.toml
+++ b/examples/supabase/config.toml
@@ -26,6 +26,11 @@ rp_display_name = "Supabase Flutter examples"
 rp_id = "localhost"
 rp_origins = ["http://localhost:3000"]
 
+# Image transformations (resize, re-encode) are used by the storage_transforms
+# example to render images on the fly.
+[storage.image_transformation]
+enabled = true
+
 # Keep the stack lean: turn off services the examples don't use. The data plane
 # (database, API/PostgREST, auth, realtime, storage) stays on. Enable any of
 # these if a new example needs it.

--- a/examples/supabase/migrations/20240603000000_storage_transforms_example.sql
+++ b/examples/supabase/migrations/20240603000000_storage_transforms_example.sql
@@ -1,0 +1,32 @@
+-- Schema for the "Storage: uploads and image transformations" example.
+--
+-- A single public bucket that the example uploads generated PNGs to and reads
+-- back from, applying image transformations on the way out.
+
+insert into storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+values (
+  'images',
+  'images',
+  true,
+  1048576,
+  array['image/png', 'image/jpeg', 'image/webp']
+)
+on conflict (id) do nothing;
+
+-- The example runs unauthenticated with the publishable (anon) key. A public
+-- bucket already serves reads without a policy; these policies additionally let
+-- the demo list, upload, overwrite and delete objects in the `images` bucket
+-- without signing in. A real app would scope these policies to the signed in
+-- user instead.
+create policy "Anyone can view images"
+  on storage.objects for select using (bucket_id = 'images');
+
+create policy "Anyone can upload images"
+  on storage.objects for insert with check (bucket_id = 'images');
+
+create policy "Anyone can update images"
+  on storage.objects for update
+  using (bucket_id = 'images') with check (bucket_id = 'images');
+
+create policy "Anyone can delete images"
+  on storage.objects for delete using (bucket_id = 'images');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,6 +21,7 @@ workspace:
   - examples/database_crud
   - examples/launcher
   - examples/passkeys
+  - examples/storage_transforms
 
 dev_dependencies:
   melos: ^8.2.1


### PR DESCRIPTION
## What

Adds a new `supabase_flutter` example under `examples/storage_transforms` that demonstrates Supabase Storage: uploading images, listing them, serving them through image transformations, downloading transformed bytes and deleting objects.

Closes SDK-1067.

## The example

A small image gallery:

- **Upload** generated PNG bytes to a public bucket (`uploadBinary`).
- **List** the objects, newest first (`list`).
- **Transform** images on the fly with `TransformOptions` (width, height, resize mode, quality) via `getPublicUrl`, so the grid loads a small cropped thumbnail and the detail view renders several resized variants.
- **Download** transformed bytes (`download`).
- **Delete** an object (`remove`).

All Storage access lives in `lib/storage_repository.dart`, kept separate from the UI so it is easy to read and to drive from an integration test. Sample images are drawn in memory in `lib/sample_image.dart`, so the example uploads real image bytes without bundling asset files or depending on an image picker.

## Backend wiring

- New migration `examples/supabase/migrations/20240603000000_storage_transforms_example.sql` creates a public `images` bucket with row level security policies allowing the demo to view, upload, overwrite and delete objects with the publishable key.
- `examples/supabase/config.toml` enables `[storage.image_transformation]`.
- Registered `examples/storage_transforms` in the root workspace and the `examples/README.md` table.

## Testing

Verified end to end against the local stack (`supabase db reset`, then upload/list/transform-render/authenticated-transformed-download/delete over HTTP): uploads succeed, the public render endpoint returns a resized image, and deletes clean up. `dart format` and `flutter analyze` are clean.

The end-to-end integration test is a follow-up stacked PR, matching the other examples.