### PR TITLE
ci(examples): fix the example integration test jobs

### DIFF
--- a/.github/scripts/run_example_integration_tests.dart
+++ b/.github/scripts/run_example_integration_tests.dart
@@ -144,6 +144,9 @@ Future<void> _runTarget(
         'integration_test',
         '-d',
         device,
+        // TODO(spydon): drop once the simulator stops hanging between the build
+        // and the first test; this shows how far the tooling gets.
+        '--verbose',
         ...defines,
       ]);
     default:

--- a/.github/scripts/run_example_integration_tests.dart
+++ b/.github/scripts/run_example_integration_tests.dart
@@ -61,7 +61,9 @@ Future<bool> _waitForPort(
   while (DateTime.now().isBefore(deadline)) {
     try {
       final socket = await Socket.connect('localhost', port);
-      await socket.close();
+      // Destroys rather than closes: close() only shuts the sending side down,
+      // and nothing reads this socket, so it would keep the process alive.
+      socket.destroy();
       return true;
     } on SocketException {
       await Future<void>.delayed(const Duration(milliseconds: 200));

--- a/.github/scripts/run_example_integration_tests.dart
+++ b/.github/scripts/run_example_integration_tests.dart
@@ -144,9 +144,6 @@ Future<void> _runTarget(
         'integration_test',
         '-d',
         device,
-        // TODO(spydon): drop once the simulator stops hanging between the build
-        // and the first test; this shows how far the tooling gets.
-        '--verbose',
         ...defines,
       ]);
     default:

--- a/.github/workflows/example-integration-tests.yml
+++ b/.github/workflows/example-integration-tests.yml
@@ -1,8 +1,10 @@
+# Runs on release pull requests, and on any pull request labelled
+# "integration tests" so the suite can be exercised on demand.
 name: Example integration tests
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize, edited]
+    types: [opened, reopened, synchronize, edited, labeled]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -18,7 +20,9 @@ env:
 jobs:
   backend:
     name: Host shared Supabase
-    if: startsWith(github.event.pull_request.title, 'chore(release)')
+    if: >-
+      startsWith(github.event.pull_request.title, 'chore(release)')
+      || contains(github.event.pull_request.labels.*.name, 'integration tests')
     timeout-minutes: 60
     runs-on: ubuntu-latest
     env:
@@ -105,7 +109,9 @@ jobs:
 
   test:
     name: ${{ matrix.id }}
-    if: startsWith(github.event.pull_request.title, 'chore(release)')
+    if: >-
+      startsWith(github.event.pull_request.title, 'chore(release)')
+      || contains(github.event.pull_request.labels.*.name, 'integration tests')
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     strategy:
@@ -135,6 +141,16 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y ninja-build libgtk-3-dev xvfb
+
+      - name: Enable KVM
+        if: matrix.target == 'android'
+        run: |
+          # Without access to /dev/kvm the emulator falls back to software
+          # emulation, which takes minutes to boot and then stops responding.
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
+            | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
 
       - name: Boot iOS simulator
         if: matrix.target == 'ios'
@@ -170,6 +186,22 @@ jobs:
             (cd "examples/$example" \
               && flutter create --platforms=${{ matrix.target }} . \
               && flutter pub get)
+          done
+
+      - name: Let the scaffolded macOS apps reach the network
+        if: matrix.target == 'macos'
+        shell: bash
+        run: |
+          set -euo pipefail
+          # The scaffolding only grants the sandbox the network server
+          # entitlement, so without the client one every request to Supabase
+          # fails with "Operation not permitted".
+          for example in database_crud passkeys; do
+            for config in DebugProfile Release; do
+              /usr/libexec/PlistBuddy \
+                -c 'Add :com.apple.security.network.client bool true' \
+                "examples/$example/macos/Runner/$config.entitlements"
+            done
           done
 
       - name: Run integration tests

--- a/.github/workflows/example-integration-tests.yml
+++ b/.github/workflows/example-integration-tests.yml
@@ -158,7 +158,9 @@ jobs:
           set -euo pipefail
           udid=$(xcrun simctl list devices available -j \
             | jq -r '[.devices[][] | select(.name | test("iPhone"))][0].udid')
-          xcrun simctl boot "$udid" || true
+          # Boots and then waits for the boot to finish, so the tests cannot
+          # launch into a simulator that is still coming up.
+          xcrun simctl bootstatus "$udid" -b
           echo "IOS_DEVICE=$udid" >> "$GITHUB_ENV"
 
       - name: Wait for the Supabase endpoint
@@ -188,7 +190,7 @@ jobs:
               && flutter pub get)
           done
 
-      - name: Let the scaffolded macOS apps reach the network
+      - name: Prepare the scaffolded macOS apps
         if: matrix.target == 'macos'
         shell: bash
         run: |
@@ -203,6 +205,20 @@ jobs:
                 "examples/$example/macos/Runner/$config.entitlements"
             done
           done
+          # The passkeys plugin is only available from macOS 13.5, so the
+          # scaffolded 10.15 target fails to compile the plugin registrant.
+          sed -i '' 's/MACOSX_DEPLOYMENT_TARGET = [0-9.]*;/MACOSX_DEPLOYMENT_TARGET = 13.5;/g' \
+            examples/passkeys/macos/Runner.xcodeproj/project.pbxproj
+
+      - name: Prepare the scaffolded iOS apps
+        if: matrix.target == 'ios'
+        shell: bash
+        run: |
+          set -euo pipefail
+          # As above, the passkeys plugin needs iOS 16 rather than the
+          # scaffolded 13.0.
+          sed -i '' 's/IPHONEOS_DEPLOYMENT_TARGET = [0-9.]*;/IPHONEOS_DEPLOYMENT_TARGET = 16.0;/g' \
+            examples/passkeys/ios/Runner.xcodeproj/project.pbxproj
 
       - name: Run integration tests
         if: matrix.target != 'android'

--- a/.github/workflows/example-integration-tests.yml
+++ b/.github/workflows/example-integration-tests.yml
@@ -4,7 +4,10 @@ name: Example integration tests
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize, edited, labeled]
+    # No "edited": a bot rewriting the description would otherwise cancel and
+    # restart the whole matrix. Release pull requests are opened with their
+    # title, and any other one can opt in with the label.
+    types: [opened, reopened, synchronize, labeled]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/example-integration-tests.yml
+++ b/.github/workflows/example-integration-tests.yml
@@ -161,8 +161,12 @@ jobs:
           set -euo pipefail
           udid=$(xcrun simctl list devices available -j \
             | jq -r '[.devices[][] | select(.name | test("iPhone"))][0].udid')
-          # Boots and then waits for the boot to finish, so the tests cannot
-          # launch into a simulator that is still coming up.
+          # Erases first: the tests hang waiting for the app's VM service on a
+          # simulator carrying state from the runner image. Then boots and waits
+          # for the boot to finish, so the tests cannot launch into a simulator
+          # that is still coming up.
+          xcrun simctl shutdown all || true
+          xcrun simctl erase "$udid"
           xcrun simctl bootstatus "$udid" -b
           echo "IOS_DEVICE=$udid" >> "$GITHUB_ENV"
 

--- a/.github/workflows/example-integration-tests.yml
+++ b/.github/workflows/example-integration-tests.yml
@@ -237,6 +237,13 @@ jobs:
           target: google_apis
           script: dart .github/scripts/run_example_integration_tests.dart android
 
+      - name: Dump the simulator log
+        if: always() && matrix.target == 'ios'
+        continue-on-error: true
+        run: |
+          xcrun simctl spawn "$IOS_DEVICE" log show --last 20m --style compact \
+            --predicate 'processImagePath CONTAINS "example"' | tail -n 300
+
       - name: Signal completion
         if: always()
         shell: bash

--- a/.github/workflows/example-integration-tests.yml
+++ b/.github/workflows/example-integration-tests.yml
@@ -242,7 +242,7 @@ jobs:
         continue-on-error: true
         run: |
           xcrun simctl spawn "$IOS_DEVICE" log show --last 20m --style compact \
-            --predicate 'processImagePath CONTAINS "example"' | tail -n 300
+            --predicate 'processImagePath ENDSWITH "Runner"' | tail -n 300
 
       - name: Signal completion
         if: always()

--- a/examples/database_crud/integration_test/tasks_test.dart
+++ b/examples/database_crud/integration_test/tasks_test.dart
@@ -139,7 +139,9 @@ String _screen() {
   final fields = find
       .byType(EditableText)
       .evaluate()
-      .map((element) => '"${(element.widget as EditableText).controller.text}"');
+      .map(
+        (element) => '"${(element.widget as EditableText).controller.text}"',
+      );
   return 'Labels: ${labels.join(' | ')}\nText fields: ${fields.join(' | ')}';
 }
 

--- a/examples/database_crud/integration_test/tasks_test.dart
+++ b/examples/database_crud/integration_test/tasks_test.dart
@@ -70,7 +70,9 @@ void main() {
       createdTitle,
     );
     await tester.tap(find.widgetWithText(FilledButton, 'Create'));
-    await _pumpUntil(tester, find.text(createdTitle));
+    // Waits for the tile instead of the title text, which also matches the text
+    // field of the dialog that is still animating away.
+    await _pumpUntil(tester, _tile(createdTitle));
 
     // Complete it by ticking the checkbox in its tile (update).
     await tester.tap(_inTile(createdTitle, find.byType(Checkbox)));
@@ -93,20 +95,21 @@ void main() {
       renamedTitle,
     );
     await tester.tap(find.widgetWithText(FilledButton, 'Save'));
-    await _pumpUntil(tester, find.text(renamedTitle));
-    expect(find.text(createdTitle), findsNothing);
+    await _pumpUntil(tester, _tile(renamedTitle));
+    expect(_tile(createdTitle), findsNothing);
 
     // Delete it (delete).
     await tester.tap(_inTile(renamedTitle, find.byIcon(Icons.delete)));
-    await _pumpUntilGone(tester, find.text(renamedTitle));
+    await _pumpUntilGone(tester, _tile(renamedTitle));
   });
 }
 
+/// Finds the [ListTile] of the task called [title].
+Finder _tile(String title) => find.widgetWithText(ListTile, title);
+
 /// Finds [target] within the [ListTile] that contains [title].
-Finder _inTile(String title, Finder target) => find.descendant(
-  of: find.ancestor(of: find.text(title), matching: find.byType(ListTile)),
-  matching: target,
-);
+Finder _inTile(String title, Finder target) =>
+    find.descendant(of: _tile(title), matching: target);
 
 /// Pumps frames until [finder] matches at least one widget or [timeout] elapses.
 ///

--- a/examples/database_crud/integration_test/tasks_test.dart
+++ b/examples/database_crud/integration_test/tasks_test.dart
@@ -125,7 +125,22 @@ Future<void> _pumpUntil(
     await tester.pump(const Duration(milliseconds: 100));
     if (finder.evaluate().isNotEmpty) return;
   }
-  fail('Timed out waiting for: $finder');
+  fail('Timed out waiting for: $finder\n${_screen()}');
+}
+
+/// What is on screen, so a timeout says whether the app got somewhere else
+/// rather than only which finder came up empty.
+String _screen() {
+  final labels = find
+      .byType(Text)
+      .evaluate()
+      .map((element) => (element.widget as Text).data)
+      .whereType<String>();
+  final fields = find
+      .byType(EditableText)
+      .evaluate()
+      .map((element) => '"${(element.widget as EditableText).controller.text}"');
+  return 'Labels: ${labels.join(' | ')}\nText fields: ${fields.join(' | ')}';
 }
 
 /// The inverse of [_pumpUntil]: pumps until [finder] matches nothing.
@@ -139,5 +154,5 @@ Future<void> _pumpUntilGone(
     await tester.pump(const Duration(milliseconds: 100));
     if (finder.evaluate().isEmpty) return;
   }
-  fail('Timed out waiting for it to disappear: $finder');
+  fail('Timed out waiting for it to disappear: $finder\n${_screen()}');
 }

--- a/examples/database_crud/integration_test/tasks_test.dart
+++ b/examples/database_crud/integration_test/tasks_test.dart
@@ -70,8 +70,12 @@ void main() {
       createdTitle,
     );
     await tester.tap(find.widgetWithText(FilledButton, 'Create'));
-    // Waits for the tile instead of the title text, which also matches the text
-    // field of the dialog that is still animating away.
+    // Searches for the new task rather than looking for it in the full list: the
+    // dialog leaves the keyboard up, and on a phone that leaves room for only a
+    // couple of tiles, so it would otherwise end up below the fold. Waits for the
+    // tile rather than the title text, which also matches the text field of the
+    // dialog that is still animating away.
+    await _searchFor(tester, createdTitle);
     await _pumpUntil(tester, _tile(createdTitle));
 
     // Complete it by ticking the checkbox in its tile (update).
@@ -95,8 +99,11 @@ void main() {
       renamedTitle,
     );
     await tester.tap(find.widgetWithText(FilledButton, 'Save'));
+    // The row stops matching the search for the old title, which is the filter
+    // still in the field, so it leaves the list.
+    await _pumpUntilGone(tester, _tile(createdTitle));
+    await _searchFor(tester, renamedTitle);
     await _pumpUntil(tester, _tile(renamedTitle));
-    expect(_tile(createdTitle), findsNothing);
 
     // Delete it (delete).
     await tester.tap(_inTile(renamedTitle, find.byIcon(Icons.delete)));
@@ -110,6 +117,10 @@ Finder _tile(String title) => find.widgetWithText(ListTile, title);
 /// Finds [target] within the [ListTile] that contains [title].
 Finder _inTile(String title, Finder target) =>
     find.descendant(of: _tile(title), matching: target);
+
+/// Filters the list down to [query] through the search field.
+Future<void> _searchFor(WidgetTester tester, String query) =>
+    tester.enterText(find.widgetWithText(TextField, 'Search title'), query);
 
 /// Pumps frames until [finder] matches at least one widget or [timeout] elapses.
 ///
@@ -142,7 +153,13 @@ String _screen() {
       .map(
         (element) => '"${(element.widget as EditableText).controller.text}"',
       );
-  return 'Labels: ${labels.join(' | ')}\nText fields: ${fields.join(' | ')}';
+  final boxes = find
+      .byType(Checkbox)
+      .evaluate()
+      .map((element) => '${(element.widget as Checkbox).value}');
+  return 'Labels: ${labels.join(' | ')}\n'
+      'Text fields: ${fields.join(' | ')}\n'
+      'Checkboxes: ${boxes.join(' | ')}';
 }
 
 /// The inverse of [_pumpUntil]: pumps until [finder] matches nothing.

--- a/examples/database_crud/lib/main.dart
+++ b/examples/database_crud/lib/main.dart
@@ -411,40 +411,47 @@ class _TaskDialogState extends State<_TaskDialog> {
   Widget build(BuildContext context) {
     return AlertDialog(
       title: const Text('New task'),
-      content: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          TextField(
-            controller: _title,
-            autofocus: true,
-            decoration: const InputDecoration(labelText: 'Title'),
-          ),
-          const SizedBox(height: 12),
-          DropdownButtonFormField<String>(
-            initialValue: _projectId,
-            isExpanded: true,
-            decoration: const InputDecoration(labelText: 'Project'),
-            items: [
-              for (final project in widget.projects)
-                DropdownMenuItem(
-                  value: project.id,
-                  child: Text(project.name),
-                ),
-            ],
-            onChanged: (value) => setState(() => _projectId = value!),
-          ),
-          const SizedBox(height: 12),
-          DropdownButtonFormField<Priority>(
-            initialValue: _priority,
-            isExpanded: true,
-            decoration: const InputDecoration(labelText: 'Priority'),
-            items: [
-              for (final priority in Priority.values)
-                DropdownMenuItem(value: priority, child: Text(priority.label)),
-            ],
-            onChanged: (value) => setState(() => _priority = value!),
-          ),
-        ],
+      // Scrolls so the fields still fit, and the actions stay reachable, when
+      // the keyboard leaves the dialog little room on a phone.
+      content: SingleChildScrollView(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            TextField(
+              controller: _title,
+              autofocus: true,
+              decoration: const InputDecoration(labelText: 'Title'),
+            ),
+            const SizedBox(height: 12),
+            DropdownButtonFormField<String>(
+              initialValue: _projectId,
+              isExpanded: true,
+              decoration: const InputDecoration(labelText: 'Project'),
+              items: [
+                for (final project in widget.projects)
+                  DropdownMenuItem(
+                    value: project.id,
+                    child: Text(project.name),
+                  ),
+              ],
+              onChanged: (value) => setState(() => _projectId = value!),
+            ),
+            const SizedBox(height: 12),
+            DropdownButtonFormField<Priority>(
+              initialValue: _priority,
+              isExpanded: true,
+              decoration: const InputDecoration(labelText: 'Priority'),
+              items: [
+                for (final priority in Priority.values)
+                  DropdownMenuItem(
+                    value: priority,
+                    child: Text(priority.label),
+                  ),
+              ],
+              onChanged: (value) => setState(() => _priority = value!),
+            ),
+          ],
+        ),
       ),
       actions: [
         TextButton(


### PR DESCRIPTION
## What

Makes the example integration tests pass, which blocks the release pull request (#1642). That workflow is gated to `chore(release)` titles, so #1642 was the first time it ever ran: every earlier trigger was skipped (49 skipped runs, 0 completed). Six separate causes, one per platform group.

## 1. The wait matched the dialog instead of the list (linux, windows, ios)

Those three failed at the same line:

```
The finder "Found 0 widgets with type "Checkbox" descending from widgets with type
"ListTile" that are ancestors of widgets with text "E2E task 1785919389726467": []"
(used in a call to "tap()") could not find any matching widgets.
```

After tapping **Create** the test waited for `find.text(createdTitle)`, which also matches an `EditableText` holding that title, which is what the dialog still has while it animates away. The wait returned about 100 ms after the tap, long before the insert round trip finished. It passes against a local stack because the insert lands inside that first frame; reproduced by putting a 500 ms delay in front of the local stack.

The waits now use the tile, `find.widgetWithText(ListTile, title)`, which a dialog cannot satisfy.

## 2. The macOS apps could not open a socket (macos)

```
ClientException with SocketException: Connection failed
(OS Error: Operation not permitted, errno = 1), address = ...trycloudflare.com
```

`flutter test -d macos` runs a real sandboxed app bundle, and `flutter create` grants it `com.apple.security.network.server` but not `com.apple.security.network.client`, so every outgoing connection is denied. The same would happen against `127.0.0.1`. The scaffolding step now adds the client entitlement. The other macOS checks are unaffected because `test.yml` runs `flutter test` on the Dart VM, with no bundle and so no sandbox.

## 3. The passkeys example could not build on Apple platforms (macos, ios)

```
GeneratedPluginRegistrant.swift:20:3: error: 'PasskeysPlugin' is only available in
macOS 13.5 or newer
```

`passkeys_darwin` annotates its plugin `@available(macOS 13.5, iOS 16.0, *)`, while the scaffolding writes 10.15 and 13.0. Both deployment targets are now raised for that example.

## 4. The Android emulator ran without KVM (android)

```
ProbeKVM: This user doesn't have permissions to use KVM (/dev/kvm).
WARNING | x86_64 emulation may not work without hardware acceleration!
Disabling Linux hardware acceleration.
...
cmd: Failure calling service input: Broken pipe (32)
```

It spent over twelve minutes booting under software emulation, then stopped responding, before any test ran. Added the udev rule from the `android-emulator-runner` readme; the emulator now boots in about 90 seconds.

## 5. web passed but the job never finished (web)

Both suites reported `All tests passed`, then the step idled until the 45 minute job timeout. The runner script itself never exits: `_waitForPort` called `socket.close()`, which only shuts the sending side down, and since nothing reads that socket the resource keeps the process alive. `lsof` on the hung process shows the `CLOSED` socket still holding an fd. Only the web target probes a port, which is why only web hung. `socket.destroy()` releases it and the script exits.

## 6. The keyboard hid the task under test (android)

Android is the only target with a soft keyboard. The create dialog opens it, and the dialog route then restores focus to the search field the test typed in earlier, so it never closes:

```
view: Size(411.4, 890.3)    viewInsets.bottom: 312.4    visible area ends at 577.9
checkbox rect: LTRB(16.0, 589.8, 64.0, 637.8)      -> behind the keyboard
Warning: A call to tap() ... derived an Offset (40.0, 613.8) that would not hit test
```

The new task defaults to Low priority and so sorts last, leaving it outside the visible part of the shortened list: on a phone the taps missed, and on the 320x640 screen the CI emulator actually uses (`avdmanager` runs with no hardware profile, giving `androidboot.qemu.skin=320x640`) the tile was never even built.

The test now searches for the task it is working on, so it is the only row on screen at any size, which is also how a user would find it again. Asserting that the row leaves the list after the rename, while the old title is still in the filter, additionally proves the write reached the server. Two rejected alternatives, both disproven by trying them: unfocusing in the app does nothing because focus restoration happens afterwards, and scrolling to the tile overshoots, since it only scrolls one way and pinned the list at the bottom after the rename.

Separately, the new-task dialog overflowed by 27 pixels with the keyboard up and pushed its actions off screen, so its content is now scrollable.

## Also

- Dropped `edited` from the trigger types. A bot rewriting the description fired it, and with `cancel-in-progress` that killed a running matrix and started it over; `coderabbitai` did exactly that mid-run here.
- The jobs also run when a pull request carries the `integration tests` label, so the suite can be exercised outside a release. That is how this pull request verified itself.
- Timeouts in the CRUD test now print what is on screen, which is what separated "the dialog stayed open" from "the row never arrived".
- The simulator is wiped before the iOS run. Those tests hung waiting for the app's VM service on five of six runs, which is reported to come from stale simulator state. Honest status: mitigation for a flake, not a proven fix.

## Testing

All six platforms and both examples green: https://github.com/supabase/supabase-flutter/actions/runs/31004067346

Locally, against a stack behind a delaying proxy:

- CRUD and passkeys suites on web at 500 ms and 1000 ms latency.
- CRUD suite on an emulator with CI's 320x640 screen, three consecutive passes, and on a pixel_6.
- `melos format` and `melos analyze` clean from the repository root.
