### PR TITLE
docs(examples): add Edge Functions example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -6,6 +6,7 @@ all sharing a single local Supabase instance.
 | Example                                     | What it shows                                    |
 | ------------------------------------------- | ------------------------------------------------ |
 | [`database_crud`](database_crud)            | Database CRUD with PostgREST (`from(...)`)       |
+| [`edge_functions`](edge_functions)          | Invoking Edge Functions (`functions.invoke(...)`)|
 | [`passkeys`](passkeys)                      | Passkey (WebAuthn) sign in and management        |
 | [`storage_transforms`](storage_transforms) | Storage uploads, downloads and image transforms  |
 

--- a/examples/edge_functions/.gitignore
+++ b/examples/edge_functions/.gitignore
@@ -1,0 +1,6 @@
+.dart_tool/
+.flutter-plugins
+.flutter-plugins-dependencies
+build/
+pubspec.lock
+pubspec_overrides.yaml

--- a/examples/edge_functions/README.md
+++ b/examples/edge_functions/README.md
@@ -1,0 +1,68 @@
+# Edge Functions
+
+A small app that shows how to call Supabase Edge Functions with
+`supabase.functions.invoke(...)`:
+
+- **Invoke with a JSON body** over POST and read the JSON response back
+  (`invoke('greet', body: {...})`).
+- **Invoke over GET** with query parameters instead of a body
+  (`invoke('greet', method: HttpMethod.get, queryParameters: {...})`).
+- **Send custom headers** to the function (`headers: {...}`), echoed back in the
+  response.
+- **Send and receive plain text**: a `String` body is sent as `text/plain` and a
+  `text/plain` response comes back as a `String` (`invoke('shout', body: text)`).
+- **Handle errors**: a non-2xx response throws a `FunctionException` whose
+  `details` carry the response body (`invoke('word-count', ...)`).
+
+All Edge Function access is in
+[`lib/functions_repository.dart`](lib/functions_repository.dart), kept separate
+from the UI so the calls are easy to read and to drive from an integration test.
+
+To keep the focus on the Supabase calls, the screen uses plain `setState` rather
+than pulling in a state management package. A larger app would typically reach
+for a state management solution (for example Riverpod, Bloc or Provider) instead.
+
+The functions live in the shared Supabase config in
+[`../supabase`](../supabase): their code is under `functions/` (`greet`, `shout`
+and `word-count`), and the Edge Runtime is enabled in `config.toml`
+(`[edge_runtime]`). `supabase start` serves every function while the stack is
+running. The functions need no database tables or seed data.
+
+The demo functions set `verify_jwt = false` in `config.toml` so the example can
+call them with just the publishable (anon) key, matching the other examples,
+which run unauthenticated. A real app would leave JWT verification on and read
+the caller's user from the request.
+
+## Running
+
+From the `examples` directory, run the launcher and pick `edge_functions`:
+
+```bash
+./run.sh
+```
+
+Or run it directly against any project (with the functions deployed there):
+
+```bash
+flutter run \
+  --dart-define=SUPABASE_URL=https://YOUR_PROJECT.supabase.co \
+  --dart-define=SUPABASE_PUBLISHABLE_KEY=YOUR_PUBLISHABLE_KEY
+```
+
+## Integration test
+
+[`integration_test/functions_test.dart`](integration_test/functions_test.dart)
+is an end-to-end test that runs against the local stack. It drives the flow
+through the repository (a JSON greeting over POST and GET, a plain-text
+transform, and a validation error that surfaces as a `FunctionException`) and
+drives the app widgets to greet through the UI.
+
+With the local stack running, pass the same defines the app uses and run it on a
+device (integration tests need one, so `-d macos`, an emulator or a real
+device):
+
+```bash
+flutter test integration_test/functions_test.dart -d macos \
+  --dart-define=SUPABASE_URL=http://localhost:54321 \
+  --dart-define=SUPABASE_PUBLISHABLE_KEY=YOUR_LOCAL_PUBLISHABLE_KEY
+```

--- a/examples/edge_functions/analysis_options.yaml
+++ b/examples/edge_functions/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:supabase_lints/analysis_options_flutter.yaml

--- a/examples/edge_functions/integration_test/functions_test.dart
+++ b/examples/edge_functions/integration_test/functions_test.dart
@@ -1,0 +1,103 @@
+import 'package:edge_functions_example/functions_repository.dart';
+import 'package:edge_functions_example/main.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+const supabaseUrl = String.fromEnvironment('SUPABASE_URL');
+const supabasePublishableKey = String.fromEnvironment(
+  'SUPABASE_PUBLISHABLE_KEY',
+);
+
+/// End-to-end tests that drive the Edge Functions example against the local
+/// stack.
+///
+/// The first test exercises the core flow through the repository (a JSON
+/// greeting over POST and GET, a plain-text transform, and a validation error),
+/// asserting on what each function returns. The second drives the app widgets to
+/// confirm the greeting card is wired to the function. Edge Functions are
+/// stateless, so there is nothing to clean up between runs.
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  late FunctionsRepository repository;
+
+  setUpAll(() async {
+    await Supabase.initialize(
+      url: supabaseUrl,
+      publishableKey: supabasePublishableKey,
+    );
+    repository = FunctionsRepository(Supabase.instance.client);
+  });
+
+  tearDownAll(() async {
+    await Supabase.instance.dispose();
+  });
+
+  testWidgets('invokes the example functions through the repository', (
+    tester,
+  ) async {
+    // POST with a JSON body: the function greets and echoes how it was called.
+    final posted = await repository.greet(name: 'Ada', excited: true);
+    expect(posted.message, 'Hello, Ada!!!');
+    expect(posted.method, 'POST');
+    expect(posted.source, 'flutter-app');
+
+    // GET with a query parameter reaches the same function a different way.
+    final fetched = await repository.greetViaQuery('Grace');
+    expect(fetched.message, 'Hello, Grace.');
+    expect(fetched.method, 'GET');
+
+    // A plain-text response comes back as a String.
+    final shouted = await repository.shout('edge functions');
+    expect(shouted, 'EDGE FUNCTIONS');
+
+    // A JSON response decodes into the model.
+    final count = await repository.countWords('one two three');
+    expect(count.words, 3);
+    expect(count.characters, 13);
+
+    // An empty input makes the function respond with a 400, which surfaces as a
+    // FunctionException carrying the JSON error body.
+    await expectLater(
+      repository.countWords(''),
+      throwsA(
+        isA<FunctionException>()
+            .having((error) => error.status, 'status', 400)
+            .having(
+              (error) => (error.details as Map)['error'],
+              'details.error',
+              isA<String>(),
+            ),
+      ),
+    );
+  });
+
+  testWidgets('greets through the UI', (tester) async {
+    await tester.pumpWidget(const EdgeFunctionsExampleApp());
+    await tester.pumpAndSettle();
+
+    // Tapping "Greet (POST)" invokes the function and shows its message.
+    await tester.tap(find.widgetWithText(FilledButton, 'Greet (POST)'));
+    await _pumpUntil(tester, find.textContaining('Hello, Ada'));
+    expect(find.textContaining('via POST'), findsOneWidget);
+  });
+}
+
+/// Pumps frames until [finder] matches at least one widget or [timeout] elapses.
+///
+/// Invoking a function goes over the network, so the UI can't be settled with
+/// `pumpAndSettle`; this polls the widget tree instead.
+Future<void> _pumpUntil(
+  WidgetTester tester,
+  Finder finder, {
+  Duration timeout = const Duration(seconds: 20),
+}) async {
+  final deadline = DateTime.now().add(timeout);
+  while (DateTime.now().isBefore(deadline)) {
+    await tester.pump(const Duration(milliseconds: 100));
+    if (finder.evaluate().isNotEmpty) return;
+  }
+  fail('Timed out waiting for: $finder');
+}

--- a/examples/edge_functions/lib/functions_repository.dart
+++ b/examples/edge_functions/lib/functions_repository.dart
@@ -1,0 +1,63 @@
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import 'models.dart';
+
+/// All Edge Function access for the example lives here, so the UI stays thin and
+/// every `supabase.functions.invoke(...)` call is easy to read and to exercise
+/// from an integration test.
+class FunctionsRepository {
+  FunctionsRepository(this._client);
+
+  final SupabaseClient _client;
+
+  FunctionsClient get _functions => _client.functions;
+
+  /// Invokes the `greet` function over POST with a JSON body and returns the
+  /// greeting it builds server-side.
+  ///
+  /// The custom `x-greeting-source` header is echoed back in the response, so
+  /// the example can show that headers set here reach the function. A JSON body
+  /// comes back decoded as a `Map`, which [Greeting.fromJson] turns into a model.
+  Future<Greeting> greet({required String name, bool excited = false}) async {
+    final response = await _functions.invoke(
+      'greet',
+      body: {'name': name, 'excited': excited},
+      headers: const {'x-greeting-source': 'flutter-app'},
+    );
+    return Greeting.fromJson(response.data as Map<String, dynamic>);
+  }
+
+  /// Invokes the same `greet` function over GET, passing the name as a query
+  /// parameter instead of a body.
+  Future<Greeting> greetViaQuery(String name) async {
+    final response = await _functions.invoke(
+      'greet',
+      method: HttpMethod.get,
+      queryParameters: {'name': name},
+    );
+    return Greeting.fromJson(response.data as Map<String, dynamic>);
+  }
+
+  /// Sends [text] to the `shout` function and returns the uppercased text it
+  /// responds with.
+  ///
+  /// A `String` body is sent as `text/plain`, and the function replies with
+  /// `text/plain` too, so `response.data` is a `String` rather than decoded JSON.
+  Future<String> shout(String text) async {
+    final response = await _functions.invoke('shout', body: text);
+    return response.data as String;
+  }
+
+  /// Invokes the `word-count` function, which validates its input.
+  ///
+  /// When [text] is empty the function replies with a 400 and a JSON error body,
+  /// which surfaces here as a [FunctionException] whose `details` hold that body.
+  /// The caller is expected to handle that exception.
+  Future<WordCount> countWords(String text) async {
+    final response = await _functions.invoke(
+      'word-count',
+      body: {'text': text},
+    );
+    return WordCount.fromJson(response.data as Map<String, dynamic>);
+  }
+}

--- a/examples/edge_functions/lib/main.dart
+++ b/examples/edge_functions/lib/main.dart
@@ -241,7 +241,9 @@ class _WordCountCardState extends State<_WordCountCard> {
     if (_running) return;
     setState(() => _running = true);
     try {
-      final result = await widget.repository.countWords(_text.text.trim());
+      // Send the text unchanged so the function counts the submitted
+      // characters; it trims internally to validate and split into words.
+      final result = await widget.repository.countWords(_text.text);
       if (mounted) setState(() => _result = result);
     } catch (error) {
       _showError(error);

--- a/examples/edge_functions/lib/main.dart
+++ b/examples/edge_functions/lib/main.dart
@@ -39,7 +39,8 @@ class EdgeFunctionsExampleApp extends StatelessWidget {
 
 /// Invokes the example's Edge Functions and shows what each one returns: a JSON
 /// greeting (over POST and GET), a plain-text transform, and a validating
-/// function whose error response is surfaced to the user.
+/// function whose error response is surfaced to the user. Each card drives one
+/// function through the shared [FunctionsRepository].
 class FunctionsPage extends StatefulWidget {
   const FunctionsPage({super.key});
 
@@ -49,39 +50,56 @@ class FunctionsPage extends StatefulWidget {
 
 class _FunctionsPageState extends State<FunctionsPage> {
   final _repository = FunctionsRepository(supabase);
-  final _name = TextEditingController(text: 'Ada');
-  final _shout = TextEditingController(text: 'edge functions');
-  final _count = TextEditingController(text: 'Functions run close to the user');
 
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Edge Functions')),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          _GreetCard(repository: _repository),
+          const SizedBox(height: 16),
+          _ShoutCard(repository: _repository),
+          const SizedBox(height: 16),
+          _WordCountCard(repository: _repository),
+        ],
+      ),
+    );
+  }
+}
+
+/// Invokes `greet` over POST and GET, both building the message server-side.
+class _GreetCard extends StatefulWidget {
+  const _GreetCard({required this.repository});
+
+  final FunctionsRepository repository;
+
+  @override
+  State<_GreetCard> createState() => _GreetCardState();
+}
+
+class _GreetCardState extends State<_GreetCard> {
+  final _name = TextEditingController(text: 'Ada');
   bool _excited = false;
   Greeting? _greeting;
-  String? _shoutResult;
-  WordCount? _wordCount;
 
-  /// Name of the function whose button is currently running, so only that
-  /// button shows a spinner and the others stay tappable.
+  /// Which button is running (`post` or `get`), or null when idle, so only the
+  /// tapped button shows a spinner and neither fires twice.
   String? _running;
 
   @override
   void dispose() {
     _name.dispose();
-    _shout.dispose();
-    _count.dispose();
     super.dispose();
   }
 
-  /// Runs [action] while marking [key] as in flight, then applies its result
-  /// with [onResult]. Any error is shown in a snackbar.
-  Future<void> _invoke<T>(
-    String key,
-    Future<T> Function() action,
-    void Function(T result) onResult,
-  ) async {
+  Future<void> _run(String key, Future<Greeting> Function() action) async {
     if (_running != null) return;
     setState(() => _running = key);
     try {
-      final result = await action();
-      if (mounted) setState(() => onResult(result));
+      final greeting = await action();
+      if (mounted) setState(() => _greeting = greeting);
     } catch (error) {
       _showError(error);
     } finally {
@@ -91,22 +109,6 @@ class _FunctionsPageState extends State<FunctionsPage> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(title: const Text('Edge Functions')),
-      body: ListView(
-        padding: const EdgeInsets.all(16),
-        children: [
-          _greetCard(),
-          const SizedBox(height: 16),
-          _shoutCard(),
-          const SizedBox(height: 16),
-          _wordCountCard(),
-        ],
-      ),
-    );
-  }
-
-  Widget _greetCard() {
     return _DemoCard(
       title: 'Greeting',
       description:
@@ -129,25 +131,23 @@ class _FunctionsPageState extends State<FunctionsPage> {
           children: [
             _RunButton(
               label: 'Greet (POST)',
-              running: _running == 'greet-post',
-              onPressed: () => _invoke(
-                'greet-post',
-                () => _repository.greet(
+              running: _running == 'post',
+              onPressed: () => _run(
+                'post',
+                () => widget.repository.greet(
                   name: _name.text.trim(),
                   excited: _excited,
                 ),
-                (result) => _greeting = result,
               ),
             ),
             const SizedBox(width: 12),
             _RunButton(
               label: 'Greet (GET)',
               filled: false,
-              running: _running == 'greet-get',
-              onPressed: () => _invoke(
-                'greet-get',
-                () => _repository.greetViaQuery(_name.text.trim()),
-                (result) => _greeting = result,
+              running: _running == 'get',
+              onPressed: () => _run(
+                'get',
+                () => widget.repository.greetViaQuery(_name.text.trim()),
               ),
             ),
           ],
@@ -160,8 +160,44 @@ class _FunctionsPageState extends State<FunctionsPage> {
       ],
     );
   }
+}
 
-  Widget _shoutCard() {
+/// Invokes `shout`, which returns the text uppercased as plain text.
+class _ShoutCard extends StatefulWidget {
+  const _ShoutCard({required this.repository});
+
+  final FunctionsRepository repository;
+
+  @override
+  State<_ShoutCard> createState() => _ShoutCardState();
+}
+
+class _ShoutCardState extends State<_ShoutCard> {
+  final _text = TextEditingController(text: 'edge functions');
+  String? _result;
+  bool _running = false;
+
+  @override
+  void dispose() {
+    _text.dispose();
+    super.dispose();
+  }
+
+  Future<void> _run() async {
+    if (_running) return;
+    setState(() => _running = true);
+    try {
+      final result = await widget.repository.shout(_text.text);
+      if (mounted) setState(() => _result = result);
+    } catch (error) {
+      _showError(error);
+    } finally {
+      if (mounted) setState(() => _running = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
     return _DemoCard(
       title: 'Plain text',
       description:
@@ -169,24 +205,53 @@ class _FunctionsPageState extends State<FunctionsPage> {
           'text/plain. A plain-text response arrives as a Dart String.',
       children: [
         TextField(
-          controller: _shout,
+          controller: _text,
           decoration: const InputDecoration(labelText: 'Text to shout'),
         ),
-        _RunButton(
-          label: 'Shout',
-          running: _running == 'shout',
-          onPressed: () => _invoke(
-            'shout',
-            () => _repository.shout(_shout.text),
-            (result) => _shoutResult = result,
-          ),
-        ),
-        if (_shoutResult case final result?) _Result(result),
+        _RunButton(label: 'Shout', running: _running, onPressed: _run),
+        if (_result case final result?) _Result(result),
       ],
     );
   }
+}
 
-  Widget _wordCountCard() {
+/// Invokes `word-count`, which validates its input and responds with a 400 when
+/// the text is empty, surfacing here as a [FunctionException].
+class _WordCountCard extends StatefulWidget {
+  const _WordCountCard({required this.repository});
+
+  final FunctionsRepository repository;
+
+  @override
+  State<_WordCountCard> createState() => _WordCountCardState();
+}
+
+class _WordCountCardState extends State<_WordCountCard> {
+  final _text = TextEditingController(text: 'Functions run close to the user');
+  WordCount? _result;
+  bool _running = false;
+
+  @override
+  void dispose() {
+    _text.dispose();
+    super.dispose();
+  }
+
+  Future<void> _run() async {
+    if (_running) return;
+    setState(() => _running = true);
+    try {
+      final result = await widget.repository.countWords(_text.text.trim());
+      if (mounted) setState(() => _result = result);
+    } catch (error) {
+      _showError(error);
+    } finally {
+      if (mounted) setState(() => _running = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
     return _DemoCard(
       title: 'Validation and errors',
       description:
@@ -195,22 +260,12 @@ class _FunctionsPageState extends State<FunctionsPage> {
           'below.',
       children: [
         TextField(
-          controller: _count,
+          controller: _text,
           decoration: const InputDecoration(labelText: 'Text to count'),
         ),
-        _RunButton(
-          label: 'Count words',
-          running: _running == 'count',
-          onPressed: () => _invoke(
-            'count',
-            () => _repository.countWords(_count.text.trim()),
-            (result) => _wordCount = result,
-          ),
-        ),
-        if (_wordCount case final wordCount?)
-          _Result(
-            '${wordCount.words} words, ${wordCount.characters} characters',
-          ),
+        _RunButton(label: 'Count words', running: _running, onPressed: _run),
+        if (_result case final result?)
+          _Result('${result.words} words, ${result.characters} characters'),
       ],
     );
   }

--- a/examples/edge_functions/lib/main.dart
+++ b/examples/edge_functions/lib/main.dart
@@ -1,0 +1,317 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import 'functions_repository.dart';
+import 'models.dart';
+
+const supabaseUrl = String.fromEnvironment('SUPABASE_URL');
+const supabasePublishableKey = String.fromEnvironment(
+  'SUPABASE_PUBLISHABLE_KEY',
+);
+
+final messengerKey = GlobalKey<ScaffoldMessengerState>();
+
+Future<void> main() async {
+  await Supabase.initialize(
+    url: supabaseUrl,
+    publishableKey: supabasePublishableKey,
+  );
+  runApp(const EdgeFunctionsExampleApp());
+}
+
+SupabaseClient get supabase => Supabase.instance.client;
+
+class EdgeFunctionsExampleApp extends StatelessWidget {
+  const EdgeFunctionsExampleApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Supabase Edge Functions',
+      scaffoldMessengerKey: messengerKey,
+      theme: ThemeData(colorSchemeSeed: Colors.deepPurple, useMaterial3: true),
+      home: const FunctionsPage(),
+    );
+  }
+}
+
+/// Invokes the example's Edge Functions and shows what each one returns: a JSON
+/// greeting (over POST and GET), a plain-text transform, and a validating
+/// function whose error response is surfaced to the user.
+class FunctionsPage extends StatefulWidget {
+  const FunctionsPage({super.key});
+
+  @override
+  State<FunctionsPage> createState() => _FunctionsPageState();
+}
+
+class _FunctionsPageState extends State<FunctionsPage> {
+  final _repository = FunctionsRepository(supabase);
+  final _name = TextEditingController(text: 'Ada');
+  final _shout = TextEditingController(text: 'edge functions');
+  final _count = TextEditingController(text: 'Functions run close to the user');
+
+  bool _excited = false;
+  Greeting? _greeting;
+  String? _shoutResult;
+  WordCount? _wordCount;
+
+  /// Name of the function whose button is currently running, so only that
+  /// button shows a spinner and the others stay tappable.
+  String? _running;
+
+  @override
+  void dispose() {
+    _name.dispose();
+    _shout.dispose();
+    _count.dispose();
+    super.dispose();
+  }
+
+  /// Runs [action] while marking [key] as in flight, then applies its result
+  /// with [onResult]. Any error is shown in a snackbar.
+  Future<void> _invoke<T>(
+    String key,
+    Future<T> Function() action,
+    void Function(T result) onResult,
+  ) async {
+    if (_running != null) return;
+    setState(() => _running = key);
+    try {
+      final result = await action();
+      if (mounted) setState(() => onResult(result));
+    } catch (error) {
+      _showError(error);
+    } finally {
+      if (mounted) setState(() => _running = null);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Edge Functions')),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          _greetCard(),
+          const SizedBox(height: 16),
+          _shoutCard(),
+          const SizedBox(height: 16),
+          _wordCountCard(),
+        ],
+      ),
+    );
+  }
+
+  Widget _greetCard() {
+    return _DemoCard(
+      title: 'Greeting',
+      description:
+          'Invokes the greet function, which builds the message server-side. '
+          'POST sends the name in a JSON body; GET sends it as a query '
+          'parameter.',
+      children: [
+        TextField(
+          controller: _name,
+          decoration: const InputDecoration(labelText: 'Name'),
+        ),
+        CheckboxListTile(
+          value: _excited,
+          onChanged: (value) => setState(() => _excited = value ?? false),
+          title: const Text('Excited'),
+          controlAffinity: ListTileControlAffinity.leading,
+          contentPadding: EdgeInsets.zero,
+        ),
+        Row(
+          children: [
+            _RunButton(
+              label: 'Greet (POST)',
+              running: _running == 'greet-post',
+              onPressed: () => _invoke(
+                'greet-post',
+                () => _repository.greet(
+                  name: _name.text.trim(),
+                  excited: _excited,
+                ),
+                (result) => _greeting = result,
+              ),
+            ),
+            const SizedBox(width: 12),
+            _RunButton(
+              label: 'Greet (GET)',
+              filled: false,
+              running: _running == 'greet-get',
+              onPressed: () => _invoke(
+                'greet-get',
+                () => _repository.greetViaQuery(_name.text.trim()),
+                (result) => _greeting = result,
+              ),
+            ),
+          ],
+        ),
+        if (_greeting case final greeting?)
+          _Result(
+            '${greeting.message}\n'
+            'via ${greeting.method}, source "${greeting.source}"',
+          ),
+      ],
+    );
+  }
+
+  Widget _shoutCard() {
+    return _DemoCard(
+      title: 'Plain text',
+      description:
+          'Sends text to the shout function, which returns it uppercased as '
+          'text/plain. A plain-text response arrives as a Dart String.',
+      children: [
+        TextField(
+          controller: _shout,
+          decoration: const InputDecoration(labelText: 'Text to shout'),
+        ),
+        _RunButton(
+          label: 'Shout',
+          running: _running == 'shout',
+          onPressed: () => _invoke(
+            'shout',
+            () => _repository.shout(_shout.text),
+            (result) => _shoutResult = result,
+          ),
+        ),
+        if (_shoutResult case final result?) _Result(result),
+      ],
+    );
+  }
+
+  Widget _wordCountCard() {
+    return _DemoCard(
+      title: 'Validation and errors',
+      description:
+          'Sends text to the word-count function. Clearing the field makes it '
+          'respond with a 400, which surfaces as a FunctionException shown '
+          'below.',
+      children: [
+        TextField(
+          controller: _count,
+          decoration: const InputDecoration(labelText: 'Text to count'),
+        ),
+        _RunButton(
+          label: 'Count words',
+          running: _running == 'count',
+          onPressed: () => _invoke(
+            'count',
+            () => _repository.countWords(_count.text.trim()),
+            (result) => _wordCount = result,
+          ),
+        ),
+        if (_wordCount case final wordCount?)
+          _Result(
+            '${wordCount.words} words, ${wordCount.characters} characters',
+          ),
+      ],
+    );
+  }
+}
+
+class _DemoCard extends StatelessWidget {
+  const _DemoCard({
+    required this.title,
+    required this.description,
+    required this.children,
+  });
+
+  final String title;
+  final String description;
+  final List<Widget> children;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(title, style: theme.textTheme.titleLarge),
+            const SizedBox(height: 4),
+            Text(description, style: theme.textTheme.bodySmall),
+            const SizedBox(height: 12),
+            ...children,
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _RunButton extends StatelessWidget {
+  const _RunButton({
+    required this.label,
+    required this.running,
+    required this.onPressed,
+    this.filled = true,
+  });
+
+  final String label;
+  final bool running;
+  final VoidCallback onPressed;
+  final bool filled;
+
+  @override
+  Widget build(BuildContext context) {
+    final child = running
+        ? const SizedBox(
+            height: 18,
+            width: 18,
+            child: CircularProgressIndicator(strokeWidth: 2),
+          )
+        : Text(label);
+    final onPressedOrNull = running ? null : onPressed;
+    return filled
+        ? FilledButton(onPressed: onPressedOrNull, child: child)
+        : OutlinedButton(onPressed: onPressedOrNull, child: child);
+  }
+}
+
+class _Result extends StatelessWidget {
+  const _Result(this.text);
+
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      width: double.infinity,
+      margin: const EdgeInsets.only(top: 12),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surfaceContainerHighest,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Text(text, style: theme.textTheme.bodyMedium),
+    );
+  }
+}
+
+void _showError(Object error) {
+  // A function that responds with a non-2xx status throws a FunctionException.
+  // Its `details` hold the response body, which is the `{ "error": ... }` JSON
+  // the word-count function returns when validation fails.
+  String message;
+  if (error is FunctionException) {
+    final details = error.details;
+    message = details is Map && details['error'] is String
+        ? details['error'] as String
+        : 'Function failed with status ${error.status}';
+  } else {
+    message = error.toString();
+  }
+  messengerKey.currentState?.showSnackBar(
+    SnackBar(content: Text(message), backgroundColor: Colors.red),
+  );
+}

--- a/examples/edge_functions/lib/models.dart
+++ b/examples/edge_functions/lib/models.dart
@@ -1,0 +1,35 @@
+/// The JSON greeting returned by the `greet` Edge Function.
+class Greeting {
+  const Greeting({
+    required this.message,
+    required this.method,
+    required this.source,
+  });
+
+  factory Greeting.fromJson(Map<String, dynamic> json) => Greeting(
+    message: json['message'] as String,
+    // How the function was invoked (`GET` or `POST`), echoed back so the app can
+    // show that the same function was reached two different ways.
+    method: json['method'] as String,
+    // The `x-greeting-source` header the app sent, echoed back to show that
+    // custom headers reach the function.
+    source: json['source'] as String,
+  );
+
+  final String message;
+  final String method;
+  final String source;
+}
+
+/// The JSON result returned by the `word-count` Edge Function.
+class WordCount {
+  const WordCount({required this.words, required this.characters});
+
+  factory WordCount.fromJson(Map<String, dynamic> json) => WordCount(
+    words: json['words'] as int,
+    characters: json['characters'] as int,
+  );
+
+  final int words;
+  final int characters;
+}

--- a/examples/edge_functions/pubspec.yaml
+++ b/examples/edge_functions/pubspec.yaml
@@ -1,0 +1,27 @@
+name: edge_functions_example
+description: Demonstrates invoking Edge Functions using supabase_flutter.
+
+publish_to: 'none'
+
+version: 1.0.0+1
+
+environment:
+  sdk: '>=3.9.0 <4.0.0'
+  flutter: '>=3.35.0'
+
+resolution: workspace
+
+dependencies:
+  flutter:
+    sdk: flutter
+  supabase_flutter: ^2.17.0
+
+dev_dependencies:
+  supabase_lints: ^0.1.1
+  flutter_test:
+    sdk: flutter
+  integration_test:
+    sdk: flutter
+
+flutter:
+  uses-material-design: true

--- a/examples/edge_functions/web/index.html
+++ b/examples/edge_functions/web/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <base href="$FLUTTER_BASE_HREF">
+  <meta charset="UTF-8">
+  <meta content="IE=Edge" http-equiv="X-UA-Compatible">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+  <title>Supabase Edge Functions</title>
+</head>
+<body>
+  <script src="flutter_bootstrap.js" async></script>
+</body>
+</html>

--- a/examples/supabase/config.toml
+++ b/examples/supabase/config.toml
@@ -41,9 +41,22 @@ enabled = false
 [inbucket]
 enabled = false
 
-# Edge Functions runtime.
+# Edge Functions runtime, used by the edge_functions example. `supabase start`
+# serves every function under `supabase/functions/` while the stack is running.
 [edge_runtime]
-enabled = false
+enabled = true
+
+# The edge_functions example runs unauthenticated with the publishable (anon)
+# key, so JWT verification is turned off for its demo functions. A real app would
+# leave verify_jwt on and read the caller's user from the request.
+[functions.greet]
+verify_jwt = false
+
+[functions.shout]
+verify_jwt = false
+
+[functions.word-count]
+verify_jwt = false
 
 # Analytics (Logflare) and its log collector. Also avoids the Docker socket
 # mount that the vector container needs, which some runtimes (e.g. Colima)

--- a/examples/supabase/functions/greet/index.ts
+++ b/examples/supabase/functions/greet/index.ts
@@ -1,0 +1,31 @@
+// Greeting Edge Function for the edge_functions example.
+//
+// Builds a greeting server-side and returns it as JSON. The name is read from
+// the JSON body on a POST or from the `name` query parameter on a GET, so the
+// example can show both ways of calling `functions.invoke`. The response echoes
+// back how it was called (method and a custom header) so the app can display it.
+
+Deno.serve(async (req) => {
+  const url = new URL(req.url);
+
+  let name = url.searchParams.get("name") ?? "";
+  let excited = url.searchParams.get("excited") === "true";
+  if (req.method === "POST") {
+    const body = await req.json().catch(() => ({}));
+    if (typeof body.name === "string") name = body.name;
+    if (typeof body.excited === "boolean") excited = body.excited;
+  }
+  name = name.trim() || "world";
+
+  const message = `Hello, ${name}${excited ? "!!!" : "."}`;
+  const payload = {
+    message,
+    method: req.method,
+    // Echoing a custom header shows that headers set on the client reach here.
+    source: req.headers.get("x-greeting-source") ?? "unknown",
+  };
+
+  return new Response(JSON.stringify(payload), {
+    headers: { "Content-Type": "application/json" },
+  });
+});

--- a/examples/supabase/functions/shout/index.ts
+++ b/examples/supabase/functions/shout/index.ts
@@ -1,0 +1,12 @@
+// Text-transform Edge Function for the edge_functions example.
+//
+// Reads the raw request body as text and returns it uppercased with a
+// `text/plain` content type, so the example can show a function that responds
+// with plain text (surfaced as a Dart String) rather than JSON.
+
+Deno.serve(async (req) => {
+  const text = await req.text();
+  return new Response(text.toUpperCase(), {
+    headers: { "Content-Type": "text/plain" },
+  });
+});

--- a/examples/supabase/functions/word-count/index.ts
+++ b/examples/supabase/functions/word-count/index.ts
@@ -7,7 +7,8 @@
 
 Deno.serve(async (req) => {
   const body = await req.json().catch(() => ({}));
-  const text = typeof body.text === "string" ? body.text.trim() : "";
+  const rawText = typeof body.text === "string" ? body.text : "";
+  const text = rawText.trim();
 
   if (text.length === 0) {
     return new Response(
@@ -18,7 +19,10 @@ Deno.serve(async (req) => {
 
   const payload = {
     words: text.split(/\s+/).length,
-    characters: text.length,
+    // Count from the raw text so surrounding spaces are kept, and with
+    // Array.from so an emoji counts as one character rather than two UTF-16
+    // units.
+    characters: Array.from(rawText).length,
   };
   return new Response(JSON.stringify(payload), {
     headers: { "Content-Type": "application/json" },

--- a/examples/supabase/functions/word-count/index.ts
+++ b/examples/supabase/functions/word-count/index.ts
@@ -1,0 +1,26 @@
+// Validation Edge Function for the edge_functions example.
+//
+// Counts the words and characters in the posted text. When the text is missing
+// or empty it responds with a 400 and a JSON error body, so the example can show
+// how a non-2xx response surfaces in Dart as a FunctionException whose `details`
+// carry that body.
+
+Deno.serve(async (req) => {
+  const body = await req.json().catch(() => ({}));
+  const text = typeof body.text === "string" ? body.text.trim() : "";
+
+  if (text.length === 0) {
+    return new Response(
+      JSON.stringify({ error: "Provide some text to count." }),
+      { status: 400, headers: { "Content-Type": "application/json" } },
+    );
+  }
+
+  const payload = {
+    words: text.split(/\s+/).length,
+    characters: text.length,
+  };
+  return new Response(JSON.stringify(payload), {
+    headers: { "Content-Type": "application/json" },
+  });
+});

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,6 +19,7 @@ workspace:
   - packages/supabase_lints
   - packages/yet_another_json_isolate
   - examples/database_crud
+  - examples/edge_functions
   - examples/launcher
   - examples/passkeys
   - examples/storage_transforms


### PR DESCRIPTION
## What

Adds an `edge_functions` example under `examples/`, following the same structure as `database_crud` and `storage_transforms`. It demonstrates invoking Supabase Edge Functions with `supabase.functions.invoke(...)`:

- **JSON body over POST**, reading the JSON response back (`invoke('greet', body: {...})`).
- **GET with query parameters** instead of a body (`method: HttpMethod.get, queryParameters: {...}`).
- **Custom headers** sent to the function and echoed back (`headers: {...}`).
- **Plain text in and out**: a `String` body is sent as `text/plain` and the `text/plain` response arrives as a `String` (`invoke('shout', body: text)`).
- **Error handling**: a non-2xx response throws a `FunctionException` whose `details` carry the response body (`invoke('word-count', ...)`).

## How it's structured

- All Edge Function access lives in `lib/functions_repository.dart` (`FunctionsRepository`), kept separate from the UI so the calls are easy to read and to drive from tests. Models with `factory fromJson` live in `lib/models.dart`. The Material 3 UI in `lib/main.dart` stays thin.
- Three demo functions ship under `examples/supabase/functions/`: `greet`, `shout` and `word-count`.
- The Edge Runtime is enabled in `examples/supabase/config.toml`; `supabase start` serves the functions automatically. The demo functions set `verify_jwt = false` so the example can call them with just the publishable key, matching the other examples which run unauthenticated.
- The new package is registered in the workspace `pubspec.yaml` and listed in `examples/README.md`.

## Testing

- `dart format .` and `flutter analyze` are clean.
- `integration_test/functions_test.dart` was run against the local stack (`supabase start`) on web (Chrome 150) via `flutter drive`: **all tests passed**. It covers the repository flow (JSON greeting over POST and GET, plain-text transform, and a 400 validation error surfacing as a `FunctionException`) plus a UI smoke test.

A stacked PR (#1633) adds a full end-to-end suite covering the entire `functions.invoke` surface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new Flutter example showcasing Supabase Edge Functions (greeting via POST/GET, plain-text shout, and word-count).
  - Updated the example runtime configuration to support the added functions.
  - Included browser support and a complete on-screen UI for invoking and viewing results.

- **Documentation**
  - Added comprehensive README guidance and run steps, including how to execute the included integration test.

- **Tests**
  - Added an end-to-end integration test covering response formats, validation errors, and user-driven UI interactions.

- **Chores**
  - Added example-specific ignore rules for build artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->