### PR TITLE
fix!: make order() default to ascending

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -112,3 +112,36 @@ await catalog.loadTableResult(
   const LoadTableOptions(snapshots: TableSnapshotScope.refs),
 );
 ```
+
+### `order()` now sorts ascending by default
+
+`PostgrestTransformBuilder.order()` and `SupabaseStreamBuilder.order()` defaulted `ascending` to
+`false`, so a call that left the parameter out sorted descending. That was the opposite of SQL's
+`ORDER BY` and of the other Supabase client libraries. Both now default to `true`.
+
+Like the `connectionState` change above, this one does not produce a compile error. The call still
+compiles and still returns the same rows, only in the reverse order, so it is worth checking every
+`.order()` call that does not pass `ascending` explicitly, in both `select()` queries and
+`stream()`.
+
+```dart
+// Before: newest first
+final messages = await supabase.from('messages').select().order('created_at');
+
+// After: oldest first
+final messages = await supabase.from('messages').select().order('created_at');
+```
+
+To keep the previous behaviour, ask for descending order explicitly:
+
+```dart
+final messages = await supabase
+    .from('messages')
+    .select()
+    .order('created_at', ascending: false);
+```
+
+`ascending: false` already means descending on v2, so you can add it to your current code before
+upgrading and leave this change out of the upgrade itself.
+
+`nullsFirst` is unchanged and still defaults to `false`.

--- a/examples/database_crud/lib/tasks_repository.dart
+++ b/examples/database_crud/lib/tasks_repository.dart
@@ -26,7 +26,7 @@ class TasksRepository {
   /// * [search] matches the title case-insensitively (`ilike`).
   /// * [onlyIncomplete] hides finished tasks (`eq`).
   ///
-  /// Results are ordered by priority (highest first) then creation time.
+  /// Results are ordered by priority (highest first) then newest first.
   Future<List<Task>> fetchTasks({
     String? projectId,
     String? search,
@@ -47,7 +47,7 @@ class TasksRepository {
 
     final rows = await query
         .order('priority', ascending: false)
-        .order('created_at');
+        .order('created_at', ascending: false);
     return rows.map(Task.fromJson).toList();
   }
 

--- a/packages/postgrest/lib/src/postgrest_transform_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_transform_builder.dart
@@ -73,14 +73,13 @@ class PostgrestTransformBuilder<T> extends RawPostgrestBuilder<T, T, T> {
 
   /// Orders the result with the specified [column].
   ///
-  /// [ascending] defaults to `false`, so results come back in **descending**
-  /// order unless `ascending: true` is passed. Note that this is the opposite
-  /// of SQL's `ORDER BY` and of `postgrest-js`, where ascending is the default.
+  /// [ascending] defaults to `true`, matching SQL's `ORDER BY`, so results come
+  /// back in ascending order unless `ascending: false` is passed.
   ///
   /// [nullsFirst] defaults to `false`, so `null`s appear last.
   ///
   /// ```dart
-  /// // Descending — the default.
+  /// // Ascending is the default.
   /// final data = await supabase
   ///     .from('users')
   ///     .select()
@@ -88,11 +87,11 @@ class PostgrestTransformBuilder<T> extends RawPostgrestBuilder<T, T, T> {
   /// ```
   ///
   /// ```dart
-  /// // Ascending has to be requested explicitly.
+  /// // Descending has to be requested explicitly.
   /// final data = await supabase
   ///     .from('users')
   ///     .select()
-  ///     .order('username', ascending: true);
+  ///     .order('username', ascending: false);
   /// ```
   ///
   /// If [column] is a referenced table column, [referencedTable] has to be set
@@ -106,7 +105,7 @@ class PostgrestTransformBuilder<T> extends RawPostgrestBuilder<T, T, T> {
   /// ```
   PostgrestTransformBuilder<T> order(
     String column, {
-    bool ascending = false,
+    bool ascending = true,
     bool nullsFirst = false,
     String? referencedTable,
   }) {

--- a/packages/postgrest/test/order_default_test.dart
+++ b/packages/postgrest/test/order_default_test.dart
@@ -1,0 +1,76 @@
+import 'package:postgrest/postgrest.dart';
+import 'package:test/test.dart';
+
+import 'custom_http_client.dart';
+
+void main() {
+  late CustomHttpClient customHttpClient;
+  late PostgrestClient postgrest;
+
+  setUp(() {
+    customHttpClient = CustomHttpClient();
+    postgrest = PostgrestClient(
+      'http://localhost:3000',
+      httpClient: customHttpClient,
+    );
+  });
+
+  Future<Map<String, String>> queryParametersOf(
+    PostgrestBuilder<dynamic, dynamic, dynamic> builder,
+  ) async {
+    try {
+      await builder;
+    } catch (_) {}
+    return customHttpClient.lastRequest!.url.queryParameters;
+  }
+
+  test('order defaults to ascending with nulls last', () async {
+    final queryParameters = await queryParametersOf(
+      postgrest.from('users').select().order('username'),
+    );
+
+    expect(queryParameters['order'], 'username.asc.nullslast');
+  });
+
+  test('order descending has to be requested explicitly', () async {
+    final queryParameters = await queryParametersOf(
+      postgrest.from('users').select().order('username', ascending: false),
+    );
+
+    expect(queryParameters['order'], 'username.desc.nullslast');
+  });
+
+  test('order puts nulls first when requested', () async {
+    final queryParameters = await queryParametersOf(
+      postgrest.from('users').select().order('username', nullsFirst: true),
+    );
+
+    expect(queryParameters['order'], 'username.asc.nullsfirst');
+  });
+
+  test('order on a referenced table defaults to ascending', () async {
+    final queryParameters = await queryParametersOf(
+      postgrest
+          .from('users')
+          .select('messages(*)')
+          .order('channel_id', referencedTable: 'messages'),
+    );
+
+    expect(queryParameters['messages.order'], 'channel_id.asc.nullslast');
+  });
+
+  test('order keeps the direction of each column when chained', () async {
+    final queryParameters = await queryParametersOf(
+      postgrest
+          .from('users')
+          .select()
+          .order('status', ascending: false)
+          .order('username'),
+    );
+
+    expect(
+      queryParameters['order'],
+      'status.desc.nullslast,username.asc.nullslast',
+    );
+  });
+}

--- a/packages/postgrest/test/resource_embedding_test.dart
+++ b/packages/postgrest/test/resource_embedding_test.dart
@@ -60,7 +60,7 @@ void main() {
     final response = await postgrest
         .from('users')
         .select('messages(*)')
-        .order('channel_id', referencedTable: 'messages');
+        .order('channel_id', referencedTable: 'messages', ascending: false);
     expect(
       response[0]['messages']!.length,
       3,
@@ -80,7 +80,7 @@ void main() {
         .from('users')
         .select('username, messages(*)')
         .order('username', ascending: true)
-        .order('channel_id', referencedTable: 'messages');
+        .order('channel_id', referencedTable: 'messages', ascending: false);
     expect(
       response[0]['username'],
       'awailas',

--- a/packages/postgrest/test/transforms_test.dart
+++ b/packages/postgrest/test/transforms_test.dart
@@ -25,13 +25,33 @@ void main() {
     await resetHelper.reset();
   });
 
-  test('order', () async {
+  test('order defaults to ascending', () async {
     final response = await postgrest.from('users').select().order('username');
     expect(
-      response[1]['username'],
-      'kiwicopple',
+      response.map((row) => row['username']),
+      [
+        'awailas',
+        'dragarcia',
+        'kiwicopple',
+        'supabot',
+      ],
     );
-    expect(response[3]['username'], 'awailas');
+  });
+
+  test('order descending', () async {
+    final response = await postgrest
+        .from('users')
+        .select()
+        .order('username', ascending: false);
+    expect(
+      response.map((row) => row['username']),
+      [
+        'supabot',
+        'kiwicopple',
+        'dragarcia',
+        'awailas',
+      ],
+    );
   });
 
   test('order on multiple columns', () async {
@@ -39,7 +59,7 @@ void main() {
         .from('users')
         .select()
         .order('status', ascending: true)
-        .order('username');
+        .order('username', ascending: false);
     expect(
       response.map((row) => row['status']),
       [
@@ -66,7 +86,7 @@ void main() {
         .select()
         .gt('username', 'b')
         .lt('username', 'r')
-        .order('username');
+        .order('username', ascending: false);
     expect(
       response.map((row) => row['username']),
       [
@@ -92,7 +112,11 @@ void main() {
         ''',
         )
         .eq("username", "supabot")
-        .order("created_at", referencedTable: "messages.reactions")
+        .order(
+          "created_at",
+          referencedTable: "messages.reactions",
+          ascending: false,
+        )
         .single();
 
     final messages = data['messages'] as List;

--- a/packages/supabase/lib/src/supabase_stream_builder.dart
+++ b/packages/supabase/lib/src/supabase_stream_builder.dart
@@ -89,15 +89,22 @@ class SupabaseStreamBuilder extends Stream<SupabaseStreamEvent> {
 
   /// Orders the result with the specified [column].
   ///
-  /// When `ascending` value is true, the result will be in ascending order.
+  /// [ascending] defaults to `true`, matching SQL's `ORDER BY`, so results come
+  /// back in ascending order unless `ascending: false` is passed.
   ///
   /// ```dart
+  /// // Ascending is the default.
+  /// supabase.from('users').stream(primaryKey: ['id']).order('username');
+  /// ```
+  ///
+  /// ```dart
+  /// // Descending has to be requested explicitly.
   /// supabase
   ///     .from('users')
   ///     .stream(primaryKey: ['id'])
   ///     .order('username', ascending: false);
   /// ```
-  SupabaseStreamBuilder order(String column, {bool ascending = false}) {
+  SupabaseStreamBuilder order(String column, {bool ascending = true}) {
     _orderBy = (column: column, ascending: ascending);
     return this;
   }

--- a/packages/supabase/test/mock_test.dart
+++ b/packages/supabase/test/mock_test.dart
@@ -74,6 +74,16 @@ void main() {
           ..headers.contentType = ContentType.json
           ..write(jsonString);
         await request.response.close();
+      } else if (url == '/rest/v1/todos?select=%2A&order=id.asc.nullslast') {
+        final jsonString = jsonEncode([
+          {'id': 1, 'task': 'task 1', 'status': true},
+          {'id': 2, 'task': 'task 2', 'status': false},
+        ]);
+        request.response
+          ..statusCode = HttpStatus.ok
+          ..headers.contentType = ContentType.json
+          ..write(jsonString);
+        await request.response.close();
       } else if (url == '/rest/v1/todos?select=%2A&order=id.desc.nullslast') {
         final jsonString = jsonEncode([
           {'id': 2, 'task': 'task 2', 'status': false},
@@ -573,11 +583,41 @@ void main() {
         );
       });
 
-      test('with order', () {
+      test('order defaults to ascending', () {
         final stream = supabase
             .from('todos')
             .stream(primaryKey: ['id'])
             .order('id');
+        expect(
+          stream,
+          emitsInOrder([
+            containsAllInOrder([
+              {'id': 1, 'task': 'task 1', 'status': true},
+              {'id': 2, 'task': 'task 2', 'status': false},
+            ]),
+            containsAllInOrder([
+              {'id': 1, 'task': 'task 1', 'status': true},
+              {'id': 2, 'task': 'task 2', 'status': false},
+              {'id': 3, 'task': 'task 3', 'status': true},
+            ]),
+            containsAllInOrder([
+              {'id': 1, 'task': 'task 1', 'status': true},
+              {'id': 2, 'task': 'task 2 updated', 'status': false},
+              {'id': 3, 'task': 'task 3', 'status': true},
+            ]),
+            containsAllInOrder([
+              {'id': 1, 'task': 'task 1', 'status': true},
+              {'id': 3, 'task': 'task 3', 'status': true},
+            ]),
+          ]),
+        );
+      });
+
+      test('with descending order', () {
+        final stream = supabase
+            .from('todos')
+            .stream(primaryKey: ['id'])
+            .order('id', ascending: false);
         expect(
           stream,
           emitsInOrder([
@@ -607,7 +647,7 @@ void main() {
         final stream = supabase
             .from('todos')
             .stream(primaryKey: ['id'])
-            .order('id')
+            .order('id', ascending: false)
             .limit(2);
         expect(
           stream,


### PR DESCRIPTION
Closes #1638

## What kind of change does this PR introduce?

Breaking change.

## What is the current behavior?

`order()` defaults `ascending` to `false` in two places, so omitting the parameter sorts descending:

- `PostgrestTransformBuilder.order()`
- `SupabaseStreamBuilder.order()`

`.order('created_at')` therefore returns newest rows first, which disagrees with SQL's `ORDER BY` (defaults to `ASC`) and with `postgrest-js` (`{ ascending = true }`). The failure is silent: the query succeeds, the row count and types are right, only the order is wrong.

The default was never chosen for Dart. `postgrest-dart` `7a8f8b7` (2020-09-10) ported the first `order()` from the pre-TypeScript `postgrest-js`, which then had `order(columnName, ascending = false, nullsFirst = false)`. `postgrest-js` `2960d09` moved to `{ ascending = true }` ten days later and Dart never followed. #1637 documented the current behavior in the meantime.

Two examples in this repository were already wrong because of it, which is the clearest evidence that the default surprises people:

- `examples/realtime_room/lib/room_repository.dart` says "SELECT the existing messages once, oldest first" and returned them newest first.
- `examples/database_crud/lib/tasks_repository.dart` says "ordered alphabetically by name" and returned projects in reverse alphabetical order.

Both are now correct without touching their query code.

## What is the new behavior?

- `PostgrestTransformBuilder.order()`: `bool ascending = true`.
- `SupabaseStreamBuilder.order()`: `bool ascending = true`, so `.stream()` and `.select()` agree on what an unqualified `.order()` means.
- Doc comments on both state the default and drop the note about diverging from SQL and `postgrest-js`, since there is no longer a divergence.

`nullsFirst` is unchanged at `false`. That already matched `postgrest-js` and PostgREST.

## Migration

`MIGRATION.md` gets an `order() now sorts ascending by default` section under v2 to v3, covering both call sites, why the analyzer will not catch it, and how to keep the old behavior:

```dart
await supabase.from('messages').select().order('created_at', ascending: false);
```

The section also points out that `ascending: false` already means descending on v2, so consumers can add it before upgrading and leave this change out of the upgrade itself.

## Tests

- New `packages/postgrest/test/order_default_test.dart` asserts the generated `order` query parameter without a backend: the default, explicit `ascending: false`, `nullsFirst: true`, a referenced table, and that chained `order()` calls keep their own direction.
- `transforms_test.dart` gains `order defaults to ascending` and `order descending` against the local stack.
- `mock_test.dart` gains `order defaults to ascending` for the stream builder, and the mock server now answers `order=id.asc.nullslast`.
- Tests that were exercising the old implicit default (multi-column order, order with filters, referenced-table order, embedded order, stream order with limit) now pass `ascending: false` explicitly, so their coverage of descending order is preserved rather than silently reinterpreted.

`melos analyze` and `melos format` are clean. `packages/postgrest` (196 tests) and `packages/supabase` (136 tests) pass in full against a local Supabase stack.

## Additional context

Part of the v3 umbrella (#1278).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Database queries and real-time streams now default to ascending order.
  * Descending order remains available with `ascending: false`.
  * Ordering continues to support null placement, referenced data, multiple columns, and filters.

* **Documentation**
  * Updated ordering guidance, examples, and migration notes to reflect the new default.

* **Tests**
  * Expanded coverage for default, ascending, descending, nested, referenced-table, filtered, and stream ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->