### PR TITLE
ci: pin SDK compliance reusable workflow to a main SHA

### DIFF
--- a/.github/workflows/sync-compliance.yml
+++ b/.github/workflows/sync-compliance.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: supabase/sdk/.github/workflows/sync-sdk-compliance.yml@faba359a57d270bbbf68fd6b583db0604ddce8af
+    uses: supabase/sdk/.github/workflows/sync-sdk-compliance.yml@d9f43f5be4056adc33c65fe54f1c9ed1714d67e0
     secrets:
       app-id: ${{ secrets.APP_ID }}
       private-key: ${{ secrets.PRIVATE_KEY }}

--- a/.github/workflows/sync-compliance.yml
+++ b/.github/workflows/sync-compliance.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: supabase/sdk/.github/workflows/sync-sdk-compliance.yml@main
+    uses: supabase/sdk/.github/workflows/sync-sdk-compliance.yml@faba359a57d270bbbf68fd6b583db0604ddce8af # main
     secrets:
       app-id: ${{ secrets.APP_ID }}
       private-key: ${{ secrets.PRIVATE_KEY }}

--- a/.github/workflows/sync-compliance.yml
+++ b/.github/workflows/sync-compliance.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: supabase/sdk/.github/workflows/sync-sdk-compliance.yml@faba359a57d270bbbf68fd6b583db0604ddce8af # main
+    uses: supabase/sdk/.github/workflows/sync-sdk-compliance.yml@faba359a57d270bbbf68fd6b583db0604ddce8af
     secrets:
       app-id: ${{ secrets.APP_ID }}
       private-key: ${{ secrets.PRIVATE_KEY }}


### PR DESCRIPTION
Pins the `sync-compliance.yml` caller's reference to the reusable workflow at supabase/sdk from `@main` to the current main SHA (`faba359a57d270bbbf68fd6b583db0604ddce8af`), matching the pinning being applied across the other SDK caller repos (supabase-js #2534, supabase-py #1541, supabase-swift #1128).

The original caller workflow was merged in #1606 with a floating `@main` reference, so this follow-up pins it. The `# main` trailing comment keeps the tracked branch visible for future bumps.