### PR TITLE
ci: stop CodeRabbit marking PRs failed on review rate limit

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,4 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+reviews:
+  commit_status: true
+  fail_commit_status: false


### PR DESCRIPTION
## What

Adds a repo-level `.coderabbit.yaml` that disables CodeRabbit's failing commit status:

```yaml
reviews:
  commit_status: true
  fail_commit_status: false
```

## Why

Open PRs are currently showing a red `CodeRabbit` check with the reason **"Review rate limited"** (e.g. #1630, #1629, #1627), even though nothing is actually wrong with the change. A completed review shows `pass` (e.g. #1626).

- `commit_status: true` keeps the useful passing check for completed reviews.
- `fail_commit_status: false` stops CodeRabbit from setting a `failure` status when it can't review (which is what the rate-limit case triggers).

Committing the config overrides CodeRabbit's cloud/org defaults.

## Note

If a rate-limited PR still goes red after this lands, the rate-limit failure path ignores this flag and the only remaining lever is `commit_status: false` (disables the check entirely, losing the green pass too).