### PR TITLE
docs(postgrest): document that order() defaults to descending

### DIFF
--- a/packages/postgrest/lib/src/postgrest_transform_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_transform_builder.dart
@@ -68,15 +68,30 @@ class PostgrestTransformBuilder<T> extends RawPostgrestBuilder<T, T, T> {
 
   /// Orders the result with the specified [column].
   ///
-  /// When [ascending] is true, the result will be in ascending order.
-  /// When [nullsFirst] is true, `null`s appear first.
+  /// [ascending] defaults to `false`, so results come back in **descending**
+  /// order unless `ascending: true` is passed. Note that this is the opposite
+  /// of SQL's `ORDER BY` and of `postgrest-js`, where ascending is the default.
+  ///
+  /// [nullsFirst] defaults to `false`, so `null`s appear last.
+  ///
   /// ```dart
+  /// // Descending — the default.
   /// final data = await supabase
   ///     .from('users')
   ///     .select()
-  ///     .order('username', ascending: false);
-  /// ````
+  ///     .order('username');
+  /// ```
+  ///
+  /// ```dart
+  /// // Ascending has to be requested explicitly.
+  /// final data = await supabase
+  ///     .from('users')
+  ///     .select()
+  ///     .order('username', ascending: true);
+  /// ```
+  ///
   /// If [column] is a referenced table column, [referencedTable] has to be set
+  ///
   /// ```dart
   /// final data = await supabase
   ///     .from('users')


### PR DESCRIPTION
## What kind of change does this PR introduce?

Documentation.

## What is the current behavior?

`order()` declares `bool ascending = false`, so a call that omits the parameter
returns rows in **descending** order. The doc comment never states this. It only
says:

> When [ascending] is true, the result will be in ascending order.

Both examples in the doc comment then pass `ascending: false` explicitly, which
suggests the opposite — that the parameter has to be passed to get descending
order, and that omitting it yields ascending.

This is easy to get wrong, because the default is inverted relative to two things
a developer is likely to expect:

- SQL's `ORDER BY`, which defaults to `ASC`
- `postgrest-js`, where `order()` destructures `{ ascending = true }`

The failure is silent: the query succeeds and returns data, just in the wrong
order. In my case it survived unit tests and only surfaced when a historical
backfill read a series inverted.

There is also a small rendering bug in the same doc comment — the first code
fence is closed with four backticks instead of three, which breaks the block in
generated dartdoc.

## What is the new behavior?

- The doc comment states the defaults for `ascending` and `nullsFirst`
  explicitly, and notes the divergence from SQL and `postgrest-js`.
- The first example now omits `ascending`, showing the actual default; a second
  example shows how to request ascending order.
- The stray fourth backtick is fixed.

Doc comment only — no behavioural change. Changing the default itself would be
breaking and is deliberately not proposed here.

## Additional context

Happy to open a follow-up for the equivalent JSDoc in `postgrest-js`, which
likewise does not state its default. Let me know if that would be useful.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that descending order and nulls-last behavior are the defaults for ordering.
  * Added examples demonstrating how to explicitly request ascending order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->