### PR TITLE
feat(typegen): add supabase_typegen skeleton package

### DIFF
--- a/.github/workflows/release-pana.yml
+++ b/.github/workflows/release-pana.yml
@@ -33,6 +33,7 @@ jobs:
           - supabase
           - supabase_common
           - supabase_flutter
+          - supabase_typegen
           - yet_another_json_isolate
     steps:
       - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -337,7 +337,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           parallel-finished: true
-          carryforward: 'functions_client,gotrue,postgrest,realtime_client,storage_client,supabase,supabase_common,yet_another_json_isolate,supabase_flutter'
+          carryforward: 'functions_client,gotrue,postgrest,realtime_client,storage_client,supabase,supabase_common,supabase_typegen,yet_another_json_isolate,supabase_flutter'
           fail-on-error: false
 
   test-result:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,7 +64,7 @@ jobs:
           echo "Affected packages:"
           echo "$CHANGED"
 
-          DART_PACKAGES="functions_client gotrue postgrest realtime_client storage_client supabase supabase_common yet_another_json_isolate"
+          DART_PACKAGES="functions_client gotrue postgrest realtime_client storage_client supabase supabase_common supabase_typegen yet_another_json_isolate"
 
           entries=()
           for package in $DART_PACKAGES; do

--- a/.sdk-parse-ignore
+++ b/.sdk-parse-ignore
@@ -14,6 +14,10 @@
 # consumers). Exclude the whole package from the public-API scan instead.
 packages/supabase_common/
 
+# supabase_typegen is a development-time code generator, not SDK client surface,
+# so its public symbols are not capability-matrix symbols.
+packages/supabase_typegen/
+
 # The examples are standalone demo apps, not part of the published SDK, so their
 # public classes are not capability-matrix symbols.
 examples/

--- a/packages/supabase_typegen/CHANGELOG.md
+++ b/packages/supabase_typegen/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 0.1.0
+
+ - Initial placeholder release reserving the `supabase_typegen` package name.

--- a/packages/supabase_typegen/LICENSE
+++ b/packages/supabase_typegen/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 Supabase Community
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/supabase_typegen/LICENSE
+++ b/packages/supabase_typegen/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 Supabase Community
+Copyright (c) 2026 Supabase Community
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/supabase_typegen/README.md
+++ b/packages/supabase_typegen/README.md
@@ -1,0 +1,10 @@
+# supabase_typegen
+
+> [!WARNING]
+> This is a placeholder release that reserves the package name on pub.dev. The
+> code generator is still under development and this version does nothing yet.
+
+A command-line code generator that turns a Supabase database schema into typed
+Dart table definitions for use with the Supabase client packages.
+
+The generator implementation will land in a future release.

--- a/packages/supabase_typegen/analysis_options.yaml
+++ b/packages/supabase_typegen/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:supabase_lints/analysis_options.yaml

--- a/packages/supabase_typegen/lib/supabase_typegen.dart
+++ b/packages/supabase_typegen/lib/supabase_typegen.dart
@@ -1,0 +1,6 @@
+/// Command-line code generator that turns a Supabase database schema into
+/// typed Dart table definitions.
+///
+/// This is a placeholder release that reserves the package name. The generator
+/// implementation is not available yet.
+library;

--- a/packages/supabase_typegen/pubspec.yaml
+++ b/packages/supabase_typegen/pubspec.yaml
@@ -1,0 +1,19 @@
+name: supabase_typegen
+description: Command-line code generator that turns a Supabase database schema into typed Dart table definitions.
+version: 0.1.0
+homepage: 'https://supabase.com'
+repository: 'https://github.com/supabase/supabase-flutter/tree/main/packages/supabase_typegen'
+issue_tracker: 'https://github.com/supabase/supabase-flutter/issues'
+topics:
+  - supabase
+  - codegen
+  - postgres
+
+environment:
+  sdk: '>=3.9.0 <4.0.0'
+
+resolution: workspace
+
+dev_dependencies:
+  supabase_lints: ^0.1.1
+  test: ^1.25.0

--- a/packages/supabase_typegen/test/supabase_typegen_test.dart
+++ b/packages/supabase_typegen/test/supabase_typegen_test.dart
@@ -1,0 +1,7 @@
+import 'package:test/test.dart';
+
+void main() {
+  test('supabase_typegen placeholder', () {
+    expect(true, isTrue);
+  });
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,6 +17,7 @@ workspace:
   - packages/supabase_flutter/example
   - packages/supabase_common
   - packages/supabase_lints
+  - packages/supabase_typegen
   - packages/yet_another_json_isolate
   - examples/authentication
   - examples/database_crud


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature. Adds an empty skeleton for a new `supabase_typegen` package so we can publish it to pub.dev and reserve the name.

The full generator implementation lands separately in #1635; this PR intentionally contains only the minimal publishable placeholder.

## What is the new behavior?

A new `packages/supabase_typegen` package containing:

- a publishable `pubspec.yaml` (version `0.1.0`, no `publish_to: none`) so the melos release pipeline picks it up,
- a placeholder library, `README`, `CHANGELOG` and `LICENSE`,
- `supabase_lints` wired in via `analysis_options.yaml` (analyzes clean).

It is wired into:

- the root workspace in `pubspec.yaml`,
- the Dart CI test matrix in `test.yml`,
- the pana release matrix in `release-pana.yml`,
- the SDK compliance parse ignore (`.sdk-parse-ignore`), since it is a development-time tool rather than SDK client surface.

## Additional context

The README and CHANGELOG flag `0.1.0` as a name-reserving placeholder; the generator implementation will replace it in a later release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `supabase_typegen` package placeholder (v0.1.0) to generate typed Dart table definitions from Supabase schemas.
* **Documentation**
  * Added initial README and changelog entries documenting current placeholder status and reserved pub.dev name.
* **CI / Chores**
  * Updated release and test workflows to run checks for `supabase_typegen` when relevant, including coverage carryforward.
  * Excluded `supabase_typegen` from SDK public API scanning (development-time generator).
* **Legal**
  * Added the MIT license for the new package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->