### PR TITLE
refactor!: share one exponential backoff calculation

### DIFF
--- a/packages/postgrest/lib/src/postgrest_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_builder.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:core';
-import 'dart:math' as math;
 
 import 'package:http/http.dart' as http;
 import 'package:http/http.dart';
@@ -152,8 +151,11 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
   Duration? get _requestTimeout => _config.requestTimeout;
   Future<void>? get _abortSignal => _config.abortSignal;
 
-  static Duration _defaultRetryDelay(int attempt) =>
-      Duration(seconds: math.min(math.pow(2, attempt).toInt(), 30));
+  static Duration _defaultRetryDelay(int attempt) => exponentialBackoff(
+    attempt,
+    initialDelay: const Duration(seconds: 1),
+    maxDelay: const Duration(seconds: 30),
+  );
 
   PostgrestBuilder({
     required Uri url,

--- a/packages/realtime_client/lib/src/retry_timer.dart
+++ b/packages/realtime_client/lib/src/retry_timer.dart
@@ -1,16 +1,12 @@
 import 'dart:async';
 
 import 'package:meta/meta.dart';
+import 'package:supabase_common/supabase_common.dart';
 
 @internal
 typedef TimerCallback = void Function();
 @internal
 typedef TimerCalculation = int Function(int tries);
-
-// Need to limit doubling to avoid overflow, this limit gives 1 million times
-// the first delay
-@internal
-const maxShift = 20;
 
 /// Creates a timer that accepts a `timerCalc` function to perform
 /// calculated timeout retries, such as exponential backoff.
@@ -62,15 +58,17 @@ class RetryTimer {
     });
   }
 
-  // Generate an exponential backoff function with first and max delays
+  /// Generates an exponential backoff function with first and max delays, both
+  /// in milliseconds.
   static TimerCalculation createRetryFunction({
     int firstDelay = 1000,
     int maxDelay = 10000,
   }) {
-    return (int tries) {
-      final shiftAmount = (tries - 1) > maxShift ? maxShift : tries - 1;
-      final delay = firstDelay << shiftAmount;
-      return delay > maxDelay ? maxDelay : delay;
-    };
+    return (int tries) => exponentialBackoff(
+      // `tries` counts the attempt this delay precedes, so the first one is 1.
+      tries - 1,
+      initialDelay: Duration(milliseconds: firstDelay),
+      maxDelay: Duration(milliseconds: maxDelay),
+    ).inMilliseconds;
   }
 }

--- a/packages/supabase_common/lib/src/backoff.dart
+++ b/packages/supabase_common/lib/src/backoff.dart
@@ -1,0 +1,30 @@
+import 'dart:math';
+
+/// The exponent is clamped so that doubling cannot overflow the delay. Every
+/// caller caps the result well below this, so the clamp is only a safety net.
+const _maxExponent = 31;
+
+/// The exponential backoff delay to wait before the retry that follows
+/// [attempt], where attempt `0` is the first failure.
+///
+/// The delay starts at [initialDelay] and doubles every attempt, capped at
+/// [maxDelay]. When [randomizationFactor] is greater than zero the delay is
+/// jittered by up to that fraction in either direction before being capped,
+/// which keeps many clients from retrying in lockstep.
+///
+/// [random] is only meant for tests that need a deterministic jitter.
+Duration exponentialBackoff(
+  int attempt, {
+  required Duration initialDelay,
+  required Duration maxDelay,
+  double randomizationFactor = 0,
+  Random? random,
+}) {
+  assert(attempt >= 0, 'attempt cannot be negative');
+  final randomization = randomizationFactor == 0
+      ? 1.0
+      : randomizationFactor * ((random ?? Random()).nextDouble() * 2 - 1) + 1;
+  final delay =
+      initialDelay * pow(2.0, min(attempt, _maxExponent)) * randomization;
+  return delay < maxDelay ? delay : maxDelay;
+}

--- a/packages/supabase_common/lib/src/retry.dart
+++ b/packages/supabase_common/lib/src/retry.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
-import 'dart:math';
+
+import 'package:supabase_common/src/backoff.dart';
 
 /// Options for retrying a function.
 ///
@@ -31,11 +32,12 @@ class RetryOptions {
     if (attempt <= 0) {
       return Duration.zero;
     }
-    final randomization =
-        randomizationFactor * (Random().nextDouble() * 2 - 1) + 1;
-    final exponent = min(attempt, 31);
-    final delay = delayFactor * pow(2.0, exponent) * randomization;
-    return delay < maxDelay ? delay : maxDelay;
+    return exponentialBackoff(
+      attempt,
+      initialDelay: delayFactor,
+      maxDelay: maxDelay,
+      randomizationFactor: randomizationFactor,
+    );
   }
 
   /// Calls [fn], retrying so long as [retryIf] returns `true` for the thrown

--- a/packages/supabase_common/lib/supabase_common.dart
+++ b/packages/supabase_common/lib/supabase_common.dart
@@ -5,6 +5,7 @@
 /// notice.
 library;
 
+export 'src/backoff.dart';
 export 'src/base64url.dart';
 export 'src/client_info.dart';
 export 'src/fetch_options.dart';

--- a/packages/supabase_common/test/backoff_test.dart
+++ b/packages/supabase_common/test/backoff_test.dart
@@ -6,7 +6,7 @@ import 'package:test/test.dart';
 /// Returns the extremes of the jitter range so a randomized delay can be
 /// checked without depending on a real random sequence.
 class _FixedRandom implements Random {
-  _FixedRandom(this.value);
+  const _FixedRandom(this.value);
 
   final double value;
 

--- a/packages/supabase_common/test/backoff_test.dart
+++ b/packages/supabase_common/test/backoff_test.dart
@@ -1,0 +1,76 @@
+import 'dart:math';
+
+import 'package:supabase_common/supabase_common.dart';
+import 'package:test/test.dart';
+
+/// Returns the extremes of the jitter range so a randomized delay can be
+/// checked without depending on a real random sequence.
+class _FixedRandom implements Random {
+  _FixedRandom(this.value);
+
+  final double value;
+
+  @override
+  double nextDouble() => value;
+
+  @override
+  bool nextBool() => throw UnimplementedError();
+
+  @override
+  int nextInt(int max) => throw UnimplementedError();
+}
+
+void main() {
+  group('exponentialBackoff', () {
+    Duration backoff(int attempt, {double randomizationFactor = 0}) =>
+        exponentialBackoff(
+          attempt,
+          initialDelay: const Duration(seconds: 1),
+          maxDelay: const Duration(seconds: 30),
+          randomizationFactor: randomizationFactor,
+        );
+
+    test('starts at the initial delay', () {
+      expect(backoff(0), const Duration(seconds: 1));
+    });
+
+    test('doubles every attempt', () {
+      expect(backoff(1), const Duration(seconds: 2));
+      expect(backoff(2), const Duration(seconds: 4));
+      expect(backoff(3), const Duration(seconds: 8));
+    });
+
+    test('caps at the maximum delay', () {
+      expect(backoff(5), const Duration(seconds: 30));
+      expect(backoff(1000), const Duration(seconds: 30));
+    });
+
+    test('is not randomized by default', () {
+      expect(
+        List.generate(10, (_) => backoff(2)),
+        everyElement(const Duration(seconds: 4)),
+      );
+    });
+
+    test('jitters by at most the randomization factor', () {
+      Duration jittered(double random) => exponentialBackoff(
+        2,
+        initialDelay: const Duration(seconds: 1),
+        maxDelay: const Duration(seconds: 30),
+        randomizationFactor: 0.25,
+        random: _FixedRandom(random),
+      );
+
+      expect(jittered(0), const Duration(seconds: 3));
+      expect(jittered(0.5), const Duration(seconds: 4));
+      expect(jittered(1), const Duration(seconds: 5));
+    });
+
+    test('rejects a negative attempt', () {
+      expect(
+        () => backoff(-1),
+        throwsA(isA<AssertionError>()),
+      );
+    });
+  });
+}


### PR DESCRIPTION
Tier 3 of #1572, third of four PRs. Stacked on #1645 (which is stacked on #1644).

## What

The same "double the delay, cap it" math existed in three places:

| Site | Before |
| --- | --- |
| `RetryOptions.delay` (supabase_common) | `delayFactor * pow(2, min(attempt, 31)) * jitter`, capped at `maxDelay` |
| `RetryTimer.createRetryFunction` (realtime_client) | `firstDelay << min(tries - 1, maxShift)`, capped at `maxDelay`, in milliseconds |
| `PostgrestBuilder._defaultRetryDelay` | `Duration(seconds: min(pow(2, attempt), 30))` |

All three now call one helper in `supabase_common`:

```dart
Duration exponentialBackoff(
  int attempt, {
  required Duration initialDelay,
  required Duration maxDelay,
  double randomizationFactor = 0,
  Random? random,
});
```

`attempt` is zero based, so attempt `0` waits `initialDelay` and each attempt after that doubles until `maxDelay`. Jitter is opt-in per caller, since only the storage upload retry uses it today.

## No behaviour change

Each call site keeps the delays it had:

- realtime keeps its one-based `tries` and its millisecond return type, so `RealtimeClient(reconnectAfterMs: ...)` and the `TimerCalculation` typedef are untouched. It just passes `tries - 1` to the helper.
- `RetryOptions.delay` keeps returning `Duration.zero` for attempt `0` and keeps its jitter.
- postgrest still starts at one second and caps at thirty.

`maxShift` (a public top-level const in `realtime_client`) is removed: the exponent clamp that stops the doubling from overflowing now lives with the shared calculation. It was not registered in the compliance matrix.

Realtime's millisecond-based options (`reconnectAfterMs`, `heartbeatIntervalMs`, `longpollerTimeout`) would read better as `Duration`s, but converting them is a separate change; doing only `reconnectAfterMs` here would leave that API half converted.

## Testing

New `backoff_test.dart` covers the start delay, the doubling, the cap, the absence of jitter by default and the jitter bounds with an injected `Random`. `realtime_client`'s existing `retry_timer_test.dart` and postgrest's `retry_test.dart` pass unchanged, which is the real check that the delays did not move.

`melos analyze` and `melos format` clean; `gotrue`, `postgrest`, `storage_client`, `realtime_client`, `supabase` and `supabase_common` suites pass against the local stack. Capability matrix symbol and drift checks pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Standardized retry timing across PostgREST, Realtime, and shared client components.
  - Retry delays now increase exponentially, start at one second, and cap at 30 seconds.
  - Added bounded jitter support to help distribute repeated retry attempts more reliably.
  - Improved protection against overflow and invalid retry-attempt values.
- **Tests**
  - Added coverage for delay growth, maximum limits, jitter behavior, defaults, and invalid inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->