### PR TITLE
refactor: share the HTTP request pieces between the fetch layers

### DIFF
--- a/packages/functions_client/lib/src/functions_client.dart
+++ b/packages/functions_client/lib/src/functions_client.dart
@@ -151,13 +151,6 @@ class FunctionsClient {
         'x-region': effectiveRegion,
     };
 
-    if (body != null) {
-      setDefaultContentType(finalHeaders, switch (body) {
-        Uint8List() => 'application/octet-stream',
-        String() => 'text/plain',
-        _ => 'application/json',
-      });
-    }
     final http.BaseRequest request;
     if (files != null) {
       assert(
@@ -166,12 +159,15 @@ class FunctionsClient {
       );
       final fields = (body as Map?)?.cast<String, String>();
 
+      // No content type is set here: a multipart request generates its own
+      // boundary while it is being finalized and sets the header itself.
       request =
           http.AbortableMultipartRequest(
               method.value,
               uri,
               abortTrigger: abortSignal,
             )
+            ..headers.addAll(finalHeaders)
             ..fields.addAll(fields ?? {})
             ..files.addAll(files);
     } else {
@@ -179,36 +175,43 @@ class FunctionsClient {
         method.value,
         uri,
         abortTrigger: abortSignal,
-      );
+      )..headers.addAll(finalHeaders);
 
-      if (body == null) {
-        // No body to set
-      } else if (body is String) {
-        bodyRequest.body = body;
-      } else if (body is Uint8List) {
-        bodyRequest.bodyBytes = body;
-      } else {
-        final bodyString = await _isolate.encode(body);
-        bodyRequest.body = bodyString;
+      if (body != null) {
+        // The content type is set before the body, so that a body given as a
+        // string is encoded with the charset the caller asked for, and so that
+        // the charset `Request.body` fills in for itself is kept.
+        bodyRequest.headers.putIfAbsent(
+          'Content-Type',
+          () => switch (body) {
+            Uint8List() => 'application/octet-stream',
+            String() => 'text/plain',
+            _ => 'application/json',
+          },
+        );
+
+        if (body is String) {
+          bodyRequest.body = body;
+        } else if (body is Uint8List) {
+          bodyRequest.bodyBytes = body;
+        } else {
+          bodyRequest.body = await _isolate.encode(body);
+        }
       }
       request = bodyRequest;
     }
-
-    finalHeaders.forEach((key, value) {
-      request.headers[key] = value;
-    });
 
     _log.finest('Request: ${request.method} ${request.url} ${request.headers}');
 
     final http.StreamedResponse response;
     try {
-      response = await sendRequest(request, httpClient: _httpClient);
+      response = await request.sendWith(_httpClient);
     } on http.RequestAbortedException {
       rethrow;
     } catch (error) {
       throw FunctionsFetchException(details: error);
     }
-    final responseType = responseMediaType(response.headers) ?? 'text/plain';
+    final responseType = response.headers.mediaType ?? 'text/plain';
 
     final isRelayError = response.headers['x-relay-error'] == 'true';
     final isSuccessStatus =

--- a/packages/functions_client/lib/src/functions_client.dart
+++ b/packages/functions_client/lib/src/functions_client.dart
@@ -151,13 +151,12 @@ class FunctionsClient {
         'x-region': effectiveRegion,
     };
 
-    if (body != null &&
-        !finalHeaders.keys.any((k) => k.toLowerCase() == 'content-type')) {
-      finalHeaders['Content-Type'] = switch (body) {
+    if (body != null) {
+      setDefaultContentType(finalHeaders, switch (body) {
         Uint8List() => 'application/octet-stream',
         String() => 'text/plain',
         _ => 'application/json',
-      };
+      });
     }
     final http.BaseRequest request;
     if (files != null) {
@@ -203,19 +202,13 @@ class FunctionsClient {
 
     final http.StreamedResponse response;
     try {
-      response = await (_httpClient?.send(request) ?? request.send());
+      response = await sendRequest(request, httpClient: _httpClient);
     } on http.RequestAbortedException {
       rethrow;
     } catch (error) {
       throw FunctionsFetchException(details: error);
     }
-    final responseType =
-        (response.headers['Content-Type'] ??
-                response.headers['content-type'] ??
-                'text/plain')
-            .split(';')[0]
-            .trim()
-            .toLowerCase();
+    final responseType = responseMediaType(response.headers) ?? 'text/plain';
 
     final isRelayError = response.headers['x-relay-error'] == 'true';
     final isSuccessStatus =

--- a/packages/functions_client/lib/src/functions_client.dart
+++ b/packages/functions_client/lib/src/functions_client.dart
@@ -37,7 +37,7 @@ class FunctionsClient {
       "Initialize FunctionsClient v$version with url '$url' and region "
       "'$region'",
     );
-    _log.finest("Initialize with headers: $headers");
+    _log.finest("Initialize with headers: ${headers.redacted}");
   }
 
   /// Getter for the headers

--- a/packages/functions_client/lib/src/functions_client.dart
+++ b/packages/functions_client/lib/src/functions_client.dart
@@ -201,7 +201,9 @@ class FunctionsClient {
       request = bodyRequest;
     }
 
-    _log.finest('Request: ${request.method} ${request.url} ${request.headers}');
+    _log.finest(
+      'Request: ${request.method} ${request.url} ${request.headers.redacted}',
+    );
 
     final http.StreamedResponse response;
     try {

--- a/packages/functions_client/test/functions_dart_test.dart
+++ b/packages/functions_client/test/functions_dart_test.dart
@@ -5,6 +5,7 @@ import 'dart:typed_data';
 import 'package:functions_client/src/functions_client.dart';
 import 'package:functions_client/src/types.dart';
 import 'package:http/http.dart';
+import 'package:logging/logging.dart';
 import 'package:supabase_common/supabase_common.dart';
 import 'package:test/test.dart';
 import 'package:yet_another_json_isolate/yet_another_json_isolate.dart';
@@ -147,6 +148,40 @@ void main() {
         expect(response.statusCode, 200);
       },
     );
+
+    test('the request log redacts credential headers', () async {
+      final messages = <String>[];
+      final previousLevel = Logger.root.level;
+      Logger.root.level = Level.ALL;
+      final subscription = Logger.root.onRecord.listen(
+        (record) => messages.add(record.message),
+      );
+      addTearDown(() async {
+        await subscription.cancel();
+        Logger.root.level = previousLevel;
+      });
+
+      final client = FunctionsClient(
+        "",
+        {
+          'Authorization': 'Bearer super-secret-token',
+          'apikey': 'the-anon-key',
+          'x-region': 'eu-west-2',
+        },
+        httpClient: CustomHttpClient(),
+      );
+      await client.invoke('function');
+
+      final requestLog = messages.singleWhere(
+        (message) => message.startsWith('Request:'),
+      );
+      expect(requestLog, isNot(contains('super-secret-token')));
+      expect(requestLog, isNot(contains('the-anon-key')));
+      expect(requestLog, contains('<redacted>'));
+      // The names, and any header that is not a credential, stay readable.
+      expect(requestLog, contains('Authorization'));
+      expect(requestLog, contains('eu-west-2'));
+    });
 
     test('function call', () async {
       final response = await functionsCustomHttpClient.invoke('function');

--- a/packages/functions_client/test/functions_dart_test.dart
+++ b/packages/functions_client/test/functions_dart_test.dart
@@ -251,8 +251,32 @@ void main() {
 
         request as Request;
         expect(request.body, 'ExampleText');
-        expect(request.headers["Content-Type"], contains("text/plain"));
+        expect(
+          request.headers["Content-Type"],
+          equals("text/plain; charset=utf-8"),
+        );
       });
+
+      test(
+        'string body is encoded with the charset the caller asked for',
+        () async {
+          await functionsCustomHttpClient.invoke(
+            'function',
+            headers: {'Content-Type': 'text/plain; charset=iso-8859-1'},
+            body: 'Ærlig',
+          );
+
+          final request = customHttpClient.receivedRequests.last;
+          expect(request, isA<Request>());
+
+          request as Request;
+          expect(request.bodyBytes, latin1.encode('Ærlig'));
+          expect(
+            request.headers["Content-Type"],
+            equals("text/plain; charset=iso-8859-1"),
+          );
+        },
+      );
 
       test('list is properly encoded', () async {
         await functionsCustomHttpClient.invoke('function', body: [1, 2, 3]);

--- a/packages/functions_client/test/functions_dart_test.dart
+++ b/packages/functions_client/test/functions_dart_test.dart
@@ -149,7 +149,7 @@ void main() {
       },
     );
 
-    test('the request log redacts credential headers', () async {
+    test('the logs redact credential headers', () async {
       final messages = <String>[];
       final previousLevel = Logger.root.level;
       Logger.root.level = Level.ALL;
@@ -172,14 +172,26 @@ void main() {
       );
       await client.invoke('function');
 
+      // No log at all, whether from the constructor or the request, may carry
+      // the values.
+      expect(messages, isNotEmpty);
+      for (final message in messages) {
+        expect(message, isNot(contains('super-secret-token')));
+        expect(message, isNot(contains('the-anon-key')));
+      }
+
+      final initializeLog = messages.singleWhere(
+        (message) => message.startsWith('Initialize with headers:'),
+      );
+      expect(initializeLog, contains('<redacted>'));
+
       final requestLog = messages.singleWhere(
         (message) => message.startsWith('Request:'),
       );
-      expect(requestLog, isNot(contains('super-secret-token')));
-      expect(requestLog, isNot(contains('the-anon-key')));
       expect(requestLog, contains('<redacted>'));
-      // The names, and any header that is not a credential, stay readable.
+      // Every name, and any header that is not a credential, stays readable.
       expect(requestLog, contains('Authorization'));
+      expect(requestLog, contains('apikey'));
       expect(requestLog, contains('eu-west-2'));
     });
 

--- a/packages/postgrest/lib/src/postgrest_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_builder.dart
@@ -539,8 +539,16 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
     }
     PostgrestApiException error;
     if (response.request!.method != HttpMethod.head.value) {
-      try {
-        final errorJson = jsonDecode(response.body) as Map<String, dynamic>;
+      // A proxy or gateway in front of PostgREST can answer with anything, so
+      // an error body that is not a JSON object is surfaced as-is.
+      final errorJson = tryDecodeJsonObject(response.body);
+      if (errorJson == null) {
+        error = PostgrestApiException(
+          message: response.body,
+          statusCode: response.statusCode,
+          details: response.reasonPhrase,
+        );
+      } else {
         error = PostgrestApiException.fromJson(
           errorJson,
           message: response.body,
@@ -551,12 +559,6 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
         if (_maybeSingle) {
           return _handleMaybeSingleError(response, error);
         }
-      } catch (_) {
-        error = PostgrestApiException(
-          message: response.body,
-          statusCode: response.statusCode,
-          details: response.reasonPhrase,
-        );
       }
     } else {
       error = PostgrestApiException(

--- a/packages/postgrest/lib/src/types.dart
+++ b/packages/postgrest/lib/src/types.dart
@@ -28,18 +28,27 @@ class PostgrestApiException extends SupabaseException
     this.hint,
   }) : super(message);
 
+  /// Builds an exception from an error response body.
+  ///
+  /// A JSON object is no guarantee that its fields carry the types PostgREST
+  /// documents, since a proxy or gateway in front of it can answer with a shape
+  /// of its own, so every field is read defensively. [message] is used when the
+  /// body reports none.
   factory PostgrestApiException.fromJson(
     Map<String, dynamic> json, {
     required int statusCode,
     String? message,
     String? details,
   }) {
+    final reportedMessage = json['message'];
     return PostgrestApiException(
-      message: (json['message'] ?? message) as String,
+      message: reportedMessage is String
+          ? reportedMessage
+          : (message ?? json.toString()),
       statusCode: statusCode,
-      errorCode: json['code'] as String?,
+      errorCode: json['code']?.toString(),
       details: (json['details'] ?? details),
-      hint: json['hint'] as String?,
+      hint: json['hint']?.toString(),
     );
   }
 

--- a/packages/postgrest/test/basic_test.dart
+++ b/packages/postgrest/test/basic_test.dart
@@ -611,6 +611,19 @@ void main() {
       );
     });
 
+    test('a JSON error body with unexpected field types still throws '
+        'a PostgrestApiException', () async {
+      await expectLater(
+        () => postgrestCustomHttpClient.from('gateway-json-error').select(),
+        throwsA(
+          isA<PostgrestApiException>()
+              .having((e) => e.statusCode, 'statusCode', 502)
+              .having((e) => e.message, 'message', 'Bad gateway')
+              .having((e) => e.errorCode, 'errorCode', '502'),
+        ),
+      );
+    });
+
     test('non-JSON body on 2xx response with maybeSingle throws', () async {
       await expectLater(
         () => postgrestCustomHttpClient

--- a/packages/postgrest/test/custom_http_client.dart
+++ b/packages/postgrest/test/custom_http_client.dart
@@ -30,6 +30,19 @@ class CustomHttpClient extends BaseClient {
         reasonPhrase: 'OK',
       );
     }
+    // A gateway error body: a JSON object, but with `code` as a number rather
+    // than the string PostgREST reports.
+    if (request.url.path.endsWith("gateway-json-error")) {
+      return StreamedResponse(
+        Stream.value(
+          utf8.encode(jsonEncode({'code': 502, 'message': 'Bad gateway'})),
+        ),
+        502,
+        request: request,
+        reasonPhrase: 'Bad Gateway',
+      );
+    }
+
     //Return custom status code to check for usage of this client.
     return StreamedResponse(
       Stream.value(lastBody!),

--- a/packages/postgrest/test/maybe_single_test.dart
+++ b/packages/postgrest/test/maybe_single_test.dart
@@ -26,6 +26,30 @@ class ZeroRowsHttpClient extends BaseClient {
   }
 }
 
+/// Mimics PostgREST rejecting a `maybeSingle()` request because more than one
+/// row matched, which is a real failure rather than an empty result.
+class MultipleRowsHttpClient extends BaseClient {
+  @override
+  Future<StreamedResponse> send(BaseRequest request) async {
+    return StreamedResponse(
+      Stream.value(
+        utf8.encode(
+          jsonEncode({
+            'code': 'PGRST116',
+            'details':
+                'Results contain 2 rows, application/vnd.pgrst.object+json '
+                'requires 1 row',
+            'hint': 'Ask for more rows',
+            'message': 'JSON object requested, multiple (or no) rows returned',
+          }),
+        ),
+      ),
+      406,
+      request: request,
+    );
+  }
+}
+
 void main() {
   test(
     'maybeSingle().count() returns null data and count 0 when no rows match',
@@ -46,4 +70,27 @@ void main() {
       expect(response.count, 0);
     },
   );
+
+  test('maybeSingle() keeps the reported code and hint on a real error', () {
+    final postgrest = PostgrestClient(
+      'https://example.com',
+      httpClient: MultipleRowsHttpClient(),
+    );
+
+    expect(
+      postgrest.from('users').select().maybeSingle(),
+      throwsA(
+        isA<PostgrestApiException>()
+            .having((e) => e.statusCode, 'statusCode', 406)
+            .having((e) => e.errorCode, 'errorCode', 'PGRST116')
+            .having((e) => e.hint, 'hint', 'Ask for more rows')
+            .having(
+              (e) => e.details,
+              'details',
+              'Results contain 2 rows, application/vnd.pgrst.object+json '
+                  'requires 1 row',
+            ),
+      ),
+    );
+  });
 }

--- a/packages/postgrest/test/maybe_single_test.dart
+++ b/packages/postgrest/test/maybe_single_test.dart
@@ -71,26 +71,29 @@ void main() {
     },
   );
 
-  test('maybeSingle() keeps the reported code and hint on a real error', () {
-    final postgrest = PostgrestClient(
-      'https://example.com',
-      httpClient: MultipleRowsHttpClient(),
-    );
+  test(
+    'maybeSingle() keeps the reported code and hint on a real error',
+    () async {
+      final postgrest = PostgrestClient(
+        'https://example.com',
+        httpClient: MultipleRowsHttpClient(),
+      );
 
-    expect(
-      postgrest.from('users').select().maybeSingle(),
-      throwsA(
-        isA<PostgrestApiException>()
-            .having((e) => e.statusCode, 'statusCode', 406)
-            .having((e) => e.errorCode, 'errorCode', 'PGRST116')
-            .having((e) => e.hint, 'hint', 'Ask for more rows')
-            .having(
-              (e) => e.details,
-              'details',
-              'Results contain 2 rows, application/vnd.pgrst.object+json '
-                  'requires 1 row',
-            ),
-      ),
-    );
-  });
+      await expectLater(
+        () => postgrest.from('users').select().maybeSingle(),
+        throwsA(
+          isA<PostgrestApiException>()
+              .having((e) => e.statusCode, 'statusCode', 406)
+              .having((e) => e.errorCode, 'errorCode', 'PGRST116')
+              .having((e) => e.hint, 'hint', 'Ask for more rows')
+              .having(
+                (e) => e.details,
+                'details',
+                'Results contain 2 rows, application/vnd.pgrst.object+json '
+                    'requires 1 row',
+              ),
+        ),
+      );
+    },
+  );
 }

--- a/packages/storage_client/lib/src/fetch.dart
+++ b/packages/storage_client/lib/src/fetch.dart
@@ -37,17 +37,7 @@ class Fetch {
       return StorageException(error.toString());
     }
 
-    // A proxy or gateway in front of storage can answer with anything, so a
-    // body that is not a JSON object is surfaced as-is instead of being cast.
-    Map<String, dynamic>? data;
-    try {
-      final decoded = json.decode(error.body);
-      if (decoded is Map<String, dynamic>) {
-        data = decoded;
-      }
-    } on FormatException catch (_) {
-      // Not JSON at all.
-    }
+    final data = tryDecodeJsonObject(error.body);
 
     if (data == null) {
       _log.fine('StorageException for $url', error.body, stackTrace);
@@ -70,12 +60,7 @@ class Fetch {
   ) async {
     final headers = {...?options?.headers};
     if (method != HttpMethod.get) {
-      final hasContentType = headers.keys.any(
-        (key) => key.toLowerCase() == 'content-type',
-      );
-      if (!hasContentType) {
-        headers['Content-Type'] = 'application/json';
-      }
+      setDefaultContentType(headers, 'application/json');
     }
 
     final request = http.Request(method.value, Uri.parse(url))
@@ -85,12 +70,10 @@ class Fetch {
     }
 
     _log.finest('Request: ${method.value} $url $headers');
-    final http.StreamedResponse streamedResponse;
-    if (httpClient != null) {
-      streamedResponse = await httpClient!.send(request);
-    } else {
-      streamedResponse = await request.send();
-    }
+    final streamedResponse = await sendRequest(
+      request,
+      httpClient: httpClient,
+    );
     return _handleResponse(streamedResponse, options);
   }
 
@@ -191,12 +174,7 @@ class Fetch {
         );
 
         // Create a fresh request for each retry attempt
-        final request = createRequest();
-
-        if (httpClient != null) {
-          return httpClient!.send(request);
-        }
-        return request.send();
+        return sendRequest(createRequest(), httpClient: httpClient);
       },
       retryIf: (error) =>
           retryController?.cancelled != true &&
@@ -257,12 +235,10 @@ class Fetch {
       ..headers.addAll({...?options?.headers});
 
     _log.finest('Request: GET (stream) $url ${request.headers}');
-    final http.StreamedResponse streamedResponse;
-    if (httpClient != null) {
-      streamedResponse = await httpClient!.send(request);
-    } else {
-      streamedResponse = await request.send();
-    }
+    final streamedResponse = await sendRequest(
+      request,
+      httpClient: httpClient,
+    );
 
     if (!isSuccessStatusCode(streamedResponse.statusCode)) {
       final response = await http.Response.fromStream(streamedResponse);

--- a/packages/storage_client/lib/src/fetch.dart
+++ b/packages/storage_client/lib/src/fetch.dart
@@ -58,22 +58,17 @@ class Fetch {
     Map<String, dynamic>? body,
     FetchOptions? options,
   ) async {
-    final headers = {...?options?.headers};
-    if (method != HttpMethod.get) {
-      setDefaultContentType(headers, 'application/json');
-    }
-
     final request = http.Request(method.value, Uri.parse(url))
-      ..headers.addAll(headers);
+      ..headers.addAll({...?options?.headers});
+    if (method != HttpMethod.get) {
+      request.headers.putIfAbsent('Content-Type', () => 'application/json');
+    }
     if (body != null) {
       request.body = json.encode(body);
     }
 
-    _log.finest('Request: ${method.value} $url $headers');
-    final streamedResponse = await sendRequest(
-      request,
-      httpClient: httpClient,
-    );
+    _log.finest('Request: ${method.value} $url ${request.headers}');
+    final streamedResponse = await request.sendWith(httpClient);
     return _handleResponse(streamedResponse, options);
   }
 
@@ -174,7 +169,7 @@ class Fetch {
         );
 
         // Create a fresh request for each retry attempt
-        return sendRequest(createRequest(), httpClient: httpClient);
+        return createRequest().sendWith(httpClient);
       },
       retryIf: (error) =>
           retryController?.cancelled != true &&
@@ -235,10 +230,7 @@ class Fetch {
       ..headers.addAll({...?options?.headers});
 
     _log.finest('Request: GET (stream) $url ${request.headers}');
-    final streamedResponse = await sendRequest(
-      request,
-      httpClient: httpClient,
-    );
+    final streamedResponse = await request.sendWith(httpClient);
 
     if (!isSuccessStatusCode(streamedResponse.statusCode)) {
       final response = await http.Response.fromStream(streamedResponse);

--- a/packages/storage_client/lib/src/fetch.dart
+++ b/packages/storage_client/lib/src/fetch.dart
@@ -67,7 +67,7 @@ class Fetch {
       request.body = json.encode(body);
     }
 
-    _log.finest('Request: ${method.value} $url ${request.headers}');
+    _log.finest('Request: ${method.value} $url ${request.headers.redacted}');
     final streamedResponse = await request.sendWith(httpClient);
     return _handleResponse(streamedResponse, options);
   }
@@ -165,7 +165,8 @@ class Fetch {
       () async {
         attempts++;
         _log.finest(
-          'Request: attempt: $attempts ${method.value} $url $headers',
+          'Request: attempt: $attempts ${method.value} $url '
+          '${headers.redacted}',
         );
 
         // Create a fresh request for each retry attempt
@@ -229,7 +230,7 @@ class Fetch {
     final request = http.Request(HttpMethod.get.value, Uri.parse(url))
       ..headers.addAll({...?options?.headers});
 
-    _log.finest('Request: GET (stream) $url ${request.headers}');
+    _log.finest('Request: GET (stream) $url ${request.headers.redacted}');
     final streamedResponse = await request.sendWith(httpClient);
 
     if (!isSuccessStatusCode(streamedResponse.statusCode)) {

--- a/packages/storage_client/lib/src/iceberg/iceberg_rest_catalog.dart
+++ b/packages/storage_client/lib/src/iceberg/iceberg_rest_catalog.dart
@@ -132,15 +132,10 @@ class IcebergRestCatalog {
     Map<String, String>? headers,
   }) async {
     final uri = _buildUri(path, query);
-    final requestHeaders = <String, String>{
-      ..._headers,
-      if (body != null) 'Content-Type': 'application/json',
-      ...?headers,
-    };
-
     final request = http.Request(method.value, uri)
-      ..headers.addAll(requestHeaders);
+      ..headers.addAll({..._headers, ...?headers});
     if (body != null) {
+      request.headers.putIfAbsent('Content-Type', () => 'application/json');
       request.body = json.encode(body);
     }
 
@@ -148,10 +143,7 @@ class IcebergRestCatalog {
 
     final http.StreamedResponse streamedResponse;
     try {
-      streamedResponse = await sendRequest(
-        request,
-        httpClient: _httpClient,
-      );
+      streamedResponse = await request.sendWith(_httpClient);
     } catch (error) {
       throw IcebergNetworkException(
         'Network request failed: $error',
@@ -165,7 +157,7 @@ class IcebergRestCatalog {
       return _IcebergResponse(304, response.headers, null);
     }
 
-    final isJson = responseMediaType(response.headers) == 'application/json';
+    final isJson = response.headers.mediaType == 'application/json';
     final decoded = isJson && response.body.isNotEmpty
         ? json.decode(response.body)
         : response.body;

--- a/packages/storage_client/lib/src/iceberg/iceberg_rest_catalog.dart
+++ b/packages/storage_client/lib/src/iceberg/iceberg_rest_catalog.dart
@@ -148,9 +148,10 @@ class IcebergRestCatalog {
 
     final http.StreamedResponse streamedResponse;
     try {
-      streamedResponse = _httpClient != null
-          ? await _httpClient.send(request)
-          : await request.send();
+      streamedResponse = await sendRequest(
+        request,
+        httpClient: _httpClient,
+      );
     } catch (error) {
       throw IcebergNetworkException(
         'Network request failed: $error',
@@ -164,8 +165,7 @@ class IcebergRestCatalog {
       return _IcebergResponse(304, response.headers, null);
     }
 
-    final contentType = response.headers['content-type'] ?? '';
-    final isJson = contentType.contains('application/json');
+    final isJson = responseMediaType(response.headers) == 'application/json';
     final decoded = isJson && response.body.isNotEmpty
         ? json.decode(response.body)
         : response.body;

--- a/packages/storage_client/lib/src/storage_client.dart
+++ b/packages/storage_client/lib/src/storage_client.dart
@@ -7,6 +7,7 @@ import 'package:storage_client/src/storage_bucket_api.dart';
 import 'package:storage_client/src/storage_file_api.dart';
 import 'package:storage_client/src/vector_client.dart';
 import 'package:storage_client/src/version.dart';
+import 'package:supabase_common/supabase_common.dart';
 
 class SupabaseStorageClient extends StorageBucketApi {
   final int _defaultRetryAttempts;
@@ -60,7 +61,7 @@ class SupabaseStorageClient extends StorageBucketApi {
       'Initialize SupabaseStorageClient v$version with url: $url, '
       'retryAttempts: $_defaultRetryAttempts',
     );
-    _log.finest('Initialize with headers: $headers');
+    _log.finest('Initialize with headers: ${headers.redacted}');
   }
 
   /// Transforms legacy storage URLs to use the dedicated storage host.

--- a/packages/storage_client/lib/src/types.dart
+++ b/packages/storage_client/lib/src/types.dart
@@ -605,14 +605,23 @@ class StorageApiException extends StorageException with SupabaseApiException {
     super.errorCode,
   });
 
+  /// Builds an exception from an error response body.
+  ///
+  /// A JSON object is no guarantee that its fields carry the types the storage
+  /// API documents, since a proxy or gateway in front of it can answer with a
+  /// shape of its own, so every field is read defensively. [statusCode] is used
+  /// when the body reports none.
   factory StorageApiException.fromJson(
     Map<String, dynamic> json,
     int statusCode,
-  ) => StorageApiException(
-    json['message'] as String? ?? json.toString(),
-    errorCode: json['error'] as String?,
-    statusCode: int.tryParse('${json['statusCode']}') ?? statusCode,
-  );
+  ) {
+    final message = json['message'];
+    return StorageApiException(
+      message is String ? message : json.toString(),
+      errorCode: json['error']?.toString(),
+      statusCode: int.tryParse('${json['statusCode']}') ?? statusCode,
+    );
+  }
 }
 
 class StorageRetryController {

--- a/packages/storage_client/test/types_test.dart
+++ b/packages/storage_client/test/types_test.dart
@@ -339,6 +339,17 @@ void main() {
       expect(exception.statusCode, 404);
     });
 
+    test('fromJson tolerates unexpected field types', () {
+      final exception = StorageApiException.fromJson({
+        'message': {'nested': 'object'},
+        'error': 502,
+      }, 502);
+
+      expect(exception.message, '{message: {nested: object}, error: 502}');
+      expect(exception.errorCode, '502');
+      expect(exception.statusCode, 502);
+    });
+
     test(
       'fromJson falls back to the response status code and stringified body',
       () {

--- a/packages/supabase_common/README.md
+++ b/packages/supabase_common/README.md
@@ -12,6 +12,6 @@ packages (`supabase_auth`, `postgrest`, `realtime_client`, `storage_client`,
 
 This package holds code that would otherwise be duplicated across those
 packages: the `SupabaseException` base class the auth, postgrest, storage and
-functions exceptions extend, the `X-Client-Info` header builder, platform
-detection, a small replay stream subject, base64url/PKCE helpers and a few
-other primitives.
+functions exceptions extend, the shared `HttpMethod` enum and HTTP request
+helpers, the `X-Client-Info` header builder, platform detection, a small replay
+stream subject, base64url/PKCE helpers and a few other primitives.

--- a/packages/supabase_common/lib/src/http.dart
+++ b/packages/supabase_common/lib/src/http.dart
@@ -1,0 +1,63 @@
+import 'dart:convert';
+
+import 'package:http/http.dart';
+
+/// Sends [request] over [httpClient], or over a one-off client when no client
+/// was provided.
+///
+/// Every Supabase client takes an optional [Client] so callers can plug in
+/// their own transport, and falls back to the default one otherwise.
+Future<StreamedResponse> sendRequest(
+  BaseRequest request, {
+  Client? httpClient,
+}) => httpClient?.send(request) ?? request.send();
+
+/// The value of the [name] header, matched case insensitively.
+///
+/// HTTP header names are case insensitive, and while `package:http` lowercases
+/// the names of received headers, headers assembled by the client packages can
+/// use any casing.
+String? headerValue(Map<String, String> headers, String name) {
+  final lowerCaseName = name.toLowerCase();
+  for (final entry in headers.entries) {
+    if (entry.key.toLowerCase() == lowerCaseName) {
+      return entry.value;
+    }
+  }
+  return null;
+}
+
+/// Sets `Content-Type` to [value] unless [headers] already carries one.
+///
+/// Requests whose body the caller controls must not have an explicitly passed
+/// content type overwritten.
+void setDefaultContentType(Map<String, String> headers, String value) {
+  if (headerValue(headers, 'content-type') == null) {
+    headers['Content-Type'] = value;
+  }
+}
+
+/// The media type of a response, lowercased and without any parameters, so
+/// `Content-Type: application/json; charset=utf-8` becomes `application/json`.
+///
+/// Returns `null` when the response carries no content type.
+String? responseMediaType(Map<String, String> headers) =>
+    headerValue(headers, 'content-type')?.split(';').first.trim().toLowerCase();
+
+/// Decodes [body] as a JSON object, or returns `null` when it is empty, is not
+/// valid JSON, or is valid JSON that is not an object.
+///
+/// Error responses are the main use: a service is expected to describe the
+/// failure in a JSON object, but a proxy or gateway in front of it can return
+/// anything at all, so decoding must not throw.
+Map<String, dynamic>? tryDecodeJsonObject(String body) {
+  if (body.isEmpty) {
+    return null;
+  }
+  try {
+    final decoded = json.decode(body);
+    return decoded is Map<String, dynamic> ? decoded : null;
+  } on FormatException {
+    return null;
+  }
+}

--- a/packages/supabase_common/lib/src/http.dart
+++ b/packages/supabase_common/lib/src/http.dart
@@ -2,47 +2,50 @@ import 'dart:convert';
 
 import 'package:http/http.dart';
 
-/// Sends [request] over [httpClient], or over a one-off client when no client
-/// was provided.
-///
-/// Every Supabase client takes an optional [Client] so callers can plug in
-/// their own transport, and falls back to the default one otherwise.
-Future<StreamedResponse> sendRequest(
-  BaseRequest request, {
-  Client? httpClient,
-}) => httpClient?.send(request) ?? request.send();
+/// Sending a request over a caller-provided transport.
+extension SendWith on BaseRequest {
+  /// Sends this request over [httpClient], or over a one-off [Client] when
+  /// [httpClient] is `null`.
+  ///
+  /// Every Supabase client takes an optional [Client] so callers can plug in
+  /// their own transport, and falls back to the default one otherwise.
+  Future<StreamedResponse> sendWith(Client? httpClient) =>
+      httpClient?.send(this) ?? send();
+}
 
-/// The value of the [name] header, matched case insensitively.
+/// Reading the headers of a response.
 ///
-/// HTTP header names are case insensitive, and while `package:http` lowercases
-/// the names of received headers, headers assembled by the client packages can
-/// use any casing.
-String? headerValue(Map<String, String> headers, String name) {
-  final lowerCaseName = name.toLowerCase();
-  for (final entry in headers.entries) {
-    if (entry.key.toLowerCase() == lowerCaseName) {
-      return entry.value;
+/// [BaseRequest.headers] already compares its keys case insensitively, so
+/// nothing here is needed on the request side. [BaseResponse.headers] is a
+/// plain map.
+extension ResponseHeaders on Map<String, String> {
+  /// The value of the [name] header, matched case insensitively.
+  ///
+  /// HTTP header names are case insensitive, and while the `package:http`
+  /// clients lowercase the names of the headers they receive, a client written
+  /// against [BaseClient] can hand back any casing.
+  String? header(String name) {
+    final lowerCaseName = name.toLowerCase();
+    for (final MapEntry(:key, :value) in entries) {
+      if (key.toLowerCase() == lowerCaseName) {
+        return value;
+      }
     }
+    return null;
   }
-  return null;
-}
 
-/// Sets `Content-Type` to [value] unless [headers] already carries one.
-///
-/// Requests whose body the caller controls must not have an explicitly passed
-/// content type overwritten.
-void setDefaultContentType(Map<String, String> headers, String value) {
-  if (headerValue(headers, 'content-type') == null) {
-    headers['Content-Type'] = value;
-  }
+  /// The media type, lowercased and without any parameters, so
+  /// `Content-Type: application/json; charset=utf-8` becomes
+  /// `application/json`.
+  ///
+  /// Returns `null` when there is no content type.
+  ///
+  /// `MediaType.parse` from `package:http_parser` is not used because it throws
+  /// on a malformed value, and a proxy or gateway in front of a service can
+  /// answer with anything at all.
+  String? get mediaType =>
+      header('content-type')?.split(';').first.trim().toLowerCase();
 }
-
-/// The media type of a response, lowercased and without any parameters, so
-/// `Content-Type: application/json; charset=utf-8` becomes `application/json`.
-///
-/// Returns `null` when the response carries no content type.
-String? responseMediaType(Map<String, String> headers) =>
-    headerValue(headers, 'content-type')?.split(';').first.trim().toLowerCase();
 
 /// Decodes [body] as a JSON object, or returns `null` when it is empty, is not
 /// valid JSON, or is valid JSON that is not an object.
@@ -51,9 +54,6 @@ String? responseMediaType(Map<String, String> headers) =>
 /// failure in a JSON object, but a proxy or gateway in front of it can return
 /// anything at all, so decoding must not throw.
 Map<String, dynamic>? tryDecodeJsonObject(String body) {
-  if (body.isEmpty) {
-    return null;
-  }
   try {
     final decoded = json.decode(body);
     return decoded is Map<String, dynamic> ? decoded : null;

--- a/packages/supabase_common/lib/src/http.dart
+++ b/packages/supabase_common/lib/src/http.dart
@@ -13,12 +13,12 @@ extension SendWith on BaseRequest {
       httpClient?.send(this) ?? send();
 }
 
-/// Reading the headers of a response.
+/// Reading and logging a map of HTTP headers.
 ///
 /// [BaseRequest.headers] already compares its keys case insensitively, so
-/// nothing here is needed on the request side. [BaseResponse.headers] is a
-/// plain map.
-extension ResponseHeaders on Map<String, String> {
+/// [header] and [mediaType] are only needed for [BaseResponse.headers], which
+/// is a plain map.
+extension HeaderMap on Map<String, String> {
   /// The value of the [name] header, matched case insensitively.
   ///
   /// HTTP header names are case insensitive, and while the `package:http`
@@ -45,7 +45,31 @@ extension ResponseHeaders on Map<String, String> {
   /// answer with anything at all.
   String? get mediaType =>
       header('content-type')?.split(';').first.trim().toLowerCase();
+
+  /// The headers with every credential-bearing value replaced by `<redacted>`.
+  ///
+  /// Request headers carry the caller's API key and access token, so logging
+  /// them as they are would export those credentials to whatever the logger
+  /// writes to. The names are kept, since knowing which headers were sent is
+  /// the useful part when reading a log.
+  Map<String, String> get redacted => {
+    for (final MapEntry(:key, :value) in entries)
+      key: _credentialHeaders.contains(key.toLowerCase())
+          ? '<redacted>'
+          : value,
+  };
 }
+
+/// The headers whose value authenticates the request, and so must not be
+/// logged.
+const _credentialHeaders = {
+  'apikey',
+  'authorization',
+  'cookie',
+  'proxy-authorization',
+  'set-cookie',
+  'x-api-key',
+};
 
 /// Decodes [body] as a JSON object, or returns `null` when it is empty, is not
 /// valid JSON, or is valid JSON that is not an object.

--- a/packages/supabase_common/lib/supabase_common.dart
+++ b/packages/supabase_common/lib/supabase_common.dart
@@ -9,6 +9,7 @@ export 'src/backoff.dart';
 export 'src/base64url.dart';
 export 'src/client_info.dart';
 export 'src/fetch_options.dart';
+export 'src/http.dart';
 export 'src/http_method.dart';
 export 'src/http_status.dart';
 export 'src/persist_session_key.dart';

--- a/packages/supabase_common/pubspec.yaml
+++ b/packages/supabase_common/pubspec.yaml
@@ -16,6 +16,7 @@ resolution: workspace
 
 dependencies:
   crypto: ^3.0.7
+  http: ^1.6.0
   meta: ^1.16.0
 
 dev_dependencies:

--- a/packages/supabase_common/test/http_test.dart
+++ b/packages/supabase_common/test/http_test.dart
@@ -47,6 +47,35 @@ void main() {
     });
   });
 
+  group('redacted', () {
+    test('replaces credential values but keeps the names', () {
+      const headers = {
+        'Authorization': 'Bearer the-access-token',
+        'apikey': 'the-anon-key',
+        'X-Api-Key': 'another-key',
+        'Cookie': 'session=abc',
+        'Content-Type': 'application/json',
+        'x-region': 'eu-west-2',
+      };
+
+      expect(headers.redacted, {
+        'Authorization': '<redacted>',
+        'apikey': '<redacted>',
+        'X-Api-Key': '<redacted>',
+        'Cookie': '<redacted>',
+        'Content-Type': 'application/json',
+        'x-region': 'eu-west-2',
+      });
+    });
+
+    test('leaves the headers themselves untouched', () {
+      final headers = {'Authorization': 'Bearer the-access-token'};
+
+      expect(headers.redacted, {'Authorization': '<redacted>'});
+      expect(headers, {'Authorization': 'Bearer the-access-token'});
+    });
+  });
+
   group('mediaType', () {
     test('drops parameters and lowercases the type', () {
       expect(

--- a/packages/supabase_common/test/http_test.dart
+++ b/packages/supabase_common/test/http_test.dart
@@ -95,7 +95,9 @@ void main() {
 
     test('returns null for JSON that is not an object', () {
       expect(tryDecodeJsonObject('["boom"]'), isNull);
+      expect(tryDecodeJsonObject('"boom"'), isNull);
       expect(tryDecodeJsonObject('42'), isNull);
+      expect(tryDecodeJsonObject('null'), isNull);
     });
   });
 }

--- a/packages/supabase_common/test/http_test.dart
+++ b/packages/supabase_common/test/http_test.dart
@@ -1,0 +1,101 @@
+import 'dart:convert';
+
+import 'package:http/http.dart';
+import 'package:supabase_common/supabase_common.dart';
+import 'package:test/test.dart';
+
+class _RecordingClient extends BaseClient {
+  BaseRequest? sentRequest;
+
+  @override
+  Future<StreamedResponse> send(BaseRequest request) async {
+    sentRequest = request;
+    return StreamedResponse(
+      Stream.value(utf8.encode('sent by the custom client')),
+      200,
+      request: request,
+    );
+  }
+}
+
+void main() {
+  group('sendRequest', () {
+    test('sends over the given client', () async {
+      final httpClient = _RecordingClient();
+      final request = Request('GET', Uri.parse('http://localhost/things'));
+
+      final response = await sendRequest(request, httpClient: httpClient);
+
+      expect(httpClient.sentRequest, same(request));
+      expect(
+        await response.stream.bytesToString(),
+        'sent by the custom client',
+      );
+    });
+  });
+
+  group('headerValue', () {
+    test('matches the name case insensitively', () {
+      const headers = {'Content-Type': 'application/json'};
+
+      expect(headerValue(headers, 'content-type'), 'application/json');
+      expect(headerValue(headers, 'CONTENT-TYPE'), 'application/json');
+    });
+
+    test('returns null when the header is absent', () {
+      expect(headerValue(const {}, 'content-type'), isNull);
+    });
+  });
+
+  group('setDefaultContentType', () {
+    test('sets the content type when there is none', () {
+      final headers = <String, String>{};
+
+      setDefaultContentType(headers, 'application/json');
+
+      expect(headers, {'Content-Type': 'application/json'});
+    });
+
+    test('keeps a content type set under any casing', () {
+      final headers = {'content-type': 'text/csv'};
+
+      setDefaultContentType(headers, 'application/json');
+
+      expect(headers, {'content-type': 'text/csv'});
+    });
+  });
+
+  group('responseMediaType', () {
+    test('drops parameters and lowercases the type', () {
+      expect(
+        responseMediaType(const {
+          'content-type': 'Application/JSON; charset=utf-8',
+        }),
+        'application/json',
+      );
+    });
+
+    test('returns null when there is no content type', () {
+      expect(responseMediaType(const {}), isNull);
+    });
+  });
+
+  group('tryDecodeJsonObject', () {
+    test('decodes a JSON object', () {
+      expect(tryDecodeJsonObject('{"message":"boom"}'), {'message': 'boom'});
+    });
+
+    test('returns null for an empty body', () {
+      expect(tryDecodeJsonObject(''), isNull);
+    });
+
+    test('returns null for a body that is not JSON', () {
+      expect(tryDecodeJsonObject('<html>502 Bad Gateway</html>'), isNull);
+    });
+
+    test('returns null for JSON that is not an object', () {
+      expect(tryDecodeJsonObject('["boom"]'), isNull);
+      expect(tryDecodeJsonObject('42'), isNull);
+    });
+  });
+}

--- a/packages/supabase_common/test/http_test.dart
+++ b/packages/supabase_common/test/http_test.dart
@@ -19,12 +19,12 @@ class _RecordingClient extends BaseClient {
 }
 
 void main() {
-  group('sendRequest', () {
+  group('sendWith', () {
     test('sends over the given client', () async {
       final httpClient = _RecordingClient();
       final request = Request('GET', Uri.parse('http://localhost/things'));
 
-      final response = await sendRequest(request, httpClient: httpClient);
+      final response = await request.sendWith(httpClient);
 
       expect(httpClient.sentRequest, same(request));
       expect(
@@ -34,49 +34,29 @@ void main() {
     });
   });
 
-  group('headerValue', () {
+  group('header', () {
     test('matches the name case insensitively', () {
       const headers = {'Content-Type': 'application/json'};
 
-      expect(headerValue(headers, 'content-type'), 'application/json');
-      expect(headerValue(headers, 'CONTENT-TYPE'), 'application/json');
+      expect(headers.header('content-type'), 'application/json');
+      expect(headers.header('CONTENT-TYPE'), 'application/json');
     });
 
     test('returns null when the header is absent', () {
-      expect(headerValue(const {}, 'content-type'), isNull);
+      expect(const <String, String>{}.header('content-type'), isNull);
     });
   });
 
-  group('setDefaultContentType', () {
-    test('sets the content type when there is none', () {
-      final headers = <String, String>{};
-
-      setDefaultContentType(headers, 'application/json');
-
-      expect(headers, {'Content-Type': 'application/json'});
-    });
-
-    test('keeps a content type set under any casing', () {
-      final headers = {'content-type': 'text/csv'};
-
-      setDefaultContentType(headers, 'application/json');
-
-      expect(headers, {'content-type': 'text/csv'});
-    });
-  });
-
-  group('responseMediaType', () {
+  group('mediaType', () {
     test('drops parameters and lowercases the type', () {
       expect(
-        responseMediaType(const {
-          'content-type': 'Application/JSON; charset=utf-8',
-        }),
+        const {'content-type': 'Application/JSON; charset=utf-8'}.mediaType,
         'application/json',
       );
     });
 
     test('returns null when there is no content type', () {
-      expect(responseMediaType(const {}), isNull);
+      expect(const <String, String>{}.mediaType, isNull);
     });
   });
 


### PR DESCRIPTION
Tier 3 of #1572, last of four PRs. Stacked on #1646 (→ #1645 → #1644).

The tier 3 note said the fetch wrappers are shareable in pieces, not as one wrapper, since each is bound to its own exception type. These are the pieces, now in `supabase_common`:

| Helper | Replaces |
| --- | --- |
| `request.sendWith(httpClient)` | `httpClient != null ? httpClient.send(request) : request.send()` in functions, storage (3 sites) and the Iceberg catalog |
| `headers.header(name)` | case-insensitive header lookups on a response |
| `headers.mediaType` | functions' `(headers['Content-Type'] ?? headers['content-type'] ?? 'text/plain').split(';')[0].trim().toLowerCase()` and the Iceberg catalog's `contentType.contains('application/json')` |
| `headers.redacted` | nothing; new, see below |
| `tryDecodeJsonObject(body)` | the "decode the error body, fall back to the raw body" dance in storage and postgrest |

`supabase_common` gains a dependency on `http` (`^1.6.0`, the constraint every other package already uses).

There is deliberately no shared helper for the "set `Content-Type` unless the caller already did" check that storage and functions each had inline. `BaseRequest.headers` is already a case-insensitive map, so once the headers are on the request that check is just `request.headers.putIfAbsent('Content-Type', ...)`, which is what all three call sites now do. The Iceberg catalog moves to it as well, which drops an ordering subtlety there: it previously relied on `...?headers` spreading after a literal `'Content-Type'` key, so a caller who spelled the header with any other casing ended up with two entries rather than an override.

## Two behaviour changes

Both follow from setting the content type on the request rather than on a detached map, and both are in functions' `invoke`:

- A body given as a `String` now goes out as `text/plain; charset=utf-8` instead of a bare `text/plain`. `Request.body` fills the charset in itself, and the old header copy ran afterwards and overwrote it.
- An explicit charset in a caller-supplied `Content-Type` now drives the body encoding, because the header is in place before `Request.body` reads it. Previously the body was always encoded as UTF-8 regardless of what the caller asked for.

Relatedly, a multipart request no longer gets a content type from the switch on the body type. It generates its own boundary while being finalized and sets the header itself, so that default never reached the wire.

## Credentials in the request logs

Raised in review. The logs interpolated the headers as sent, so `_log.finest` handed the caller's `apikey` and access token to whatever the logger writes to. `headers.redacted` replaces the value of every credential-bearing header with `<redacted>` and keeps the names, since knowing which headers went out is the useful part when reading a log. It is applied to the request logs and the `Initialize with headers:` logs in functions and storage.

Those log lines date back to #1042, so this is a pre-existing leak rather than one this PR introduces, but it is fixed here since the shared helper it needs is what this PR is adding.

## Two bugs this surfaces

Each has a regression test that fails without the fix.

**Postgrest swallowed typed errors for `maybeSingle()`.** The decode and the `maybeSingle` handling shared one `try`/`catch (_)`:

```dart
try {
  final errorJson = jsonDecode(response.body) as Map<String, dynamic>;
  error = PostgrestException.fromJson(...);
  if (_maybeSingle) {
    return _handleMaybeSingleError(response, error); // rethrows `error` for a real failure
  }
} catch (_) {
  error = PostgrestException(message: response.body, ...); // ...and catches it here
}
```

`_handleMaybeSingleError` returns null data for the "0 rows" case and rethrows otherwise, but that rethrow landed in the `catch (_)` and was replaced by a generic exception built from the raw body. So a `maybeSingle()` request that failed for a real reason lost its `errorCode`, `details` and `hint`. Splitting the decode from the handling fixes it.

**A JSON error body with unexpected field types crashed.** Removing that catch-all exposed the next layer of the same problem: `PostgrestException.fromJson` cast `code` and `hint` to `String` and required a `String` message, so `{"code": 502, "message": "Bad gateway"}` — a shape gateways really do return — threw a `TypeError` out of the builder. Both `fromJson` factories now read every field defensively, so any JSON object yields an exception. `StorageException.fromJson` had the same casts and the same exposure.

The matching storage bug, where a JSON error body that is not an object escaped as a `TypeError`, is fixed in #1644; here its inline guard collapses into `tryDecodeJsonObject`.

## Not converted

Postgrest's own send site keeps managing its `Client` explicitly. It has to close a client it created even when the response body fails midway, and `BaseRequest.send` only closes its internal client when the stream completes normally.

supabase_auth and postgrest also keep setting `Content-Type` unconditionally rather than defaulting it with `putIfAbsent`: both always JSON-encode the body, so honouring a caller-provided content type there would mislabel the request rather than respect it.

The `Initialize with headers:` log in postgrest, realtime_client and supabase_auth still prints the caller's `apikey` and access token. Those packages are outside this refactor, and realtime's `params` map, which carries the `apikey` too, is a `Map<String, dynamic>`, so covering it needs a different shape of helper than the one on `Map<String, String>`.

## Testing

New `http_test.dart` in `supabase_common` covers each helper, plus the three regression tests described above. Functions gains a test that a caller-supplied charset is what the body is actually encoded with, a test that no log record carries a credential value while every header name stays readable, and its existing `text/plain` assertion is tightened from `contains` to the full header value.

`melos analyze` and `melos format` clean; `dcm analyze` passes (its only two hits are `avoid-inferrable-type-arguments` in `timestamp_test.dart`, which is unchanged from `main`). The `supabase_auth`, `postgrest`, `storage_client`, `functions_client`, `realtime_client`, `supabase`, `supabase_common`, `supabase_flutter`, `supabase_typegen` and `yet_another_json_isolate` suites pass. Capability matrix symbol and drift checks pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of malformed, unexpected, or non-object API error responses.
  - Preserved error details, including status codes, messages, hints, codes, and additional information.
  - Improved request and response handling across Functions and Storage, including content types, media types, text encoding, and custom HTTP clients.
  - Redacted credentials from request logs.

- **Tests**
  - Added coverage for malformed errors, multiple-row responses, custom clients, encoding, and HTTP utilities.

- **Documentation**
  - Updated descriptions of shared HTTP functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
