### PR TITLE
feat(storage): expose the service error code on StorageException

### DIFF
--- a/packages/storage_client/lib/src/types.dart
+++ b/packages/storage_client/lib/src/types.dart
@@ -611,6 +611,13 @@ class StorageApiException extends StorageException with SupabaseApiException {
   /// API documents, since a proxy or gateway in front of it can answer with a
   /// shape of its own, so every field is read defensively. [statusCode] is used
   /// when the body reports none.
+  ///
+  /// [SupabaseException.errorCode] is read from the body's `code`, the
+  /// documented storage error code such as `NoSuchKey` or `AccessDenied`. The
+  /// body's `error` is the fallback for servers old enough not to send `code`,
+  /// and carries a plain sentence as often as an identifier.
+  ///
+  /// See https://supabase.com/docs/guides/storage/debugging/error-codes
   factory StorageApiException.fromJson(
     Map<String, dynamic> json,
     int statusCode,
@@ -618,7 +625,7 @@ class StorageApiException extends StorageException with SupabaseApiException {
     final message = json['message'];
     return StorageApiException(
       message is String ? message : json.toString(),
-      errorCode: json['error']?.toString(),
+      errorCode: (json['code'] ?? json['error'])?.toString(),
       statusCode: int.tryParse('${json['statusCode']}') ?? statusCode,
     );
   }

--- a/packages/storage_client/test/basic_test.dart
+++ b/packages/storage_client/test/basic_test.dart
@@ -558,6 +558,49 @@ void main() {
       );
     });
 
+    test('surfaces the service error code from the response body', () async {
+      addTearDown(() => customHttpClient.statusCode = 201);
+      customHttpClient.statusCode = 404;
+      // Mirrors a real storage payload, which sends statusCode, error and code.
+      customHttpClient.response = {
+        'statusCode': '404',
+        'error': 'not_found',
+        'code': 'NoSuchKey',
+        'message': 'Object not found',
+      };
+
+      await expectLater(
+        client.from('public_bucket').download('missing.txt'),
+        throwsA(
+          isA<StorageApiException>()
+              .having((e) => e.errorCode, 'errorCode', 'NoSuchKey')
+              .having((e) => e.statusCode, 'statusCode', 404)
+              .having((e) => e.message, 'message', 'Object not found'),
+        ),
+      );
+    });
+
+    test('falls back to error when the response body has no code', () async {
+      addTearDown(() => customHttpClient.statusCode = 201);
+      customHttpClient.statusCode = 404;
+      customHttpClient.response = {
+        'statusCode': '404',
+        'error': 'not_found',
+        'message': 'Object not found',
+      };
+
+      await expectLater(
+        client.from('public_bucket').download('missing.txt'),
+        throwsA(
+          isA<StorageException>().having(
+            (e) => e.errorCode,
+            'errorCode',
+            'not_found',
+          ),
+        ),
+      );
+    });
+
     test('should get public URL of a path', () {
       final response = client.from('files').getPublicUrl('b.txt');
       expect(response, '$objectUrl/public/files/b.txt');

--- a/packages/storage_client/test/types_test.dart
+++ b/packages/storage_client/test/types_test.dart
@@ -350,6 +350,34 @@ void main() {
       expect(exception.statusCode, 502);
     });
 
+    test('fromJson reads the service error code apart from statusCode', () {
+      final exception = StorageApiException.fromJson({
+        'message': 'Object not found',
+        'statusCode': '404',
+        'error': 'not_found',
+        'code': 'NoSuchKey',
+      }, 404);
+      expect(exception.errorCode, 'NoSuchKey');
+      expect(exception.statusCode, 404);
+    });
+
+    test('fromJson falls back to error when the body carries no code', () {
+      final exception = StorageApiException.fromJson({
+        'message': 'Object not found',
+        'statusCode': '404',
+        'error': 'not_found',
+      }, 404);
+      expect(exception.errorCode, 'not_found');
+    });
+
+    test('fromJson leaves the error code null when the body has neither', () {
+      final exception = StorageApiException.fromJson({
+        'message': 'not found',
+        'statusCode': '404',
+      }, 404);
+      expect(exception.errorCode, isNull);
+    });
+
     test(
       'fromJson falls back to the response status code and stringified body',
       () {

--- a/packages/supabase_common/lib/src/supabase_exception.dart
+++ b/packages/supabase_common/lib/src/supabase_exception.dart
@@ -21,7 +21,7 @@ abstract class SupabaseException implements Exception {
   final String message;
 
   /// Identifier for the error, for example `weak_password` (auth), `PGRST116`
-  /// (postgrest) or `not_found` (storage).
+  /// (postgrest) or `NoSuchKey` (storage).
   ///
   /// `null` when neither the service nor the client named the failure.
   final String? errorCode;


### PR DESCRIPTION
Closes #1650. SDK-1426.

Stacked on #1647, which is where `StorageException` becomes a `SupabaseException` and its `fromJson` gets its defensive field reads. Review that one first; the diff here is only the last commit.

Storage answers a failed request with a body like:

```json
{ "statusCode": "404", "error": "not_found", "code": "NoSuchKey", "message": "Object not found" }
```

`code` is the [documented storage error code](https://supabase.com/docs/guides/storage/debugging/error-codes) and is what STORAGE-629 added to the server's error schema. supabase-js picked it up in [supabase/supabase-js#2537](https://github.com/supabase/supabase-js/pull/2537) as a new `code` field on `StorageApiError`.

## The Dart shape

A second `code` field alongside `errorCode` would give storage two overlapping identifiers and undo the point of the unified exception in this stack, so `code` goes into `SupabaseException.errorCode` instead. That field is already documented as "service specific identifier for the error", which is exactly what this is.

`error` stays as the fallback for servers that predate the schema change. It is not a good primary source: against a local stack, the same field is `not_found` for a missing object and `Bucket not found` for a missing bucket, so it carries a plain sentence about as often as an identifier. `code` does not have that problem.

```dart
try {
  await supabase.storage.from('avatars').download('missing.png');
} on StorageException catch (error) {
  if (error.errorCode == 'NoSuchKey') {
    // ...
  }
}
```

The example in `SupabaseException.errorCode`'s doc comment moves from `not_found` to `NoSuchKey` to match what storage now yields.

## Testing

`types_test.dart` covers the three `fromJson` branches (`code` wins over `error`, `error` as fallback, null when the body has neither). `basic_test.dart` covers the same through a real request, so the value survives the fetch layer rather than only the factory.

`melos analyze` and `melos format` clean. The full `storage_client` suite passes against a local stack (220 tests), as does `supabase_common`.

## Compliance matrix

`storage.errors.error_codes` → `implemented`. Symbol, drift and schema checks pass locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Storage errors now consistently preserve service-provided error codes.
  - Added fallback handling when the primary error-code field is unavailable.
  - Download errors now retain the correct status code and message.

- **Documentation**
  - Updated storage error-code examples to reflect current identifiers.

- **Tests**
  - Added coverage for error-code parsing, fallback behavior, missing codes, status codes, and messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->