### PR TITLE
refactor(supabase): rename stream regex filters and cover stream filters with tests

### DIFF
--- a/packages/supabase/lib/src/supabase_query_builder.dart
+++ b/packages/supabase/lib/src/supabase_query_builder.dart
@@ -24,7 +24,8 @@ class SupabaseQueryBuilder extends PostgrestQueryBuilder<dynamic> {
        );
 
   /// Combines the current state of your table from PostgREST with changes from
-  /// the realtime server to return real-time data from your table as a [Stream].
+  /// the realtime server to return real-time data from your table as a
+  /// [Stream].
   ///
   /// Realtime is disabled by default for new tables. You can turn it on by
   /// [managing replication](https://supabase.com/docs/guides/realtime/subscribing-to-database-changes#enable-postgres-changes).
@@ -57,7 +58,10 @@ class SupabaseQueryBuilder extends PostgrestQueryBuilder<dynamic> {
   ///   the documentation about [receiving old records](https://supabase.com/docs/guides/realtime/postgres-changes?queryGroups=language&language=dart#receiving-old-records).
   ///
   /// ```dart
-  /// supabase.from('chats').stream(primaryKey: ['id']).listen(_onChatsReceived);
+  /// supabase
+  ///     .from('chats')
+  ///     .stream(primaryKey: ['id'])
+  ///     .listen(_onChatsReceived);
   /// ```
   ///
   /// `eq`, `neq`, `lt`, `lte`, `gt`, `gte`, `inFilter`, `like`, `ilike`,
@@ -66,11 +70,22 @@ class SupabaseQueryBuilder extends PostgrestQueryBuilder<dynamic> {
   /// `order` and `limit` are available to sort and cap the result.
   ///
   /// ```dart
-  /// supabase.from('chats').stream(primaryKey: ['id']).eq('room_id','123').order('created_at').limit(20).listen(_onChatsReceived);
+  /// supabase
+  ///     .from('chats')
+  ///     .stream(primaryKey: ['id'])
+  ///     .eq('room_id', '123')
+  ///     .order('created_at')
+  ///     .limit(20)
+  ///     .listen(_onChatsReceived);
   /// ```
   ///
   /// ```dart
-  /// supabase.from('chats').stream(primaryKey: ['id']).eq('room_id','123').like('message', '%supabase%').listen(_onChatsReceived);
+  /// supabase
+  ///     .from('chats')
+  ///     .stream(primaryKey: ['id'])
+  ///     .eq('room_id', '123')
+  ///     .like('message', '%supabase%')
+  ///     .listen(_onChatsReceived);
   /// ```
   SupabaseStreamFilterBuilder stream({
     required List<String> primaryKey,

--- a/packages/supabase/lib/src/supabase_query_builder.dart
+++ b/packages/supabase/lib/src/supabase_query_builder.dart
@@ -50,19 +50,27 @@ class SupabaseQueryBuilder extends PostgrestQueryBuilder<dynamic> {
   ///   will be received. Therefore, an update that changes a record to no
   ///   longer match the filter will not be received, and the record will remain
   ///   in the stream.
-  /// - By default, for DELETE events only the primary key columns can be used.
-  ///   Refer to the documentation about [receiving old records](https://supabase.com/docs/guides/realtime/postgres-changes?queryGroups=language&language=dart#receiving-old-records).
+  /// - By default, the old record of a DELETE event only contains the primary
+  ///   key columns, so a filter on any other column never matches and the
+  ///   deleted record remains in the stream. Set the replica identity of the
+  ///   table to `full` to filter deletions on other columns as well. Refer to
+  ///   the documentation about [receiving old records](https://supabase.com/docs/guides/realtime/postgres-changes?queryGroups=language&language=dart#receiving-old-records).
   ///
   /// ```dart
   /// supabase.from('chats').stream(primaryKey: ['id']).listen(_onChatsReceived);
   /// ```
   ///
-  /// `eq`, `neq`, `lt`, `lte`, `gt` `gte`, `like`, `ilike`, `match`, `imatch`,
-  /// `isDistinct`, `isFilter` or `inFilter` and `order`, `limit` filter are available to limit the
-  /// data being queried.
+  /// `eq`, `neq`, `lt`, `lte`, `gt`, `gte`, `inFilter`, `like`, `ilike`,
+  /// `matchRegex`, `imatchRegex`, `isFilter` and `isDistinct` are available to
+  /// limit the data being queried. Multiple filters are combined with an `AND`.
+  /// `order` and `limit` are available to sort and cap the result.
   ///
   /// ```dart
   /// supabase.from('chats').stream(primaryKey: ['id']).eq('room_id','123').order('created_at').limit(20).listen(_onChatsReceived);
+  /// ```
+  ///
+  /// ```dart
+  /// supabase.from('chats').stream(primaryKey: ['id']).eq('room_id','123').like('message', '%supabase%').listen(_onChatsReceived);
   /// ```
   SupabaseStreamFilterBuilder stream({
     required List<String> primaryKey,

--- a/packages/supabase/lib/src/supabase_stream_builder.dart
+++ b/packages/supabase/lib/src/supabase_stream_builder.dart
@@ -58,8 +58,8 @@ class SupabaseStreamBuilder extends Stream<SupabaseStreamEvent> {
   /// Contains the combined data of postgrest and realtime to emit as stream.
   SupabaseStreamEvent _streamData = [];
 
-  /// Filters to be applied to the stream
-  final List<_StreamPostgrestFilter> _streamFilter = [];
+  /// Filters to be applied to the stream, combined with an `AND`
+  final List<_StreamPostgrestFilter> _streamFilters = [];
 
   /// Which column to order by and whether it's ascending
   _Order? _orderBy;
@@ -147,7 +147,7 @@ class SupabaseStreamBuilder extends Stream<SupabaseStreamEvent> {
 
   void _getStreamData() {
     _streamData = [];
-    List<PostgresChangeFilter> realtimeFilter = _streamFilter
+    final realtimeFilters = _streamFilters
         .map(
           (filter) => PostgresChangeFilter(
             column: filter.column,
@@ -169,7 +169,7 @@ class SupabaseStreamBuilder extends Stream<SupabaseStreamEvent> {
           event: PostgresChangeEvent.all,
           schema: _schema,
           table: _table,
-          filters: realtimeFilter,
+          filters: realtimeFilters,
           callback: (payload) {
             switch (payload.eventType) {
               case PostgresChangeEvent.insert:
@@ -225,7 +225,7 @@ class SupabaseStreamBuilder extends Stream<SupabaseStreamEvent> {
 
   Future<void> _getPostgrestData() async {
     PostgrestFilterBuilder<PostgrestList> query = _queryBuilder.select();
-    for (final filter in _streamFilter) {
+    for (final filter in _streamFilters) {
       query = switch (filter.type) {
         PostgresChangeFilterType.eq => query.eq(
           filter.column,

--- a/packages/supabase/lib/src/supabase_stream_filter_builder.dart
+++ b/packages/supabase/lib/src/supabase_stream_filter_builder.dart
@@ -98,7 +98,10 @@ class SupabaseStreamFilterBuilder extends SupabaseStreamBuilder {
   /// Filters the results where [column] is included in [values].
   ///
   /// ```dart
-  /// supabase.from('users').stream(primaryKey: ['id']).inFilter('name', ['Andy', 'Amy', 'Terry']);
+  /// supabase
+  ///     .from('users')
+  ///     .stream(primaryKey: ['id'])
+  ///     .inFilter('name', ['Andy', 'Amy', 'Terry']);
   /// ```
   SupabaseStreamFilterBuilder inFilter(String column, List<Object> values) {
     _streamFilters.add((
@@ -141,7 +144,10 @@ class SupabaseStreamFilterBuilder extends SupabaseStreamBuilder {
   /// expression [pattern] case-sensitive.
   ///
   /// ```dart
-  /// supabase.from('users').stream(primaryKey: ['id']).matchRegex('slug', r'^post-\d+$');
+  /// supabase
+  ///     .from('users')
+  ///     .stream(primaryKey: ['id'])
+  ///     .matchRegex('slug', r'^post-\d+$');
   /// ```
   SupabaseStreamFilterBuilder matchRegex(String column, String pattern) {
     _streamFilters.add((
@@ -156,7 +162,10 @@ class SupabaseStreamFilterBuilder extends SupabaseStreamBuilder {
   /// expression [pattern] case-insensitive.
   ///
   /// ```dart
-  /// supabase.from('users').stream(primaryKey: ['id']).imatchRegex('slug', r'^post-\d+$');
+  /// supabase
+  ///     .from('users')
+  ///     .stream(primaryKey: ['id'])
+  ///     .imatchRegex('slug', r'^post-\d+$');
   /// ```
   SupabaseStreamFilterBuilder imatchRegex(String column, String pattern) {
     _streamFilters.add((

--- a/packages/supabase/lib/src/supabase_stream_filter_builder.dart
+++ b/packages/supabase/lib/src/supabase_stream_filter_builder.dart
@@ -17,7 +17,7 @@ class SupabaseStreamFilterBuilder extends SupabaseStreamBuilder {
   /// supabase.from('users').stream(primaryKey: ['id']).eq('name', 'Supabase');
   /// ```
   SupabaseStreamFilterBuilder eq(String column, Object value) {
-    _streamFilter.add((
+    _streamFilters.add((
       type: PostgresChangeFilterType.eq,
       column: column,
       value: value,
@@ -31,7 +31,7 @@ class SupabaseStreamFilterBuilder extends SupabaseStreamBuilder {
   /// supabase.from('users').stream(primaryKey: ['id']).neq('name', 'Supabase');
   /// ```
   SupabaseStreamFilterBuilder neq(String column, Object value) {
-    _streamFilter.add((
+    _streamFilters.add((
       type: PostgresChangeFilterType.neq,
       column: column,
       value: value,
@@ -45,7 +45,7 @@ class SupabaseStreamFilterBuilder extends SupabaseStreamBuilder {
   /// supabase.from('users').stream(primaryKey: ['id']).lt('likes', 100);
   /// ```
   SupabaseStreamFilterBuilder lt(String column, Object value) {
-    _streamFilter.add((
+    _streamFilters.add((
       type: PostgresChangeFilterType.lt,
       column: column,
       value: value,
@@ -59,7 +59,7 @@ class SupabaseStreamFilterBuilder extends SupabaseStreamBuilder {
   /// supabase.from('users').stream(primaryKey: ['id']).lte('likes', 100);
   /// ```
   SupabaseStreamFilterBuilder lte(String column, Object value) {
-    _streamFilter.add((
+    _streamFilters.add((
       type: PostgresChangeFilterType.lte,
       column: column,
       value: value,
@@ -73,7 +73,7 @@ class SupabaseStreamFilterBuilder extends SupabaseStreamBuilder {
   /// supabase.from('users').stream(primaryKey: ['id']).gt('likes', '100');
   /// ```
   SupabaseStreamFilterBuilder gt(String column, Object value) {
-    _streamFilter.add((
+    _streamFilters.add((
       type: PostgresChangeFilterType.gt,
       column: column,
       value: value,
@@ -87,7 +87,7 @@ class SupabaseStreamFilterBuilder extends SupabaseStreamBuilder {
   /// supabase.from('users').stream(primaryKey: ['id']).gte('likes', 100);
   /// ```
   SupabaseStreamFilterBuilder gte(String column, Object value) {
-    _streamFilter.add((
+    _streamFilters.add((
       type: PostgresChangeFilterType.gte,
       column: column,
       value: value,
@@ -101,7 +101,7 @@ class SupabaseStreamFilterBuilder extends SupabaseStreamBuilder {
   /// supabase.from('users').stream(primaryKey: ['id']).inFilter('name', ['Andy', 'Amy', 'Terry']);
   /// ```
   SupabaseStreamFilterBuilder inFilter(String column, List<Object> values) {
-    _streamFilter.add((
+    _streamFilters.add((
       type: PostgresChangeFilterType.inFilter,
       column: column,
       value: values,
@@ -115,7 +115,7 @@ class SupabaseStreamFilterBuilder extends SupabaseStreamBuilder {
   /// supabase.from('users').stream(primaryKey: ['id']).like('title', '%foo%');
   /// ```
   SupabaseStreamFilterBuilder like(String column, String pattern) {
-    _streamFilter.add((
+    _streamFilters.add((
       type: PostgresChangeFilterType.like,
       column: column,
       value: pattern,
@@ -129,7 +129,7 @@ class SupabaseStreamFilterBuilder extends SupabaseStreamBuilder {
   /// supabase.from('users').stream(primaryKey: ['id']).ilike('title', '%foo%');
   /// ```
   SupabaseStreamFilterBuilder ilike(String column, String pattern) {
-    _streamFilter.add((
+    _streamFilters.add((
       type: PostgresChangeFilterType.ilike,
       column: column,
       value: pattern,
@@ -137,30 +137,32 @@ class SupabaseStreamFilterBuilder extends SupabaseStreamBuilder {
     return this;
   }
 
-  /// Filters the results where [column] matches the POSIX [regex] case-sensitive.
+  /// Filters the results where [column] matches the PostgreSQL regular
+  /// expression [pattern] case-sensitive.
   ///
   /// ```dart
-  /// supabase.from('users').stream(primaryKey: ['id']).match('slug', r'^post-\d+$');
+  /// supabase.from('users').stream(primaryKey: ['id']).matchRegex('slug', r'^post-\d+$');
   /// ```
-  SupabaseStreamFilterBuilder match(String column, String regex) {
-    _streamFilter.add((
+  SupabaseStreamFilterBuilder matchRegex(String column, String pattern) {
+    _streamFilters.add((
       type: PostgresChangeFilterType.match,
       column: column,
-      value: regex,
+      value: pattern,
     ));
     return this;
   }
 
-  /// Filters the results where [column] matches the POSIX [regex] case-insensitive.
+  /// Filters the results where [column] matches the PostgreSQL regular
+  /// expression [pattern] case-insensitive.
   ///
   /// ```dart
-  /// supabase.from('users').stream(primaryKey: ['id']).imatch('slug', r'^post-\d+$');
+  /// supabase.from('users').stream(primaryKey: ['id']).imatchRegex('slug', r'^post-\d+$');
   /// ```
-  SupabaseStreamFilterBuilder imatch(String column, String regex) {
-    _streamFilter.add((
+  SupabaseStreamFilterBuilder imatchRegex(String column, String pattern) {
+    _streamFilters.add((
       type: PostgresChangeFilterType.imatch,
       column: column,
-      value: regex,
+      value: pattern,
     ));
     return this;
   }
@@ -171,7 +173,7 @@ class SupabaseStreamFilterBuilder extends SupabaseStreamBuilder {
   /// supabase.from('users').stream(primaryKey: ['id']).isFilter('data', null);
   /// ```
   SupabaseStreamFilterBuilder isFilter(String column, bool? value) {
-    _streamFilter.add((
+    _streamFilters.add((
       type: PostgresChangeFilterType.isFilter,
       column: column,
       value: value,
@@ -186,7 +188,7 @@ class SupabaseStreamFilterBuilder extends SupabaseStreamBuilder {
   /// supabase.from('users').stream(primaryKey: ['id']).isDistinct('age', null);
   /// ```
   SupabaseStreamFilterBuilder isDistinct(String column, Object? value) {
-    _streamFilter.add((
+    _streamFilters.add((
       type: PostgresChangeFilterType.isDistinct,
       column: column,
       value: value,

--- a/packages/supabase/test/stream_filter_test.dart
+++ b/packages/supabase/test/stream_filter_test.dart
@@ -121,100 +121,101 @@ typedef _TestCase = ({
   Map<String, String> restQuery,
 });
 
-const _testCases = <_TestCase>[
+final _testCases = <_TestCase>[
   (
     name: 'without filters no filter is sent',
-    filter: _noFilter,
+    filter: (stream) => stream,
     realtimeFilter: null,
     restQuery: {'select': '*'},
   ),
   (
     name: 'eq',
-    filter: _eq,
+    filter: (stream) => stream.eq('status', 'ONLINE'),
     realtimeFilter: 'status=eq.ONLINE',
     restQuery: {'select': '*', 'status': 'eq.ONLINE'},
   ),
   (
     name: 'neq',
-    filter: _neq,
+    filter: (stream) => stream.neq('status', 'ONLINE'),
     realtimeFilter: 'status=neq.ONLINE',
     restQuery: {'select': '*', 'status': 'neq.ONLINE'},
   ),
   (
     name: 'lt',
-    filter: _lt,
+    filter: (stream) => stream.lt('age', 20),
     realtimeFilter: 'age=lt.20',
     restQuery: {'select': '*', 'age': 'lt.20'},
   ),
   (
     name: 'lte',
-    filter: _lte,
+    filter: (stream) => stream.lte('age', 20),
     realtimeFilter: 'age=lte.20',
     restQuery: {'select': '*', 'age': 'lte.20'},
   ),
   (
     name: 'gt',
-    filter: _gt,
+    filter: (stream) => stream.gt('age', 20),
     realtimeFilter: 'age=gt.20',
     restQuery: {'select': '*', 'age': 'gt.20'},
   ),
   (
     name: 'gte',
-    filter: _gte,
+    filter: (stream) => stream.gte('age', 20),
     realtimeFilter: 'age=gte.20',
     restQuery: {'select': '*', 'age': 'gte.20'},
   ),
   (
     name: 'inFilter',
-    filter: _inFilter,
+    filter: (stream) => stream.inFilter('status', ['ONLINE', 'OFFLINE']),
     realtimeFilter: 'status=in.(ONLINE,OFFLINE)',
     restQuery: {'select': '*', 'status': 'in.("ONLINE","OFFLINE")'},
   ),
   (
     name: 'like',
-    filter: _like,
+    filter: (stream) => stream.like('username', '%supa%'),
     realtimeFilter: 'username=like.%supa%',
     restQuery: {'select': '*', 'username': 'like.%supa%'},
   ),
   (
     name: 'ilike',
-    filter: _ilike,
+    filter: (stream) => stream.ilike('username', '%SUPA%'),
     realtimeFilter: 'username=ilike.%SUPA%',
     restQuery: {'select': '*', 'username': 'ilike.%SUPA%'},
   ),
   (
     name: 'matchRegex',
-    filter: _matchRegex,
+    filter: (stream) => stream.matchRegex('username', '^supa.*'),
     realtimeFilter: 'username=match.^supa.*',
     restQuery: {'select': '*', 'username': 'match.^supa.*'},
   ),
   (
     name: 'imatchRegex',
-    filter: _imatchRegex,
+    filter: (stream) => stream.imatchRegex('username', '^SUPA.*'),
     realtimeFilter: 'username=imatch.^SUPA.*',
     restQuery: {'select': '*', 'username': 'imatch.^SUPA.*'},
   ),
   (
     name: 'isFilter with null',
-    filter: _isFilterNull,
+    filter: (stream) => stream.isFilter('data', null),
     realtimeFilter: 'data=is.null',
     restQuery: {'select': '*', 'data': 'is.null'},
   ),
   (
     name: 'isFilter with a boolean',
-    filter: _isFilterTrue,
+    filter: (stream) => stream.isFilter('confirmed', true),
     realtimeFilter: 'confirmed=is.true',
     restQuery: {'select': '*', 'confirmed': 'is.true'},
   ),
   (
     name: 'isDistinct',
-    filter: _isDistinct,
+    filter: (stream) => stream.isDistinct('status', 'ONLINE'),
     realtimeFilter: 'status=isdistinct.ONLINE',
     restQuery: {'select': '*', 'status': 'isdistinct.ONLINE'},
   ),
   (
     name: 'multiple filters are combined with a comma',
-    filter: _eqAndLike,
+    filter: (stream) =>
+        stream.eq('status', 'ONLINE').like('username', '%supa%'),
     realtimeFilter: 'status=eq.ONLINE,username=like.%supa%',
     restQuery: {
       'select': '*',
@@ -224,7 +225,9 @@ const _testCases = <_TestCase>[
   ),
   (
     name: 'the values of an inFilter are not confused with further filters',
-    filter: _inFilterAndLike,
+    filter: (stream) => stream
+        .inFilter('status', ['ONLINE', 'OFFLINE'])
+        .like('username', '%supa%'),
     realtimeFilter: 'status=in.(ONLINE,OFFLINE),username=like.%supa%',
     restQuery: {
       'select': '*',
@@ -237,64 +240,11 @@ const _testCases = <_TestCase>[
   // query parameter, where quoting would become part of the value.
   (
     name: 'a value with a comma is only quoted for realtime',
-    filter: _eqWithComma,
+    filter: (stream) => stream.eq('username', 'supa,bot'),
     realtimeFilter: 'username=eq."supa,bot"',
     restQuery: {'select': '*', 'username': 'eq.supa,bot'},
   ),
 ];
-
-SupabaseStreamBuilder _noFilter(SupabaseStreamFilterBuilder stream) => stream;
-
-SupabaseStreamBuilder _eq(SupabaseStreamFilterBuilder stream) =>
-    stream.eq('status', 'ONLINE');
-
-SupabaseStreamBuilder _neq(SupabaseStreamFilterBuilder stream) =>
-    stream.neq('status', 'ONLINE');
-
-SupabaseStreamBuilder _lt(SupabaseStreamFilterBuilder stream) =>
-    stream.lt('age', 20);
-
-SupabaseStreamBuilder _lte(SupabaseStreamFilterBuilder stream) =>
-    stream.lte('age', 20);
-
-SupabaseStreamBuilder _gt(SupabaseStreamFilterBuilder stream) =>
-    stream.gt('age', 20);
-
-SupabaseStreamBuilder _gte(SupabaseStreamFilterBuilder stream) =>
-    stream.gte('age', 20);
-
-SupabaseStreamBuilder _inFilter(SupabaseStreamFilterBuilder stream) =>
-    stream.inFilter('status', ['ONLINE', 'OFFLINE']);
-
-SupabaseStreamBuilder _like(SupabaseStreamFilterBuilder stream) =>
-    stream.like('username', '%supa%');
-
-SupabaseStreamBuilder _ilike(SupabaseStreamFilterBuilder stream) =>
-    stream.ilike('username', '%SUPA%');
-
-SupabaseStreamBuilder _matchRegex(SupabaseStreamFilterBuilder stream) =>
-    stream.matchRegex('username', '^supa.*');
-
-SupabaseStreamBuilder _imatchRegex(SupabaseStreamFilterBuilder stream) =>
-    stream.imatchRegex('username', '^SUPA.*');
-
-SupabaseStreamBuilder _isFilterNull(SupabaseStreamFilterBuilder stream) =>
-    stream.isFilter('data', null);
-
-SupabaseStreamBuilder _isFilterTrue(SupabaseStreamFilterBuilder stream) =>
-    stream.isFilter('confirmed', true);
-
-SupabaseStreamBuilder _isDistinct(SupabaseStreamFilterBuilder stream) =>
-    stream.isDistinct('status', 'ONLINE');
-
-SupabaseStreamBuilder _eqAndLike(SupabaseStreamFilterBuilder stream) =>
-    stream.eq('status', 'ONLINE').like('username', '%supa%');
-
-SupabaseStreamBuilder _inFilterAndLike(SupabaseStreamFilterBuilder stream) =>
-    stream.inFilter('status', ['ONLINE', 'OFFLINE']).like('username', '%supa%');
-
-SupabaseStreamBuilder _eqWithComma(SupabaseStreamFilterBuilder stream) =>
-    stream.eq('username', 'supa,bot');
 
 Future<void> _eventually(bool Function() condition, String description) async {
   for (var attempt = 0; attempt < 100; attempt++) {

--- a/packages/supabase/test/stream_filter_test.dart
+++ b/packages/supabase/test/stream_filter_test.dart
@@ -19,7 +19,9 @@ void main() {
   setUp(() async {
     postgresChanges = [];
     restQueries = [];
-    mockServer = await HttpServer.bind('localhost', 0);
+    // Bound to an explicit address, because `localhost` can resolve to `::1`,
+    // which does not survive being interpolated into a URL unbracketed.
+    mockServer = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
 
     mockServer.listen((request) {
       unawaited(
@@ -32,7 +34,7 @@ void main() {
     });
 
     supabase = SupabaseClient(
-      'http://${mockServer.address.host}:${mockServer.port}',
+      'http://${InternetAddress.loopbackIPv4.address}:${mockServer.port}',
       serviceRoleKey,
     );
   });

--- a/packages/supabase/test/stream_filter_test.dart
+++ b/packages/supabase/test/stream_filter_test.dart
@@ -1,0 +1,305 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:supabase/supabase.dart';
+import 'package:test/test.dart';
+import 'package:web_socket_channel/io.dart';
+
+import 'utils/local_stack.dart';
+
+/// Asserts how the filters of `stream()` are sent to the realtime server and to
+/// PostgREST, without needing either of them to be running.
+void main() {
+  late HttpServer mockServer;
+  late SupabaseClient supabase;
+  late List<Map<String, dynamic>> postgresChanges;
+  late List<Map<String, String>> restQueries;
+
+  setUp(() async {
+    postgresChanges = [];
+    restQueries = [];
+    mockServer = await HttpServer.bind('localhost', 0);
+
+    mockServer.listen((request) {
+      unawaited(
+        _handleRequest(
+          request,
+          postgresChanges: postgresChanges,
+          restQueries: restQueries,
+        ),
+      );
+    });
+
+    supabase = SupabaseClient(
+      'http://${mockServer.address.host}:${mockServer.port}',
+      serviceRoleKey,
+    );
+  });
+
+  tearDown(() async {
+    await supabase.removeAllChannels();
+    await supabase.dispose();
+    await mockServer.close(force: true);
+  });
+
+  for (final testCase in _testCases) {
+    test(testCase.name, () async {
+      final subscription = testCase
+          .filter(supabase.from('users').stream(primaryKey: ['username']))
+          .listen(null);
+      addTearDown(subscription.cancel);
+
+      await _eventually(
+        () => postgresChanges.isNotEmpty && restQueries.isNotEmpty,
+        'the channel to join and the PostgREST request to arrive',
+      );
+
+      expect(postgresChanges.single['filter'], testCase.realtimeFilter);
+      expect(restQueries.single, testCase.restQuery);
+    });
+  }
+}
+
+/// Records what the client sends and answers just enough for the channel to
+/// reach the subscribed state and for the PostgREST request to succeed.
+Future<void> _handleRequest(
+  HttpRequest request, {
+  required List<Map<String, dynamic>> postgresChanges,
+  required List<Map<String, String>> restQueries,
+}) async {
+  if (WebSocketTransformer.isUpgradeRequest(request)) {
+    final socket = IOWebSocketChannel(
+      await WebSocketTransformer.upgrade(request),
+    );
+    socket.stream.listen((message) {
+      // Realtime protocol 2.0.0 frames are the positional JSON array
+      // `[joinRef, ref, topic, event, payload]`.
+      final frame = json.decode(message as String) as List;
+      if (frame[3] != 'phx_join') {
+        return;
+      }
+      final config =
+          (frame[4] as Map<String, dynamic>)['config'] as Map<String, dynamic>;
+      final changes = (config['postgres_changes'] as List)
+          .cast<Map<String, dynamic>>();
+      postgresChanges.addAll(changes);
+      socket.sink.add(
+        json.encode([
+          frame[0],
+          frame[1],
+          frame[2],
+          'phx_reply',
+          {
+            'status': 'ok',
+            'response': {
+              'postgres_changes': changes.indexed
+                  .map((entry) => {...entry.$2, 'id': entry.$1})
+                  .toList(),
+            },
+          },
+        ]),
+      );
+    });
+    return;
+  }
+
+  restQueries.add(request.uri.queryParameters);
+  request.response
+    ..statusCode = 200
+    ..headers.contentType = ContentType.json
+    ..write('[]');
+  await request.response.close();
+}
+
+typedef _TestCase = ({
+  String name,
+  SupabaseStreamBuilder Function(SupabaseStreamFilterBuilder stream) filter,
+  String? realtimeFilter,
+  Map<String, String> restQuery,
+});
+
+const _testCases = <_TestCase>[
+  (
+    name: 'without filters no filter is sent',
+    filter: _noFilter,
+    realtimeFilter: null,
+    restQuery: {'select': '*'},
+  ),
+  (
+    name: 'eq',
+    filter: _eq,
+    realtimeFilter: 'status=eq.ONLINE',
+    restQuery: {'select': '*', 'status': 'eq.ONLINE'},
+  ),
+  (
+    name: 'neq',
+    filter: _neq,
+    realtimeFilter: 'status=neq.ONLINE',
+    restQuery: {'select': '*', 'status': 'neq.ONLINE'},
+  ),
+  (
+    name: 'lt',
+    filter: _lt,
+    realtimeFilter: 'age=lt.20',
+    restQuery: {'select': '*', 'age': 'lt.20'},
+  ),
+  (
+    name: 'lte',
+    filter: _lte,
+    realtimeFilter: 'age=lte.20',
+    restQuery: {'select': '*', 'age': 'lte.20'},
+  ),
+  (
+    name: 'gt',
+    filter: _gt,
+    realtimeFilter: 'age=gt.20',
+    restQuery: {'select': '*', 'age': 'gt.20'},
+  ),
+  (
+    name: 'gte',
+    filter: _gte,
+    realtimeFilter: 'age=gte.20',
+    restQuery: {'select': '*', 'age': 'gte.20'},
+  ),
+  (
+    name: 'inFilter',
+    filter: _inFilter,
+    realtimeFilter: 'status=in.(ONLINE,OFFLINE)',
+    restQuery: {'select': '*', 'status': 'in.("ONLINE","OFFLINE")'},
+  ),
+  (
+    name: 'like',
+    filter: _like,
+    realtimeFilter: 'username=like.%supa%',
+    restQuery: {'select': '*', 'username': 'like.%supa%'},
+  ),
+  (
+    name: 'ilike',
+    filter: _ilike,
+    realtimeFilter: 'username=ilike.%SUPA%',
+    restQuery: {'select': '*', 'username': 'ilike.%SUPA%'},
+  ),
+  (
+    name: 'matchRegex',
+    filter: _matchRegex,
+    realtimeFilter: 'username=match.^supa.*',
+    restQuery: {'select': '*', 'username': 'match.^supa.*'},
+  ),
+  (
+    name: 'imatchRegex',
+    filter: _imatchRegex,
+    realtimeFilter: 'username=imatch.^SUPA.*',
+    restQuery: {'select': '*', 'username': 'imatch.^SUPA.*'},
+  ),
+  (
+    name: 'isFilter with null',
+    filter: _isFilterNull,
+    realtimeFilter: 'data=is.null',
+    restQuery: {'select': '*', 'data': 'is.null'},
+  ),
+  (
+    name: 'isFilter with a boolean',
+    filter: _isFilterTrue,
+    realtimeFilter: 'confirmed=is.true',
+    restQuery: {'select': '*', 'confirmed': 'is.true'},
+  ),
+  (
+    name: 'isDistinct',
+    filter: _isDistinct,
+    realtimeFilter: 'status=isdistinct.ONLINE',
+    restQuery: {'select': '*', 'status': 'isdistinct.ONLINE'},
+  ),
+  (
+    name: 'multiple filters are combined with a comma',
+    filter: _eqAndLike,
+    realtimeFilter: 'status=eq.ONLINE,username=like.%supa%',
+    restQuery: {
+      'select': '*',
+      'status': 'eq.ONLINE',
+      'username': 'like.%supa%',
+    },
+  ),
+  (
+    name: 'the values of an inFilter are not confused with further filters',
+    filter: _inFilterAndLike,
+    realtimeFilter: 'status=in.(ONLINE,OFFLINE),username=like.%supa%',
+    restQuery: {
+      'select': '*',
+      'status': 'in.("ONLINE","OFFLINE")',
+      'username': 'like.%supa%',
+    },
+  ),
+  // Realtime sends all filters as one comma separated string, so a comma in a
+  // value has to be quoted there. PostgREST receives every filter as its own
+  // query parameter, where quoting would become part of the value.
+  (
+    name: 'a value with a comma is only quoted for realtime',
+    filter: _eqWithComma,
+    realtimeFilter: 'username=eq."supa,bot"',
+    restQuery: {'select': '*', 'username': 'eq.supa,bot'},
+  ),
+];
+
+SupabaseStreamBuilder _noFilter(SupabaseStreamFilterBuilder stream) => stream;
+
+SupabaseStreamBuilder _eq(SupabaseStreamFilterBuilder stream) =>
+    stream.eq('status', 'ONLINE');
+
+SupabaseStreamBuilder _neq(SupabaseStreamFilterBuilder stream) =>
+    stream.neq('status', 'ONLINE');
+
+SupabaseStreamBuilder _lt(SupabaseStreamFilterBuilder stream) =>
+    stream.lt('age', 20);
+
+SupabaseStreamBuilder _lte(SupabaseStreamFilterBuilder stream) =>
+    stream.lte('age', 20);
+
+SupabaseStreamBuilder _gt(SupabaseStreamFilterBuilder stream) =>
+    stream.gt('age', 20);
+
+SupabaseStreamBuilder _gte(SupabaseStreamFilterBuilder stream) =>
+    stream.gte('age', 20);
+
+SupabaseStreamBuilder _inFilter(SupabaseStreamFilterBuilder stream) =>
+    stream.inFilter('status', ['ONLINE', 'OFFLINE']);
+
+SupabaseStreamBuilder _like(SupabaseStreamFilterBuilder stream) =>
+    stream.like('username', '%supa%');
+
+SupabaseStreamBuilder _ilike(SupabaseStreamFilterBuilder stream) =>
+    stream.ilike('username', '%SUPA%');
+
+SupabaseStreamBuilder _matchRegex(SupabaseStreamFilterBuilder stream) =>
+    stream.matchRegex('username', '^supa.*');
+
+SupabaseStreamBuilder _imatchRegex(SupabaseStreamFilterBuilder stream) =>
+    stream.imatchRegex('username', '^SUPA.*');
+
+SupabaseStreamBuilder _isFilterNull(SupabaseStreamFilterBuilder stream) =>
+    stream.isFilter('data', null);
+
+SupabaseStreamBuilder _isFilterTrue(SupabaseStreamFilterBuilder stream) =>
+    stream.isFilter('confirmed', true);
+
+SupabaseStreamBuilder _isDistinct(SupabaseStreamFilterBuilder stream) =>
+    stream.isDistinct('status', 'ONLINE');
+
+SupabaseStreamBuilder _eqAndLike(SupabaseStreamFilterBuilder stream) =>
+    stream.eq('status', 'ONLINE').like('username', '%supa%');
+
+SupabaseStreamBuilder _inFilterAndLike(SupabaseStreamFilterBuilder stream) =>
+    stream.inFilter('status', ['ONLINE', 'OFFLINE']).like('username', '%supa%');
+
+SupabaseStreamBuilder _eqWithComma(SupabaseStreamFilterBuilder stream) =>
+    stream.eq('username', 'supa,bot');
+
+Future<void> _eventually(bool Function() condition, String description) async {
+  for (var attempt = 0; attempt < 100; attempt++) {
+    if (condition()) {
+      return;
+    }
+    await Future.delayed(const Duration(milliseconds: 50));
+  }
+  fail('Timed out waiting for $description.');
+}

--- a/packages/supabase/test/stream_integration_test.dart
+++ b/packages/supabase/test/stream_integration_test.dart
@@ -14,8 +14,10 @@ void main() {
   setUpAll(() async {
     final client = _createClient();
     await _restoreSeedUsers(client);
-    await _warmUpReplication(client);
+    // Before the warm up, so that rows left behind by an aborted run cannot
+    // collide with the ones it inserts.
     await _deleteExtraUsers(client);
+    await _warmUpReplication(client);
     await client.dispose();
   });
 
@@ -27,6 +29,14 @@ void main() {
   tearDown(() async {
     await _supabase.removeAllChannels();
     await _supabase.dispose();
+  });
+
+  // The users table is shared with the tests of the other packages, so leave it
+  // the way it was found.
+  tearDownAll(() async {
+    final client = _createClient();
+    await _deleteExtraUsers(client);
+    await client.dispose();
   });
 
   group('stream() without filters', () {
@@ -529,6 +539,7 @@ void main() {
 }
 
 const _streamTimeout = Duration(seconds: 10);
+const _warmUpPrefix = 'warm_up_';
 
 SupabaseClient _createClient() => SupabaseClient(localStackUrl, serviceRoleKey);
 
@@ -536,8 +547,8 @@ SupabaseClient _createClient() => SupabaseClient(localStackUrl, serviceRoleKey);
 /// where every snapshot is the result of [project] applied to the emitted rows.
 ///
 /// [mutate] runs once the initial PostgREST snapshot has been emitted and the
-/// realtime channel has joined, so its changes are guaranteed to be seen by the
-/// subscription instead of racing with it.
+/// realtime channel has joined, so that its changes are not lost to a
+/// subscription that is still starting up.
 Future<void> _expectSnapshots({
   required Stream<SupabaseStreamEvent> stream,
   required List<Set<String>> expectedSnapshots,
@@ -610,34 +621,48 @@ Future<void> _waitUntilJoined() async {
 /// free of guessed delays.
 Future<void> _warmUpReplication(SupabaseClient client) async {
   final received = <String>{};
+  Object? streamError;
   final subscription = client
       .from('users')
       .stream(primaryKey: ['username'])
-      .listen((rows) => received.addAll(_usernames(rows)));
+      .listen(
+        (rows) => received.addAll(_usernames(rows)),
+        onError: (Object error) => streamError ??= error,
+      );
 
-  for (var attempt = 0; attempt < 20; attempt++) {
-    final username = 'warm_up_$attempt';
-    await client.from('users').insert({
-      'username': username,
-      'status': 'ONLINE',
-    });
-    for (var wait = 0; wait < 20 && !received.contains(username); wait++) {
-      await Future.delayed(const Duration(milliseconds: 250));
+  try {
+    // The budget has to stay well below the timeout of the test that runs
+    // this, so that a stack which never delivers changes fails with the
+    // message below instead of an unexplained timeout.
+    for (var attempt = 0; attempt < 8 && streamError == null; attempt++) {
+      final username = '$_warmUpPrefix$attempt';
+      await client.from('users').insert({
+        'username': username,
+        'status': 'ONLINE',
+      });
+      for (
+        var wait = 0;
+        wait < 12 && !received.contains(username) && streamError == null;
+        wait++
+      ) {
+        await Future.delayed(const Duration(milliseconds: 250));
+      }
+      if (received.contains(username)) {
+        return;
+      }
     }
-    if (received.contains(username)) {
-      await subscription.cancel();
-      await client.removeAllChannels();
-      return;
-    }
+
+    fail(
+      'Realtime did not deliver any change of the users table. Make sure the '
+      'local stack is running and up to date, the table has to be part of the '
+      'supabase_realtime publication. '
+      '${streamError == null ? '' : 'The stream failed with: $streamError'}',
+    );
+  } finally {
+    await subscription.cancel();
+    await client.removeAllChannels();
+    await client.from('users').delete().like('username', '$_warmUpPrefix%');
   }
-
-  await subscription.cancel();
-  await client.removeAllChannels();
-  fail(
-    'Realtime did not deliver any change of the users table. Make sure the '
-    'local stack is up to date, the table has to be part of the '
-    'supabase_realtime publication.',
-  );
 }
 
 Future<void> _insertUsers(List<_User> users) async {

--- a/packages/supabase/test/stream_integration_test.dart
+++ b/packages/supabase/test/stream_integration_test.dart
@@ -6,44 +6,42 @@ import 'dart:async';
 import 'package:supabase/supabase.dart';
 import 'package:test/test.dart';
 
-import '../../postgrest/test/test_utils.dart' show serviceRoleKey;
+import 'utils/local_stack.dart';
 
 late SupabaseClient _supabase;
 
-/// Track if this is the first connection to the stream. This is used to wait a
-/// bit longer for the first connection to get the replication working properly.
-bool _firstConnection = true;
-
 void main() {
   setUpAll(() async {
-    final client = SupabaseClient(
-      _apiUrl,
-      serviceRoleKey,
-    );
-
-    for (final user in _seedUsers) {
-      await client.from('users').upsert({
-        'username': user.username,
-        'status': user.status,
-      });
-    }
+    final client = _createClient();
+    await _restoreSeedUsers(client);
+    await _warmUpReplication(client);
+    await _deleteExtraUsers(client);
     await client.dispose();
-    await Future.delayed(
-      const Duration(milliseconds: 500),
-    ); // wait for replication
   });
 
   setUp(() async {
-    _supabase = SupabaseClient(
-      _apiUrl,
-      serviceRoleKey,
-    );
-    await _resetUsers(_supabase);
+    _supabase = _createClient();
+    await _deleteExtraUsers(_supabase);
   });
 
   tearDown(() async {
     await _supabase.removeAllChannels();
     await _supabase.dispose();
+  });
+
+  group('stream() without filters', () {
+    test('receives every insert', () async {
+      await _expectSnapshots(
+        stream: _supabase.from('users').stream(primaryKey: ['username']),
+        expectedSnapshots: [
+          {'awailas', 'dragarcia', 'kiwicopple', 'supabot'},
+          {'awailas', 'dragarcia', 'kiwicopple', 'no_filter', 'supabot'},
+        ],
+        mutate: () => _insertUsers([
+          (username: 'no_filter', status: 'OFFLINE'),
+        ]),
+      );
+    });
   });
 
   group('stream() filters', () {
@@ -57,16 +55,10 @@ void main() {
           {'awailas', 'dragarcia', 'supabot'},
           {'awailas', 'dragarcia', 'new_online', 'supabot'},
         ],
-        inserts: [
-          (
-            username: 'new_offline',
-            status: 'OFFLINE',
-          ),
-          (
-            username: 'new_online',
-            status: 'ONLINE',
-          ),
-        ],
+        mutate: () => _insertUsers([
+          (username: 'new_offline', status: 'OFFLINE'),
+          (username: 'new_online', status: 'ONLINE'),
+        ]),
       );
     });
 
@@ -80,16 +72,10 @@ void main() {
           {'kiwicopple'},
           {'kiwicopple', 'new_offline'},
         ],
-        inserts: [
-          (
-            username: 'new_online',
-            status: 'ONLINE',
-          ),
-          (
-            username: 'new_offline',
-            status: 'OFFLINE',
-          ),
-        ],
+        mutate: () => _insertUsers([
+          (username: 'new_online', status: 'ONLINE'),
+          (username: 'new_offline', status: 'OFFLINE'),
+        ]),
       );
     });
 
@@ -103,16 +89,10 @@ void main() {
           {'supabot'},
           {'supabot', 'zeta_match'},
         ],
-        inserts: [
-          (
-            username: 'alpha_miss',
-            status: 'ONLINE',
-          ),
-          (
-            username: 'zeta_match',
-            status: 'ONLINE',
-          ),
-        ],
+        mutate: () => _insertUsers([
+          (username: 'alpha_miss', status: 'ONLINE'),
+          (username: 'zeta_match', status: 'ONLINE'),
+        ]),
       );
     });
 
@@ -126,16 +106,10 @@ void main() {
           {'kiwicopple', 'supabot'},
           {'kiwicopple', 'supabot', 'zeta_match'},
         ],
-        inserts: [
-          (
-            username: 'alpha_miss',
-            status: 'ONLINE',
-          ),
-          (
-            username: 'zeta_match',
-            status: 'ONLINE',
-          ),
-        ],
+        mutate: () => _insertUsers([
+          (username: 'alpha_miss', status: 'ONLINE'),
+          (username: 'zeta_match', status: 'ONLINE'),
+        ]),
       );
     });
 
@@ -149,16 +123,10 @@ void main() {
           {'awailas', 'dragarcia'},
           {'alpha_match', 'awailas', 'dragarcia'},
         ],
-        inserts: [
-          (
-            username: 'zeta_miss',
-            status: 'ONLINE',
-          ),
-          (
-            username: 'alpha_match',
-            status: 'ONLINE',
-          ),
-        ],
+        mutate: () => _insertUsers([
+          (username: 'zeta_miss', status: 'ONLINE'),
+          (username: 'alpha_match', status: 'ONLINE'),
+        ]),
       );
     });
 
@@ -172,16 +140,10 @@ void main() {
           {'awailas', 'dragarcia', 'kiwicopple'},
           {'alpha_match', 'awailas', 'dragarcia', 'kiwicopple'},
         ],
-        inserts: [
-          (
-            username: 'zeta_miss',
-            status: 'ONLINE',
-          ),
-          (
-            username: 'alpha_match',
-            status: 'ONLINE',
-          ),
-        ],
+        mutate: () => _insertUsers([
+          (username: 'zeta_miss', status: 'ONLINE'),
+          (username: 'alpha_match', status: 'ONLINE'),
+        ]),
       );
     });
 
@@ -195,16 +157,10 @@ void main() {
           {'awailas', 'dragarcia', 'supabot'},
           {'awailas', 'dragarcia', 'in_online', 'supabot'},
         ],
-        inserts: [
-          (
-            username: 'in_offline',
-            status: 'OFFLINE',
-          ),
-          (
-            username: 'in_online',
-            status: 'ONLINE',
-          ),
-        ],
+        mutate: () => _insertUsers([
+          (username: 'in_offline', status: 'OFFLINE'),
+          (username: 'in_online', status: 'ONLINE'),
+        ]),
       );
     });
 
@@ -218,16 +174,10 @@ void main() {
           {'supabot'},
           {'supabot', 'super-supa'},
         ],
-        inserts: [
-          (
-            username: 'kiwi-extra',
-            status: 'ONLINE',
-          ),
-          (
-            username: 'super-supa',
-            status: 'ONLINE',
-          ),
-        ],
+        mutate: () => _insertUsers([
+          (username: 'kiwi-extra', status: 'ONLINE'),
+          (username: 'super-supa', status: 'ONLINE'),
+        ]),
       );
     });
 
@@ -241,62 +191,44 @@ void main() {
           {'supabot'},
           {'SUPAfriend', 'supabot'},
         ],
-        inserts: [
-          (
-            username: 'kiwi-extra',
-            status: 'ONLINE',
-          ),
-          (
-            username: 'SUPAfriend',
-            status: 'ONLINE',
-          ),
-        ],
+        mutate: () => _insertUsers([
+          (username: 'kiwi-extra', status: 'ONLINE'),
+          (username: 'SUPAfriend', status: 'ONLINE'),
+        ]),
       );
     });
 
-    test('match', () async {
+    test('matchRegex', () async {
       await _expectSnapshots(
         stream: _supabase
             .from('users')
             .stream(primaryKey: ['username'])
-            .match('username', '^supa.*'),
+            .matchRegex('username', '^supa.*'),
         expectedSnapshots: [
           {'supabot'},
           {'supa_friend', 'supabot'},
         ],
-        inserts: [
-          (
-            username: 'bot_supa',
-            status: 'ONLINE',
-          ),
-          (
-            username: 'supa_friend',
-            status: 'ONLINE',
-          ),
-        ],
+        mutate: () => _insertUsers([
+          (username: 'bot_supa', status: 'ONLINE'),
+          (username: 'supa_friend', status: 'ONLINE'),
+        ]),
       );
     });
 
-    test('imatch', () async {
+    test('imatchRegex', () async {
       await _expectSnapshots(
         stream: _supabase
             .from('users')
             .stream(primaryKey: ['username'])
-            .imatch('username', '^SUPA.*'),
+            .imatchRegex('username', '^SUPA.*'),
         expectedSnapshots: [
           {'supabot'},
           {'SUPA_friend', 'supabot'},
         ],
-        inserts: [
-          (
-            username: 'bot_supa',
-            status: 'ONLINE',
-          ),
-          (
-            username: 'SUPA_friend',
-            status: 'ONLINE',
-          ),
-        ],
+        mutate: () => _insertUsers([
+          (username: 'bot_supa', status: 'ONLINE'),
+          (username: 'SUPA_friend', status: 'ONLINE'),
+        ]),
       );
     });
 
@@ -310,12 +242,9 @@ void main() {
           {'awailas', 'dragarcia', 'kiwicopple', 'supabot'},
           {'awailas', 'dragarcia', 'kiwicopple', 'null_view', 'supabot'},
         ],
-        inserts: [
-          (
-            username: 'null_view',
-            status: 'ONLINE',
-          ),
-        ],
+        mutate: () => _insertUsers([
+          (username: 'null_view', status: 'ONLINE'),
+        ]),
       );
     });
 
@@ -329,12 +258,9 @@ void main() {
           {'kiwicopple'},
           {'distinct_null', 'kiwicopple'},
         ],
-        inserts: [
-          (
-            username: 'distinct_null',
-            status: null,
-          ),
-        ],
+        mutate: () => _insertUsers([
+          (username: 'distinct_null', status: null),
+        ]),
       );
     });
   });
@@ -351,16 +277,10 @@ void main() {
           {'supabot'},
           {'supa_online', 'supabot'},
         ],
-        inserts: [
-          (
-            username: 'supa_offline',
-            status: 'OFFLINE',
-          ),
-          (
-            username: 'supa_online',
-            status: 'ONLINE',
-          ),
-        ],
+        mutate: () => _insertUsers([
+          (username: 'supa_offline', status: 'OFFLINE'),
+          (username: 'supa_online', status: 'ONLINE'),
+        ]),
       );
     });
 
@@ -375,16 +295,10 @@ void main() {
           {'dragarcia'},
           {'GAR_user', 'dragarcia'},
         ],
-        inserts: [
-          (
-            username: 'other_null',
-            status: 'ONLINE',
-          ),
-          (
-            username: 'GAR_user',
-            status: 'ONLINE',
-          ),
-        ],
+        mutate: () => _insertUsers([
+          (username: 'other_null', status: 'ONLINE'),
+          (username: 'GAR_user', status: 'ONLINE'),
+        ]),
       );
     });
 
@@ -399,91 +313,376 @@ void main() {
           {'dragarcia', 'supabot'},
           {'charlie_online', 'dragarcia', 'supabot'},
         ],
-        inserts: [
-          (
-            username: 'alpha_online',
-            status: 'ONLINE',
-          ),
-          (
-            username: 'charlie_online',
-            status: 'ONLINE',
-          ),
+        mutate: () => _insertUsers([
+          (username: 'alpha_online', status: 'ONLINE'),
+          (username: 'charlie_online', status: 'ONLINE'),
+        ]),
+      );
+    });
+
+    // The values of an `inFilter` are comma separated, just like the filters
+    // themselves are on the wire, so combining the two is worth its own test.
+    test('inFilter + like uses AND semantics', () async {
+      await _expectSnapshots(
+        stream: _supabase
+            .from('users')
+            .stream(primaryKey: ['username'])
+            .inFilter('status', ['ONLINE', 'OFFLINE'])
+            .like('username', '%supa%'),
+        expectedSnapshots: [
+          {'supabot'},
+          {'supa_combo', 'supabot'},
         ],
+        mutate: () => _insertUsers([
+          (username: 'combo_miss', status: 'ONLINE'),
+          (username: 'supa_combo', status: 'OFFLINE'),
+        ]),
+      );
+    });
+
+    test('eq + like + gt uses AND semantics', () async {
+      await _expectSnapshots(
+        stream: _supabase
+            .from('users')
+            .stream(primaryKey: ['username'])
+            .eq('status', 'ONLINE')
+            .like('username', '%supa%')
+            .gt('username', 'b'),
+        expectedSnapshots: [
+          {'supabot'},
+          {'supa_third', 'supabot'},
+        ],
+        mutate: () => _insertUsers([
+          (username: 'a_supa_miss', status: 'ONLINE'),
+          (username: 'supa_third', status: 'ONLINE'),
+        ]),
+      );
+    });
+  });
+
+  group('stream() updates', () {
+    test(
+      'an update that keeps matching the filter replaces the record',
+      () async {
+        await _expectSnapshots(
+          stream: _supabase
+              .from('users')
+              .stream(primaryKey: ['username'])
+              .like('username', '%updated%'),
+          expectedSnapshots: [
+            <String>{},
+            {'is_updated:ONLINE'},
+            {'is_updated:OFFLINE'},
+          ],
+          project: _usernamesWithStatus,
+          mutate: () async {
+            await _insertUsers([
+              (username: 'is_updated', status: 'ONLINE'),
+            ]);
+            await _supabase
+                .from('users')
+                .update({'status': 'OFFLINE'})
+                .eq('username', 'is_updated');
+          },
+        );
+      },
+    );
+
+    test('an update that stops matching the filter is not received', () async {
+      await _expectSnapshots(
+        stream: _supabase
+            .from('users')
+            .stream(primaryKey: ['username'])
+            .eq('status', 'ONLINE'),
+        expectedSnapshots: [
+          {'awailas:ONLINE', 'dragarcia:ONLINE', 'supabot:ONLINE'},
+          {
+            'awailas:ONLINE',
+            'dragarcia:ONLINE',
+            'moves_out:ONLINE',
+            'supabot:ONLINE',
+          },
+          // `moves_out` is OFFLINE in the database by now, but the update was
+          // filtered out by the realtime server, so the stream keeps the stale
+          // record. The insert that follows proves no snapshot was emitted in
+          // between.
+          {
+            'awailas:ONLINE',
+            'dragarcia:ONLINE',
+            'moves_out:ONLINE',
+            'proof:ONLINE',
+            'supabot:ONLINE',
+          },
+        ],
+        project: _usernamesWithStatus,
+        mutate: () async {
+          await _insertUsers([
+            (username: 'moves_out', status: 'ONLINE'),
+          ]);
+          await _supabase
+              .from('users')
+              .update({'status': 'OFFLINE'})
+              .eq('username', 'moves_out');
+          await _insertUsers([
+            (username: 'proof', status: 'ONLINE'),
+          ]);
+        },
+      );
+    });
+
+    test('an update that starts matching the filter adds the record', () async {
+      await _expectSnapshots(
+        stream: _supabase
+            .from('users')
+            .stream(primaryKey: ['username'])
+            .eq('status', 'ONLINE'),
+        expectedSnapshots: [
+          {'awailas', 'dragarcia', 'supabot'},
+          {'awailas', 'dragarcia', 'moves_in', 'supabot'},
+        ],
+        mutate: () async {
+          await _insertUsers([
+            (username: 'moves_in', status: 'OFFLINE'),
+          ]);
+          await _supabase
+              .from('users')
+              .update({'status': 'ONLINE'})
+              .eq('username', 'moves_in');
+        },
+      );
+    });
+  });
+
+  group('stream() deletes', () {
+    // The users table has `replica identity full`, so the realtime server can
+    // match a filter on a column that is not part of the primary key against
+    // the deleted record.
+    test(
+      'a delete matching a non primary key filter removes the record',
+      () async {
+        await _expectSnapshots(
+          stream: _supabase
+              .from('users')
+              .stream(primaryKey: ['username'])
+              .eq('status', 'ONLINE'),
+          expectedSnapshots: [
+            {'awailas', 'dragarcia', 'supabot'},
+            {'awailas', 'deleted_soon', 'dragarcia', 'supabot'},
+            {'awailas', 'dragarcia', 'supabot'},
+          ],
+          mutate: () async {
+            await _insertUsers([
+              (username: 'deleted_soon', status: 'ONLINE'),
+            ]);
+            await _supabase
+                .from('users')
+                .delete()
+                .eq('username', 'deleted_soon');
+          },
+        );
+      },
+    );
+
+    test('a delete matching a primary key filter removes the record', () async {
+      await _expectSnapshots(
+        stream: _supabase
+            .from('users')
+            .stream(primaryKey: ['username'])
+            .like('username', '%deleted%'),
+        expectedSnapshots: [
+          <String>{},
+          {'deleted_by_key'},
+          <String>{},
+        ],
+        mutate: () async {
+          await _insertUsers([
+            (username: 'deleted_by_key', status: 'ONLINE'),
+          ]);
+          await _supabase
+              .from('users')
+              .delete()
+              .eq('username', 'deleted_by_key');
+        },
+      );
+    });
+  });
+
+  group('stream() modifiers', () {
+    test('filters combine with order and limit', () async {
+      await _expectSnapshots(
+        stream: _supabase
+            .from('users')
+            .stream(primaryKey: ['username'])
+            .eq('status', 'ONLINE')
+            .order('username', ascending: true)
+            .limit(2),
+        expectedSnapshots: [
+          {'awailas', 'dragarcia'},
+          {'aaa_online', 'awailas'},
+        ],
+        mutate: () => _insertUsers([
+          (username: 'aaa_online', status: 'ONLINE'),
+        ]),
       );
     });
   });
 }
 
-const _apiUrl = 'http://127.0.0.1:54421';
 const _streamTimeout = Duration(seconds: 10);
 
-Future<void> _expectSnapshots({
-  required Stream<List<Map<String, dynamic>>> stream,
-  required List<Set<String>> expectedSnapshots,
-  required List<_UserSeed> inserts,
-}) async {
-  final bStream = stream.asBroadcastStream();
-  unawaited(
-    bStream.first.then((_) async {
-      if (_firstConnection) {
-        _firstConnection = false;
-        // We need to wait a bit longer for the first connection to get the replication working properly
-        await Future.delayed(
-          const Duration(seconds: 3),
-        ); // wait for replication
-      }
-      await Future.delayed(
-        const Duration(milliseconds: 500),
-      ); // wait for replication
-      for (final user in inserts) {
-        await _supabase.from('users').insert({
-          'username': user.username,
-          'status': user.status,
-        });
-      }
-    }),
-  );
+SupabaseClient _createClient() => SupabaseClient(localStackUrl, serviceRoleKey);
 
-  await expectLater(
-    bStream.map(_usernamesFromRows).timeout(_streamTimeout),
-    emitsInOrder(expectedSnapshots),
+/// Listens to [stream] and asserts that it emits [expectedSnapshots] in order,
+/// where every snapshot is the result of [project] applied to the emitted rows.
+///
+/// [mutate] runs once the initial PostgREST snapshot has been emitted and the
+/// realtime channel has joined, so its changes are guaranteed to be seen by the
+/// subscription instead of racing with it.
+Future<void> _expectSnapshots({
+  required Stream<SupabaseStreamEvent> stream,
+  required List<Set<String>> expectedSnapshots,
+  required Future<void> Function() mutate,
+  Set<String> Function(SupabaseStreamEvent rows) project = _usernames,
+}) async {
+  final broadcastStream = stream.asBroadcastStream();
+
+  Object? mutationError;
+  StackTrace? mutationStackTrace;
+  final mutations = broadcastStream.first
+      .timeout(_streamTimeout)
+      .then((_) async {
+        await _waitUntilJoined();
+        await mutate();
+      })
+      .onError<Object>((error, stackTrace) {
+        mutationError = error;
+        mutationStackTrace = stackTrace;
+      });
+
+  try {
+    await expectLater(
+      broadcastStream
+          .map(project)
+          // The stream emits its current state, so changes that leave the
+          // projected snapshot untouched, like the refetch after a rejoin,
+          // repeat the previous snapshot without carrying information.
+          .distinct(_isSameSnapshot)
+          .timeout(_streamTimeout),
+      emitsInOrder(expectedSnapshots),
+    );
+  } finally {
+    // Let the mutations settle before the test ends, so a failing expectation
+    // cannot leave them running against a client that tearDown disposed.
+    await mutations;
+  }
+
+  if (mutationError != null) {
+    Error.throwWithStackTrace(mutationError!, mutationStackTrace!);
+  }
+}
+
+/// Waits until every channel of [_supabase] has joined.
+///
+/// The first emitted snapshot comes from PostgREST, which is fetched in parallel
+/// with the realtime subscription, so it does not imply that changes are being
+/// streamed yet.
+Future<void> _waitUntilJoined() async {
+  for (var attempt = 0; attempt < 200; attempt++) {
+    final channels = _supabase.getChannels();
+    if (channels.isNotEmpty &&
+        // ignore: invalid_use_of_internal_member
+        channels.every((channel) => channel.isJoined)) {
+      // Joining is acknowledged before the server has necessarily started
+      // streaming changes for the new subscription.
+      await Future.delayed(const Duration(milliseconds: 300));
+      return;
+    }
+    await Future.delayed(const Duration(milliseconds: 50));
+  }
+  fail('The realtime channel did not join within the timeout.');
+}
+
+/// Round-trips throwaway inserts until realtime delivers one of them.
+///
+/// The very first subscription against a fresh stack has to wait for the
+/// replication slot to start streaming, which takes considerably longer than
+/// every subsequent subscription. Doing it once here keeps the tests themselves
+/// free of guessed delays.
+Future<void> _warmUpReplication(SupabaseClient client) async {
+  final received = <String>{};
+  final subscription = client
+      .from('users')
+      .stream(primaryKey: ['username'])
+      .listen((rows) => received.addAll(_usernames(rows)));
+
+  for (var attempt = 0; attempt < 20; attempt++) {
+    final username = 'warm_up_$attempt';
+    await client.from('users').insert({
+      'username': username,
+      'status': 'ONLINE',
+    });
+    for (var wait = 0; wait < 20 && !received.contains(username); wait++) {
+      await Future.delayed(const Duration(milliseconds: 250));
+    }
+    if (received.contains(username)) {
+      await subscription.cancel();
+      await client.removeAllChannels();
+      return;
+    }
+  }
+
+  await subscription.cancel();
+  await client.removeAllChannels();
+  fail(
+    'Realtime did not deliver any change of the users table. Make sure the '
+    'local stack is up to date, the table has to be part of the '
+    'supabase_realtime publication.',
   );
 }
 
-Future<void> _resetUsers(SupabaseClient client) async {
+Future<void> _insertUsers(List<_User> users) async {
+  for (final user in users) {
+    await _supabase.from('users').insert({
+      'username': user.username,
+      'status': user.status,
+    });
+  }
+}
+
+Future<void> _restoreSeedUsers(SupabaseClient client) async {
+  await client
+      .from('users')
+      .upsert(
+        _seedUsers
+            .map((user) => {'username': user.username, 'status': user.status})
+            .toList(),
+      );
+}
+
+Future<void> _deleteExtraUsers(SupabaseClient client) async {
   await client
       .from('users')
       .delete()
-      .not('username', 'in', _seedUsers.map((u) => u.username).toList());
-  await Future.delayed(
-    const Duration(milliseconds: 500),
-  ); // wait for replication
+      .not('username', 'in', _seedUsers.map((user) => user.username).toList());
 }
 
-Set<String> _usernamesFromRows(List<Map<String, dynamic>> rows) {
+bool _isSameSnapshot(Set<String> a, Set<String> b) {
+  return a.length == b.length && a.containsAll(b);
+}
+
+Set<String> _usernames(SupabaseStreamEvent rows) {
   return rows.map((row) => row['username']).whereType<String>().toSet();
 }
 
-final _seedUsers = <_UserSeed>[
-  (
-    username: 'supabot',
-    status: 'ONLINE',
-  ),
-  (
-    username: 'kiwicopple',
-    status: 'OFFLINE',
-  ),
-  (
-    username: 'awailas',
-    status: 'ONLINE',
-  ),
-  (
-    username: 'dragarcia',
-    status: 'ONLINE',
-  ),
+Set<String> _usernamesWithStatus(SupabaseStreamEvent rows) {
+  return rows.map((row) => '${row['username']}:${row['status']}').toSet();
+}
+
+const _seedUsers = <_User>[
+  (username: 'supabot', status: 'ONLINE'),
+  (username: 'kiwicopple', status: 'OFFLINE'),
+  (username: 'awailas', status: 'ONLINE'),
+  (username: 'dragarcia', status: 'ONLINE'),
 ];
 
-typedef _UserSeed = ({
-  String? status,
-  String username,
-});
+typedef _User = ({String username, String? status});

--- a/packages/supabase/test/utils/local_stack.dart
+++ b/packages/supabase/test/utils/local_stack.dart
@@ -1,0 +1,13 @@
+/// Shared configuration for the integration tests that run against the local
+/// Supabase CLI stack.
+///
+/// Requests go through the API gateway, which requires an apikey. The
+/// service_role key is used so the tests have unrestricted access to the test
+/// tables.
+library;
+
+const localStackUrl = 'http://127.0.0.1:54421';
+
+// RS256 JWT signed by the committed supabase/signing_keys.json.
+const serviceRoleKey =
+    'eyJhbGciOiJSUzI1NiIsImtpZCI6IjNkZjU5YWIxLWI4ZWMtNDlkMy05YzkyLThiOWQ0MmNhYzFmZSIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MjA5Njg5NTE5Mn0.jO5vwkRNFZTiVHNjFzaypvWV4aJkKm6TvFsdl0W5x9g7LttQMWMopC7HanUpeFLmg4E9gMb-v1e6f6oZ9e0PHYpsRwEdSOxKfYwKhzFI9DsDGLrX4ueArZuKgaV_bulWpwGKI3xwLugeuCp6N0hYFkXvMmUjaKx9nClWckJ33cchSpgjVQ5YxL8PGrUj2Sjhw-5IyGiwrdPfWjTQmpWnCjePoVrRf2jEMF_VGoxDAEqt72w_HGOrdXRFU5BW9-LkvpfzkrTENrj555JtYP4mkZgvUlrkXFRSh010o3n2UehN5WonfDRzwOeTC56QEbPVS6ubvWGR9luykdMNlXawZA';

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -606,10 +606,12 @@ features:
     status: implemented
     symbols:
       - PostgrestTransformBuilder.order
+      - SupabaseStreamBuilder.order
   database.using_modifiers.limit:
     status: implemented
     symbols:
       - PostgrestTransformBuilder.limit
+      - SupabaseStreamBuilder.limit
   database.using_modifiers.range:
     status: implemented
     symbols:

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -472,22 +472,27 @@ features:
     status: implemented
     symbols:
       - PostgrestFilterBuilder.neq
+      - SupabaseStreamFilterBuilder.neq
   database.using_filters.gt:
     status: implemented
     symbols:
       - PostgrestFilterBuilder.gt
+      - SupabaseStreamFilterBuilder.gt
   database.using_filters.gte:
     status: implemented
     symbols:
       - PostgrestFilterBuilder.gte
+      - SupabaseStreamFilterBuilder.gte
   database.using_filters.lt:
     status: implemented
     symbols:
       - PostgrestFilterBuilder.lt
+      - SupabaseStreamFilterBuilder.lt
   database.using_filters.lte:
     status: implemented
     symbols:
       - PostgrestFilterBuilder.lte
+      - SupabaseStreamFilterBuilder.lte
   database.using_filters.like:
     status: implemented
     symbols:
@@ -528,6 +533,7 @@ features:
     status: implemented
     symbols:
       - PostgrestFilterBuilder.inFilter
+      - SupabaseStreamFilterBuilder.inFilter
   database.using_filters.not_in:
     status: implemented
     symbols:
@@ -584,12 +590,12 @@ features:
     status: implemented
     symbols:
       - PostgrestFilterBuilder.matchRegex
-      - SupabaseStreamFilterBuilder.match
+      - SupabaseStreamFilterBuilder.matchRegex
   database.using_filters.regex_icase:
     status: implemented
     symbols:
       - PostgrestFilterBuilder.imatchRegex
-      - SupabaseStreamFilterBuilder.imatch
+      - SupabaseStreamFilterBuilder.imatchRegex
   database.using_filters.raw:
     status: implemented
     symbols:


### PR DESCRIPTION
Follow-up to #1610.

- Renames `match` and `imatch` to `matchRegex` and `imatchRegex`. `PostgrestFilterBuilder.match` takes a map of equality checks and maps to a different capability, its regex filters are `matchRegex` and `imatchRegex`, and the stream filters delegated to `query.matchRegex` while being named `match`. Every other stream filter already mirrors the PostgREST name. Both methods are unreleased, so no published API changes.
- Fixes the `stream()` docs: filter list, and what the DELETE limitation means and how `replica identity full` lifts it.
- Registers the remaining stream filters in `sdk-compliance.yaml`.
- Adds `test/stream_filter_test.dart`, which asserts what every filter sends to realtime and to PostgREST against a mock server, so the mapping is covered without a backend.
- Extends the integration tests to unfiltered streams, more filter combinations, updates that stay inside, leave and enter the filter, deletes, and `order` with `limit`.
- Makes the integration tests wait for the channel to join instead of sleeping, warm up replication once, and settle their mutations before the test ends.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Expanded stream filtering with comparison, membership, pattern, null, boolean, and distinct filters.
  - Added support for ordering and limiting stream results.
  - Renamed regex filters to `matchRegex` and `imatchRegex`.
  - Multiple stream filters are now combined with `AND`.

- **Documentation**
  - Clarified delete behavior, replica identity requirements, supported filters, and usage examples.

- **Tests**
  - Added comprehensive coverage for filter serialization, combined filters, updates, deletes, ordering, and limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->