### PR TITLE
docs(examples): add authentication example covering all sign in methods

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -3,11 +3,12 @@
 A collection of small apps that each show off a feature of `supabase_flutter`,
 all sharing a single local Supabase instance.
 
-| Example                                     | What it shows                                    |
-| ------------------------------------------- | ------------------------------------------------ |
-| [`database_crud`](database_crud)            | Database CRUD with PostgREST (`from(...)`)       |
-| [`passkeys`](passkeys)                      | Passkey (WebAuthn) sign in and management        |
-| [`storage_transforms`](storage_transforms) | Storage uploads, downloads and image transforms  |
+| Example                                     | What it shows                                                         |
+| ------------------------------------------- | --------------------------------------------------------------------- |
+| [`authentication`](authentication)         | Email/password, magic link, OTP, phone, OAuth, anonymous and MFA auth |
+| [`database_crud`](database_crud)            | Database CRUD with PostgREST (`from(...)`)                            |
+| [`passkeys`](passkeys)                      | Passkey (WebAuthn) sign in and management                             |
+| [`storage_transforms`](storage_transforms) | Storage uploads, downloads and image transforms                       |
 
 ## Quick start
 

--- a/examples/authentication/.gitignore
+++ b/examples/authentication/.gitignore
@@ -1,0 +1,6 @@
+.dart_tool/
+.flutter-plugins
+.flutter-plugins-dependencies
+build/
+pubspec.lock
+pubspec_overrides.yaml

--- a/examples/authentication/README.md
+++ b/examples/authentication/README.md
@@ -7,8 +7,9 @@ and can upgrade an anonymous user to a permanent account.
 
 What it shows, grouped by method:
 
-- **Email & password**: sign up, sign in and password reset
-  (`signUp`, `signInWithPassword`, `resetPasswordForEmail`).
+- **Email & password**: sign up, sign in and a full password reset (`signUp`,
+  `signInWithPassword`, `resetPasswordForEmail`, then `verifyOTP` with
+  `OtpType.recovery` and `updateUser`).
 - **Magic link & email OTP**: passwordless email sign in
   (`signInWithOtp(email: ...)` then `verifyOTP(type: OtpType.email)`).
 - **Phone (SMS OTP)**: passwordless phone sign in
@@ -49,7 +50,9 @@ flutter run \
 ## Trying each method locally
 
 - **Email & password** works out of the box; email confirmation is disabled in
-  the shared config, so creating an account signs you straight in.
+  the shared config, so creating an account signs you straight in. *Forgot
+  password?* sends a reset email; enter the code from it plus a new password to
+  finish resetting.
 - **Magic link & email OTP** and **password reset** send an email. Locally it is
   captured by the mail server, not delivered: open its web UI at
   http://localhost:54324 to read the code or link.

--- a/examples/authentication/README.md
+++ b/examples/authentication/README.md
@@ -1,0 +1,65 @@
+# Authentication
+
+A single app that shows every `supabase_flutter` sign in method except passkeys
+(those have their own [`passkeys`](../passkeys) example). Pick a method with the
+chips at the top; once signed in you land on an account screen that manages MFA
+and can upgrade an anonymous user to a permanent account.
+
+What it shows, grouped by method:
+
+- **Email & password**: sign up, sign in and password reset
+  (`signUp`, `signInWithPassword`, `resetPasswordForEmail`).
+- **Magic link & email OTP**: passwordless email sign in
+  (`signInWithOtp(email: ...)` then `verifyOTP(type: OtpType.email)`).
+- **Phone (SMS OTP)**: passwordless phone sign in
+  (`signInWithOtp(phone: ...)` then `verifyOTP(type: OtpType.sms)`).
+- **OAuth social**: Google, GitHub and Apple (`signInWithOAuth`), including the
+  deep-link redirect back into the app.
+- **Anonymous**: `signInAnonymously`, then `updateUser` to add an email and
+  password and keep the account.
+- **Multi-factor authentication**: enroll, verify and remove a TOTP factor
+  (`auth.mfa.enroll`, `challengeAndVerify`, `listFactors`, `unenroll`).
+
+All Supabase calls live in
+[`lib/auth_repository.dart`](lib/auth_repository.dart), kept separate from the
+UI so the flows are easy to read and to drive from an integration test. The UI
+just calls the repository and rebuilds from `onAuthStateChange`.
+
+The auth providers this example needs are enabled in the shared Supabase config
+in [`../supabase`](../supabase): anonymous sign in, phone (with a local test
+OTP), TOTP MFA and the local mail server, all in `config.toml`. The example
+stores no data of its own, so it needs no migration or seed.
+
+## Running
+
+From the `examples` directory, run the launcher and pick `authentication`:
+
+```bash
+./run.sh
+```
+
+Or run it directly against any project:
+
+```bash
+flutter run \
+  --dart-define=SUPABASE_URL=https://YOUR_PROJECT.supabase.co \
+  --dart-define=SUPABASE_PUBLISHABLE_KEY=YOUR_PUBLISHABLE_KEY
+```
+
+## Trying each method locally
+
+- **Email & password** works out of the box; email confirmation is disabled in
+  the shared config, so creating an account signs you straight in.
+- **Magic link & email OTP** and **password reset** send an email. Locally it is
+  captured by the mail server, not delivered: open its web UI at
+  http://localhost:54324 to read the code or link.
+- **Phone (SMS OTP)** accepts the number `+15555550100` with the fixed code
+  `123456`, set as a test OTP in `config.toml`, so no SMS provider is needed.
+- **OAuth social** needs each provider enabled and configured with client
+  credentials in the Supabase dashboard, so the buttons only complete against a
+  project set up for them. On mobile and desktop you also need to register the
+  redirect deep link for your app.
+- **Anonymous** works out of the box. After continuing as a guest, use *Keep
+  this account* to attach an email and password.
+- **MFA** works out of the box: tap *Add app*, add the shown secret to any TOTP
+  authenticator, and enter the six-digit code to confirm the factor.

--- a/examples/authentication/README.md
+++ b/examples/authentication/README.md
@@ -60,8 +60,15 @@ flutter run \
   `123456`, set as a test OTP in `config.toml`, so no SMS provider is needed.
 - **OAuth social** needs each provider enabled and configured with client
   credentials in the Supabase dashboard, so the buttons only complete against a
-  project set up for them. On mobile and desktop you also need to register the
-  redirect deep link for your app.
+  project set up for them.
+
+On native platforms the OAuth, magic link and password reset flows return to the
+app through a deep link. The example passes `io.supabase.authexample://login-callback/`
+as the `redirectTo` (it is null on web, which uses the site URL). That URL is
+already in the shared config's `additional_redirect_urls`; to actually receive
+it on iOS, Android or desktop you still need to register the URL scheme with the
+platform, as described in the
+[deep linking guide](https://supabase.com/docs/guides/auth/native-mobile-deep-linking?platform=flutter).
 - **Anonymous** works out of the box. After continuing as a guest, use *Keep
   this account* to attach an email and password.
 - **MFA** works out of the box: tap *Add app*, add the shown secret to any TOTP

--- a/examples/authentication/analysis_options.yaml
+++ b/examples/authentication/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:supabase_lints/analysis_options_flutter.yaml

--- a/examples/authentication/lib/auth_repository.dart
+++ b/examples/authentication/lib/auth_repository.dart
@@ -37,14 +37,27 @@ class AuthRepository {
     return _client.auth.signInWithPassword(email: email, password: password);
   }
 
-  /// Sends a password recovery email. The user follows the link (or enters the
-  /// `recovery` OTP) and then calls [updatePassword] to set a new one.
+  /// Sends a password recovery email carrying a `recovery` OTP and a link.
   Future<void> sendPasswordReset(String email) {
     return _client.auth.resetPasswordForEmail(email);
   }
 
-  /// Sets a new password for the signed in user, for example after verifying a
-  /// recovery OTP.
+  /// Verifies the recovery code from a password reset email. On success this
+  /// starts a short-lived recovery session, after which [updatePassword] can
+  /// set the new password.
+  Future<AuthResponse> verifyRecoveryOtp({
+    required String email,
+    required String token,
+  }) {
+    return _client.auth.verifyOTP(
+      email: email,
+      token: token,
+      type: OtpType.recovery,
+    );
+  }
+
+  /// Sets a new password for the signed in user, for example right after
+  /// verifying a recovery OTP.
   Future<UserResponse> updatePassword(String password) {
     return _client.auth.updateUser(UserAttributes(password: password));
   }

--- a/examples/authentication/lib/auth_repository.dart
+++ b/examples/authentication/lib/auth_repository.dart
@@ -1,0 +1,150 @@
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+/// Every `supabase.auth.*` call for the example lives here, so the UI stays thin
+/// and each authentication flow is easy to read and to drive from an integration
+/// test. The methods are grouped by the sign in method they belong to.
+class AuthRepository {
+  AuthRepository(this._client);
+
+  final SupabaseClient _client;
+
+  /// Emits on every sign in, sign out, token refresh and user update, so the UI
+  /// can rebuild whenever the session changes.
+  Stream<AuthState> get onAuthStateChange => _client.auth.onAuthStateChange;
+
+  /// The signed in user, or `null` when there is no session.
+  User? get currentUser => _client.auth.currentUser;
+
+  /// Ends the session and clears it from storage.
+  Future<void> signOut() => _client.auth.signOut();
+
+  // Email & password ---------------------------------------------------------
+
+  /// Creates an account with an email and password. Email confirmations are
+  /// disabled in the shared config, so this returns a session right away.
+  Future<AuthResponse> signUpWithPassword({
+    required String email,
+    required String password,
+  }) {
+    return _client.auth.signUp(email: email, password: password);
+  }
+
+  /// Signs an existing user in with their email and password.
+  Future<AuthResponse> signInWithPassword({
+    required String email,
+    required String password,
+  }) {
+    return _client.auth.signInWithPassword(email: email, password: password);
+  }
+
+  /// Sends a password recovery email. The user follows the link (or enters the
+  /// `recovery` OTP) and then calls [updatePassword] to set a new one.
+  Future<void> sendPasswordReset(String email) {
+    return _client.auth.resetPasswordForEmail(email);
+  }
+
+  /// Sets a new password for the signed in user, for example after verifying a
+  /// recovery OTP.
+  Future<UserResponse> updatePassword(String password) {
+    return _client.auth.updateUser(UserAttributes(password: password));
+  }
+
+  // Magic link & email OTP ---------------------------------------------------
+
+  /// Sends a passwordless sign in email containing both a magic link and a
+  /// one-time code. `shouldCreateUser` lets a brand new email sign up on its
+  /// first code.
+  Future<void> sendEmailOtp(String email) {
+    return _client.auth.signInWithOtp(email: email, shouldCreateUser: true);
+  }
+
+  /// Verifies the code from a magic link email and, on success, starts a
+  /// session.
+  Future<AuthResponse> verifyEmailOtp({
+    required String email,
+    required String token,
+  }) {
+    return _client.auth.verifyOTP(
+      email: email,
+      token: token,
+      type: OtpType.email,
+    );
+  }
+
+  // Phone (SMS OTP) ----------------------------------------------------------
+
+  /// Sends a one-time code over SMS, creating the user if this phone number has
+  /// not signed in before.
+  Future<void> sendPhoneOtp(String phone) {
+    return _client.auth.signInWithOtp(phone: phone, shouldCreateUser: true);
+  }
+
+  /// Verifies the SMS code and, on success, starts a session.
+  Future<AuthResponse> verifyPhoneOtp({
+    required String phone,
+    required String token,
+  }) {
+    return _client.auth.verifyOTP(
+      phone: phone,
+      token: token,
+      type: OtpType.sms,
+    );
+  }
+
+  // OAuth social -------------------------------------------------------------
+
+  /// Starts an OAuth flow with the given [provider]. On web this redirects the
+  /// current page; on mobile and desktop it opens the provider in a browser and
+  /// returns to the app through the deep link registered as [redirectTo]. The
+  /// session is stored automatically once the redirect comes back.
+  Future<bool> signInWithOAuth(OAuthProvider provider, {String? redirectTo}) {
+    return _client.auth.signInWithOAuth(provider, redirectTo: redirectTo);
+  }
+
+  // Anonymous ----------------------------------------------------------------
+
+  /// Signs in without any credentials, creating a throwaway anonymous user.
+  Future<AuthResponse> signInAnonymously() {
+    return _client.auth.signInAnonymously();
+  }
+
+  /// Turns the current anonymous user into a permanent one by adding an email
+  /// and password, keeping the same user id and any data attached to it.
+  Future<UserResponse> linkEmailAndPassword({
+    required String email,
+    required String password,
+  }) {
+    return _client.auth.updateUser(
+      UserAttributes(email: email, password: password),
+    );
+  }
+
+  // Multi-factor authentication (TOTP) ---------------------------------------
+
+  /// Starts enrolling a TOTP factor. The response carries the secret and a QR
+  /// code to show the user so they can add it to their authenticator app.
+  Future<AuthMFAEnrollResponse> enrollTotpFactor() {
+    return _client.auth.mfa.enroll(factorType: FactorType.totp);
+  }
+
+  /// Confirms a freshly enrolled factor with a code from the authenticator app.
+  /// This runs the challenge and verify steps together and promotes the session
+  /// to `aal2`.
+  Future<AuthMFAVerifyResponse> confirmTotpFactor({
+    required String factorId,
+    required String code,
+  }) {
+    return _client.auth.mfa.challengeAndVerify(factorId: factorId, code: code);
+  }
+
+  /// Lists the user's enrolled factors so the UI can show and manage them.
+  Future<List<Factor>> listFactors() async {
+    final response = await _client.auth.mfa.listFactors();
+    return response.all;
+  }
+
+  /// Removes an enrolled factor.
+  Future<void> unenrollFactor(String factorId) {
+    return _client.auth.mfa.unenroll(factorId);
+  }
+}

--- a/examples/authentication/lib/auth_repository.dart
+++ b/examples/authentication/lib/auth_repository.dart
@@ -38,8 +38,11 @@ class AuthRepository {
   }
 
   /// Sends a password recovery email carrying a `recovery` OTP and a link.
-  Future<void> sendPasswordReset(String email) {
-    return _client.auth.resetPasswordForEmail(email);
+  ///
+  /// [redirectTo] is the deep link the recovery link returns to on native
+  /// platforms; leave it null on web to use the project's site URL.
+  Future<void> sendPasswordReset(String email, {String? redirectTo}) {
+    return _client.auth.resetPasswordForEmail(email, redirectTo: redirectTo);
   }
 
   /// Verifies the recovery code from a password reset email. On success this
@@ -67,8 +70,15 @@ class AuthRepository {
   /// Sends a passwordless sign in email containing both a magic link and a
   /// one-time code. `shouldCreateUser` lets a brand new email sign up on its
   /// first code.
-  Future<void> sendEmailOtp(String email) {
-    return _client.auth.signInWithOtp(email: email, shouldCreateUser: true);
+  ///
+  /// [emailRedirectTo] is the deep link the magic link returns to on native
+  /// platforms; leave it null on web to use the project's site URL.
+  Future<void> sendEmailOtp(String email, {String? emailRedirectTo}) {
+    return _client.auth.signInWithOtp(
+      email: email,
+      emailRedirectTo: emailRedirectTo,
+      shouldCreateUser: true,
+    );
   }
 
   /// Verifies the code from a magic link email and, on success, starts a

--- a/examples/authentication/lib/main.dart
+++ b/examples/authentication/lib/main.dart
@@ -1,0 +1,733 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import 'auth_repository.dart';
+import 'models.dart';
+
+const supabaseUrl = String.fromEnvironment('SUPABASE_URL');
+const supabasePublishableKey = String.fromEnvironment(
+  'SUPABASE_PUBLISHABLE_KEY',
+);
+
+final messengerKey = GlobalKey<ScaffoldMessengerState>();
+
+Future<void> main() async {
+  await Supabase.initialize(
+    url: supabaseUrl,
+    publishableKey: supabasePublishableKey,
+  );
+  runApp(const AuthExampleApp());
+}
+
+SupabaseClient get supabase => Supabase.instance.client;
+
+class AuthExampleApp extends StatelessWidget {
+  const AuthExampleApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Supabase Authentication',
+      scaffoldMessengerKey: messengerKey,
+      theme: ThemeData(colorSchemeSeed: Colors.green, useMaterial3: true),
+      home: const HomePage(),
+    );
+  }
+}
+
+/// Shows the sign in methods while signed out and the account screen once a
+/// session exists. Rebuilds on every auth change so signing in or out swaps the
+/// screen automatically.
+class HomePage extends StatelessWidget {
+  const HomePage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return StreamBuilder<AuthState>(
+      stream: supabase.auth.onAuthStateChange,
+      builder: (context, snapshot) {
+        final session = supabase.auth.currentSession;
+        return Scaffold(
+          appBar: AppBar(title: const Text('Supabase Authentication')),
+          body: SafeArea(
+            child: session == null
+                ? const _SignedOutView()
+                : const _SignedInView(),
+          ),
+        );
+      },
+    );
+  }
+}
+
+/// Lets you pick one of the sign in methods and shows its form.
+class _SignedOutView extends StatefulWidget {
+  const _SignedOutView();
+
+  @override
+  State<_SignedOutView> createState() => _SignedOutViewState();
+}
+
+class _SignedOutViewState extends State<_SignedOutView> {
+  AuthMethod _method = AuthMethod.password;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView(
+      padding: const EdgeInsets.all(24),
+      children: [
+        Wrap(
+          spacing: 8,
+          children: [
+            for (final method in AuthMethod.values)
+              ChoiceChip(
+                label: Text(method.label),
+                selected: _method == method,
+                onSelected: (_) => setState(() => _method = method),
+              ),
+          ],
+        ),
+        const SizedBox(height: 24),
+        switch (_method) {
+          AuthMethod.password => const _PasswordForm(),
+          AuthMethod.magicLink => const _EmailOtpForm(),
+          AuthMethod.phone => const _PhoneOtpForm(),
+          AuthMethod.oauth => const _OAuthButtons(),
+          AuthMethod.anonymous => const _AnonymousForm(),
+        },
+      ],
+    );
+  }
+}
+
+/// Sign up, sign in and password reset with `signUp` / `signInWithPassword` /
+/// `resetPasswordForEmail`.
+class _PasswordForm extends StatefulWidget {
+  const _PasswordForm();
+
+  @override
+  State<_PasswordForm> createState() => _PasswordFormState();
+}
+
+class _PasswordFormState extends State<_PasswordForm> {
+  final _auth = AuthRepository(supabase);
+  final _email = TextEditingController();
+  final _password = TextEditingController();
+  bool _busy = false;
+
+  @override
+  void dispose() {
+    _email.dispose();
+    _password.dispose();
+    super.dispose();
+  }
+
+  Future<void> _run(Future<void> Function() action) async {
+    setState(() => _busy = true);
+    try {
+      await action();
+    } catch (error) {
+      _showError(error);
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  Future<void> _signIn() => _run(
+    () => _auth.signInWithPassword(
+      email: _email.text.trim(),
+      password: _password.text,
+    ),
+  );
+
+  Future<void> _signUp() => _run(
+    () => _auth.signUpWithPassword(
+      email: _email.text.trim(),
+      password: _password.text,
+    ),
+  );
+
+  Future<void> _resetPassword() => _run(() async {
+    await _auth.sendPasswordReset(_email.text.trim());
+    _showMessage('Password reset email sent.');
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        TextField(
+          controller: _email,
+          decoration: const InputDecoration(labelText: 'Email'),
+          keyboardType: TextInputType.emailAddress,
+        ),
+        const SizedBox(height: 12),
+        TextField(
+          controller: _password,
+          decoration: const InputDecoration(labelText: 'Password'),
+          obscureText: true,
+        ),
+        const SizedBox(height: 24),
+        FilledButton(
+          onPressed: _busy ? null : _signIn,
+          child: const Text('Sign in'),
+        ),
+        const SizedBox(height: 12),
+        OutlinedButton(
+          onPressed: _busy ? null : _signUp,
+          child: const Text('Create an account'),
+        ),
+        TextButton(
+          onPressed: _busy ? null : _resetPassword,
+          child: const Text('Forgot password?'),
+        ),
+      ],
+    );
+  }
+}
+
+/// Passwordless sign in with `signInWithOtp` (email) then `verifyOTP`. The email
+/// carries both a magic link and the code entered here.
+class _EmailOtpForm extends StatefulWidget {
+  const _EmailOtpForm();
+
+  @override
+  State<_EmailOtpForm> createState() => _EmailOtpFormState();
+}
+
+class _EmailOtpFormState extends State<_EmailOtpForm> {
+  final _auth = AuthRepository(supabase);
+  final _email = TextEditingController();
+  final _token = TextEditingController();
+  bool _codeSent = false;
+  bool _busy = false;
+
+  @override
+  void dispose() {
+    _email.dispose();
+    _token.dispose();
+    super.dispose();
+  }
+
+  Future<void> _sendCode() async {
+    setState(() => _busy = true);
+    try {
+      await _auth.sendEmailOtp(_email.text.trim());
+      setState(() => _codeSent = true);
+      _showMessage('Check your email for the code.');
+    } catch (error) {
+      _showError(error);
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  Future<void> _verify() async {
+    setState(() => _busy = true);
+    try {
+      await _auth.verifyEmailOtp(
+        email: _email.text.trim(),
+        token: _token.text.trim(),
+      );
+    } catch (error) {
+      _showError(error);
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        TextField(
+          controller: _email,
+          enabled: !_codeSent,
+          decoration: const InputDecoration(labelText: 'Email'),
+          keyboardType: TextInputType.emailAddress,
+        ),
+        const SizedBox(height: 12),
+        if (!_codeSent)
+          FilledButton(
+            onPressed: _busy ? null : _sendCode,
+            child: const Text('Send code'),
+          )
+        else ...[
+          TextField(
+            controller: _token,
+            decoration: const InputDecoration(labelText: 'Email code'),
+            keyboardType: TextInputType.number,
+          ),
+          const SizedBox(height: 24),
+          FilledButton(
+            onPressed: _busy ? null : _verify,
+            child: const Text('Verify'),
+          ),
+          TextButton(
+            onPressed: _busy ? null : () => setState(() => _codeSent = false),
+            child: const Text('Use a different email'),
+          ),
+        ],
+      ],
+    );
+  }
+}
+
+/// Phone sign in with `signInWithOtp` (SMS) then `verifyOTP`.
+class _PhoneOtpForm extends StatefulWidget {
+  const _PhoneOtpForm();
+
+  @override
+  State<_PhoneOtpForm> createState() => _PhoneOtpFormState();
+}
+
+class _PhoneOtpFormState extends State<_PhoneOtpForm> {
+  final _auth = AuthRepository(supabase);
+  final _phone = TextEditingController();
+  final _token = TextEditingController();
+  bool _codeSent = false;
+  bool _busy = false;
+
+  @override
+  void dispose() {
+    _phone.dispose();
+    _token.dispose();
+    super.dispose();
+  }
+
+  Future<void> _sendCode() async {
+    setState(() => _busy = true);
+    try {
+      await _auth.sendPhoneOtp(_phone.text.trim());
+      setState(() => _codeSent = true);
+      _showMessage('Check your phone for the code.');
+    } catch (error) {
+      _showError(error);
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  Future<void> _verify() async {
+    setState(() => _busy = true);
+    try {
+      await _auth.verifyPhoneOtp(
+        phone: _phone.text.trim(),
+        token: _token.text.trim(),
+      );
+    } catch (error) {
+      _showError(error);
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        TextField(
+          controller: _phone,
+          enabled: !_codeSent,
+          decoration: const InputDecoration(
+            labelText: 'Phone',
+            hintText: '+15555550100',
+          ),
+          keyboardType: TextInputType.phone,
+        ),
+        const SizedBox(height: 12),
+        if (!_codeSent)
+          FilledButton(
+            onPressed: _busy ? null : _sendCode,
+            child: const Text('Send code'),
+          )
+        else ...[
+          TextField(
+            controller: _token,
+            decoration: const InputDecoration(labelText: 'SMS code'),
+            keyboardType: TextInputType.number,
+          ),
+          const SizedBox(height: 24),
+          FilledButton(
+            onPressed: _busy ? null : _verify,
+            child: const Text('Verify'),
+          ),
+          TextButton(
+            onPressed: _busy ? null : () => setState(() => _codeSent = false),
+            child: const Text('Use a different number'),
+          ),
+        ],
+      ],
+    );
+  }
+}
+
+/// OAuth social sign in with `signInWithOAuth`. On web this redirects the page;
+/// on native platforms it opens a browser and returns through a deep link.
+class _OAuthButtons extends StatelessWidget {
+  const _OAuthButtons();
+
+  static const _providers = <(OAuthProvider, String)>[
+    (OAuthProvider.google, 'Continue with Google'),
+    (OAuthProvider.github, 'Continue with GitHub'),
+    (OAuthProvider.apple, 'Continue with Apple'),
+  ];
+
+  Future<void> _signIn(OAuthProvider provider) async {
+    try {
+      await AuthRepository(supabase).signInWithOAuth(provider);
+    } catch (error) {
+      _showError(error);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        for (final (provider, label) in _providers) ...[
+          OutlinedButton(
+            onPressed: () => _signIn(provider),
+            child: Text(label),
+          ),
+          const SizedBox(height: 12),
+        ],
+        Text(
+          'Each provider must be enabled and configured in the Supabase '
+          'dashboard first.',
+          style: Theme.of(context).textTheme.bodySmall,
+        ),
+      ],
+    );
+  }
+}
+
+/// Anonymous sign in with `signInAnonymously`. The created user can later be
+/// turned into a permanent account from the signed-in screen.
+class _AnonymousForm extends StatefulWidget {
+  const _AnonymousForm();
+
+  @override
+  State<_AnonymousForm> createState() => _AnonymousFormState();
+}
+
+class _AnonymousFormState extends State<_AnonymousForm> {
+  final _auth = AuthRepository(supabase);
+  bool _busy = false;
+
+  Future<void> _signIn() async {
+    setState(() => _busy = true);
+    try {
+      await _auth.signInAnonymously();
+    } catch (error) {
+      _showError(error);
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Text(
+          'Try the app without an account. You can add an email and password '
+          'later to keep it.',
+          style: Theme.of(context).textTheme.bodyMedium,
+        ),
+        const SizedBox(height: 24),
+        FilledButton(
+          onPressed: _busy ? null : _signIn,
+          child: const Text('Continue as guest'),
+        ),
+      ],
+    );
+  }
+}
+
+/// The account screen: shows who is signed in, lets an anonymous user upgrade to
+/// a permanent account, manages MFA factors and signs out.
+class _SignedInView extends StatelessWidget {
+  const _SignedInView();
+
+  @override
+  Widget build(BuildContext context) {
+    final user = supabase.auth.currentUser!;
+    final identity = user.email ?? user.phone;
+    return ListView(
+      padding: const EdgeInsets.all(24),
+      children: [
+        Text(
+          user.isAnonymous ? 'Anonymous user' : (identity ?? 'Signed in'),
+          style: Theme.of(context).textTheme.titleLarge,
+        ),
+        const SizedBox(height: 4),
+        SelectableText(
+          user.id,
+          style: Theme.of(context).textTheme.bodySmall,
+        ),
+        const SizedBox(height: 24),
+        if (user.isAnonymous) ...[
+          const _LinkAccountForm(),
+          const Divider(height: 48),
+        ],
+        const _MfaSection(),
+        const SizedBox(height: 24),
+        OutlinedButton(
+          onPressed: () => AuthRepository(supabase).signOut(),
+          child: const Text('Sign out'),
+        ),
+      ],
+    );
+  }
+}
+
+/// Upgrades an anonymous user to a permanent one with `updateUser`, keeping the
+/// same user id.
+class _LinkAccountForm extends StatefulWidget {
+  const _LinkAccountForm();
+
+  @override
+  State<_LinkAccountForm> createState() => _LinkAccountFormState();
+}
+
+class _LinkAccountFormState extends State<_LinkAccountForm> {
+  final _auth = AuthRepository(supabase);
+  final _email = TextEditingController();
+  final _password = TextEditingController();
+  bool _busy = false;
+
+  @override
+  void dispose() {
+    _email.dispose();
+    _password.dispose();
+    super.dispose();
+  }
+
+  Future<void> _link() async {
+    setState(() => _busy = true);
+    try {
+      await _auth.linkEmailAndPassword(
+        email: _email.text.trim(),
+        password: _password.text,
+      );
+      _showMessage('Account saved.');
+    } catch (error) {
+      _showError(error);
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Text(
+          'Keep this account',
+          style: Theme.of(context).textTheme.titleMedium,
+        ),
+        const SizedBox(height: 12),
+        TextField(
+          controller: _email,
+          decoration: const InputDecoration(labelText: 'Email'),
+          keyboardType: TextInputType.emailAddress,
+        ),
+        const SizedBox(height: 12),
+        TextField(
+          controller: _password,
+          decoration: const InputDecoration(labelText: 'Password'),
+          obscureText: true,
+        ),
+        const SizedBox(height: 12),
+        FilledButton(
+          onPressed: _busy ? null : _link,
+          child: const Text('Save account'),
+        ),
+      ],
+    );
+  }
+}
+
+/// Lists the user's MFA factors and lets them enroll a TOTP factor or remove an
+/// existing one, using the `auth.mfa` API.
+class _MfaSection extends StatefulWidget {
+  const _MfaSection();
+
+  @override
+  State<_MfaSection> createState() => _MfaSectionState();
+}
+
+class _MfaSectionState extends State<_MfaSection> {
+  final _auth = AuthRepository(supabase);
+  List<Factor> _factors = [];
+  bool _loading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    unawaited(_refresh());
+  }
+
+  Future<void> _refresh() async {
+    setState(() => _loading = true);
+    try {
+      final factors = await _auth.listFactors();
+      if (mounted) setState(() => _factors = factors);
+    } catch (error) {
+      _showError(error);
+    } finally {
+      if (mounted) setState(() => _loading = false);
+    }
+  }
+
+  /// Enrolls a factor, then asks for a code from the authenticator app to
+  /// confirm it. Leaving the enrollment unconfirmed just leaves a factor in the
+  /// list that can be removed.
+  Future<void> _enroll() async {
+    try {
+      final enrollment = await _auth.enrollTotpFactor();
+      if (!mounted) return;
+      final code = await showDialog<String>(
+        context: context,
+        builder: (context) => _EnrollDialog(enrollment: enrollment),
+      );
+      if (code != null && code.isNotEmpty) {
+        await _auth.confirmTotpFactor(
+          factorId: enrollment.id,
+          code: code,
+        );
+      }
+      await _refresh();
+    } catch (error) {
+      _showError(error);
+    }
+  }
+
+  Future<void> _unenroll(Factor factor) async {
+    try {
+      await _auth.unenrollFactor(factor.id);
+      await _refresh();
+    } catch (error) {
+      _showError(error);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Row(
+          children: [
+            Expanded(
+              child: Text(
+                'Two-factor authentication',
+                style: Theme.of(context).textTheme.titleMedium,
+              ),
+            ),
+            FilledButton.icon(
+              onPressed: _enroll,
+              icon: const Icon(Icons.add),
+              label: const Text('Add app'),
+            ),
+          ],
+        ),
+        const SizedBox(height: 8),
+        if (_loading)
+          const Center(child: CircularProgressIndicator())
+        else if (_factors.isEmpty)
+          const Text('No authenticator apps yet.')
+        else
+          for (final factor in _factors)
+            ListTile(
+              contentPadding: EdgeInsets.zero,
+              leading: const Icon(Icons.security),
+              title: Text(factor.friendlyName ?? factor.factorType.name),
+              subtitle: Text(factor.status.name),
+              trailing: IconButton(
+                icon: const Icon(Icons.delete),
+                onPressed: () => _unenroll(factor),
+              ),
+            ),
+      ],
+    );
+  }
+}
+
+/// Shows the TOTP secret from an enrollment and collects the code the
+/// authenticator app generates for it.
+class _EnrollDialog extends StatefulWidget {
+  const _EnrollDialog({required this.enrollment});
+
+  final AuthMFAEnrollResponse enrollment;
+
+  @override
+  State<_EnrollDialog> createState() => _EnrollDialogState();
+}
+
+class _EnrollDialogState extends State<_EnrollDialog> {
+  final _code = TextEditingController();
+
+  @override
+  void dispose() {
+    _code.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final secret = widget.enrollment.totp?.secret ?? '';
+    return AlertDialog(
+      title: const Text('Add authenticator app'),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          const Text('Add this secret to your authenticator app:'),
+          const SizedBox(height: 8),
+          SelectableText(
+            secret,
+            style: Theme.of(context).textTheme.titleMedium,
+          ),
+          const SizedBox(height: 16),
+          TextField(
+            controller: _code,
+            autofocus: true,
+            decoration: const InputDecoration(labelText: 'Six-digit code'),
+            keyboardType: TextInputType.number,
+          ),
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          onPressed: () => Navigator.pop(context, _code.text.trim()),
+          child: const Text('Verify'),
+        ),
+      ],
+    );
+  }
+}
+
+void _showMessage(String message) {
+  messengerKey.currentState?.showSnackBar(SnackBar(content: Text(message)));
+}
+
+void _showError(Object error) {
+  final message = error is AuthException ? error.message : error.toString();
+  messengerKey.currentState?.showSnackBar(
+    SnackBar(content: Text(message), backgroundColor: Colors.red),
+  );
+}

--- a/examples/authentication/lib/main.dart
+++ b/examples/authentication/lib/main.dart
@@ -54,7 +54,11 @@ class HomePage extends StatelessWidget {
           body: SafeArea(
             child: session == null
                 ? const _SignedOutView()
-                : const _SignedInView(),
+                // Pass the user so the view rebuilds when it changes, for
+                // example when an anonymous account is upgraded. A const
+                // `_SignedInView()` would be a single canonical instance that
+                // the framework skips rebuilding on later auth events.
+                : _SignedInView(user: session.user),
           ),
         );
       },
@@ -500,12 +504,16 @@ class _AnonymousFormState extends State<_AnonymousForm> {
 /// The account screen: shows who is signed in, lets an anonymous user upgrade to
 /// a permanent account, manages MFA factors and signs out.
 class _SignedInView extends StatelessWidget {
-  const _SignedInView();
+  const _SignedInView({required this.user});
+
+  final User user;
 
   @override
   Widget build(BuildContext context) {
-    final user = supabase.auth.currentUser!;
-    final identity = user.email ?? user.phone;
+    // A phone-only user comes back with an empty email rather than null, so
+    // fall back to the phone number when the email is blank.
+    final email = user.email;
+    final identity = (email != null && email.isNotEmpty) ? email : user.phone;
     return ListView(
       padding: const EdgeInsets.all(24),
       children: [

--- a/examples/authentication/lib/main.dart
+++ b/examples/authentication/lib/main.dart
@@ -115,12 +115,20 @@ class _PasswordFormState extends State<_PasswordForm> {
   final _auth = AuthRepository(supabase);
   final _email = TextEditingController();
   final _password = TextEditingController();
+  final _recoveryCode = TextEditingController();
+  final _newPassword = TextEditingController();
+
+  /// Whether the reset email has been sent and the form is now collecting the
+  /// recovery code and new password.
+  bool _resetting = false;
   bool _busy = false;
 
   @override
   void dispose() {
     _email.dispose();
     _password.dispose();
+    _recoveryCode.dispose();
+    _newPassword.dispose();
     super.dispose();
   }
 
@@ -149,9 +157,22 @@ class _PasswordFormState extends State<_PasswordForm> {
     ),
   );
 
-  Future<void> _resetPassword() => _run(() async {
+  /// Sends the reset email, then reveals the fields to finish the reset with the
+  /// code from that email.
+  Future<void> _startReset() => _run(() async {
     await _auth.sendPasswordReset(_email.text.trim());
+    if (mounted) setState(() => _resetting = true);
     _showMessage('Password reset email sent.');
+  });
+
+  /// Verifies the recovery code and sets the new password, which signs the user
+  /// in.
+  Future<void> _completeReset() => _run(() async {
+    await _auth.verifyRecoveryOtp(
+      email: _email.text.trim(),
+      token: _recoveryCode.text.trim(),
+    );
+    await _auth.updatePassword(_newPassword.text);
   });
 
   @override
@@ -161,29 +182,53 @@ class _PasswordFormState extends State<_PasswordForm> {
       children: [
         TextField(
           controller: _email,
+          enabled: !_resetting,
           decoration: const InputDecoration(labelText: 'Email'),
           keyboardType: TextInputType.emailAddress,
         ),
         const SizedBox(height: 12),
-        TextField(
-          controller: _password,
-          decoration: const InputDecoration(labelText: 'Password'),
-          obscureText: true,
-        ),
-        const SizedBox(height: 24),
-        FilledButton(
-          onPressed: _busy ? null : _signIn,
-          child: const Text('Sign in'),
-        ),
-        const SizedBox(height: 12),
-        OutlinedButton(
-          onPressed: _busy ? null : _signUp,
-          child: const Text('Create an account'),
-        ),
-        TextButton(
-          onPressed: _busy ? null : _resetPassword,
-          child: const Text('Forgot password?'),
-        ),
+        if (!_resetting) ...[
+          TextField(
+            controller: _password,
+            decoration: const InputDecoration(labelText: 'Password'),
+            obscureText: true,
+          ),
+          const SizedBox(height: 24),
+          FilledButton(
+            onPressed: _busy ? null : _signIn,
+            child: const Text('Sign in'),
+          ),
+          const SizedBox(height: 12),
+          OutlinedButton(
+            onPressed: _busy ? null : _signUp,
+            child: const Text('Create an account'),
+          ),
+          TextButton(
+            onPressed: _busy ? null : _startReset,
+            child: const Text('Forgot password?'),
+          ),
+        ] else ...[
+          TextField(
+            controller: _recoveryCode,
+            decoration: const InputDecoration(labelText: 'Recovery code'),
+            keyboardType: TextInputType.number,
+          ),
+          const SizedBox(height: 12),
+          TextField(
+            controller: _newPassword,
+            decoration: const InputDecoration(labelText: 'New password'),
+            obscureText: true,
+          ),
+          const SizedBox(height: 24),
+          FilledButton(
+            onPressed: _busy ? null : _completeReset,
+            child: const Text('Set new password'),
+          ),
+          TextButton(
+            onPressed: _busy ? null : () => setState(() => _resetting = false),
+            child: const Text('Cancel'),
+          ),
+        ],
       ],
     );
   }

--- a/examples/authentication/lib/main.dart
+++ b/examples/authentication/lib/main.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
@@ -10,6 +11,14 @@ const supabaseUrl = String.fromEnvironment('SUPABASE_URL');
 const supabasePublishableKey = String.fromEnvironment(
   'SUPABASE_PUBLISHABLE_KEY',
 );
+
+/// Where an email link or OAuth provider returns the user after authenticating.
+/// On web the project's site URL is used, so this stays null; native builds
+/// return through this deep link, which must be registered with the platform
+/// and added to the Supabase redirect allow list.
+const authRedirectTo = kIsWeb
+    ? null
+    : 'io.supabase.authexample://login-callback/';
 
 final messengerKey = GlobalKey<ScaffoldMessengerState>();
 
@@ -164,7 +173,10 @@ class _PasswordFormState extends State<_PasswordForm> {
   /// Sends the reset email, then reveals the fields to finish the reset with the
   /// code from that email.
   Future<void> _startReset() => _run(() async {
-    await _auth.sendPasswordReset(_email.text.trim());
+    await _auth.sendPasswordReset(
+      _email.text.trim(),
+      redirectTo: authRedirectTo,
+    );
     if (mounted) setState(() => _resetting = true);
     _showMessage('Password reset email sent.');
   });
@@ -264,7 +276,10 @@ class _EmailOtpFormState extends State<_EmailOtpForm> {
   Future<void> _sendCode() async {
     setState(() => _busy = true);
     try {
-      await _auth.sendEmailOtp(_email.text.trim());
+      await _auth.sendEmailOtp(
+        _email.text.trim(),
+        emailRedirectTo: authRedirectTo,
+      );
       setState(() => _codeSent = true);
       _showMessage('Check your email for the code.');
     } catch (error) {
@@ -429,7 +444,9 @@ class _OAuthButtons extends StatelessWidget {
 
   Future<void> _signIn(OAuthProvider provider) async {
     try {
-      await AuthRepository(supabase).signInWithOAuth(provider);
+      await AuthRepository(
+        supabase,
+      ).signInWithOAuth(provider, redirectTo: authRedirectTo);
     } catch (error) {
       _showError(error);
     }

--- a/examples/authentication/lib/models.dart
+++ b/examples/authentication/lib/models.dart
@@ -1,0 +1,14 @@
+/// The sign in methods the example offers on its signed-out screen. Each maps to
+/// one or two calls on [AuthRepository]; the label is what the method picker
+/// shows.
+enum AuthMethod {
+  password('Email & password'),
+  magicLink('Magic link & email OTP'),
+  phone('Phone (SMS OTP)'),
+  oauth('OAuth social'),
+  anonymous('Anonymous');
+
+  const AuthMethod(this.label);
+
+  final String label;
+}

--- a/examples/authentication/pubspec.yaml
+++ b/examples/authentication/pubspec.yaml
@@ -1,0 +1,27 @@
+name: authentication_example
+description: Demonstrates every supabase_flutter sign in method except passkeys.
+
+publish_to: 'none'
+
+version: 1.0.0+1
+
+environment:
+  sdk: '>=3.9.0 <4.0.0'
+  flutter: '>=3.35.0'
+
+resolution: workspace
+
+dependencies:
+  flutter:
+    sdk: flutter
+  supabase_flutter: ^2.17.0
+
+dev_dependencies:
+  supabase_lints: ^0.1.1
+  flutter_test:
+    sdk: flutter
+  integration_test:
+    sdk: flutter
+
+flutter:
+  uses-material-design: true

--- a/examples/authentication/web/index.html
+++ b/examples/authentication/web/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <base href="$FLUTTER_BASE_HREF">
+  <meta charset="UTF-8">
+  <meta content="IE=Edge" http-equiv="X-UA-Compatible">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+  <title>Supabase Authentication</title>
+</head>
+<body>
+  <script src="flutter_bootstrap.js" async></script>
+</body>
+</html>

--- a/examples/supabase/config.toml
+++ b/examples/supabase/config.toml
@@ -9,11 +9,36 @@ project_id = "supabase_flutter_examples"
 [auth]
 site_url = "http://localhost:3000"
 additional_redirect_urls = ["http://localhost:3000"]
+# Anonymous sign in, used by the authentication example.
+enable_anonymous_sign_ins = true
 
 [auth.email]
 enable_signup = true
 # Skip email confirmation so the examples can sign in right away.
 enable_confirmations = false
+
+# Phone sign in for the authentication example.
+[auth.sms]
+enable_signup = true
+enable_confirmations = true
+
+# A provider has to be enabled for phone login to turn on, but the test OTP
+# below short-circuits before anything is actually sent, so these placeholder
+# Twilio credentials are never used and no real SMS provider is needed locally.
+[auth.sms.twilio]
+enabled = true
+account_sid = "test-account-sid"
+message_service_sid = "test-message-service-sid"
+auth_token = "test-auth-token"
+
+# Accept a fixed code for one phone number so the phone flow works offline.
+[auth.sms.test_otp]
+15555550100 = "123456"
+
+# TOTP multi-factor authentication for the authentication example.
+[auth.mfa.totp]
+enroll_enabled = true
+verify_enabled = true
 
 # Passkeys (WebAuthn) are a BETA Auth feature, used by the passkeys example.
 [auth.passkey]
@@ -37,9 +62,11 @@ enabled = true
 [studio]
 enabled = false
 
-# Email testing server.
-[inbucket]
-enabled = false
+# Local mail server that captures the emails the examples send (magic link,
+# email OTP, password reset) so no real SMTP provider is needed. Its web UI and
+# API are served on port 54324.
+[local_smtp]
+enabled = true
 
 # Edge Functions runtime.
 [edge_runtime]

--- a/examples/supabase/config.toml
+++ b/examples/supabase/config.toml
@@ -17,6 +17,13 @@ enable_signup = true
 # Skip email confirmation so the examples can sign in right away.
 enable_confirmations = false
 
+# Include the one-time code ({{ .Token }}) in the passwordless email so the
+# authentication example's email OTP flow can be completed by typing the code,
+# not only by following the magic link.
+[auth.email.template.magic_link]
+subject = "Your sign-in code"
+content_path = "./supabase/templates/magic_link.html"
+
 # Phone sign in for the authentication example.
 [auth.sms]
 enable_signup = true

--- a/examples/supabase/config.toml
+++ b/examples/supabase/config.toml
@@ -8,7 +8,12 @@ project_id = "supabase_flutter_examples"
 
 [auth]
 site_url = "http://localhost:3000"
-additional_redirect_urls = ["http://localhost:3000"]
+# The deep link is where the authentication example's native builds return
+# after an email link or OAuth redirect.
+additional_redirect_urls = [
+  "http://localhost:3000",
+  "io.supabase.authexample://login-callback/",
+]
 # Anonymous sign in, used by the authentication example.
 enable_anonymous_sign_ins = true
 

--- a/examples/supabase/config.toml
+++ b/examples/supabase/config.toml
@@ -17,12 +17,16 @@ enable_signup = true
 # Skip email confirmation so the examples can sign in right away.
 enable_confirmations = false
 
-# Include the one-time code ({{ .Token }}) in the passwordless email so the
-# authentication example's email OTP flow can be completed by typing the code,
-# not only by following the magic link.
+# Include the one-time code ({{ .Token }}) in the passwordless and recovery
+# emails so the authentication example's email OTP and password reset flows can
+# be completed by typing the code, not only by following the link.
 [auth.email.template.magic_link]
 subject = "Your sign-in code"
 content_path = "./supabase/templates/magic_link.html"
+
+[auth.email.template.recovery]
+subject = "Reset your password"
+content_path = "./supabase/templates/recovery.html"
 
 # Phone sign in for the authentication example.
 [auth.sms]

--- a/examples/supabase/templates/magic_link.html
+++ b/examples/supabase/templates/magic_link.html
@@ -1,0 +1,7 @@
+<h2>Your sign-in code</h2>
+
+<p>Enter this code in the app to sign in:</p>
+<p><strong>{{ .Token }}</strong></p>
+
+<p>Or follow this link to sign in directly:</p>
+<p><a href="{{ .ConfirmationURL }}">Sign in</a></p>

--- a/examples/supabase/templates/recovery.html
+++ b/examples/supabase/templates/recovery.html
@@ -1,0 +1,7 @@
+<h2>Reset your password</h2>
+
+<p>Enter this code in the app to choose a new password:</p>
+<p><strong>{{ .Token }}</strong></p>
+
+<p>Or follow this link to reset it directly:</p>
+<p><a href="{{ .ConfirmationURL }}">Reset password</a></p>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,6 +18,7 @@ workspace:
   - packages/supabase_common
   - packages/supabase_lints
   - packages/yet_another_json_isolate
+  - examples/authentication
   - examples/database_crud
   - examples/launcher
   - examples/passkeys


### PR DESCRIPTION
## What

Adds a single example app under `examples/authentication` that demonstrates every `supabase_flutter` sign in method except passkeys (which already have their own [`passkeys`](../passkeys) example). Pick a method with the chips at the top; once signed in you land on an account screen that manages MFA and can upgrade an anonymous user to a permanent account.

Covers these parity example tickets:

- **SDK-1059** Email & password: `signUp`, `signInWithPassword`, and a full password reset (`resetPasswordForEmail`, then `verifyOTP` with `OtpType.recovery` and `updateUser`)
- **SDK-1060** Passwordless: `signInWithOtp(email:)` + `verifyOTP(type: OtpType.email)`
- **SDK-1061** OAuth social: `signInWithOAuth` (Google, GitHub, Apple), including deep-link redirect
- **SDK-1062** Phone / SMS: `signInWithOtp(phone:)` + `verifyOTP(type: OtpType.sms)`
- **SDK-1063** Anonymous: `signInAnonymously`, then `updateUser` to upgrade to a permanent account
- **SDK-1064** MFA (TOTP): `auth.mfa.enroll`, `challengeAndVerify`, `listFactors`, `unenroll`

## How

- All `supabase.auth.*` calls live in `lib/auth_repository.dart`, kept separate from the UI so the flows are easy to read and to drive from an integration test. The UI just calls the repository and rebuilds from `onAuthStateChange`.
- Follows the structure, naming and comment style of the `database_crud` example.
- The shared Supabase config in `examples/supabase/config.toml` enables anonymous sign in, phone auth (with a local test OTP so no SMS provider is needed), TOTP MFA, and the local mail server. Custom `magic_link` and `recovery` email templates include the one-time code so the email OTP and reset flows can be completed by typing it. `[inbucket]` was renamed to the current `[local_smtp]` section along the way. The example stores no data of its own, so it needs no migration or seed.

## Testing

Booted the shared local stack and verified against the API that email/password sign up, email OTP (captured by the local mail server), the full password reset loop, phone OTP with the test number, anonymous sign in and its upgrade to a permanent account all work. `dart format` and `flutter analyze` are clean. End-to-end integration tests follow in stacked PR #1628; writing them surfaced two display/rebuild bugs that are fixed here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a Flutter authentication example covering password, magic-link/email OTP, phone OTP, OAuth, anonymous sign-in, password recovery, and TOTP MFA.
  - Added native deep-link handling for email and OAuth flows.
  - Added local authentication testing support, including email capture and fixed SMS OTP configuration.
  - Added magic-link and password-recovery email templates displaying verification codes and links.

- **Documentation**
  - Added setup, configuration, usage, and local testing instructions for the authentication example.
  - Updated the examples feature table.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->