### PR TITLE
refactor!: share one HttpMethod enum across the client packages

### DIFF
--- a/packages/functions_client/lib/functions_client.dart
+++ b/packages/functions_client/lib/functions_client.dart
@@ -3,7 +3,8 @@ library;
 
 export 'package:http/http.dart'
     show ByteStream, MultipartFile, RequestAbortedException;
-export 'package:supabase_common/supabase_common.dart' show SupabaseException;
+export 'package:supabase_common/supabase_common.dart'
+    show HttpMethod, SupabaseException;
 
 export 'src/functions_client.dart';
 export 'src/types.dart';

--- a/packages/functions_client/lib/src/functions_client.dart
+++ b/packages/functions_client/lib/src/functions_client.dart
@@ -166,7 +166,7 @@ class FunctionsClient {
 
       request =
           http.AbortableMultipartRequest(
-              method.name.toUpperCase(),
+              method.value,
               uri,
               abortTrigger: abortSignal,
             )
@@ -174,7 +174,7 @@ class FunctionsClient {
             ..files.addAll(files);
     } else {
       final bodyRequest = http.AbortableRequest(
-        method.name.toUpperCase(),
+        method.value,
         uri,
         abortTrigger: abortSignal,
       );

--- a/packages/functions_client/lib/src/types.dart
+++ b/packages/functions_client/lib/src/types.dart
@@ -4,14 +4,6 @@ import 'dart:typed_data';
 import 'package:http/http.dart';
 import 'package:supabase_common/supabase_common.dart';
 
-enum HttpMethod {
-  get,
-  post,
-  put,
-  delete,
-  patch,
-}
-
 class FunctionResponse {
   /// The data returned by the function. Type depends on the header `Content-Type`:
   /// - 'text/plain': [String]

--- a/packages/functions_client/test/functions_dart_test.dart
+++ b/packages/functions_client/test/functions_dart_test.dart
@@ -5,6 +5,7 @@ import 'dart:typed_data';
 import 'package:functions_client/src/functions_client.dart';
 import 'package:functions_client/src/types.dart';
 import 'package:http/http.dart';
+import 'package:supabase_common/supabase_common.dart';
 import 'package:test/test.dart';
 import 'package:yet_another_json_isolate/yet_another_json_isolate.dart';
 

--- a/packages/gotrue/lib/src/fetch.dart
+++ b/packages/gotrue/lib/src/fetch.dart
@@ -9,8 +9,6 @@ import 'package:gotrue/src/types/fetch_options.dart';
 import 'package:http/http.dart';
 import 'package:supabase_common/supabase_common.dart';
 
-enum RequestMethodType { get, post, put, patch, delete }
-
 class GotrueFetch {
   final Client? httpClient;
 
@@ -114,7 +112,7 @@ class GotrueFetch {
 
   Future<dynamic> request(
     String url,
-    RequestMethodType method, {
+    HttpMethod method, {
     GotrueRequestOptions? options,
   }) async {
     // Copy the maps before mutating them. Callers pass the client's shared
@@ -147,39 +145,43 @@ class GotrueFetch {
   }
 
   Future<dynamic> _handleRequest({
-    required RequestMethodType method,
+    required HttpMethod method,
     required Uri uri,
     required GotrueRequestOptions? options,
     required Map<String, String> headers,
   }) async {
     final bodyStr = json.encode(options?.body ?? {});
 
-    if (method != RequestMethodType.get) {
+    if (method != HttpMethod.get && method != HttpMethod.head) {
       headers['Content-Type'] = 'application/json';
     }
     Response response;
     try {
       response = await switch (method) {
-        RequestMethodType.get => (httpClient?.get ?? get)(
+        HttpMethod.get => (httpClient?.get ?? get)(
           uri,
           headers: headers,
         ),
-        RequestMethodType.post => (httpClient?.post ?? post)(
+        HttpMethod.head => (httpClient?.head ?? head)(
           uri,
           headers: headers,
-          body: bodyStr,
         ),
-        RequestMethodType.put => (httpClient?.put ?? put)(
-          uri,
-          headers: headers,
-          body: bodyStr,
-        ),
-        RequestMethodType.patch => (httpClient?.patch ?? patch)(
+        HttpMethod.post => (httpClient?.post ?? post)(
           uri,
           headers: headers,
           body: bodyStr,
         ),
-        RequestMethodType.delete => (httpClient?.delete ?? delete)(
+        HttpMethod.put => (httpClient?.put ?? put)(
+          uri,
+          headers: headers,
+          body: bodyStr,
+        ),
+        HttpMethod.patch => (httpClient?.patch ?? patch)(
+          uri,
+          headers: headers,
+          body: bodyStr,
+        ),
+        HttpMethod.delete => (httpClient?.delete ?? delete)(
           uri,
           headers: headers,
           body: bodyStr,

--- a/packages/gotrue/lib/src/gotrue_admin_api.dart
+++ b/packages/gotrue/lib/src/gotrue_admin_api.dart
@@ -72,7 +72,7 @@ class GoTrueAdminApi {
 
     await _fetch.request(
       '$_url/logout',
-      RequestMethodType.post,
+      HttpMethod.post,
       options: options,
     );
   }
@@ -89,7 +89,7 @@ class GoTrueAdminApi {
     );
     final response = await _fetch.request(
       '$_url/admin/users',
-      RequestMethodType.post,
+      HttpMethod.post,
       options: options,
     );
     return UserResponse.fromJson(response);
@@ -112,7 +112,7 @@ class GoTrueAdminApi {
     );
     await _fetch.request(
       '$_url/admin/users/$id',
-      RequestMethodType.delete,
+      HttpMethod.delete,
       options: options,
     );
   }
@@ -132,7 +132,7 @@ class GoTrueAdminApi {
     );
     final response = await _fetch.request(
       '$_url/admin/users',
-      RequestMethodType.get,
+      HttpMethod.get,
       options: options,
     );
     return (response['users'] as List).map((e) => User.fromJson(e)!).toList();
@@ -156,7 +156,7 @@ class GoTrueAdminApi {
 
     final response = await _fetch.request(
       '$_url/invite',
-      RequestMethodType.post,
+      HttpMethod.post,
       options: fetchOptions,
     );
     return UserResponse.fromJson(response);
@@ -204,7 +204,7 @@ class GoTrueAdminApi {
 
     final response = await _fetch.request(
       '$_url/admin/generate_link',
-      RequestMethodType.post,
+      HttpMethod.post,
       options: fetchOptions,
     );
     return GenerateLinkResponse.fromJson(response);
@@ -216,7 +216,7 @@ class GoTrueAdminApi {
     final options = GotrueRequestOptions(headers: _headers);
     final response = await _fetch.request(
       '$_url/admin/users/$uid',
-      RequestMethodType.get,
+      HttpMethod.get,
       options: options,
     );
     return UserResponse.fromJson(response);
@@ -232,7 +232,7 @@ class GoTrueAdminApi {
     final options = GotrueRequestOptions(headers: _headers, body: body);
     final response = await _fetch.request(
       '$_url/admin/users/$uid',
-      RequestMethodType.put,
+      HttpMethod.put,
       options: options,
     );
     return UserResponse.fromJson(response);

--- a/packages/gotrue/lib/src/gotrue_admin_custom_providers_api.dart
+++ b/packages/gotrue/lib/src/gotrue_admin_custom_providers_api.dart
@@ -1,3 +1,4 @@
+import 'package:supabase_common/supabase_common.dart';
 import 'fetch.dart';
 import 'types/custom_oauth_provider.dart';
 import 'types/fetch_options.dart';
@@ -29,7 +30,7 @@ class GoTrueAdminCustomProvidersApi {
   }) async {
     final data = await _fetch.request(
       '$_url/admin/custom-providers',
-      RequestMethodType.get,
+      HttpMethod.get,
       options: GotrueRequestOptions(
         headers: _headers,
         query: {
@@ -60,7 +61,7 @@ class GoTrueAdminCustomProvidersApi {
   ) async {
     final data = await _fetch.request(
       '$_url/admin/custom-providers',
-      RequestMethodType.post,
+      HttpMethod.post,
       options: GotrueRequestOptions(
         headers: _headers,
         body: params.toJson(),
@@ -77,7 +78,7 @@ class GoTrueAdminCustomProvidersApi {
   Future<CustomOAuthProvider> getProvider(String identifier) async {
     final data = await _fetch.request(
       '$_url/admin/custom-providers/$identifier',
-      RequestMethodType.get,
+      HttpMethod.get,
       options: GotrueRequestOptions(
         headers: _headers,
       ),
@@ -101,7 +102,7 @@ class GoTrueAdminCustomProvidersApi {
   ) async {
     final data = await _fetch.request(
       '$_url/admin/custom-providers/$identifier',
-      RequestMethodType.put,
+      HttpMethod.put,
       options: GotrueRequestOptions(
         headers: _headers,
         body: params.toJson(),
@@ -118,7 +119,7 @@ class GoTrueAdminCustomProvidersApi {
   Future<void> deleteProvider(String identifier) async {
     await _fetch.request(
       '$_url/admin/custom-providers/$identifier',
-      RequestMethodType.delete,
+      HttpMethod.delete,
       options: GotrueRequestOptions(
         headers: _headers,
         noResolveJson: true,

--- a/packages/gotrue/lib/src/gotrue_admin_mfa_api.dart
+++ b/packages/gotrue/lib/src/gotrue_admin_mfa_api.dart
@@ -1,5 +1,5 @@
+import 'package:supabase_common/supabase_common.dart';
 import 'fetch.dart';
-import 'helper.dart';
 import 'types/fetch_options.dart';
 import 'types/mfa.dart';
 
@@ -23,7 +23,7 @@ class GoTrueAdminMFAApi {
 
     final data = await _fetch.request(
       '$_url/admin/users/$userId/factors',
-      RequestMethodType.get,
+      HttpMethod.get,
       options: GotrueRequestOptions(
         headers: _headers,
       ),
@@ -43,7 +43,7 @@ class GoTrueAdminMFAApi {
 
     final data = await _fetch.request(
       '$_url/admin/users/$userId/factors/$factorId',
-      RequestMethodType.delete,
+      HttpMethod.delete,
       options: GotrueRequestOptions(
         headers: _headers,
       ),

--- a/packages/gotrue/lib/src/gotrue_admin_oauth_api.dart
+++ b/packages/gotrue/lib/src/gotrue_admin_oauth_api.dart
@@ -1,5 +1,5 @@
+import 'package:supabase_common/supabase_common.dart';
 import 'fetch.dart';
-import 'helper.dart';
 import 'types/fetch_options.dart';
 import 'types/types.dart';
 
@@ -72,7 +72,7 @@ class GoTrueAdminOAuthApi {
   }) async {
     final data = await _fetch.request(
       '$_url/admin/oauth/clients',
-      RequestMethodType.get,
+      HttpMethod.get,
       options: GotrueRequestOptions(
         headers: _headers,
         query: {
@@ -94,7 +94,7 @@ class GoTrueAdminOAuthApi {
   ) async {
     final data = await _fetch.request(
       '$_url/admin/oauth/clients',
-      RequestMethodType.post,
+      HttpMethod.post,
       options: GotrueRequestOptions(
         headers: _headers,
         body: params.toJson(),
@@ -113,7 +113,7 @@ class GoTrueAdminOAuthApi {
 
     final data = await _fetch.request(
       '$_url/admin/oauth/clients/$clientId',
-      RequestMethodType.get,
+      HttpMethod.get,
       options: GotrueRequestOptions(
         headers: _headers,
       ),
@@ -134,7 +134,7 @@ class GoTrueAdminOAuthApi {
 
     final data = await _fetch.request(
       '$_url/admin/oauth/clients/$clientId',
-      RequestMethodType.put,
+      HttpMethod.put,
       options: GotrueRequestOptions(
         headers: _headers,
         body: params.toJson(),
@@ -153,7 +153,7 @@ class GoTrueAdminOAuthApi {
 
     final data = await _fetch.request(
       '$_url/admin/oauth/clients/$clientId',
-      RequestMethodType.delete,
+      HttpMethod.delete,
       options: GotrueRequestOptions(
         headers: _headers,
       ),
@@ -171,7 +171,7 @@ class GoTrueAdminOAuthApi {
 
     final data = await _fetch.request(
       '$_url/admin/oauth/clients/$clientId/regenerate_secret',
-      RequestMethodType.post,
+      HttpMethod.post,
       options: GotrueRequestOptions(
         headers: _headers,
       ),

--- a/packages/gotrue/lib/src/gotrue_admin_passkey_api.dart
+++ b/packages/gotrue/lib/src/gotrue_admin_passkey_api.dart
@@ -1,7 +1,7 @@
 import 'package:meta/meta.dart';
+import 'package:supabase_common/supabase_common.dart';
 
 import 'fetch.dart';
-import 'helper.dart';
 import 'types/fetch_options.dart';
 import 'types/passkey.dart';
 
@@ -32,7 +32,7 @@ class GoTrueAdminPasskeyApi {
 
     final data = await _fetch.request(
       '$_url/admin/users/$userId/passkeys',
-      RequestMethodType.get,
+      HttpMethod.get,
       options: GotrueRequestOptions(
         headers: _headers,
       ),
@@ -57,7 +57,7 @@ class GoTrueAdminPasskeyApi {
 
     await _fetch.request(
       '$_url/admin/users/$userId/passkeys/$passkeyId',
-      RequestMethodType.delete,
+      HttpMethod.delete,
       options: GotrueRequestOptions(
         headers: _headers,
       ),

--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -243,7 +243,7 @@ class GoTrueClient {
   }) async {
     final response = await _fetch.request(
       '$_url/signup',
-      RequestMethodType.post,
+      HttpMethod.post,
       options: GotrueRequestOptions(
         headers: _headers,
         body: {
@@ -302,7 +302,7 @@ class GoTrueClient {
 
       response = await _fetch.request(
         '$_url/signup',
-        RequestMethodType.post,
+        HttpMethod.post,
         options: GotrueRequestOptions(
           headers: _headers,
           redirectTo: emailRedirectTo,
@@ -328,7 +328,7 @@ class GoTrueClient {
       response =
           await _fetch.request(
                 '$_url/signup',
-                RequestMethodType.post,
+                HttpMethod.post,
                 options: fetchOptions,
               )
               as Map<String, dynamic>;
@@ -361,7 +361,7 @@ class GoTrueClient {
     if (email != null) {
       response = await _fetch.request(
         '$_url/token',
-        RequestMethodType.post,
+        HttpMethod.post,
         options: GotrueRequestOptions(
           headers: _headers,
           body: {
@@ -375,7 +375,7 @@ class GoTrueClient {
     } else if (phone != null) {
       response = await _fetch.request(
         '$_url/token',
-        RequestMethodType.post,
+        HttpMethod.post,
         options: GotrueRequestOptions(
           headers: _headers,
           body: {
@@ -436,7 +436,7 @@ class GoTrueClient {
 
     final Map<String, dynamic> response = await _fetch.request(
       '$_url/token',
-      RequestMethodType.post,
+      HttpMethod.post,
       options: GotrueRequestOptions(
         headers: _headers,
         body: {'auth_code': authCode, 'code_verifier': codeVerifier},
@@ -509,7 +509,7 @@ class GoTrueClient {
   }) async {
     final response = await _fetch.request(
       '$_url/token',
-      RequestMethodType.post,
+      HttpMethod.post,
       options: GotrueRequestOptions(
         headers: _headers,
         body: {
@@ -557,7 +557,7 @@ class GoTrueClient {
   }) async {
     final response = await _fetch.request(
       '$_url/token',
-      RequestMethodType.post,
+      HttpMethod.post,
       options: GotrueRequestOptions(
         headers: _headers,
         body: {
@@ -613,7 +613,7 @@ class GoTrueClient {
       final codeChallenge = await _generatePKCECodeChallenge();
       await _fetch.request(
         '$_url/otp',
-        RequestMethodType.post,
+        HttpMethod.post,
         options: GotrueRequestOptions(
           headers: _headers,
           redirectTo: emailRedirectTo,
@@ -641,7 +641,7 @@ class GoTrueClient {
 
       await _fetch.request(
         '$_url/otp',
-        RequestMethodType.post,
+        HttpMethod.post,
         options: fetchOptions,
       );
       return;
@@ -703,7 +703,7 @@ class GoTrueClient {
     final fetchOptions = GotrueRequestOptions(headers: _headers, body: body);
     final response = await _fetch.request(
       '$_url/verify',
-      RequestMethodType.post,
+      HttpMethod.post,
       options: fetchOptions,
     );
 
@@ -751,7 +751,7 @@ class GoTrueClient {
 
     final res = await _fetch.request(
       '$_url/sso',
-      RequestMethodType.post,
+      HttpMethod.post,
       options: GotrueRequestOptions(
         body: {
           'provider_id': ?providerId,
@@ -803,7 +803,7 @@ class GoTrueClient {
 
     await _fetch.request(
       '$_url/reauthenticate',
-      RequestMethodType.get,
+      HttpMethod.get,
       options: options,
     );
   }
@@ -860,7 +860,7 @@ class GoTrueClient {
 
     final response = await _fetch.request(
       '$_url/resend',
-      RequestMethodType.post,
+      HttpMethod.post,
       options: options,
     );
 
@@ -881,7 +881,7 @@ class GoTrueClient {
     );
     final response = await _fetch.request(
       '$_url/user',
-      RequestMethodType.get,
+      HttpMethod.get,
       options: options,
     );
     return UserResponse.fromJson(response);
@@ -916,7 +916,7 @@ class GoTrueClient {
     );
     final response = await _fetch.request(
       '$_url/user',
-      RequestMethodType.put,
+      HttpMethod.put,
       options: options,
     );
     final userResponse = UserResponse.fromJson(response);
@@ -1137,7 +1137,7 @@ class GoTrueClient {
     );
     await _fetch.request(
       '$_url/recover',
-      RequestMethodType.post,
+      HttpMethod.post,
       options: fetchOptions,
     );
   }
@@ -1169,7 +1169,7 @@ class GoTrueClient {
   }) async {
     final response = await _fetch.request(
       '$_url/token',
-      RequestMethodType.post,
+      HttpMethod.post,
       options: GotrueRequestOptions(
         headers: _headers,
         jwt: _currentSession?.accessToken,
@@ -1214,7 +1214,7 @@ class GoTrueClient {
     );
     final res = await _fetch.request(
       urlResponse.url,
-      RequestMethodType.get,
+      HttpMethod.get,
       options: GotrueRequestOptions(
         headers: _headers,
         jwt: _currentSession?.accessToken,
@@ -1229,7 +1229,7 @@ class GoTrueClient {
   Future<void> unlinkIdentity(UserIdentity identity) async {
     await _fetch.request(
       '$_url/user/identities/${identity.identityId}',
-      RequestMethodType.delete,
+      HttpMethod.delete,
       options: GotrueRequestOptions(
         headers: headers,
         jwt: _currentSession?.accessToken,
@@ -1405,7 +1405,7 @@ class GoTrueClient {
         );
         final response = await _fetch.request(
           '$_url/token',
-          RequestMethodType.post,
+          HttpMethod.post,
           options: options,
         );
         final authResponse = AuthResponse.fromJson(response);
@@ -1709,7 +1709,7 @@ class GoTrueClient {
     // jwk isn't cached in memory so we need to fetch it from the well-known endpoint
     final jwksResponse = await _fetch.request(
       '$_url/.well-known/jwks.json',
-      RequestMethodType.get,
+      HttpMethod.get,
       options: GotrueRequestOptions(headers: _headers),
     );
 

--- a/packages/gotrue/lib/src/gotrue_mfa_api.dart
+++ b/packages/gotrue/lib/src/gotrue_mfa_api.dart
@@ -16,7 +16,7 @@ class GoTrueMFAApi {
 
     final data = await _fetch.request(
       '${_client._url}/factors/$factorId',
-      RequestMethodType.delete,
+      HttpMethod.delete,
       options: GotrueRequestOptions(
         headers: _client._headers,
         jwt: session?.accessToken,
@@ -75,7 +75,7 @@ class GoTrueMFAApi {
 
     final data = await _fetch.request(
       '${_client._url}/factors',
-      RequestMethodType.post,
+      HttpMethod.post,
       options: GotrueRequestOptions(
         headers: _client._headers,
         body: body,
@@ -104,7 +104,7 @@ class GoTrueMFAApi {
 
     final data = await _fetch.request(
       '${_client._url}/factors/$factorId/verify',
-      RequestMethodType.post,
+      HttpMethod.post,
       options: GotrueRequestOptions(
         headers: _client._headers,
         body: {
@@ -143,7 +143,7 @@ class GoTrueMFAApi {
 
     final data = await _fetch.request(
       '${_client._url}/factors/$factorId/challenge',
-      RequestMethodType.post,
+      HttpMethod.post,
       options: GotrueRequestOptions(
         headers: _client._headers,
         body: channel == null ? null : {'channel': channel.name},

--- a/packages/gotrue/lib/src/gotrue_oauth_api.dart
+++ b/packages/gotrue/lib/src/gotrue_oauth_api.dart
@@ -234,7 +234,7 @@ class GoTrueOAuthApi {
 
     final data = await _fetch.request(
       '${_client._url}/oauth/authorizations/$authorizationId',
-      RequestMethodType.get,
+      HttpMethod.get,
       options: GotrueRequestOptions(
         headers: _client._headers,
         jwt: session?.accessToken,
@@ -257,7 +257,7 @@ class GoTrueOAuthApi {
 
     final data = await _fetch.request(
       '${_client._url}/oauth/authorizations/$authorizationId/consent',
-      RequestMethodType.post,
+      HttpMethod.post,
       options: GotrueRequestOptions(
         headers: _client._headers,
         jwt: session?.accessToken,
@@ -283,7 +283,7 @@ class GoTrueOAuthApi {
 
     final data = await _fetch.request(
       '${_client._url}/oauth/authorizations/$authorizationId/consent',
-      RequestMethodType.post,
+      HttpMethod.post,
       options: GotrueRequestOptions(
         headers: _client._headers,
         jwt: session?.accessToken,
@@ -304,7 +304,7 @@ class GoTrueOAuthApi {
 
     final data = await _fetch.request(
       '${_client._url}/user/oauth/grants',
-      RequestMethodType.get,
+      HttpMethod.get,
       options: GotrueRequestOptions(
         headers: _client._headers,
         jwt: session?.accessToken,
@@ -323,7 +323,7 @@ class GoTrueOAuthApi {
 
     await _fetch.request(
       '${_client._url}/user/oauth/grants',
-      RequestMethodType.delete,
+      HttpMethod.delete,
       options: GotrueRequestOptions(
         headers: _client._headers,
         jwt: session?.accessToken,

--- a/packages/gotrue/lib/src/gotrue_passkey_api.dart
+++ b/packages/gotrue/lib/src/gotrue_passkey_api.dart
@@ -69,7 +69,7 @@ class GoTruePasskeyApi {
 
     final data = await _fetch.request(
       '${_client._url}/passkeys/registration/options',
-      RequestMethodType.post,
+      HttpMethod.post,
       options: GotrueRequestOptions(
         headers: _client._headers,
         body: {},
@@ -123,7 +123,7 @@ class GoTruePasskeyApi {
 
     final data = await _fetch.request(
       '${_client._url}/passkeys/registration/verify',
-      RequestMethodType.post,
+      HttpMethod.post,
       options: GotrueRequestOptions(
         headers: _client._headers,
         body: {
@@ -148,7 +148,7 @@ class GoTruePasskeyApi {
   }) async {
     final data = await _fetch.request(
       '${_client._url}/passkeys/authentication/options',
-      RequestMethodType.post,
+      HttpMethod.post,
       options: GotrueRequestOptions(
         headers: _client._headers,
         body: {
@@ -176,7 +176,7 @@ class GoTruePasskeyApi {
   }) async {
     final data = await _fetch.request(
       '${_client._url}/passkeys/authentication/verify',
-      RequestMethodType.post,
+      HttpMethod.post,
       options: GotrueRequestOptions(
         headers: _client._headers,
         body: {
@@ -202,7 +202,7 @@ class GoTruePasskeyApi {
 
     final data = await _fetch.request(
       '${_client._url}/passkeys',
-      RequestMethodType.get,
+      HttpMethod.get,
       options: GotrueRequestOptions(
         headers: _client._headers,
         jwt: session?.accessToken,
@@ -227,7 +227,7 @@ class GoTruePasskeyApi {
 
     final data = await _fetch.request(
       '${_client._url}/passkeys/$passkeyId',
-      RequestMethodType.patch,
+      HttpMethod.patch,
       options: GotrueRequestOptions(
         headers: _client._headers,
         body: {'friendly_name': friendlyName},
@@ -247,7 +247,7 @@ class GoTruePasskeyApi {
 
     await _fetch.request(
       '${_client._url}/passkeys/$passkeyId',
-      RequestMethodType.delete,
+      HttpMethod.delete,
       options: GotrueRequestOptions(
         headers: _client._headers,
         jwt: session?.accessToken,

--- a/packages/gotrue/test/fetch_test.dart
+++ b/packages/gotrue/test/fetch_test.dart
@@ -2,6 +2,7 @@ import 'package:gotrue/gotrue.dart';
 import 'package:gotrue/src/constants.dart';
 import 'package:gotrue/src/fetch.dart';
 import 'package:http/http.dart';
+import 'package:supabase_common/supabase_common.dart';
 import 'package:test/test.dart';
 
 import 'custom_http_client.dart';
@@ -77,7 +78,7 @@ void main() {
 Future<void> _testFetchRequest(Client client) async {
   final GotrueFetch fetch = GotrueFetch(client);
   await expectLater(
-    fetch.request(_mockUrl, RequestMethodType.get),
+    fetch.request(_mockUrl, HttpMethod.get),
     throwsA(
       isA<AuthException>()
           .having((e) => e.errorCode, 'errorCode', 'weak_password')

--- a/packages/postgrest/lib/postgrest.dart
+++ b/packages/postgrest/lib/postgrest.dart
@@ -1,7 +1,8 @@
 /// PostgREST client for Dart. Provides an ORM interface to PostgREST.
 library;
 
-export 'package:supabase_common/supabase_common.dart' show SupabaseException;
+export 'package:supabase_common/supabase_common.dart'
+    show HttpMethod, SupabaseException;
 
 export 'src/postgrest.dart';
 export 'src/postgrest_builder.dart';

--- a/packages/postgrest/lib/src/postgrest_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_builder.dart
@@ -18,17 +18,6 @@ part 'postgrest_transform_builder.dart';
 part 'raw_postgrest_builder.dart';
 part 'response_postgrest_builder.dart';
 
-enum HttpMethod {
-  get,
-  head,
-  post,
-  put,
-  patch,
-  delete;
-
-  String get value => name.toUpperCase();
-}
-
 typedef _Nullable<T> = T?;
 
 /// Bundles the automatic retry configuration so it can be carried through the

--- a/packages/storage_client/lib/src/fetch.dart
+++ b/packages/storage_client/lib/src/fetch.dart
@@ -62,13 +62,13 @@ class Fetch {
   }
 
   Future<dynamic> _handleRequest(
-    String method,
+    HttpMethod method,
     String url,
     Map<String, dynamic>? body,
     FetchOptions? options,
   ) async {
     final headers = {...?options?.headers};
-    if (method != 'GET') {
+    if (method != HttpMethod.get) {
       final hasContentType = headers.keys.any(
         (key) => key.toLowerCase() == 'content-type',
       );
@@ -77,13 +77,13 @@ class Fetch {
       }
     }
 
-    final request = http.Request(method, Uri.parse(url))
+    final request = http.Request(method.value, Uri.parse(url))
       ..headers.addAll(headers);
     if (body != null) {
       request.body = json.encode(body);
     }
 
-    _log.finest('Request: $method $url $headers');
+    _log.finest('Request: ${method.value} $url $headers');
     final http.StreamedResponse streamedResponse;
     if (httpClient != null) {
       streamedResponse = await httpClient!.send(request);
@@ -94,7 +94,7 @@ class Fetch {
   }
 
   Future<dynamic> _handleFileRequest(
-    String method,
+    HttpMethod method,
     String url,
     File file,
     FileOptions fileOptions,
@@ -123,7 +123,7 @@ class Fetch {
   }
 
   Future<dynamic> _handleBinaryFileRequest(
-    String method,
+    HttpMethod method,
     String url,
     Uint8List data,
     FileOptions fileOptions,
@@ -152,7 +152,7 @@ class Fetch {
   }
 
   Future<dynamic> _handleMultipartRequest(
-    String method,
+    HttpMethod method,
     String url,
     MultipartFile Function() createMultipartFile,
     FileOptions fileOptions,
@@ -164,7 +164,7 @@ class Fetch {
 
     // Create a factory function that generates a fresh MultipartRequest for each attempt
     http.MultipartRequest createRequest() {
-      final request = http.MultipartRequest(method, Uri.parse(url))
+      final request = http.MultipartRequest(method.value, Uri.parse(url))
         ..headers.addAll(headers)
         ..files.add(createMultipartFile())
         ..fields['cacheControl'] = fileOptions.cacheControl
@@ -184,7 +184,9 @@ class Fetch {
     streamedResponse = await r.retry<http.StreamedResponse>(
       () async {
         attempts++;
-        _log.finest('Request: attempt: $attempts $method $url $headers');
+        _log.finest(
+          'Request: attempt: $attempts ${method.value} $url $headers',
+        );
 
         // Create a fresh request for each retry attempt
         final request = createRequest();
@@ -227,7 +229,7 @@ class Fetch {
 
   Future<dynamic> head(String url, {FetchOptions? options}) {
     return _handleRequest(
-      'HEAD',
+      HttpMethod.head,
       url,
       null,
       FetchOptions(options?.headers, noResolveJson: true),
@@ -235,7 +237,7 @@ class Fetch {
   }
 
   Future<dynamic> get(String url, {FetchOptions? options}) {
-    return _handleRequest('GET', url, null, options);
+    return _handleRequest(HttpMethod.get, url, null, options);
   }
 
   /// Performs a GET request and yields the response body as a byte stream
@@ -249,7 +251,7 @@ class Fetch {
     String url, {
     FetchOptions? options,
   }) async* {
-    final request = http.Request('GET', Uri.parse(url))
+    final request = http.Request(HttpMethod.get.value, Uri.parse(url))
       ..headers.addAll({...?options?.headers});
 
     _log.finest('Request: GET (stream) $url ${request.headers}');
@@ -280,7 +282,7 @@ class Fetch {
     Map<String, dynamic>? body, {
     FetchOptions? options,
   }) {
-    return _handleRequest('POST', url, body, options);
+    return _handleRequest(HttpMethod.post, url, body, options);
   }
 
   Future<dynamic> put(
@@ -288,7 +290,7 @@ class Fetch {
     Map<String, dynamic>? body, {
     FetchOptions? options,
   }) {
-    return _handleRequest('PUT', url, body, options);
+    return _handleRequest(HttpMethod.put, url, body, options);
   }
 
   Future<dynamic> delete(
@@ -296,7 +298,7 @@ class Fetch {
     Map<String, dynamic>? body, {
     FetchOptions? options,
   }) {
-    return _handleRequest('DELETE', url, body, options);
+    return _handleRequest(HttpMethod.delete, url, body, options);
   }
 
   Future<dynamic> postFile(
@@ -308,7 +310,7 @@ class Fetch {
     required StorageRetryController? retryController,
   }) {
     return _handleFileRequest(
-      'POST',
+      HttpMethod.post,
       url,
       file,
       fileOptions,
@@ -327,7 +329,7 @@ class Fetch {
     required StorageRetryController? retryController,
   }) {
     return _handleFileRequest(
-      'PUT',
+      HttpMethod.put,
       url,
       file,
       fileOptions,
@@ -346,7 +348,7 @@ class Fetch {
     required StorageRetryController? retryController,
   }) {
     return _handleBinaryFileRequest(
-      'POST',
+      HttpMethod.post,
       url,
       data,
       fileOptions,
@@ -365,7 +367,7 @@ class Fetch {
     required StorageRetryController? retryController,
   }) {
     return _handleBinaryFileRequest(
-      'PUT',
+      HttpMethod.put,
       url,
       data,
       fileOptions,

--- a/packages/storage_client/lib/src/iceberg/iceberg_rest_catalog.dart
+++ b/packages/storage_client/lib/src/iceberg/iceberg_rest_catalog.dart
@@ -7,6 +7,7 @@ import 'package:storage_client/src/iceberg/iceberg_error.dart';
 import 'package:storage_client/src/iceberg/iceberg_types.dart';
 import 'package:storage_client/src/iceberg/table_requirement.dart';
 import 'package:storage_client/src/iceberg/table_update.dart';
+import 'package:supabase_common/supabase_common.dart';
 
 class _IcebergResponse {
   final int statusCode;
@@ -90,7 +91,7 @@ class IcebergRestCatalog {
     }
     try {
       final response = await _request(
-        'GET',
+        HttpMethod.get,
         'v1/config',
         query: {'warehouse': _warehouse},
       );
@@ -124,7 +125,7 @@ class IcebergRestCatalog {
   }
 
   Future<_IcebergResponse> _request(
-    String method,
+    HttpMethod method,
     String path, {
     Map<String, String>? query,
     Object? body,
@@ -137,12 +138,13 @@ class IcebergRestCatalog {
       ...?headers,
     };
 
-    final request = http.Request(method, uri)..headers.addAll(requestHeaders);
+    final request = http.Request(method.value, uri)
+      ..headers.addAll(requestHeaders);
     if (body != null) {
       request.body = json.encode(body);
     }
 
-    _log.finest('Request: $method $uri');
+    _log.finest('Request: ${method.value} $uri');
 
     final http.StreamedResponse streamedResponse;
     try {
@@ -190,7 +192,7 @@ class IcebergRestCatalog {
       if (options?.pageSize != null) 'pageSize': '${options!.pageSize}',
     };
     final response = await _request(
-      'GET',
+      HttpMethod.get,
       '$prefix/namespaces',
       query: query.isEmpty ? null : query,
     );
@@ -210,7 +212,7 @@ class IcebergRestCatalog {
   }) async {
     final prefix = await _resolvePrefix();
     final response = await _request(
-      'POST',
+      HttpMethod.post,
       '$prefix/namespaces',
       body: {
         'namespace': namespace,
@@ -228,7 +230,7 @@ class IcebergRestCatalog {
   ) async {
     final prefix = await _resolvePrefix();
     final response = await _request(
-      'GET',
+      HttpMethod.get,
       '$prefix/namespaces/${_namespaceToPath(namespace)}',
     );
     final body = response.body as Map<String, dynamic>;
@@ -243,7 +245,7 @@ class IcebergRestCatalog {
   }) async {
     final prefix = await _resolvePrefix();
     final response = await _request(
-      'POST',
+      HttpMethod.post,
       '$prefix/namespaces/${_namespaceToPath(namespace)}/properties',
       body: {
         'updates': ?updates,
@@ -260,7 +262,7 @@ class IcebergRestCatalog {
   Future<void> dropNamespace(List<String> namespace) async {
     final prefix = await _resolvePrefix();
     await _request(
-      'DELETE',
+      HttpMethod.delete,
       '$prefix/namespaces/${_namespaceToPath(namespace)}',
       headers: {'Idempotency-Key': _idempotencyKey()},
     );
@@ -271,7 +273,7 @@ class IcebergRestCatalog {
     final prefix = await _resolvePrefix();
     try {
       await _request(
-        'HEAD',
+        HttpMethod.head,
         '$prefix/namespaces/${_namespaceToPath(namespace)}',
       );
       return true;
@@ -303,7 +305,7 @@ class IcebergRestCatalog {
       if (options?.pageSize != null) 'pageSize': '${options!.pageSize}',
     };
     final response = await _request(
-      'GET',
+      HttpMethod.get,
       '$prefix/namespaces/${_namespaceToPath(namespace)}/tables',
       query: query.isEmpty ? null : query,
     );
@@ -336,7 +338,7 @@ class IcebergRestCatalog {
   ) async {
     final prefix = await _resolvePrefix();
     final response = await _request(
-      'POST',
+      HttpMethod.post,
       '$prefix/namespaces/${_namespaceToPath(namespace)}/tables',
       body: request.toJson(),
       headers: {
@@ -371,7 +373,7 @@ class IcebergRestCatalog {
   ) async {
     final prefix = await _resolvePrefix();
     final response = await _request(
-      'POST',
+      HttpMethod.post,
       '$prefix/namespaces/${_namespaceToPath(namespace)}/register',
       body: request.toJson(),
       headers: {
@@ -405,9 +407,9 @@ class IcebergRestCatalog {
       if (options?.snapshots != null) 'snapshots': options!.snapshots!.value,
     };
     final response = await _request(
-      'GET',
+      HttpMethod.get,
       '$prefix/namespaces/${_namespaceToPath(id.namespace)}/tables/'
-          '${Uri.encodeComponent(id.name)}',
+      '${Uri.encodeComponent(id.name)}',
       query: query.isEmpty ? null : query,
       headers: {
         ..._accessDelegationHeader(),
@@ -429,9 +431,9 @@ class IcebergRestCatalog {
     final prefix = await _resolvePrefix();
     try {
       await _request(
-        'HEAD',
+        HttpMethod.head,
         '$prefix/namespaces/${_namespaceToPath(id.namespace)}/tables/'
-            '${Uri.encodeComponent(id.name)}',
+        '${Uri.encodeComponent(id.name)}',
         headers: _accessDelegationHeader(),
       );
       return true;
@@ -448,9 +450,9 @@ class IcebergRestCatalog {
   }) async {
     final prefix = await _resolvePrefix();
     final response = await _request(
-      'POST',
+      HttpMethod.post,
       '$prefix/namespaces/${_namespaceToPath(id.namespace)}/tables/'
-          '${Uri.encodeComponent(id.name)}',
+      '${Uri.encodeComponent(id.name)}',
       body: {
         'requirements': requirements
             .map((requirement) => requirement.toJson())
@@ -481,9 +483,9 @@ class IcebergRestCatalog {
   Future<void> dropTable(TableIdentifier id, {bool purge = false}) async {
     final prefix = await _resolvePrefix();
     await _request(
-      'DELETE',
+      HttpMethod.delete,
       '$prefix/namespaces/${_namespaceToPath(id.namespace)}/tables/'
-          '${Uri.encodeComponent(id.name)}',
+      '${Uri.encodeComponent(id.name)}',
       query: {'purgeRequested': '$purge'},
       headers: {'Idempotency-Key': _idempotencyKey()},
     );
@@ -496,7 +498,7 @@ class IcebergRestCatalog {
   ) async {
     final prefix = await _resolvePrefix();
     await _request(
-      'POST',
+      HttpMethod.post,
       '$prefix/tables/rename',
       body: {'source': source.toJson(), 'destination': destination.toJson()},
       headers: {'Idempotency-Key': _idempotencyKey()},

--- a/packages/supabase/lib/supabase.dart
+++ b/packages/supabase/lib/supabase.dart
@@ -5,7 +5,7 @@ library;
 
 export 'package:functions_client/functions_client.dart';
 export 'package:gotrue/gotrue.dart';
-export 'package:postgrest/postgrest.dart' hide HttpMethod;
+export 'package:postgrest/postgrest.dart';
 export 'package:realtime_client/realtime_client.dart';
 export 'package:storage_client/storage_client.dart';
 

--- a/packages/supabase_common/lib/src/http_method.dart
+++ b/packages/supabase_common/lib/src/http_method.dart
@@ -1,0 +1,12 @@
+/// The HTTP methods the Supabase client packages send requests with.
+enum HttpMethod {
+  get,
+  head,
+  post,
+  put,
+  patch,
+  delete;
+
+  /// The method as it appears on the wire, for example `GET`.
+  String get value => name.toUpperCase();
+}

--- a/packages/supabase_common/lib/supabase_common.dart
+++ b/packages/supabase_common/lib/supabase_common.dart
@@ -8,6 +8,7 @@ library;
 export 'src/base64url.dart';
 export 'src/client_info.dart';
 export 'src/fetch_options.dart';
+export 'src/http_method.dart';
 export 'src/http_status.dart';
 export 'src/pkce.dart';
 export 'src/platform/platform_info.dart';

--- a/packages/supabase_common/test/http_method_test.dart
+++ b/packages/supabase_common/test/http_method_test.dart
@@ -1,0 +1,19 @@
+import 'package:supabase_common/supabase_common.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('HttpMethod', () {
+    test('value is the uppercase method name', () {
+      expect(HttpMethod.get.value, 'GET');
+      expect(HttpMethod.head.value, 'HEAD');
+      expect(HttpMethod.post.value, 'POST');
+      expect(HttpMethod.put.value, 'PUT');
+      expect(HttpMethod.patch.value, 'PATCH');
+      expect(HttpMethod.delete.value, 'DELETE');
+    });
+
+    test('covers every method the client packages send', () {
+      expect(HttpMethod.values, hasLength(6));
+    });
+  });
+}

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -1539,7 +1539,7 @@ features:
   functions.invocation.method_override:
     status: implemented
     symbols:
-      - HttpMethod
+      - FunctionsClient.invoke
   functions.invocation.streaming_response:
     status: implemented
     symbols:


### PR DESCRIPTION
Tier 3 of #1572, second of four PRs. Stacked on #1644, so review that one first.

## What

Four packages had four takes on the same enum:

| Package | Before |
| --- | --- |
| postgrest | `HttpMethod { get, head, post, put, patch, delete }` with `String get value` |
| functions_client | `HttpMethod { get, post, put, delete, patch }`, callers did `method.name.toUpperCase()` |
| gotrue | `RequestMethodType { get, post, put, patch, delete }` |
| storage_client | raw `'GET'` / `'POST'` / `'HEAD'` strings threaded through the fetch layer and the Iceberg catalog |

All four now use one `HttpMethod` in `supabase_common`:

```dart
enum HttpMethod {
  get, head, post, put, patch, delete;

  /// The method as it appears on the wire, for example `GET`.
  String get value => name.toUpperCase();
}
```

## The conflict this removes

`supabase` could not re-export both packages' enums, so it carried:

```dart
export 'package:postgrest/postgrest.dart' hide HttpMethod;
```

Both now resolve to the same declaration, so the `hide` is gone and `HttpMethod` is reachable from `package:supabase` and `package:supabase_flutter` for the first time (previously `functions.invoke(method: ...)` was usable from `supabase_flutter` only because functions_client's copy happened to win).

## Breaking changes

- `RequestMethodType` is gone; gotrue's `GotrueFetch.request` takes `HttpMethod`. It lived in `lib/src/` and was not exported from `package:gotrue`.
- `functions_client`'s `HttpMethod` gains a `head` value and a `value` getter. Existing `HttpMethod.post` style usage is unaffected.
- postgrest's `HttpMethod` is unchanged in shape, it just moved packages.

Storage's changes are internal: its fetch layer and Iceberg REST catalog take `HttpMethod` instead of a `String`, which removes the last stringly-typed methods in the monorepo.

gotrue's request switch gained a `head` branch to stay exhaustive; it sends via `Client.head` like the other verbs.

## Compliance matrix

`functions.invocation.method_override` listed the `HttpMethod` symbol. The enum now lives in the internal `supabase_common`, which is excluded from the public API scan, so the entry points at `FunctionsClient.invoke` (the method that actually takes the override) instead.

## Testing

`melos analyze` and `melos format` clean. Full suites pass for `gotrue`, `postgrest`, `storage_client`, `functions_client`, `realtime_client`, `supabase`, `supabase_common` and `supabase_flutter`, plus the `examples` analyzer. The capability matrix symbol, drift and compliance checks pass.
