### PR TITLE
fix(gotrue): preserve the error message on 5xx responses

### DIFF
--- a/packages/gotrue/lib/src/fetch.dart
+++ b/packages/gotrue/lib/src/fetch.dart
@@ -62,7 +62,8 @@ class GotrueFetch {
 
     final dynamic data;
 
-    // Catch this case as trying to decode it will throw a misleading [FormatException]
+    // Catch this case as trying to decode it will throw a misleading
+    // [FormatException]
     if (response.body.isEmpty) {
       if (isRetryable) {
         throw AuthRetryableFetchException(

--- a/packages/gotrue/lib/src/fetch.dart
+++ b/packages/gotrue/lib/src/fetch.dart
@@ -38,6 +38,18 @@ class GotrueFetch {
     return null;
   }
 
+  /// Message to use when a response body carries no usable error description.
+  ///
+  /// Falls back to the reason phrase, which HTTP/2 responses don't have, and
+  /// then to a message synthesized from the status code.
+  String _getStatusMessage(Response response) {
+    final reasonPhrase = response.reasonPhrase;
+    if (reasonPhrase != null && reasonPhrase.isNotEmpty) {
+      return reasonPhrase;
+    }
+    return 'HTTP ${response.statusCode}';
+  }
+
   AuthException _handleError(dynamic error) {
     if (error is! Response) {
       throw AuthRetryableFetchException(message: error.toString());
@@ -46,17 +58,18 @@ class GotrueFetch {
 
     // If the status is 500 or above, it's likely a server error,
     // and can be retried.
-    if (response.statusCode >= 500) {
-      throw AuthRetryableFetchException(
-        message: response.body,
-        statusCode: response.statusCode.toString(),
-      );
-    }
+    final isRetryable = response.statusCode >= 500;
 
     final dynamic data;
 
     // Catch this case as trying to decode it will throw a misleading [FormatException]
     if (response.body.isEmpty) {
+      if (isRetryable) {
+        throw AuthRetryableFetchException(
+          message: _getStatusMessage(response),
+          statusCode: response.statusCode.toString(),
+        );
+      }
       throw AuthUnknownException(
         message:
             'Received an empty response with status code ${response.statusCode}',
@@ -66,11 +79,25 @@ class GotrueFetch {
     try {
       data = jsonDecode(response.body);
     } catch (error) {
+      if (isRetryable) {
+        throw AuthRetryableFetchException(
+          message: _getStatusMessage(response),
+          statusCode: response.statusCode.toString(),
+        );
+      }
       throw AuthUnknownException(
         message: 'Failed to decode error response',
         originalError: error,
       );
     }
+
+    if (isRetryable) {
+      throw AuthRetryableFetchException(
+        message: _getErrorMessage(data),
+        statusCode: response.statusCode.toString(),
+      );
+    }
+
     String? errorCode;
 
     final responseApiVersion = ApiVersion.fromResponse(response);

--- a/packages/gotrue/test/custom_http_client.dart
+++ b/packages/gotrue/test/custom_http_client.dart
@@ -252,6 +252,9 @@ class RawBodyHttpClient extends BaseClient {
       statusCode,
       request: request,
       reasonPhrase: reasonPhrase,
+      // Without an explicit charset `package:http` decodes the body as
+      // Latin-1, which would mangle non-ASCII bodies.
+      headers: {'content-type': 'text/plain; charset=utf-8'},
     );
   }
 }

--- a/packages/gotrue/test/custom_http_client.dart
+++ b/packages/gotrue/test/custom_http_client.dart
@@ -233,6 +233,29 @@ class SingleUseRefreshTokenHttpClient extends BaseClient {
   }
 }
 
+/// Returns [body] verbatim, so that non-JSON error responses can be tested.
+class RawBodyHttpClient extends BaseClient {
+  RawBodyHttpClient(
+    this.body, {
+    required this.statusCode,
+    this.reasonPhrase,
+  });
+
+  final String body;
+  final int statusCode;
+  final String? reasonPhrase;
+
+  @override
+  Future<StreamedResponse> send(BaseRequest request) async {
+    return StreamedResponse(
+      Stream.value(utf8.encode(body)),
+      statusCode,
+      request: request,
+      reasonPhrase: reasonPhrase,
+    );
+  }
+}
+
 class MockedHttpClient extends BaseClient {
   MockedHttpClient(
     this.response, {

--- a/packages/gotrue/test/fetch_test.dart
+++ b/packages/gotrue/test/fetch_test.dart
@@ -175,6 +175,20 @@ void main() {
       );
     });
 
+    test(
+      'falls back to the status code on an empty 5xx body without a reason '
+      'phrase',
+      () async {
+        final client = RawBodyHttpClient('', statusCode: 503);
+
+        await _expectRetryableFetch(
+          client,
+          message: 'HTTP 503',
+          statusCode: '503',
+        );
+      },
+    );
+
     test('throws an unknown exception on a non-JSON 4xx body', () async {
       final client = RawBodyHttpClient(
         '<html><body><h1>400 Bad Request</h1></body></html>',

--- a/packages/gotrue/test/fetch_test.dart
+++ b/packages/gotrue/test/fetch_test.dart
@@ -72,6 +72,120 @@ void main() {
       await _testFetchRequest(client);
     });
   });
+
+  group('GotrueFetch server errors', () {
+    test('preserves the server sent message on a JSON 5xx body', () async {
+      final client = MockedHttpClient(
+        {
+          'code': 'unexpected_failure',
+          'message': 'Error sending confirmation email',
+        },
+        headers: {
+          Constants.apiVersionHeaderName: '2024-01-01',
+        },
+        statusCode: 500,
+      );
+
+      await _expectRetryableFetch(
+        client,
+        message: 'Error sending confirmation email',
+        statusCode: '500',
+      );
+    });
+
+    test(
+      'preserves the server sent message on a JSON 5xx body without an API '
+      'version',
+      () async {
+        final client = MockedHttpClient(
+          {
+            'code': 500,
+            'error_code': 'unexpected_failure',
+            'msg': 'Error sending confirmation email',
+          },
+          statusCode: 500,
+        );
+
+        await _expectRetryableFetch(
+          client,
+          message: 'Error sending confirmation email',
+          statusCode: '500',
+        );
+      },
+    );
+
+    test('falls back to the reason phrase on a non-JSON 5xx body', () async {
+      final client = RawBodyHttpClient(
+        '<html><body><h1>502 Bad Gateway</h1></body></html>',
+        statusCode: 502,
+        reasonPhrase: 'Bad Gateway',
+      );
+
+      await _expectRetryableFetch(
+        client,
+        message: 'Bad Gateway',
+        statusCode: '502',
+      );
+    });
+
+    test(
+      'falls back to the status code when there is no reason phrase',
+      () async {
+        final client = RawBodyHttpClient(
+          '<html><body><h1>502 Bad Gateway</h1></body></html>',
+          statusCode: 502,
+        );
+
+        await _expectRetryableFetch(
+          client,
+          message: 'HTTP 502',
+          statusCode: '502',
+        );
+      },
+    );
+
+    test('falls back to the reason phrase on an empty 5xx body', () async {
+      final client = RawBodyHttpClient(
+        '',
+        statusCode: 503,
+        reasonPhrase: 'Service Unavailable',
+      );
+
+      await _expectRetryableFetch(
+        client,
+        message: 'Service Unavailable',
+        statusCode: '503',
+      );
+    });
+
+    test('throws an unknown exception on a non-JSON 4xx body', () async {
+      final client = RawBodyHttpClient(
+        '<html><body><h1>400 Bad Request</h1></body></html>',
+        statusCode: 400,
+        reasonPhrase: 'Bad Request',
+      );
+
+      await expectLater(
+        GotrueFetch(client).request(_mockUrl, RequestMethodType.get),
+        throwsA(isA<AuthUnknownException>()),
+      );
+    });
+  });
+}
+
+Future<void> _expectRetryableFetch(
+  Client client, {
+  required String message,
+  required String statusCode,
+}) async {
+  await expectLater(
+    GotrueFetch(client).request(_mockUrl, RequestMethodType.get),
+    throwsA(
+      isA<AuthRetryableFetchException>()
+          .having((e) => e.message, 'message', message)
+          .having((e) => e.statusCode, 'statusCode', statusCode),
+    ),
+  );
 }
 
 Future<void> _testFetchRequest(Client client) async {

--- a/packages/gotrue/test/fetch_test.dart
+++ b/packages/gotrue/test/fetch_test.dart
@@ -144,6 +144,23 @@ void main() {
       },
     );
 
+    test(
+      'falls back to the status code when the reason phrase is empty',
+      () async {
+        final client = RawBodyHttpClient(
+          '<html><body><h1>502 Bad Gateway</h1></body></html>',
+          statusCode: 502,
+          reasonPhrase: '',
+        );
+
+        await _expectRetryableFetch(
+          client,
+          message: 'HTTP 502',
+          statusCode: '502',
+        );
+      },
+    );
+
     test('falls back to the reason phrase on an empty 5xx body', () async {
       final client = RawBodyHttpClient(
         '',


### PR DESCRIPTION
## What

`GotrueFetch._handleError` short-circuited on `statusCode >= 500` before it looked at the body, and set `message: response.body` unconditionally. That meant:

- a JSON error body such as `{"code":"unexpected_failure","msg":"Error sending confirmation email"}` surfaced as the raw JSON string instead of the server sent message
- an HTML error page from a proxy surfaced as a wall of markup
- an empty body surfaced as an empty message

The 5xx check now runs after the body is parsed, so the server sent message wins. When the body isn't JSON (or is empty), the message falls back to the response's reason phrase, and then to a synthesized `HTTP <status>` since HTTP/2 responses carry no reason phrase.

Non-5xx handling is untouched: a non-JSON 4xx body still throws `AuthUnknownException`.

| Response | Before | After |
| --- | --- | --- |
| 500 with `{"msg":"Error sending confirmation email"}` | `{"msg":"Error sending confirmation email"}` | `Error sending confirmation email` |
| 502 with an HTML body, reason phrase `Bad Gateway` | the full HTML | `Bad Gateway` |
| 502 with an HTML body, no reason phrase | the full HTML | `HTTP 502` |
| 503 with an empty body | `` | `Service Unavailable` |

`AuthRetryableFetchException` and its `statusCode` are unchanged, so retry behavior is unaffected.

## Why

Parity with `supabase-js`, which made the same reordering in supabase/supabase-js#2587 (`a6bcd6ae`).

Fixes #1651


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved authentication error handling for server-side failures.
  - Retryable server errors now consistently provide a meaningful message and status code.
  - Error messages now use available server details, HTTP reason phrases, or a clear status-based fallback.
  - Improved handling of empty and malformed error responses.
  - Non-JSON client errors are now reported with the appropriate unknown-error classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->