### PR TITLE
fix(supabase_common): accept uppercase and mixed-case UUIDs in validation

### DIFF
--- a/packages/gotrue/test/src/helper_test.dart
+++ b/packages/gotrue/test/src/helper_test.dart
@@ -146,10 +146,17 @@ void main() {
         );
       });
 
-      test('rejects UUID with uppercase characters', () {
+      test('accepts UUID with uppercase characters', () {
         expect(
           () => validateUuid('550E8400-E29B-41D4-A716-446655440000'),
-          throwsArgumentError,
+          returnsNormally,
+        );
+      });
+
+      test('accepts UUID with mixed case characters', () {
+        expect(
+          () => validateUuid('550e8400-E29B-41d4-A716-446655440000'),
+          returnsNormally,
         );
       });
 
@@ -305,12 +312,14 @@ void main() {
         );
       });
 
-      test('only matches lowercase hexadecimal characters', () {
-        // Note: The uuidRegex specifically checks for lowercase hex characters
-        // while validateUuid accepts both cases
+      test('matches hexadecimal characters regardless of case', () {
         expect(
           uuidRegex.hasMatch('550E8400-E29B-41D4-A716-446655440000'),
-          isFalse,
+          isTrue,
+        );
+        expect(
+          uuidRegex.hasMatch('550e8400-E29B-41d4-A716-446655440000'),
+          isTrue,
         );
         expect(
           uuidRegex.hasMatch('550e8400-e29b-41d4-a716-446655440000'),

--- a/packages/supabase_common/lib/src/uuid.dart
+++ b/packages/supabase_common/lib/src/uuid.dart
@@ -1,5 +1,6 @@
 final uuidRegex = RegExp(
   r'^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$',
+  caseSensitive: false,
 );
 
 /// Throws an [ArgumentError] if [id] is not a valid UUID.


### PR DESCRIPTION
## Summary

`uuidRegex` in `packages/supabase_common/lib/src/uuid.dart` only matched lowercase hexadecimal characters, so `validateUuid` rejected otherwise valid uppercase or mixed-case UUID strings. UUIDs are case-insensitive per RFC 9562/4122, and such identifiers are commonly returned by external identity providers and databases.

This affects `GoTrueAdminOAuthApi.getClient`, `updateClient`, `deleteClient` and `regenerateClientSecret`, which validate the client id before issuing the request.

## Changes

- `packages/supabase_common/lib/src/uuid.dart` — pass `caseSensitive: false` to the UUID `RegExp`.
- `packages/gotrue/test/src/helper_test.dart` — flip the uppercase test from rejecting to accepting, add a mixed-case case, and update the `uuidRegex` case test. Non-hexadecimal characters such as `G` are still rejected.

## Outcome

Implemented.

## Reference

- supabase-js PR https://github.com/supabase/supabase-js/pull/2467 (commit e138184574b9a0f092508ee8d961006c8550b9a8)

Fixes #1649

## Compliance matrix

No change needed. The fix is internal to an existing helper and adds no public symbols; the capabilities it affects (`auth.oauth_admin.get_client`, `auth.oauth_admin.update_client`, `auth.oauth_admin.delete_client`, `auth.oauth_admin.regenerate_client_secret`) are already `implemented` in `sdk-compliance.yaml`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * UUID validation now accepts uppercase and mixed-case hexadecimal characters.
  * UUID format matching is consistently case-insensitive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


SDK-1424
