### PR TITLE
refactor!: singularize plural enum names and fold enum extensions in

### DIFF
--- a/packages/gotrue/lib/gotrue.dart
+++ b/packages/gotrue/lib/gotrue.dart
@@ -1,8 +1,7 @@
 /// A dart client library for the GoTrue API (Supabase Auth).
 library;
 
-export 'src/constants.dart'
-    hide Constants, GenerateLinkTypeExtended, AuthChangeEventExtended;
+export 'src/constants.dart' hide Constants;
 export 'src/gotrue_admin_api.dart';
 export 'src/gotrue_client.dart';
 export 'src/helper.dart' show decodeJwt, validateExp;

--- a/packages/gotrue/lib/src/constants.dart
+++ b/packages/gotrue/lib/src/constants.dart
@@ -1,5 +1,6 @@
 import 'package:gotrue/src/types/api_version.dart';
 import 'package:gotrue/src/version.dart';
+import 'package:meta/meta.dart';
 import 'package:supabase_common/supabase_common.dart';
 
 class Constants {
@@ -48,9 +49,8 @@ enum AuthChangeEvent {
 
   final String jsName;
   const AuthChangeEvent(this.jsName);
-}
 
-extension AuthChangeEventExtended on AuthChangeEvent {
+  @internal
   static AuthChangeEvent? fromString(String? val) {
     for (final event in AuthChangeEvent.values) {
       if (event.name == val) {
@@ -68,10 +68,9 @@ enum GenerateLinkType {
   recovery,
   emailChangeCurrent,
   emailChangeNew,
-  unknown,
-}
+  unknown;
 
-extension GenerateLinkTypeExtended on GenerateLinkType {
+  @internal
   static GenerateLinkType fromString(String? val) {
     for (final type in GenerateLinkType.values) {
       if (type.snakeCase == val) {

--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -432,7 +432,7 @@ class GoTrueClient {
     }
     final codeVerifier = codeVerifierRawString.split('/').first;
     final eventName = codeVerifierRawString.split('/').last;
-    final redirectType = AuthChangeEventExtended.fromString(eventName);
+    final redirectType = AuthChangeEvent.fromString(eventName);
 
     final Map<String, dynamic> response = await _fetch.request(
       '$_url/token',

--- a/packages/gotrue/lib/src/gotrue_mfa_api.dart
+++ b/packages/gotrue/lib/src/gotrue_mfa_api.dart
@@ -221,7 +221,7 @@ class GoTrueMFAApi {
     }
     final payload = decodeJwtPayload(session.accessToken).claims;
 
-    final currentLevel = AuthenticatorAssuranceLevels.values.firstWhereOrNull(
+    final currentLevel = AuthenticatorAssuranceLevel.values.firstWhereOrNull(
       (level) => level.name == payload['aal'],
     );
 
@@ -231,7 +231,7 @@ class GoTrueMFAApi {
           (factor) => factor.status == FactorStatus.verified,
         ) ??
         false) {
-      nextLevel = AuthenticatorAssuranceLevels.aal2;
+      nextLevel = AuthenticatorAssuranceLevel.aal2;
     }
 
     final amr = (payload['amr'] as List? ?? [])

--- a/packages/gotrue/lib/src/types/auth_response.dart
+++ b/packages/gotrue/lib/src/types/auth_response.dart
@@ -1,5 +1,4 @@
 import 'package:gotrue/gotrue.dart';
-import 'package:gotrue/src/constants.dart';
 
 /// Response which might or might not contain session and/or user
 class AuthResponse {
@@ -98,7 +97,7 @@ class GenerateLinkProperties {
       emailOtp = json['email_otp'] ?? '',
       hashedToken = json['hashed_token'] ?? '',
       redirectTo = json['redirect_to'] ?? '',
-      verificationType = GenerateLinkTypeExtended.fromString(
+      verificationType = GenerateLinkType.fromString(
         json['verification_type'],
       );
 }

--- a/packages/gotrue/lib/src/types/mfa.dart
+++ b/packages/gotrue/lib/src/types/mfa.dart
@@ -351,7 +351,7 @@ class Factor {
   }
 }
 
-enum AuthenticatorAssuranceLevels {
+enum AuthenticatorAssuranceLevel {
   // The user's identity has been verified only with a conventional login (email+password, OTP, magic link, social login, etc.).
   aal1,
 
@@ -361,12 +361,12 @@ enum AuthenticatorAssuranceLevels {
 
 class AuthMFAGetAuthenticatorAssuranceLevelResponse {
   /// Current AAL level of the session.
-  final AuthenticatorAssuranceLevels? currentLevel;
+  final AuthenticatorAssuranceLevel? currentLevel;
 
   /// Next possible AAL level for the session. If the next level is higher than the current one, the user should go through MFA.
   ///
   /// see [GoTrueMFAApi.challenge]
-  final AuthenticatorAssuranceLevels? nextLevel;
+  final AuthenticatorAssuranceLevel? nextLevel;
 
   /// A list of all authentication methods attached to this session.
   ///

--- a/packages/gotrue/lib/src/types/mfa.dart
+++ b/packages/gotrue/lib/src/types/mfa.dart
@@ -352,10 +352,12 @@ class Factor {
 }
 
 enum AuthenticatorAssuranceLevel {
-  // The user's identity has been verified only with a conventional login (email+password, OTP, magic link, social login, etc.).
+  /// The user's identity has been verified only with a conventional login
+  /// (email+password, OTP, magic link, social login, etc.).
   aal1,
 
-  // The user's identity has been verified both with a conventional login and at least one MFA factor.
+  /// The user's identity has been verified both with a conventional login and
+  /// at least one MFA factor.
   aal2,
 }
 
@@ -363,7 +365,8 @@ class AuthMFAGetAuthenticatorAssuranceLevelResponse {
   /// Current AAL level of the session.
   final AuthenticatorAssuranceLevel? currentLevel;
 
-  /// Next possible AAL level for the session. If the next level is higher than the current one, the user should go through MFA.
+  /// Next possible AAL level for the session. If the next level is higher than
+  /// the current one, the user should go through MFA.
   ///
   /// see [GoTrueMFAApi.challenge]
   final AuthenticatorAssuranceLevel? nextLevel;

--- a/packages/gotrue/test/src/constants_test.dart
+++ b/packages/gotrue/test/src/constants_test.dart
@@ -101,58 +101,58 @@ void main() {
       expect(AuthChangeEvent.userDeleted.jsName, equals(''));
     });
 
-    group('AuthChangeEventExtended', () {
+    group('AuthChangeEvent', () {
       test('fromString returns correct event for valid names', () {
         expect(
-          AuthChangeEventExtended.fromString('initialSession'),
+          AuthChangeEvent.fromString('initialSession'),
           equals(AuthChangeEvent.initialSession),
         );
         expect(
-          AuthChangeEventExtended.fromString('passwordRecovery'),
+          AuthChangeEvent.fromString('passwordRecovery'),
           equals(AuthChangeEvent.passwordRecovery),
         );
         expect(
-          AuthChangeEventExtended.fromString('signedIn'),
+          AuthChangeEvent.fromString('signedIn'),
           equals(AuthChangeEvent.signedIn),
         );
         expect(
-          AuthChangeEventExtended.fromString('signedOut'),
+          AuthChangeEvent.fromString('signedOut'),
           equals(AuthChangeEvent.signedOut),
         );
         expect(
-          AuthChangeEventExtended.fromString('tokenRefreshed'),
+          AuthChangeEvent.fromString('tokenRefreshed'),
           equals(AuthChangeEvent.tokenRefreshed),
         );
         expect(
-          AuthChangeEventExtended.fromString('userUpdated'),
+          AuthChangeEvent.fromString('userUpdated'),
           equals(AuthChangeEvent.userUpdated),
         );
         // ignore: deprecated_member_use
         expect(
-          AuthChangeEventExtended.fromString('userDeleted'),
+          AuthChangeEvent.fromString('userDeleted'),
           equals(AuthChangeEvent.userDeleted),
         );
         expect(
-          AuthChangeEventExtended.fromString('mfaChallengeVerified'),
+          AuthChangeEvent.fromString('mfaChallengeVerified'),
           equals(AuthChangeEvent.mfaChallengeVerified),
         );
       });
 
       test('fromString returns null for invalid names', () {
-        expect(AuthChangeEventExtended.fromString('invalid'), isNull);
-        expect(AuthChangeEventExtended.fromString('SIGNED_IN'), isNull);
-        expect(AuthChangeEventExtended.fromString('signed_in'), isNull);
-        expect(AuthChangeEventExtended.fromString(''), isNull);
+        expect(AuthChangeEvent.fromString('invalid'), isNull);
+        expect(AuthChangeEvent.fromString('SIGNED_IN'), isNull);
+        expect(AuthChangeEvent.fromString('signed_in'), isNull);
+        expect(AuthChangeEvent.fromString(''), isNull);
       });
 
       test('fromString returns null for null input', () {
-        expect(AuthChangeEventExtended.fromString(null), isNull);
+        expect(AuthChangeEvent.fromString(null), isNull);
       });
 
       test('fromString uses enum name, not jsName', () {
-        expect(AuthChangeEventExtended.fromString('SIGNED_IN'), isNull);
+        expect(AuthChangeEvent.fromString('SIGNED_IN'), isNull);
         expect(
-          AuthChangeEventExtended.fromString('signedIn'),
+          AuthChangeEvent.fromString('signedIn'),
           equals(AuthChangeEvent.signedIn),
         );
       });
@@ -177,56 +177,56 @@ void main() {
       expect(GenerateLinkType.values, contains(GenerateLinkType.unknown));
     });
 
-    group('GenerateLinkTypeExtended', () {
+    group('GenerateLinkType', () {
       test('fromString returns correct type for valid snake_case names', () {
         expect(
-          GenerateLinkTypeExtended.fromString('signup'),
+          GenerateLinkType.fromString('signup'),
           equals(GenerateLinkType.signup),
         );
         expect(
-          GenerateLinkTypeExtended.fromString('invite'),
+          GenerateLinkType.fromString('invite'),
           equals(GenerateLinkType.invite),
         );
         expect(
-          GenerateLinkTypeExtended.fromString('magiclink'),
+          GenerateLinkType.fromString('magiclink'),
           equals(GenerateLinkType.magiclink),
         );
         expect(
-          GenerateLinkTypeExtended.fromString('recovery'),
+          GenerateLinkType.fromString('recovery'),
           equals(GenerateLinkType.recovery),
         );
         expect(
-          GenerateLinkTypeExtended.fromString('email_change_current'),
+          GenerateLinkType.fromString('email_change_current'),
           equals(GenerateLinkType.emailChangeCurrent),
         );
         expect(
-          GenerateLinkTypeExtended.fromString('email_change_new'),
+          GenerateLinkType.fromString('email_change_new'),
           equals(GenerateLinkType.emailChangeNew),
         );
       });
 
       test('fromString returns unknown for invalid names', () {
         expect(
-          GenerateLinkTypeExtended.fromString('invalid'),
+          GenerateLinkType.fromString('invalid'),
           equals(GenerateLinkType.unknown),
         );
         expect(
-          GenerateLinkTypeExtended.fromString('emailChangeCurrent'),
+          GenerateLinkType.fromString('emailChangeCurrent'),
           equals(GenerateLinkType.unknown),
         );
         expect(
-          GenerateLinkTypeExtended.fromString('SIGNUP'),
+          GenerateLinkType.fromString('SIGNUP'),
           equals(GenerateLinkType.unknown),
         );
         expect(
-          GenerateLinkTypeExtended.fromString(''),
+          GenerateLinkType.fromString(''),
           equals(GenerateLinkType.unknown),
         );
       });
 
       test('fromString returns unknown for null input', () {
         expect(
-          GenerateLinkTypeExtended.fromString(null),
+          GenerateLinkType.fromString(null),
           equals(GenerateLinkType.unknown),
         );
       });
@@ -234,7 +234,7 @@ void main() {
       test('all enum values have corresponding snake_case representation', () {
         for (final type in GenerateLinkType.values) {
           if (type != GenerateLinkType.unknown) {
-            final result = GenerateLinkTypeExtended.fromString(type.snakeCase);
+            final result = GenerateLinkType.fromString(type.snakeCase);
             expect(result, equals(type), reason: 'Failed for ${type.name}');
           }
         }

--- a/packages/gotrue/test/src/gotrue_mfa_api_test.dart
+++ b/packages/gotrue/test/src/gotrue_mfa_api_test.dart
@@ -222,16 +222,16 @@ void main() {
     test('aal1 for only password', () async {
       await client.signInWithPassword(password: password, email: email2);
       final response = client.mfa.getAuthenticatorAssuranceLevel();
-      expect(response.currentLevel, AuthenticatorAssuranceLevels.aal1);
-      expect(response.nextLevel, AuthenticatorAssuranceLevels.aal2);
+      expect(response.currentLevel, AuthenticatorAssuranceLevel.aal1);
+      expect(response.nextLevel, AuthenticatorAssuranceLevel.aal2);
     });
 
     test('aal2 for password and totp', () async {
       await client.signInWithPassword(password: password, email: email2);
       await client.mfa.challengeAndVerify(factorId: factorId2, code: getTOTP());
       final response = client.mfa.getAuthenticatorAssuranceLevel();
-      expect(response.currentLevel, AuthenticatorAssuranceLevels.aal2);
-      expect(response.nextLevel, AuthenticatorAssuranceLevels.aal2);
+      expect(response.currentLevel, AuthenticatorAssuranceLevel.aal2);
+      expect(response.nextLevel, AuthenticatorAssuranceLevel.aal2);
       final passwordEntry = response.currentAuthenticationMethods
           .firstWhereOrNull((element) => element.method == AMRMethod.password);
       final totpEntry = response.currentAuthenticationMethods.firstWhereOrNull(
@@ -278,7 +278,7 @@ void main() {
 
       final result = localClient.mfa.getAuthenticatorAssuranceLevel();
 
-      expect(result.currentLevel, AuthenticatorAssuranceLevels.aal1);
+      expect(result.currentLevel, AuthenticatorAssuranceLevel.aal1);
       expect(result.currentAuthenticationMethods, isEmpty);
     },
   );

--- a/packages/realtime_client/lib/realtime_client.dart
+++ b/packages/realtime_client/lib/realtime_client.dart
@@ -11,5 +11,4 @@ export 'src/realtime_channel.dart';
 export 'src/realtime_client.dart';
 export 'src/realtime_presence.dart';
 export 'src/transformers.dart' hide getEnrichedPayload, getPayloadRecords;
-export 'src/types.dart'
-    hide ToType, PostgresChangeEventMethods, ChannelFilter, RealtimeListenTypes;
+export 'src/types.dart' hide ChannelFilter, RealtimeListenType;

--- a/packages/realtime_client/lib/src/constants.dart
+++ b/packages/realtime_client/lib/src/constants.dart
@@ -1,3 +1,4 @@
+import 'package:meta/meta.dart';
 import 'package:realtime_client/src/version.dart';
 import 'package:supabase_common/supabase_common.dart';
 
@@ -43,9 +44,11 @@ enum SocketStates {
   disconnected,
 }
 
-enum ChannelStates { closed, errored, joined, joining, leaving }
+@internal
+enum ChannelState { closed, errored, joined, joining, leaving }
 
-enum ChannelEvents {
+@internal
+enum ChannelEvent {
   close,
   error,
   join,
@@ -55,30 +58,28 @@ enum ChannelEvents {
   accessToken,
   broadcast,
   presence,
-  postgresChanges,
-}
+  postgresChanges;
 
-extension ChannelEventsExtended on ChannelEvents {
-  static ChannelEvents fromType(String type) {
-    for (ChannelEvents enumVariant in ChannelEvents.values) {
-      if (enumVariant.name == type || enumVariant.eventName() == type) {
-        return enumVariant;
+  static ChannelEvent fromType(String type) {
+    for (final event in ChannelEvent.values) {
+      if (event.name == type || event.eventName() == type) {
+        return event;
       }
     }
     throw 'No type $type exists';
   }
 
   String eventName() => switch (this) {
-    ChannelEvents.accessToken => 'access_token',
-    ChannelEvents.postgresChanges => 'postgres_changes',
-    ChannelEvents.broadcast => 'broadcast',
-    ChannelEvents.presence => 'presence',
-    ChannelEvents.close ||
-    ChannelEvents.error ||
-    ChannelEvents.join ||
-    ChannelEvents.reply ||
-    ChannelEvents.leave ||
-    ChannelEvents.heartbeat => 'phx_$name',
+    ChannelEvent.accessToken => 'access_token',
+    ChannelEvent.postgresChanges => 'postgres_changes',
+    ChannelEvent.broadcast => 'broadcast',
+    ChannelEvent.presence => 'presence',
+    ChannelEvent.close ||
+    ChannelEvent.error ||
+    ChannelEvent.join ||
+    ChannelEvent.reply ||
+    ChannelEvent.leave ||
+    ChannelEvent.heartbeat => 'phx_$name',
   };
 }
 

--- a/packages/realtime_client/lib/src/message.dart
+++ b/packages/realtime_client/lib/src/message.dart
@@ -3,7 +3,7 @@ import 'package:realtime_client/src/constants.dart';
 
 class Message {
   final String topic;
-  final ChannelEvents event;
+  final ChannelEvent event;
   final dynamic payload;
   final String? ref;
   final String? joinRef;
@@ -45,7 +45,7 @@ class Message {
     }
     return {
       'topic': topic,
-      'event': event != ChannelEvents.heartbeat
+      'event': event != ChannelEvent.heartbeat
           ? event.eventName()
           : 'heartbeat',
       'payload': processedPayload,

--- a/packages/realtime_client/lib/src/push.dart
+++ b/packages/realtime_client/lib/src/push.dart
@@ -21,8 +21,8 @@ class Push {
   /// The channel
   final RealtimeChannel _channel;
 
-  /// The event, for example [ChannelEvents.join]
-  final ChannelEvents _event;
+  /// The event, for example [ChannelEvent.join]
+  final ChannelEvent _event;
 
   /// The payload, for example `{user_id: 123}`
   late Map<String, dynamic> payload;

--- a/packages/realtime_client/lib/src/realtime_channel.dart
+++ b/packages/realtime_client/lib/src/realtime_channel.dart
@@ -15,7 +15,7 @@ import 'package:realtime_client/src/types.dart';
 class RealtimeChannel {
   final Map<String, List<Binding>> _bindings = {};
   final Duration _timeout;
-  ChannelStates _state = ChannelStates.closed;
+  ChannelState _state = ChannelState.closed;
   @internal
   bool joinedOnce = false;
   @internal
@@ -52,7 +52,7 @@ class RealtimeChannel {
 
     joinPush = Push(
       this,
-      ChannelEvents.join,
+      ChannelEvent.join,
       this.params,
       _timeout,
     );
@@ -61,7 +61,7 @@ class RealtimeChannel {
       socket.reconnectAfterMs,
     );
     joinPush.receive('ok', (_) {
-      _state = ChannelStates.joined;
+      _state = ChannelState.joined;
       _rejoinTimer.reset();
       for (final pushEvent in _pushBuffer) {
         pushEvent.send();
@@ -72,7 +72,7 @@ class RealtimeChannel {
     _onClose(() {
       _rejoinTimer.reset();
       socket.log('channel', 'close $topic $joinRef');
-      _state = ChannelStates.closed;
+      _state = ChannelState.closed;
       socket.remove(this);
     });
 
@@ -81,7 +81,7 @@ class RealtimeChannel {
         return;
       }
       socket.log('channel', 'error $topic', reason);
-      _state = ChannelStates.errored;
+      _state = ChannelState.errored;
       _rejoinTimer.scheduleTimeout();
     });
 
@@ -90,11 +90,11 @@ class RealtimeChannel {
         return;
       }
       socket.log('channel', 'timeout $topic', joinPush.timeout);
-      _state = ChannelStates.errored;
+      _state = ChannelState.errored;
       _rejoinTimer.scheduleTimeout();
     });
 
-    onEvents(ChannelEvents.reply.eventName(), ChannelFilter(), (
+    onEvents(ChannelEvent.reply.eventName(), ChannelFilter(), (
       payload, [
       ref,
     ]) {
@@ -323,7 +323,7 @@ class RealtimeChannel {
     Map<String, dynamic> opts = const {},
   ]) {
     return send(
-      type: RealtimeListenTypes.presence,
+      type: RealtimeListenType.presence,
       payload: {
         'event': 'track',
         'payload': payload,
@@ -339,7 +339,7 @@ class RealtimeChannel {
     Map<String, dynamic> opts = const {},
   ]) {
     return send(
-      type: RealtimeListenTypes.presence,
+      type: RealtimeListenType.presence,
       payload: {
         'event': 'untrack',
       },
@@ -350,7 +350,7 @@ class RealtimeChannel {
   /// Registers a callback that will be executed when the channel closes.
   void _onClose(Function callback) {
     onEvents(
-      ChannelEvents.close.eventName(),
+      ChannelEvent.close.eventName(),
       ChannelFilter(),
       (reason, [ref]) => callback(),
     );
@@ -359,7 +359,7 @@ class RealtimeChannel {
   /// Registers a callback that will be executed when the channel encounters an error.
   void _onError(Function callback) {
     onEvents(
-      ChannelEvents.error.eventName(),
+      ChannelEvent.error.eventName(),
       ChannelFilter(),
       (reason, [ref]) => callback(reason),
     );
@@ -632,7 +632,7 @@ class RealtimeChannel {
 
   @internal
   Push push(
-    ChannelEvents event,
+    ChannelEvent event,
     Map<String, dynamic> payload, [
     Duration? timeout,
   ]) {
@@ -770,7 +770,7 @@ class RealtimeChannel {
     required Map<String, dynamic> payload,
   }) {
     return send(
-      type: RealtimeListenTypes.broadcast,
+      type: RealtimeListenType.broadcast,
       event: event,
       payload: payload,
     );
@@ -778,7 +778,7 @@ class RealtimeChannel {
 
   @internal
   Future<ChannelResponse> send({
-    required RealtimeListenTypes type,
+    required RealtimeListenType type,
     String? event,
     required Map<String, dynamic> payload,
     Map<String, dynamic> opts = const {},
@@ -790,7 +790,7 @@ class RealtimeChannel {
       payload['event'] = event;
     }
 
-    if (!canPush && type == RealtimeListenTypes.broadcast) {
+    if (!canPush && type == RealtimeListenType.broadcast) {
       socket.log(
         'channel',
         'send() is automatically falling back to REST API. '
@@ -814,7 +814,7 @@ class RealtimeChannel {
       }
     } else {
       final push = this.push(
-        ChannelEventsExtended.fromType(payload['type']),
+        ChannelEvent.fromType(payload['type']),
         payload,
         opts['timeout'] ?? _timeout,
       );
@@ -885,10 +885,10 @@ class RealtimeChannel {
   /// channel.unsubscribe().receive("ok", (_){print("left!");} );
   /// ```
   Future<String> unsubscribe([Duration? timeout]) {
-    _state = ChannelStates.leaving;
+    _state = ChannelState.leaving;
     void onClose() {
       socket.log('channel', 'leave $topic');
-      trigger(ChannelEvents.close.eventName(), 'leave', joinRef);
+      trigger(ChannelEvent.close.eventName(), 'leave', joinRef);
     }
 
     // Destroy joinPush to avoid connection timeouts during unsubscription phase
@@ -896,7 +896,7 @@ class RealtimeChannel {
 
     final completer = Completer<String>();
 
-    final leavePush = Push(this, ChannelEvents.leave, {}, timeout ?? _timeout);
+    final leavePush = Push(this, ChannelEvent.leave, {}, timeout ?? _timeout);
 
     leavePush
         .receive('ok', (_) {
@@ -950,16 +950,16 @@ class RealtimeChannel {
       return;
     }
     socket.leaveOpenTopic(topic);
-    _state = ChannelStates.joining;
+    _state = ChannelState.joining;
     joinPush.resend(timeout ?? _timeout);
   }
 
   /// Resends [joinPush] to tell the server we join this channel again and marks
-  /// the channel as [ChannelStates.joining].
+  /// the channel as [ChannelState.joining].
   ///
   /// Usually [rejoin] only happens when the channel timeouts or errors out.
   /// When manually disconnecting, the channel is still marked as
-  /// [ChannelStates.joined]. Calling [RealtimeClient.leaveOpenTopic] will
+  /// [ChannelState.joined]. Calling [RealtimeClient.leaveOpenTopic] will
   /// unsubscribe itself, which causes issues when trying to rejoin. This method
   /// therefore doesn't call [RealtimeClient.leaveOpenTopic].
   @internal
@@ -967,7 +967,7 @@ class RealtimeChannel {
     if (isLeaving) {
       return;
     }
-    _state = ChannelStates.joining;
+    _state = ChannelState.joining;
     joinPush.resend(timeout ?? _timeout);
   }
 
@@ -975,10 +975,10 @@ class RealtimeChannel {
     final typeLower = type.toLowerCase();
 
     final events = [
-      ChannelEvents.close,
-      ChannelEvents.error,
-      ChannelEvents.leave,
-      ChannelEvents.join,
+      ChannelEvent.close,
+      ChannelEvent.error,
+      ChannelEvent.leave,
+      ChannelEvent.join,
     ].map((e) => e.eventName()).toSet();
 
     if (ref != null && events.contains(typeLower) && ref != joinRef) {
@@ -1036,19 +1036,19 @@ class RealtimeChannel {
   }
 
   @internal
-  bool get isClosed => _state == ChannelStates.closed;
+  bool get isClosed => _state == ChannelState.closed;
 
   @internal
-  bool get isErrored => _state == ChannelStates.errored;
+  bool get isErrored => _state == ChannelState.errored;
 
   @internal
-  bool get isJoined => _state == ChannelStates.joined;
+  bool get isJoined => _state == ChannelState.joined;
 
   @internal
-  bool get isJoining => _state == ChannelStates.joining;
+  bool get isJoining => _state == ChannelState.joining;
 
   @internal
-  bool get isLeaving => _state == ChannelStates.leaving;
+  bool get isLeaving => _state == ChannelState.leaving;
 
   static bool _isEqual(Map<String, Object?> obj1, Map<String, Object?> obj2) {
     if (obj1.keys.length != obj2.keys.length) {

--- a/packages/realtime_client/lib/src/realtime_client.dart
+++ b/packages/realtime_client/lib/src/realtime_client.dart
@@ -628,7 +628,7 @@ class RealtimeClient {
         });
       }
       if (channel.joinedOnce && channel.isJoined) {
-        channel.push(ChannelEvents.accessToken, {'access_token': tokenToSend});
+        channel.push(ChannelEvent.accessToken, {'access_token': tokenToSend});
       }
     }
   }
@@ -702,7 +702,7 @@ class RealtimeClient {
 
   void _triggerChanError([dynamic error]) {
     for (final channel in channels) {
-      channel.trigger(ChannelEvents.error.eventName(), error);
+      channel.trigger(ChannelEvent.error.eventName(), error);
     }
   }
 
@@ -784,7 +784,7 @@ class RealtimeClient {
     push(
       Message(
         topic: 'phoenix',
-        event: ChannelEvents.heartbeat,
+        event: ChannelEvent.heartbeat,
         payload: {},
         ref: pendingHeartbeatRef!,
       ),

--- a/packages/realtime_client/lib/src/transformers.dart
+++ b/packages/realtime_client/lib/src/transformers.dart
@@ -5,7 +5,7 @@ import 'dart:convert';
 
 import 'package:collection/collection.dart' show IterableExtension;
 
-enum PostgresTypes {
+enum PostgresType {
   abstime,
   bool,
   date,
@@ -139,41 +139,41 @@ dynamic convertCell(String type, dynamic value) {
     return toArray(value, dataType);
   }
 
-  final typeEnum = PostgresTypes.values.firstWhereOrNull((e) => e.name == type);
+  final typeEnum = PostgresType.values.firstWhereOrNull((e) => e.name == type);
   // If not null, convert to correct type.
   switch (typeEnum) {
-    case PostgresTypes.bool:
+    case PostgresType.bool:
       return toBoolean(value);
-    case PostgresTypes.float4:
-    case PostgresTypes.float8:
-    case PostgresTypes.numeric:
+    case PostgresType.float4:
+    case PostgresType.float8:
+    case PostgresType.numeric:
       return toDouble(value);
-    case PostgresTypes.int2:
-    case PostgresTypes.int4:
-    case PostgresTypes.int8:
-    case PostgresTypes.oid:
+    case PostgresType.int2:
+    case PostgresType.int4:
+    case PostgresType.int8:
+    case PostgresType.oid:
       return toInt(value);
-    case PostgresTypes.json:
-    case PostgresTypes.jsonb:
+    case PostgresType.json:
+    case PostgresType.jsonb:
       return toJson(value);
-    case PostgresTypes.timestamp:
+    case PostgresType.timestamp:
       return toTimestampString(
         value?.toString(),
       ); // Format to be consistent with PostgREST
-    case PostgresTypes.abstime: // To allow users to cast it based on Timezone
-    case PostgresTypes.date: // To allow users to cast it based on Timezone
-    case PostgresTypes.daterange:
-    case PostgresTypes.int4range:
-    case PostgresTypes.int8range:
-    case PostgresTypes.money:
-    case PostgresTypes.reltime: // To allow users to cast it based on Timezone
-    case PostgresTypes.text:
-    case PostgresTypes.time: // To allow users to cast it based on Timezone
-    case PostgresTypes
+    case PostgresType.abstime: // To allow users to cast it based on Timezone
+    case PostgresType.date: // To allow users to cast it based on Timezone
+    case PostgresType.daterange:
+    case PostgresType.int4range:
+    case PostgresType.int8range:
+    case PostgresType.money:
+    case PostgresType.reltime: // To allow users to cast it based on Timezone
+    case PostgresType.text:
+    case PostgresType.time: // To allow users to cast it based on Timezone
+    case PostgresType
         .timestamptz: // To allow users to cast it based on Timezone
-    case PostgresTypes.timetz: // To allow users to cast it based on Timezone
-    case PostgresTypes.tsrange:
-    case PostgresTypes.tstzrange:
+    case PostgresType.timetz: // To allow users to cast it based on Timezone
+    case PostgresType.tsrange:
+    case PostgresType.tstzrange:
     case null:
       return noop(value);
   }

--- a/packages/realtime_client/lib/src/types.dart
+++ b/packages/realtime_client/lib/src/types.dart
@@ -66,7 +66,8 @@ enum PostgresChangeEvent {
 }
 
 class ChannelFilter {
-  /// For [RealtimeListenType.postgresChanges] it's one of: `INSERT`, `UPDATE`, `DELETE`
+  /// For [RealtimeListenType.postgresChanges] it's one of: `INSERT`, `UPDATE`,
+  /// `DELETE`
   ///
   /// For [RealtimeListenType.presence] it's one of: `sync`, `join`, `leave`
   ///
@@ -75,10 +76,12 @@ class ChannelFilter {
   final String? schema;
   final String? table;
 
-  /// For [RealtimeListenType.postgresChanges] it's of the format `column=filter.value` with `filter` being one of `eq, neq, lt, lte, gt, gte, in, like, ilike, is, match, imatch, isdistinct`.
+  /// For [RealtimeListenType.postgresChanges] it's of the format
+  /// `column=filter.value` with `filter` being one of `eq, neq, lt, lte, gt,
+  /// gte, in, like, ilike, is, match, imatch, isdistinct`.
   ///
-  /// Multiple conditions can be combined with commas; they are applied as an `AND`.
-  /// Any operator can be negated with the `not.` prefix.
+  /// Multiple conditions can be combined with commas; they are applied as an
+  /// `AND`. Any operator can be negated with the `not.` prefix.
   final String? filter;
 
   /// For [RealtimeListenType.postgresChanges], restricts the change payload to

--- a/packages/realtime_client/lib/src/types.dart
+++ b/packages/realtime_client/lib/src/types.dart
@@ -1,5 +1,6 @@
 // ignore_for_file: public_member_api_docs, sort_constructors_first
 import 'package:collection/collection.dart';
+import 'package:meta/meta.dart';
 import 'package:realtime_client/realtime_client.dart';
 
 typedef BindingCallback = void Function(dynamic payload, [dynamic ref]);
@@ -43,10 +44,9 @@ enum PostgresChangeEvent {
   update,
 
   /// Listen to delete events.
-  delete,
-}
+  delete;
 
-extension PostgresChangeEventMethods on PostgresChangeEvent {
+  @internal
   String toRealtimeEvent() {
     if (this == PostgresChangeEvent.all) {
       return '*';
@@ -54,6 +54,7 @@ extension PostgresChangeEventMethods on PostgresChangeEvent {
     return name.toUpperCase();
   }
 
+  @internal
   static PostgresChangeEvent fromString(String event) => switch (event) {
     'INSERT' => PostgresChangeEvent.insert,
     'UPDATE' => PostgresChangeEvent.update,
@@ -65,22 +66,22 @@ extension PostgresChangeEventMethods on PostgresChangeEvent {
 }
 
 class ChannelFilter {
-  /// For [RealtimeListenTypes.postgresChanges] it's one of: `INSERT`, `UPDATE`, `DELETE`
+  /// For [RealtimeListenType.postgresChanges] it's one of: `INSERT`, `UPDATE`, `DELETE`
   ///
-  /// For [RealtimeListenTypes.presence] it's one of: `sync`, `join`, `leave`
+  /// For [RealtimeListenType.presence] it's one of: `sync`, `join`, `leave`
   ///
-  /// For [RealtimeListenTypes.broadcast] it can be any string
+  /// For [RealtimeListenType.broadcast] it can be any string
   final String? event;
   final String? schema;
   final String? table;
 
-  /// For [RealtimeListenTypes.postgresChanges] it's of the format `column=filter.value` with `filter` being one of `eq, neq, lt, lte, gt, gte, in, like, ilike, is, match, imatch, isdistinct`.
+  /// For [RealtimeListenType.postgresChanges] it's of the format `column=filter.value` with `filter` being one of `eq, neq, lt, lte, gt, gte, in, like, ilike, is, match, imatch, isdistinct`.
   ///
   /// Multiple conditions can be combined with commas; they are applied as an `AND`.
   /// Any operator can be negated with the `not.` prefix.
   final String? filter;
 
-  /// For [RealtimeListenTypes.postgresChanges], restricts the change payload to
+  /// For [RealtimeListenType.postgresChanges], restricts the change payload to
   /// a subset of columns instead of the full row.
   final List<String>? select;
 
@@ -113,11 +114,27 @@ enum ChannelResponse {
   error,
 }
 
-enum RealtimeListenTypes { postgresChanges, broadcast, presence, system }
+@internal
+enum RealtimeListenType {
+  postgresChanges,
+  broadcast,
+  presence,
+  system;
 
-enum PresenceEvent { sync, join, leave }
+  String toType() {
+    if (this == RealtimeListenType.postgresChanges) {
+      return 'postgres_changes';
+    }
+    return name;
+  }
+}
 
-extension PresenceEventExtended on PresenceEvent {
+enum PresenceEvent {
+  sync,
+  join,
+  leave;
+
+  @internal
   static PresenceEvent fromString(String val) {
     for (final event in PresenceEvent.values) {
       if (event.name == val) {
@@ -131,15 +148,6 @@ extension PresenceEventExtended on PresenceEvent {
 }
 
 enum RealtimeSubscribeStatus { subscribed, channelError, closed, timedOut }
-
-extension ToType on RealtimeListenTypes {
-  String toType() {
-    if (this == RealtimeListenTypes.postgresChanges) {
-      return 'postgres_changes';
-    }
-    return name;
-  }
-}
 
 /// Configuration for broadcast replay feature.
 /// Allows replaying broadcast messages from a specific timestamp.
@@ -308,7 +316,7 @@ class PostgresChangePayload {
       schema: payload['schema'] as String,
       table: payload['table'] as String,
       commitTimestamp: commitTimestamp,
-      eventType: PostgresChangeEventMethods.fromString(
+      eventType: PostgresChangeEvent.fromString(
         payload['eventType'] as String,
       ),
       newRecord: newData is Map ? Map.from(newData) : {},
@@ -480,7 +488,7 @@ abstract class RealtimePresencePayload {
   });
 
   RealtimePresencePayload.fromJson(Map<String, dynamic> json)
-    : event = PresenceEventExtended.fromString(json['event']);
+    : event = PresenceEvent.fromString(json['event']);
 
   @override
   String toString() => 'PresencePayload(event: ${event.name})';
@@ -494,7 +502,7 @@ class RealtimePresenceSyncPayload extends RealtimePresencePayload {
 
   factory RealtimePresenceSyncPayload.fromJson(Map<String, dynamic> json) {
     return RealtimePresenceSyncPayload(
-      event: PresenceEventExtended.fromString(json['event']),
+      event: PresenceEvent.fromString(json['event']),
     );
   }
 
@@ -524,7 +532,7 @@ class RealtimePresenceJoinPayload extends RealtimePresencePayload {
 
   factory RealtimePresenceJoinPayload.fromJson(Map<String, dynamic> json) {
     return RealtimePresenceJoinPayload(
-      event: PresenceEventExtended.fromString(json['event']),
+      event: PresenceEvent.fromString(json['event']),
       key: json['key'] as String,
       newPresences: (json['newPresences'] as List).cast(),
       currentPresences: (json['currentPresences'] as List).cast(),
@@ -558,7 +566,7 @@ class RealtimePresenceLeavePayload extends RealtimePresencePayload {
 
   factory RealtimePresenceLeavePayload.fromJson(Map<String, dynamic> json) {
     return RealtimePresenceLeavePayload(
-      event: PresenceEventExtended.fromString(json['event']),
+      event: PresenceEvent.fromString(json['event']),
       key: json['key'] as String,
       leftPresences: (json['leftPresences'] as List).cast(),
       currentPresences: (json['currentPresences'] as List).cast(),

--- a/packages/realtime_client/test/channel_test.dart
+++ b/packages/realtime_client/test/channel_test.dart
@@ -755,7 +755,7 @@ void main() {
       // Once subscribed, broadcasts are pushed over the websocket instead of
       // falling back to the REST endpoint.
       final sendResult = await channel.send(
-        type: RealtimeListenTypes.broadcast,
+        type: RealtimeListenType.broadcast,
         payload: {'myKey': 'myValue'},
       );
       expect(sendResult, ChannelResponse.ok);
@@ -771,7 +771,7 @@ void main() {
       () async {
         final requestFuture = mockServer.first;
         final sendFuture = channel.send(
-          type: RealtimeListenTypes.broadcast,
+          type: RealtimeListenType.broadcast,
           payload: {'myKey': 'myValue'},
         );
 
@@ -1383,7 +1383,7 @@ class _OptsCapturingChannel extends RealtimeChannel {
 
   @override
   Future<ChannelResponse> send({
-    required RealtimeListenTypes type,
+    required RealtimeListenType type,
     String? event,
     required Map<String, dynamic> payload,
     Map<String, dynamic> opts = const {},

--- a/packages/realtime_client/test/message_test.dart
+++ b/packages/realtime_client/test/message_test.dart
@@ -7,7 +7,7 @@ void main() {
     test('message with null refs serializes correctly', () {
       final message = Message(
         topic: 'phoenix',
-        event: ChannelEvents.heartbeat,
+        event: ChannelEvent.heartbeat,
         payload: {},
         ref: null,
         joinRef: null,
@@ -23,7 +23,7 @@ void main() {
     test('heartbeat message with null joinRef', () {
       final message = Message(
         topic: 'phoenix',
-        event: ChannelEvents.heartbeat,
+        event: ChannelEvent.heartbeat,
         payload: {},
         ref: '123',
         joinRef: null,
@@ -38,7 +38,7 @@ void main() {
     test('message with null ref but valid joinRef', () {
       final message = Message(
         topic: 'room:lobby',
-        event: ChannelEvents.join,
+        event: ChannelEvent.join,
         payload: {'user_id': '123'},
         ref: null,
         joinRef: 'join-456',
@@ -53,7 +53,7 @@ void main() {
     test('message with both ref and joinRef', () {
       final message = Message(
         topic: 'room:lobby',
-        event: ChannelEvents.join,
+        event: ChannelEvent.join,
         payload: {'user_id': '123'},
         ref: 'ref-789',
         joinRef: 'join-456',
@@ -68,7 +68,7 @@ void main() {
     test('message with ref but null joinRef', () {
       final message = Message(
         topic: 'room:lobby',
-        event: ChannelEvents.leave,
+        event: ChannelEvent.leave,
         payload: {},
         ref: 'ref-999',
         joinRef: null,
@@ -82,7 +82,7 @@ void main() {
     test('ref parameter is optional in constructor', () {
       final message = Message(
         topic: 'phoenix',
-        event: ChannelEvents.heartbeat,
+        event: ChannelEvent.heartbeat,
         payload: {},
         // ref is not provided, should be null
       );
@@ -94,7 +94,7 @@ void main() {
     test('a nested empty map is preserved, not dropped', () {
       final message = Message(
         topic: 'room:lobby',
-        event: ChannelEvents.presence,
+        event: ChannelEvent.presence,
         payload: {'event': 'track', 'payload': <String, dynamic>{}},
       );
       final json = message.toJson();
@@ -104,7 +104,7 @@ void main() {
     test('nested non-empty maps still serialize correctly', () {
       final message = Message(
         topic: 'room:lobby',
-        event: ChannelEvents.presence,
+        event: ChannelEvent.presence,
         payload: {
           'event': 'track',
           'payload': {'name': 'alice'},

--- a/packages/realtime_client/test/socket_test.dart
+++ b/packages/realtime_client/test/socket_test.dart
@@ -779,7 +779,7 @@ void main() {
 
   group('push', () {
     const topic = 'topic';
-    const event = ChannelEvents.join;
+    const event = ChannelEvent.join;
     const payload = 'payload';
     const ref = 'ref';
     // Protocol 2.0.0 text frames are positional arrays:
@@ -859,7 +859,7 @@ void main() {
       final binaryPayload = Uint8List.fromList([1, 2, 3]);
       final message = Message(
         topic: 'realtime:room',
-        event: ChannelEvents.broadcast,
+        event: ChannelEvent.broadcast,
         payload: {
           'type': 'broadcast',
           'event': 'file',
@@ -1052,14 +1052,14 @@ void main() {
         when(() => mockedChannel1.joinedOnce).thenReturn(true);
         when(() => mockedChannel1.isJoined).thenReturn(true);
         when(
-          () => mockedChannel1.push(ChannelEvents.accessToken, pushPayload),
+          () => mockedChannel1.push(ChannelEvent.accessToken, pushPayload),
         ).thenReturn(MockPush());
 
         final mockedChannel2 = MockChannel();
         when(() => mockedChannel2.joinedOnce).thenReturn(true);
         when(() => mockedChannel2.isJoined).thenReturn(true);
         when(
-          () => mockedChannel2.push(ChannelEvents.accessToken, pushPayload),
+          () => mockedChannel2.push(ChannelEvent.accessToken, pushPayload),
         ).thenReturn(MockPush());
 
         const tTopic1 = 'topic-1';
@@ -1081,10 +1081,10 @@ void main() {
         verify(() => channel1.updateJoinPayload(updateJoinPayload)).called(1);
         verify(() => channel2.updateJoinPayload(updateJoinPayload)).called(1);
         verify(
-          () => channel1.push(ChannelEvents.accessToken, pushPayload),
+          () => channel1.push(ChannelEvent.accessToken, pushPayload),
         ).called(1);
         verify(
-          () => channel2.push(ChannelEvents.accessToken, pushPayload),
+          () => channel2.push(ChannelEvent.accessToken, pushPayload),
         ).called(1);
       },
     );
@@ -1099,19 +1099,19 @@ void main() {
         when(() => mockedChannel1.joinedOnce).thenReturn(true);
         when(() => mockedChannel1.isJoined).thenReturn(true);
         when(
-          () => mockedChannel1.push(ChannelEvents.accessToken, any()),
+          () => mockedChannel1.push(ChannelEvent.accessToken, any()),
         ).thenReturn(MockPush());
 
         when(() => mockedChannel2.joinedOnce).thenReturn(false);
         when(() => mockedChannel2.isJoined).thenReturn(false);
         when(
-          () => mockedChannel2.push(ChannelEvents.accessToken, any()),
+          () => mockedChannel2.push(ChannelEvent.accessToken, any()),
         ).thenReturn(MockPush());
 
         when(() => mockedChannel3.joinedOnce).thenReturn(true);
         when(() => mockedChannel3.isJoined).thenReturn(true);
         when(
-          () => mockedChannel3.push(ChannelEvents.accessToken, any()),
+          () => mockedChannel3.push(ChannelEvent.accessToken, any()),
         ).thenReturn(MockPush());
 
         const tTopic1 = 'test-topic1';
@@ -1151,13 +1151,13 @@ void main() {
         ).called(1);
 
         verify(
-          () => channel1.push(ChannelEvents.accessToken, expectedPushPayload),
+          () => channel1.push(ChannelEvent.accessToken, expectedPushPayload),
         ).called(1);
         verifyNever(
-          () => channel2.push(ChannelEvents.accessToken, expectedPushPayload),
+          () => channel2.push(ChannelEvent.accessToken, expectedPushPayload),
         );
         verify(
-          () => channel3.push(ChannelEvents.accessToken, expectedPushPayload),
+          () => channel3.push(ChannelEvent.accessToken, expectedPushPayload),
         ).called(1);
       },
     );
@@ -1229,7 +1229,7 @@ void main() {
           final raw = invocation.positionalArguments.first as String;
           capturedMessages.add(raw);
           final frame = json.decode(raw) as List;
-          if (frame[3] == ChannelEvents.join.eventName() &&
+          if (frame[3] == ChannelEvent.join.eventName() &&
               !joinSent.isCompleted) {
             joinSent.complete(frame[4] as Map);
           }

--- a/packages/storage_client/lib/src/iceberg/iceberg_types.dart
+++ b/packages/storage_client/lib/src/iceberg/iceberg_types.dart
@@ -69,11 +69,11 @@ enum AccessDelegation {
 }
 
 /// Which snapshots the server should include when loading a table.
-enum LoadTableSnapshots {
+enum TableSnapshotScope {
   all('all'),
   refs('refs');
 
-  const LoadTableSnapshots(this.value);
+  const TableSnapshotScope(this.value);
 
   final String value;
 }
@@ -730,7 +730,7 @@ class LoadTableOptions {
   final String? ifNoneMatch;
 
   /// Which snapshots the server should include in the returned metadata.
-  final LoadTableSnapshots? snapshots;
+  final TableSnapshotScope? snapshots;
 
   const LoadTableOptions({this.ifNoneMatch, this.snapshots});
 }

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -167,6 +167,7 @@ features:
   auth.mfa.get_authenticator_assurance_level:
     status: implemented
     symbols:
+      - AuthenticatorAssuranceLevel
       - GoTrueMFAApi.getAuthenticatorAssuranceLevel
 
   # auth — passkeys (experimental)
@@ -1166,9 +1167,6 @@ features:
       - LoadTableResult.metadata
       - LoadTableResult.metadataLocation
       - LoadTableResult.storageCredentials
-      - LoadTableSnapshots
-      - LoadTableSnapshots.LoadTableSnapshots
-      - LoadTableSnapshots.value
       - MapType
       - MapType.MapType
       - MapType.fromJson
@@ -1356,6 +1354,9 @@ features:
       - TableSchema.identifierFieldIds
       - TableSchema.schemaId
       - TableSchema.toJson
+      - TableSnapshotScope
+      - TableSnapshotScope.TableSnapshotScope
+      - TableSnapshotScope.value
       - TableUpdate
       - TableUpdate.TableUpdate
       - TableUpdate.raw
@@ -1434,6 +1435,7 @@ features:
     status: implemented
     symbols:
       - ChannelFilter.select
+      - PostgresType
       - RealtimeChannelConfig.replicationReady
       - RealtimeSystemPayload
       - RealtimeSystemPayload.RealtimeSystemPayload


### PR DESCRIPTION
Closes #1652

## What

A Dart enum type names one value rather than the set, so its name should be singular. Five enums were ports of `realtime-js` / `gotrue-js` names instead:

| Before | After | Was reachable by consumers? |
| --- | --- | --- |
| `ChannelStates` | `ChannelState` | No (omitted from the `show` list) |
| `ChannelEvents` | `ChannelEvent` | No (omitted from the `show` list) |
| `RealtimeListenTypes` | `RealtimeListenType` | No (named in the `hide` clause) |
| `PostgresTypes` | `PostgresType` | Yes |
| `AuthenticatorAssuranceLevels` | `AuthenticatorAssuranceLevel` | Yes |

The three unreachable ones are now annotated `@internal`, which is both the accurate annotation and enough to keep them out of the capability matrix scan.

Sweeping the rest of the monorepo's 51 enums turned up one more name that did not read as a noun naming a single value: `LoadTableSnapshots` (storage, Iceberg) is now `TableSnapshotScope`.

## Enum extensions folded in

Enums can declare methods and static methods directly, so every extension that only existed to hang helpers off an enum is now part of the enum:

- `ChannelEventsExtended` → `ChannelEvent.fromType` / `ChannelEvent.eventName`
- `ToType` → `RealtimeListenType.toType`
- `PostgresChangeEventMethods` → `PostgresChangeEvent.fromString` / `PostgresChangeEvent.toRealtimeEvent`
- `PresenceEventExtended` → `PresenceEvent.fromString`
- `AuthChangeEventExtended` → `AuthChangeEvent.fromString`
- `GenerateLinkTypeExtended` → `GenerateLinkType.fromString`

Those helpers decode wire values, so the folded members carry `@internal`, matching the visibility the extensions already had through the `hide` clauses. The now-unnecessary `hide` entries are dropped from the gotrue and realtime_client exports.

`SupabaseEventTypesName` is deliberately left alone: its member is `name()`, which would shadow `Enum.name` if declared on the enum, and both it and its deprecated enum are due for removal anyway.

## Not changed

- `SocketStates`, because #1404 already renames it.
- `AMRMethod` / `AMREntry` violate Dart's "capitalize acronyms longer than two letters like words" rule (`AmrMethod` / `AmrEntry`). Out of scope here, worth a follow-up.
- `RequestMethodType` in gotrue is replaced by the shared `HttpMethod` in #1645.
- `FactorStatus`, `RealtimeHeartbeatStatus` and `RealtimeSubscribeStatus` end in `s` but are singular ("status").
- Enum *values* such as `GenerateLinkType.magiclink` and `OtpType.magiclink` are not lowerCamelCase, but they are load-bearing: the wire value is derived from the value name.

## Behaviour

None. No enum value changes: `ChannelEvent.eventName()` still produces the same `phx_*` strings and `TableSnapshotScope` still sends `all` / `refs`.

## Capability matrix

`PostgresType`, `AuthenticatorAssuranceLevel` and `TableSnapshotScope` are registered under `realtime.subscriptions.postgres_changes`, `auth.mfa.get_authenticator_assurance_level` and `storage.analytics.iceberg_table` (replacing the stale `LoadTableSnapshots` entries).

## Testing

- `dart analyze packages examples`: clean
- `realtime_client`, `supabase`, `supabase_flutter` suites: pass
- `gotrue` MFA, constants and types suites: pass (the rest of the `gotrue` suite has pre-existing failures against my local stack on `main` too)
- supabase/sdk `check-api-symbols`, `check-drift` and `validate-compliance` run locally against this branch: all pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Breaking Changes**
  - Renamed authentication assurance-level, realtime channel/event, Postgres type, and table snapshot enums.
  - Updated related method parameters and response fields to use the new names.

- **Improvements**
  - Simplified enum parsing and conversion APIs.
  - Corrected public exports for supported types and utilities.
  - Preserved existing authentication, MFA, realtime, storage, and data-conversion behavior.

- **Tests**
  - Updated coverage for enum parsing, serialization, realtime events, and MFA flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->