### PR TITLE
test(examples): add full e2e suite for Edge Functions

### DIFF
--- a/examples/edge_functions/README.md
+++ b/examples/edge_functions/README.md
@@ -49,20 +49,29 @@ flutter run \
   --dart-define=SUPABASE_PUBLISHABLE_KEY=YOUR_PUBLISHABLE_KEY
 ```
 
-## Integration test
+## Integration tests
 
-[`integration_test/functions_test.dart`](integration_test/functions_test.dart)
-is an end-to-end test that runs against the local stack. It drives the flow
-through the repository (a JSON greeting over POST and GET, a plain-text
-transform, and a validation error that surfaces as a `FunctionException`) and
-drives the app widgets to greet through the UI.
+There are two end-to-end test files, both run against the local stack:
 
-With the local stack running, pass the same defines the app uses and run it on a
-device (integration tests need one, so `-d macos`, an emulator or a real
+- [`integration_test/functions_test.dart`](integration_test/functions_test.dart)
+  drives the flow through the repository (a JSON greeting over POST and GET, a
+  plain-text transform, and a validation error that surfaces as a
+  `FunctionException`) and drives the app widgets to greet through the UI.
+- [`integration_test/invoke_test.dart`](integration_test/invoke_test.dart)
+  covers the full surface of `functions.invoke`: every HTTP method, query
+  parameters, custom headers, JSON / text / binary / multipart request bodies, a
+  region, every response type (JSON, text, binary, an SSE `ByteStream`), custom
+  status codes, the three `FunctionException` variants and request aborting. It
+  drives an `echo` test-support function (in `../supabase/functions/echo`) that
+  reflects the request back in whatever shape a query parameter asks for. That
+  function is not used by the example UI.
+
+With the local stack running, pass the same defines the app uses and run them on
+a device (integration tests need one, so `-d macos`, an emulator or a real
 device):
 
 ```bash
-flutter test integration_test/functions_test.dart -d macos \
+flutter test integration_test -d macos \
   --dart-define=SUPABASE_URL=http://localhost:54321 \
   --dart-define=SUPABASE_PUBLISHABLE_KEY=YOUR_LOCAL_PUBLISHABLE_KEY
 ```

--- a/examples/edge_functions/integration_test/invoke_test.dart
+++ b/examples/edge_functions/integration_test/invoke_test.dart
@@ -1,0 +1,253 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+const supabaseUrl = String.fromEnvironment('SUPABASE_URL');
+const supabasePublishableKey = String.fromEnvironment(
+  'SUPABASE_PUBLISHABLE_KEY',
+);
+
+/// End-to-end suite covering the full surface of `functions.invoke` against the
+/// local stack.
+///
+/// It drives the `echo` test-support function, which reflects the request back
+/// as JSON (or returns text, binary, an SSE stream or a chosen status code,
+/// depending on its query parameters). Between them the tests exercise every
+/// request option (method, query, headers, JSON / text / binary / multipart
+/// bodies, region), every response type, custom status codes, the three
+/// `FunctionException` variants and request aborting.
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  late FunctionsClient functions;
+
+  setUpAll(() async {
+    await Supabase.initialize(
+      url: supabaseUrl,
+      publishableKey: supabasePublishableKey,
+    );
+    functions = Supabase.instance.client.functions;
+  });
+
+  tearDownAll(() async {
+    await Supabase.instance.dispose();
+  });
+
+  group('request', () {
+    testWidgets('POST sends a JSON body that comes back decoded', (_) async {
+      final response = await functions.invoke('echo', body: {'hello': 'world'});
+      expect(response.status, 200);
+      expect(response.data['method'], 'POST');
+      expect(response.data['body'], {'hello': 'world'});
+    });
+
+    testWidgets('GET sends query parameters instead of a body', (_) async {
+      final response = await functions.invoke(
+        'echo',
+        method: HttpMethod.get,
+        queryParameters: {'a': '1', 'b': '2'},
+      );
+      expect(response.data['method'], 'GET');
+      expect(response.data['query'], containsPair('a', '1'));
+      expect(response.data['query'], containsPair('b', '2'));
+    });
+
+    testWidgets('every HTTP method reaches the function', (_) async {
+      for (final method in HttpMethod.values) {
+        final response = await functions.invoke(
+          'echo',
+          method: method,
+          // GET and DELETE carry no body.
+          body: method == HttpMethod.get || method == HttpMethod.delete
+              ? null
+              : {'value': 1},
+        );
+        expect(response.data['method'], method.name.toUpperCase());
+      }
+    });
+
+    testWidgets('custom headers reach the function', (_) async {
+      final response = await functions.invoke(
+        'echo',
+        headers: const {'x-custom-header': 'from-test'},
+      );
+      expect(response.data['header'], 'from-test');
+    });
+
+    testWidgets('a String body is sent as text/plain', (_) async {
+      final response = await functions.invoke('echo', body: 'plain text body');
+      expect(response.data['body'], 'plain text body');
+    });
+
+    testWidgets('a Uint8List body is sent as binary', (_) async {
+      final response = await functions.invoke(
+        'echo',
+        body: Uint8List.fromList([1, 2, 3, 4]),
+      );
+      // The function reports how many bytes it received.
+      expect(response.data['body'], 4);
+    });
+
+    testWidgets('files are sent as a multipart request', (_) async {
+      final response = await functions.invoke(
+        'echo',
+        body: {'caption': 'hello'},
+        files: [
+          MultipartFile.fromString(
+            'upload',
+            'file contents',
+            filename: 'a.txt',
+          ),
+        ],
+      );
+      expect(response.data['fields'], containsPair('caption', 'hello'));
+      expect(response.data['files'], [
+        {'name': 'a.txt', 'size': 'file contents'.length},
+      ]);
+    });
+
+    testWidgets('a region adds the forceFunctionRegion query and x-region '
+        'header', (_) async {
+      final response = await functions.invoke('echo', region: 'us-east-1');
+      expect(
+        response.data['query'],
+        containsPair('forceFunctionRegion', 'us-east-1'),
+      );
+      expect(response.data['region'], 'us-east-1');
+    });
+  });
+
+  group('response', () {
+    testWidgets('a JSON response decodes to a Map', (_) async {
+      final response = await functions.invoke('echo');
+      expect(response.data, isA<Map<String, dynamic>>());
+    });
+
+    testWidgets('a text/plain response is a String', (_) async {
+      final response = await functions.invoke(
+        'echo',
+        queryParameters: {'format': 'text'},
+      );
+      expect(response.data, isA<String>());
+      expect(response.data, 'echo');
+    });
+
+    testWidgets('an octet-stream response is a Uint8List', (_) async {
+      final response = await functions.invoke(
+        'echo',
+        queryParameters: {'format': 'binary'},
+      );
+      expect(response.data, isA<Uint8List>());
+      expect(response.data, [1, 2, 3, 4, 5]);
+    });
+
+    testWidgets('an event-stream response is a readable ByteStream', (_) async {
+      final response = await functions.invoke(
+        'echo',
+        queryParameters: {'format': 'sse'},
+      );
+      expect(response.data, isA<ByteStream>());
+      final body = await (response.data as ByteStream)
+          .transform(const Utf8Decoder())
+          .join();
+      expect(body, contains('data: tick 1'));
+      expect(body, contains('data: tick 3'));
+    });
+
+    testWidgets('the response exposes a non-200 success status', (_) async {
+      final response = await functions.invoke(
+        'echo',
+        queryParameters: {'status': '201'},
+      );
+      expect(response.status, 201);
+    });
+  });
+
+  group('errors', () {
+    testWidgets('a non-2xx JSON response throws with a Map in details', (
+      _,
+    ) async {
+      await expectLater(
+        functions.invoke('echo', queryParameters: {'status': '422'}),
+        throwsA(
+          isA<FunctionsHttpException>()
+              .having((error) => error.status, 'status', 422)
+              .having(
+                (error) => (error.details as Map)['error'],
+                'details.error',
+                'boom',
+              ),
+        ),
+      );
+    });
+
+    testWidgets('a non-2xx text response throws with a String in details', (
+      _,
+    ) async {
+      await expectLater(
+        functions.invoke(
+          'echo',
+          queryParameters: {'status': '500', 'format': 'text'},
+        ),
+        throwsA(
+          isA<FunctionsHttpException>()
+              .having((error) => error.status, 'status', 500)
+              .having((error) => error.details, 'details', 'boom'),
+        ),
+      );
+    });
+
+    testWidgets('an unreachable function throws a FunctionsFetchException', (
+      _,
+    ) async {
+      // A client pointed at a closed port can never connect, so the request
+      // fails before any response, surfacing as a fetch exception with status 0.
+      final unreachable = FunctionsClient(
+        'http://127.0.0.1:1/functions/v1',
+        const {'apikey': supabasePublishableKey},
+      );
+      addTearDown(unreachable.dispose);
+      await expectLater(
+        unreachable.invoke('echo'),
+        throwsA(
+          isA<FunctionsFetchException>().having(
+            (error) => error.status,
+            'status',
+            0,
+          ),
+        ),
+      );
+    });
+  });
+
+  group('abort', () {
+    testWidgets('an already-completed abort signal cancels the request', (
+      _,
+    ) async {
+      final signal = Completer<void>()..complete();
+      await expectLater(
+        functions.invoke(
+          'echo',
+          queryParameters: {'delay': '2000'},
+          abortSignal: signal.future,
+        ),
+        throwsA(isA<RequestAbortedException>()),
+      );
+    });
+
+    testWidgets('an abort signal acts as a request timeout', (_) async {
+      await expectLater(
+        functions.invoke(
+          'echo',
+          queryParameters: {'delay': '3000'},
+          abortSignal: Future.delayed(const Duration(milliseconds: 300)),
+        ),
+        throwsA(isA<RequestAbortedException>()),
+      );
+    });
+  });
+}

--- a/examples/supabase/config.toml
+++ b/examples/supabase/config.toml
@@ -58,6 +58,11 @@ verify_jwt = false
 [functions.word-count]
 verify_jwt = false
 
+# Test-support function used only by the edge_functions integration suite, not
+# by the example UI.
+[functions.echo]
+verify_jwt = false
+
 # Analytics (Logflare) and its log collector. Also avoids the Docker socket
 # mount that the vector container needs, which some runtimes (e.g. Colima)
 # reject.

--- a/examples/supabase/functions/echo/index.ts
+++ b/examples/supabase/functions/echo/index.ts
@@ -1,0 +1,106 @@
+// Test-support Edge Function for the edge_functions integration suite.
+//
+// This function is not used by the example UI. It reflects the incoming request
+// back to the caller in whatever shape the `format` query parameter asks for, so
+// the tests can exercise the full surface of `functions.invoke`: every HTTP
+// method, query parameters, custom headers, JSON / text / binary / multipart
+// request bodies, JSON / text / binary / Server-Sent-Events responses, custom
+// status codes (including errors) and a delay for testing abort signals.
+
+Deno.serve(async (req) => {
+  const url = new URL(req.url);
+  const params = url.searchParams;
+
+  // Sleep first, so an abort signal can fire before anything is returned.
+  const delayMs = Number(params.get("delay") ?? "0");
+  if (delayMs > 0) {
+    await new Promise((resolve) => setTimeout(resolve, delayMs));
+  }
+
+  const status = Number(params.get("status") ?? "200");
+  const format = params.get("format") ?? "json";
+
+  if (status >= 400) {
+    // Error bodies come back as either JSON or text, matching the two ways the
+    // SDK surfaces `details` on a FunctionException.
+    if (format === "text") {
+      return new Response("boom", {
+        status,
+        headers: { "Content-Type": "text/plain" },
+      });
+    }
+    return new Response(JSON.stringify({ error: "boom", status }), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  if (format === "binary") {
+    // Raw bytes so the SDK returns a Uint8List.
+    return new Response(new Uint8Array([1, 2, 3, 4, 5]), {
+      status,
+      headers: { "Content-Type": "application/octet-stream" },
+    });
+  }
+
+  if (format === "sse") {
+    // A short Server-Sent-Events stream so the SDK returns a live ByteStream.
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream({
+      start(controller) {
+        for (let i = 1; i <= 3; i++) {
+          controller.enqueue(encoder.encode(`data: tick ${i}\n\n`));
+        }
+        controller.close();
+      },
+    });
+    return new Response(stream, {
+      status,
+      headers: { "Content-Type": "text/event-stream" },
+    });
+  }
+
+  if (format === "text") {
+    return new Response("echo", {
+      status,
+      headers: { "Content-Type": "text/plain" },
+    });
+  }
+
+  // Default: reflect the request as JSON.
+  const contentType = req.headers.get("content-type") ?? "";
+  let body: unknown = null;
+  const fields: Record<string, string> = {};
+  const files: { name: string; size: number }[] = [];
+
+  if (contentType.includes("multipart/form-data")) {
+    const form = await req.formData();
+    for (const [key, value] of form.entries()) {
+      if (value instanceof File) {
+        files.push({ name: value.name, size: value.size });
+      } else {
+        fields[key] = value;
+      }
+    }
+  } else if (contentType.includes("application/json")) {
+    body = await req.json().catch(() => null);
+  } else if (contentType.includes("application/octet-stream")) {
+    body = (await req.arrayBuffer()).byteLength;
+  } else if (req.method !== "GET" && req.method !== "DELETE") {
+    body = await req.text();
+  }
+
+  const payload = {
+    method: req.method,
+    query: Object.fromEntries(params.entries()),
+    header: req.headers.get("x-custom-header"),
+    region: req.headers.get("x-region"),
+    body,
+    fields,
+    files,
+  };
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+});


### PR DESCRIPTION
> Stacked on #1632. Review and merge that first; this PR targets its branch and the diff below is only the test suite.

## What

Adds a full end-to-end integration test suite for the `edge_functions` example, covering the entire surface of `functions.invoke`.

`integration_test/invoke_test.dart` exercises:

**Request**
- POST with a JSON body (decoded on the round trip)
- GET with query parameters
- Every `HttpMethod` (GET, POST, PUT, DELETE, PATCH)
- Custom headers
- `String` body sent as `text/plain`
- `Uint8List` body sent as binary
- `MultipartFile` uploads (`files:`) with form fields
- `region` (adds the `forceFunctionRegion` query and `x-region` header)

**Response**
- JSON decoded to a `Map`
- `text/plain` as a `String`
- `application/octet-stream` as a `Uint8List`
- `text/event-stream` as a readable `ByteStream` (SSE)
- Non-200 success status on `FunctionResponse.status`

**Errors**
- `FunctionsHttpException` on a non-2xx JSON response (Map in `details`)
- `FunctionsHttpException` on a non-2xx text response (String in `details`)
- `FunctionsFetchException` when the function is unreachable

**Abort**
- An already-completed `abortSignal` cancels the request (`RequestAbortedException`)
- An `abortSignal` used as a request timeout

## How

The suite drives a new `echo` test-support function (`examples/supabase/functions/echo`) that reflects the request back in whatever shape a query parameter asks for (JSON reflection, text, binary, SSE, or a chosen status code). It is not used by the example UI and has `verify_jwt = false` like the other demo functions.

## Testing

- `dart format .` and `flutter analyze` are clean.
- The suite was run against the local stack (`supabase start`) on web (Chrome 150) via `flutter drive`: **all tests passed**, including the binary, multipart, SSE `ByteStream` and abort cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive end-to-end coverage for Edge Function invocation, including request methods, payload formats, headers, regions, response types, errors, timeouts, and cancellation.
  * Updated integration test documentation and commands to run the full test suite.

* **New Features**
  * Added an echo Edge Function for validating JSON, text, binary, multipart, streaming, and error responses.
  * Added configuration for the new echo function.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->