### PR TITLE
docs: fix inaccurate dartdoc comments across all packages

### DIFF
--- a/packages/functions_client/lib/src/functions_client.dart
+++ b/packages/functions_client/lib/src/functions_client.dart
@@ -56,15 +56,16 @@ class FunctionsClient {
   ///
   /// [headers] to send with the request
   ///
-  /// [body] of the request when [files] is null and can be of type String
-  /// or an Object that is encodable to JSON with `jsonEncode`.
+  /// [body] of the request when [files] is null and can be of type String,
+  /// [Uint8List], or an Object that is encodable to JSON with `jsonEncode`.
   /// If [files] is not null, [body] represents the fields of the
   /// [MultipartRequest] and must be of type `Map<String, String>`.
   ///
   /// [files] to send in a `MultipartRequest`. [body] is used for the fields.
   ///
   /// [region] optionally specify the region to invoke the function in.
-  /// When specified, adds both `x-region` header and `forceFunctionRegion` query parameter.
+  /// When specified and not equal to `'any'`, adds both the `x-region`
+  /// header and the `forceFunctionRegion` query parameter.
   ///
   /// [abortSignal] cancels the in-flight request when the provided [Future]
   /// completes. It must not complete with an error. On abort, a

--- a/packages/functions_client/lib/src/types.dart
+++ b/packages/functions_client/lib/src/types.dart
@@ -14,7 +14,7 @@ enum HttpMethod {
 class FunctionResponse {
   /// The data returned by the function. Type depends on the header `Content-Type`:
   /// - 'text/plain': [String]
-  /// - 'octet/stream': [Uint8List]
+  /// - 'application/octet-stream': [Uint8List]
   /// - 'application/json': dynamic ([jsonDecode] is used)
   /// - 'text/event-stream': [ByteStream]
   final dynamic data;

--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -1756,12 +1756,13 @@ class GoTrueClient {
   /// sends a request to the Auth server for each JWT.
   ///
   /// If the project is not using an asymmetric JWT signing key (like ECC or
-  /// RSA) it always sends a request to the Auth server (similar to [getUser])
-  /// to verify the JWT.
+  /// RSA), or the JWT header does not carry a `kid`, it always sends a
+  /// request to the Auth server (similar to [getUser]) to verify the JWT.
   ///
-  /// For JWTs signed with an RSA-based asymmetric algorithm (e.g. RS256), the
-  /// JWKS is fetched from the server on the first call and cached for
-  /// subsequent calls. The cache is refreshed automatically after 10 minutes.
+  /// For JWTs signed with an RSA-based asymmetric algorithm (e.g. RS256) that
+  /// carry a `kid`, the JWKS is fetched from the server on the first call and
+  /// cached for subsequent calls. The cache is refreshed automatically after
+  /// 10 minutes.
   ///
   /// [jwt] An optional specific JWT you wish to verify, not the one you
   ///       can obtain from [currentSession].

--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -1731,9 +1731,9 @@ class GoTrueClient {
   /// If the project is not using an asymmetric JWT signing key (like ECC or
   /// RSA) it always sends a request to the Auth server (similar to [getUser]) to verify the JWT.
   ///
-  /// For JWTs signed with asymmetric algorithms (RS256, ES256, etc.), the JWKS
-  /// is fetched from the server on the first call and cached for subsequent calls.
-  /// The cache is refreshed automatically after 10 minutes.
+  /// For JWTs signed with an RSA-based asymmetric algorithm (e.g. RS256), the
+  /// JWKS is fetched from the server on the first call and cached for
+  /// subsequent calls. The cache is refreshed automatically after 10 minutes.
   ///
   /// [jwt] An optional specific JWT you wish to verify, not the one you
   ///       can obtain from [currentSession].

--- a/packages/gotrue/lib/src/types/mfa.dart
+++ b/packages/gotrue/lib/src/types/mfa.dart
@@ -39,9 +39,9 @@ class AuthMFAEnrollResponse {
 }
 
 class TOTPEnrollment {
-  ///Contains a QR code encoding the authenticator URI.
+  ///A `data:image/svg+xml;utf-8,` URL containing a QR code that encodes the authenticator URI.
   ///
-  ///You can convert it to a URL by prepending `data:image/svg+xml;utf-8,` to the value. Avoid logging this value to the console.
+  ///Ready to use directly as an image source. Avoid logging this value to the console.
   final String qrCode;
 
   ///The TOTP secret (also encoded in the QR code).

--- a/packages/gotrue/lib/src/types/session.dart
+++ b/packages/gotrue/lib/src/types/session.dart
@@ -69,7 +69,9 @@ class Session {
   }
 
   /// The Unix timestamp, in **seconds**, of when the token will expire.
-  /// Returned when a login is confirmed.
+  ///
+  /// Derived from the `exp` claim of [accessToken], not read from the login
+  /// response's JSON body.
   ///
   /// To convert this to a [DateTime], multiply by 1000 since
   /// [DateTime.fromMillisecondsSinceEpoch] expects milliseconds:
@@ -84,9 +86,9 @@ class Session {
     }
   }
 
-  /// Returns 'true` if the token is expired or will expire in the next 10 seconds.
+  /// Returns 'true` if the token is expired or will expire in the next 30 seconds.
   ///
-  /// The 10 second buffer is to account for latency issues.
+  /// The 30 second buffer is to account for latency issues.
   bool get isExpired {
     if (expiresAt == null) return false;
     return DateTime.now()

--- a/packages/postgrest/lib/src/postgrest_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_builder.dart
@@ -144,7 +144,7 @@ String? _emptyPreferAsNull(String? prefer) =>
 ///
 /// [T] for the overall return type, so `PostgrestResponse<S>` or [S]
 ///
-/// When using [_converter], [S] is the input and [R] is the output
+/// When using [_converter], [R] is the input and [S] is the output
 /// Otherwise [S] and [R] are the same
 @immutable
 class PostgrestBuilder<T, S, R> implements Future<T> {

--- a/packages/postgrest/lib/src/postgrest_filter_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_filter_builder.dart
@@ -330,7 +330,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   /// await supabase
   ///     .from('users')
   ///     .select()
-  ///     .sl('age_range', '[2,25)');
+  ///     .rangeLt('age_range', '[2,25)');
   /// ```
   PostgrestFilterBuilder<T> rangeLt(String column, String range) {
     return copyWithUrl(appendSearchParams(column, 'sl.$range'));

--- a/packages/postgrest/lib/src/postgrest_query_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_query_builder.dart
@@ -7,8 +7,10 @@ part of 'postgrest_builder.dart';
 /// Call one of
 /// * select() - "get"
 /// * insert() - "post"
+/// * upsert() - "post"
 /// * update() - "patch"
 /// * delete() - "delete"
+/// * count() - "head"
 /// first. Each of these returns a filter builder that allows the user to
 /// stack filter functions before the request is sent.
 /// {@endtemplate}

--- a/packages/postgrest/lib/src/postgrest_query_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_query_builder.dart
@@ -3,12 +3,13 @@ part of 'postgrest_builder.dart';
 /// {@template postgrest_query_builder}
 /// The query builder class provides a convenient interface to creating request queries.
 ///
-/// Allows the user to stack the filter functions before they call any of
+/// Call one of
 /// * select() - "get"
 /// * insert() - "post"
 /// * update() - "patch"
 /// * delete() - "delete"
-/// Once any of these are called the filters are passed down to the Request.
+/// first. Each of these returns a filter builder that allows the user to
+/// stack filter functions before the request is sent.
 /// {@endtemplate}
 class PostgrestQueryBuilder<T> extends RawPostgrestBuilder<T, T, T> {
   /// {@macro postgrest_query_builder}

--- a/packages/postgrest/lib/src/postgrest_rpc_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_rpc_builder.dart
@@ -30,7 +30,12 @@ class PostgrestRpcBuilder
          ),
        );
 
-  /// {@macro postgrest_rpc}
+  /// Performs a stored procedure call.
+  ///
+  /// [params] is an optional object to pass as arguments to the function call.
+  ///
+  /// When [get] is set to `true`, the function will be called with read-only
+  /// access mode.
   PostgrestFilterBuilder<T> rpc<T>([
     Object? params,
     bool get = false,

--- a/packages/postgrest/lib/src/postgrest_rpc_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_rpc_builder.dart
@@ -30,12 +30,12 @@ class PostgrestRpcBuilder
          ),
        );
 
-  /// Performs a stored procedure call.
+  /// Performs a database function call.
   ///
   /// [params] is an optional object to pass as arguments to the function call.
   ///
-  /// When [get] is set to `true`, the function will be called with read-only
-  /// access mode.
+  /// When [get] is set to `true`, [params] must be a [Map], and the function
+  /// is called with read-only access mode.
   PostgrestFilterBuilder<T> rpc<T>([
     Object? params,
     bool get = false,

--- a/packages/postgrest/lib/src/types.dart
+++ b/packages/postgrest/lib/src/types.dart
@@ -103,7 +103,7 @@ enum ExplainFormat {
 }
 
 // coverage:ignore-[start]
-/// Returns count as part of the response when specified.
+/// Controls whether the affected row's representation is returned in the response.
 @Deprecated('Not used anywhere. Will be removed in the next major version.')
 enum ReturningOption {
   minimal,

--- a/packages/postgrest/lib/src/types.dart
+++ b/packages/postgrest/lib/src/types.dart
@@ -105,7 +105,8 @@ enum ExplainFormat {
 }
 
 // coverage:ignore-[start]
-/// Controls whether the affected row's representation is returned in the response.
+/// Controls whether the affected row's representation is returned in the
+/// response.
 @Deprecated('Not used anywhere. Will be removed in the next major version.')
 enum ReturningOption {
   minimal,

--- a/packages/realtime_client/lib/realtime_client.dart
+++ b/packages/realtime_client/lib/realtime_client.dart
@@ -1,4 +1,5 @@
-/// Listens to changes in a PostgreSQL database via websockets using Supabase Realtime.
+/// Client library for Supabase Realtime: subscribe to PostgreSQL database
+/// changes, broadcast messages, and presence over a websocket connection.
 library;
 
 export 'src/constants.dart'

--- a/packages/realtime_client/lib/src/realtime_channel.dart
+++ b/packages/realtime_client/lib/src/realtime_channel.dart
@@ -880,9 +880,11 @@ class RealtimeChannel {
   /// Unsubscribes from server events, and instructs channel to terminate on server.
   /// Triggers onClose() hooks.
   ///
-  /// To receive leave acknowledgements, use the a `receive` hook to bind to the server ack,
+  /// Returns a [Future] that resolves to `'ok'`, `'timed out'`, or `'error'`
+  /// depending on the outcome of the leave request.
   /// ```dart
-  /// channel.unsubscribe().receive("ok", (_){print("left!");} );
+  /// final status = await channel.unsubscribe();
+  /// print(status); // 'ok'
   /// ```
   Future<String> unsubscribe([Duration? timeout]) {
     _state = ChannelState.leaving;

--- a/packages/realtime_client/lib/src/realtime_client.dart
+++ b/packages/realtime_client/lib/src/realtime_client.dart
@@ -130,7 +130,8 @@ class RealtimeClient {
   /// Used to keep track of whether the client is connected to the server.
   String? pendingHeartbeatRef;
 
-  /// Unique reference ID for every heartbeat.
+  /// Counter used by [makeRef] to generate a unique reference ID for every
+  /// pushed message, including heartbeats.
   int ref = 0;
   late RetryTimer reconnectTimer;
   void Function(String? kind, String? message, dynamic data)? logger;
@@ -442,7 +443,8 @@ class RealtimeClient {
     stateChangeCallbacks['message']!.add(callback);
   }
 
-  /// Emits a status whenever a heartbeat is sent, acknowledged, or times out.
+  /// Emits a status whenever a heartbeat is sent, acknowledged, errors, or
+  /// times out.
   Stream<RealtimeHeartbeatStatus> get onHeartbeat =>
       _heartbeatController.stream;
 

--- a/packages/realtime_client/lib/src/retry_timer.dart
+++ b/packages/realtime_client/lib/src/retry_timer.dart
@@ -13,15 +13,16 @@ const maxShift = 20;
 ///
 /// ```dart
 /// int calculateRetryDuration(int tries) {
-///   return [1000, 5000, 10000][tries - 1] ?? 10000;
+///   const delays = [1000, 5000, 10000];
+///   return tries <= delays.length ? delays[tries - 1] : 10000;
 /// }
 ///
-/// let reconnectTimer = new RetryTimer(() => this.connect(), calculateRetryDuration)
+/// final reconnectTimer = RetryTimer(connect, calculateRetryDuration);
 ///
-/// reconnectTimer.scheduleTimeout() // fires after 1000
-/// reconnectTimer.scheduleTimeout() // fires after 5000
-/// reconnectTimer.reset()
-/// reconnectTimer.scheduleTimeout() // fires after 1000
+/// reconnectTimer.scheduleTimeout(); // fires after 1000
+/// reconnectTimer.scheduleTimeout(); // fires after 5000
+/// reconnectTimer.reset();
+/// reconnectTimer.scheduleTimeout(); // fires after 1000
 ///
 /// ```
 class RetryTimer {

--- a/packages/realtime_client/lib/src/transformers.dart
+++ b/packages/realtime_client/lib/src/transformers.dart
@@ -61,7 +61,7 @@ class PostgresColumn {
 /// `skipTypes` The array of types that should not be converted
 ///
 /// ```dart
-/// convertChangeData([{name: 'first_name', type: 'text'}, {name: 'age', type: 'int4'}], {'first_name': 'Paul', 'age':'33'}, {})
+/// convertChangeData([{name: 'first_name', type: 'text'}, {name: 'age', type: 'int4'}], {'first_name': 'Paul', 'age':'33'})
 /// => { 'first_name': 'Paul', 'age': 33 }
 /// ```
 Map<String, dynamic> convertChangeData(
@@ -90,13 +90,13 @@ Map<String, dynamic> convertChangeData(
 ///
 /// `columnName` The column that you want to convert
 /// `columns` All of the columns
-/// `records` The map of string values
+/// `record` The map of string values
 /// `skipTypes` An array of types that should not be converted
 ///
 /// ```dart
-/// convertColumn('age', [{name: 'first_name', type: 'text'}, {name: 'age', type: 'int4'}], ['Paul', '33'], [])
+/// convertColumn('age', [{name: 'first_name', type: 'text'}, {name: 'age', type: 'int4'}], {'first_name': 'Paul', 'age': '33'}, [])
 /// => 33
-/// convertColumn('age', [{name: 'first_name', type: 'text'}, {name: 'age', type: 'int4'}], ['Paul', '33'], ['int4'])
+/// convertColumn('age', [{name: 'first_name', type: 'text'}, {name: 'age', type: 'int4'}], {'first_name': 'Paul', 'age': '33'}, ['int4'])
 /// => "33"
 /// ```
 dynamic convertColumn(

--- a/packages/realtime_client/lib/src/transformers.dart
+++ b/packages/realtime_client/lib/src/transformers.dart
@@ -63,7 +63,7 @@ class PostgresColumn {
 ///
 /// ```dart
 /// convertChangeData(
-///   [{name: 'first_name', type: 'text'}, {name: 'age', type: 'int4'}],
+///   [{'name': 'first_name', 'type': 'text'}, {'name': 'age', 'type': 'int4'}],
 ///   {'first_name': 'Paul', 'age':'33'},
 /// )
 /// => { 'first_name': 'Paul', 'age': 33 }
@@ -100,14 +100,14 @@ Map<String, dynamic> convertChangeData(
 /// ```dart
 /// convertColumn(
 ///   'age',
-///   [{name: 'first_name', type: 'text'}, {name: 'age', type: 'int4'}],
+///   [{'name': 'first_name', 'type': 'text'}, {'name': 'age', 'type': 'int4'}],
 ///   {'first_name': 'Paul', 'age': '33'},
 ///   [],
 /// )
 /// => 33
 /// convertColumn(
 ///   'age',
-///   [{name: 'first_name', type: 'text'}, {name: 'age', type: 'int4'}],
+///   [{'name': 'first_name', 'type': 'text'}, {'name': 'age', 'type': 'int4'}],
 ///   {'first_name': 'Paul', 'age': '33'},
 ///   ['int4'],
 /// )

--- a/packages/storage_client/lib/src/iceberg/iceberg_rest_catalog.dart
+++ b/packages/storage_client/lib/src/iceberg/iceberg_rest_catalog.dart
@@ -387,8 +387,9 @@ class IcebergRestCatalog {
 
   /// Loads a table's metadata.
   ///
-  /// When [options] carries an `ifNoneMatch` ETag and the server answers 304,
-  /// this returns `null`.
+  /// Use [loadTableResult] instead if you need a conditional request via
+  /// `ifNoneMatch`, or the full load result including server configuration
+  /// and vended storage credentials.
   Future<TableMetadata> loadTable(TableIdentifier id) async {
     final result = await loadTableResult(id);
     return result!.metadata;

--- a/packages/storage_client/lib/src/storage_bucket_api.dart
+++ b/packages/storage_client/lib/src/storage_bucket_api.dart
@@ -64,13 +64,13 @@ class StorageBucketApi {
   ///
   /// [bucketOptions] is a parameter to optionally make the bucket public.
   ///
-  /// It returns the newly created bucket it. To get the bucket reference, use
-  /// [getBucket]:
+  /// It returns the ID of the newly created bucket. To get the bucket
+  /// reference, use [getBucket]:
   ///
   /// ```dart
   /// void bucket() async {
   ///   final newBucketId = await createBucket('images');
-  ///   final bucket = await Bucket(newBucketId);
+  ///   final bucket = await getBucket(newBucketId);
   ///   print('${bucket.id}');
   /// }
   /// ```

--- a/packages/storage_client/lib/src/storage_client.dart
+++ b/packages/storage_client/lib/src/storage_client.dart
@@ -156,8 +156,10 @@ class SupabaseStorageClient extends StorageBucketApi {
 
   /// Sets an HTTP header for subsequent requests.
   ///
-  /// Creates a shallow copy of headers to avoid mutating shared state.
-  /// Returns this for method chaining.
+  /// Mutates the headers map used by this client in place. Instances of
+  /// [StorageFileApi] already obtained through [from] hold their own copy of
+  /// the headers, so only calls to [from] made after this one will include
+  /// the new header. Returns this for method chaining.
   ///
   /// ```dart
   /// storage.setHeader('x-custom-header', 'value').from('bucket').upload(...);

--- a/packages/storage_client/lib/src/types.dart
+++ b/packages/storage_client/lib/src/types.dart
@@ -258,7 +258,7 @@ class FileOptions {
   /// Used as Content-Type
   /// Gets parsed with [MediaType.parse(mime)]
   ///
-  /// Throws a FormatError if the media type is invalid.
+  /// Throws a FormatException if the media type is invalid.
   final String? contentType;
 
   /// The metadata option is an object that allows you to store additional

--- a/packages/supabase/lib/src/realtime_client_options.dart
+++ b/packages/supabase/lib/src/realtime_client_options.dart
@@ -4,9 +4,8 @@ import 'package:realtime_client/realtime_client.dart';
 /// Options to pass to the RealtimeClient.
 /// {@endtemplate}
 class RealtimeClientOptions {
-  /// How many events the RealtimeClient can push in a second
-  ///
-  /// Defaults to 10 events per second
+  /// No longer has any effect. Client side rate limiting has been removed,
+  /// so this value is ignored.
   @Deprecated(
     'Client side rate limit has been removed. This option will be ignored.',
   )

--- a/packages/supabase/lib/src/supabase_client.dart
+++ b/packages/supabase/lib/src/supabase_client.dart
@@ -19,14 +19,16 @@ import 'trace_http_client.dart';
 /// Pass the `publishable` (anon) key for client-side usage or the `secret`
 /// key for trusted server-side environments.
 ///
-/// You can access none public schema by passing different [schema].
+/// You can access a schema other than the default `public` schema by setting
+/// the `schema` field of [postgrestOptions].
 ///
 /// Default headers can be overridden by specifying [headers].
 ///
 /// Custom http client can be used by passing [httpClient] parameter.
 ///
-/// [storageRetryAttempts] specifies how many retry attempts there should be to
-///  upload a file to Supabase storage when failed due to network interruption.
+/// Set the `retryAttempts` field of [storageOptions] to specify how many
+/// retry attempts there should be to upload a file to Supabase storage when
+/// failed due to network interruption.
 ///
 /// [realtimeClientOptions] specifies different options you can pass to `RealtimeClient`.
 ///
@@ -40,8 +42,9 @@ import 'trace_http_client.dart';
 /// Pass an instance of `YAJsonIsolate` to [isolate] to use your own persisted
 /// isolate instance. A new instance will be created if [isolate] is omitted.
 ///
-/// Pass an instance of [gotrueAsyncStorage] and set the [authFlowType] to
-/// `AuthFlowType.pkce`in order to perform auth actions with pkce flow.
+/// Pass an instance of `GotrueAsyncStorage` to the `pkceAsyncStorage` field of
+/// [authOptions] and set its `authFlowType` field to `AuthFlowType.pkce` in
+/// order to perform auth actions with pkce flow.
 /// {@endtemplate}
 class SupabaseClient {
   final String _supabaseKey;
@@ -262,7 +265,7 @@ class SupabaseClient {
 
   /// Unsubscribes and removes Realtime channel from Realtime client.
   ///
-  /// [channel] - The name of the Realtime channel.
+  /// [channel] - The Realtime channel to remove.
   Future<String> removeChannel(RealtimeChannel channel) {
     return realtime.removeChannel(channel);
   }

--- a/packages/supabase_common/lib/src/client_info.dart
+++ b/packages/supabase_common/lib/src/client_info.dart
@@ -33,9 +33,9 @@ String normalizePlatformName(String operatingSystem) =>
 /// Builds the value of the `X-Client-Info` header.
 ///
 /// When [platformInfo] is `null` the minimal `'$clientName/$version'` form is
-/// returned. Otherwise a `; `-joined list is returned, appending `platform`,
-/// `platform-version`, `runtime` and `runtime-version` segments for the
-/// non-null fields.
+/// returned. Otherwise a `; `-joined list is returned, always including a
+/// `runtime=dart` segment and appending `platform`, `platform-version` and
+/// `runtime-version` segments for the non-null fields.
 String buildClientInfoHeader(
   String clientName,
   String version, {

--- a/packages/supabase_flutter/lib/src/local_storage.dart
+++ b/packages/supabase_flutter/lib/src/local_storage.dart
@@ -18,9 +18,7 @@ const supabasePersistSessionKey = 'SUPABASE_PERSIST_SESSION_KEY';
 ///
 ///   * [SupabaseAuth], the instance used to manage authentication
 ///   * [EmptyLocalStorage], used to disable session persistence
-///   * [HiveLocalStorage], that implements Hive as storage method
 ///   * [SharedPreferencesLocalStorage], that implements SharedPreferences as storage method
-///   * [MigrationLocalStorage], to migrate from Hive to SharedPreferences
 abstract class LocalStorage {
   const LocalStorage();
 

--- a/packages/supabase_flutter/lib/src/supabase.dart
+++ b/packages/supabase_flutter/lib/src/supabase.dart
@@ -50,33 +50,39 @@ class Supabase {
 
   /// Initialize the current supabase instance
   ///
-  /// This must be called only once. If called more than once, an
-  /// [AssertionError] is thrown
+  /// This should only be called once. If called again while an instance is
+  /// already initialized, initialization is skipped and the existing
+  /// instance is returned.
   ///
   /// [url] and [publishableKey] can be found on your Supabase dashboard.
-  /// Use the `publishable` (anon) key here — never the secret key in a
+  /// Use the `publishable` (anon) key here, never the secret key in a
   /// Flutter app.
-  ///
-  /// You can access none public schema by passing different [schema].
   ///
   /// Default headers can be overridden by specifying [headers].
   ///
-  /// Pass [localStorage] to override the default local storage option used to
-  /// persist auth.
-  ///
   /// Custom http client can be used by passing [httpClient] parameter.
   ///
-  /// [storageRetryAttempts] specifies how many retry attempts there should be
-  /// to upload a file to Supabase storage when failed due to network
-  /// interruption.
+  /// [realtimeClientOptions], [postgrestOptions], and [storageOptions]
+  /// configure their respective underlying clients, for example
+  /// `storageOptions.retryAttempts` controls how many retry attempts there
+  /// should be to upload a file to Supabase storage when it fails due to a
+  /// network interruption.
   ///
-  /// Set [authFlowType] to [AuthFlowType.implicit] to use the old implicit flow for authentication
+  /// [authOptions] configures authentication behavior. Pass a custom
+  /// [FlutterAuthClientOptions.localStorage] there to override the default
+  /// local storage option used to persist auth.
+  ///
+  /// Set [AuthClientOptions.authFlowType] on [authOptions] to
+  /// [AuthFlowType.implicit] to use the old implicit flow for authentication
   /// involving deep links.
   ///
-  /// PKCE flow uses shared preferences for storing the code verifier by default.
-  /// Pass a custom storage to [pkceAsyncStorage] to override the behavior.
+  /// PKCE flow uses shared preferences for storing the code verifier by
+  /// default. Pass a custom storage to [AuthClientOptions.pkceAsyncStorage]
+  /// on [authOptions] to override the behavior.
   ///
-  /// If [debug] is set to `true`, debug logs will be printed in debug console. Default is `kDebugMode`.
+  /// If [debug] is set to `true`, debug logs will be printed in debug
+  /// console. Defaults to `kDebugMode`, and is always disabled while running
+  /// in a Flutter test.
   static Future<Supabase> initialize({
     required String url,
     String? publishableKey,

--- a/packages/supabase_flutter/lib/src/supabase.dart
+++ b/packages/supabase_flutter/lib/src/supabase.dart
@@ -82,8 +82,8 @@ class Supabase {
   /// on [authOptions] to override the behavior.
   ///
   /// If [debug] is set to `true`, debug logs will be printed in debug
-  /// console. Defaults to `kDebugMode`, and is always disabled while running
-  /// in a Flutter test.
+  /// console. Defaults to `kDebugMode`, and is disabled by default while
+  /// running in a Flutter test unless [debug] is explicitly set to `true`.
   static Future<Supabase> initialize({
     required String url,
     String? publishableKey,

--- a/packages/supabase_flutter/lib/src/supabase_auth.dart
+++ b/packages/supabase_flutter/lib/src/supabase_auth.dart
@@ -50,8 +50,10 @@ import 'clear_auth_url_parameters_stub.dart'
 ///    stops deep link monitoring.
 ///
 /// **Platform notes:**
-/// - Deep link handling is skipped on web (`kIsWeb`) because the browser
-///   handles URL-based redirects directly.
+/// - On web (`kIsWeb`), the continuous deep link stream is not listened to;
+///   only the URL the app was loaded with is inspected once at startup,
+///   since browser navigation triggers a full page load rather than a
+///   stream event.
 class SupabaseAuth with WidgetsBindingObserver {
   static WidgetsBinding get _widgetsBindingInstance => WidgetsBinding.instance;
 
@@ -337,7 +339,7 @@ extension GoTrueClientSignInProvider on GoTrueClient {
   ///
   /// The return value of this method is not the auth result, and whether the
   /// OAuth sign-in has succeeded or not should be observed by setting a listener
-  /// on [auth.onAuthStateChanged].
+  /// on [GoTrueClient.onAuthStateChange].
   ///
   /// To obtain the OAuth URL without launching a browser, use
   /// [getOAuthSignInUrl] instead.

--- a/packages/yet_another_json_isolate/lib/src/_isolates_io.dart
+++ b/packages/yet_another_json_isolate/lib/src/_isolates_io.dart
@@ -43,7 +43,7 @@ class YAJsonIsolate {
 
   /// Dispose the isolate
   ///
-  /// This exists the isolate
+  /// This exits the isolate
   Future<void> dispose() async {
     await _createdIsolate.future;
     _sendPort.send(null);


### PR DESCRIPTION
## Summary
- Audited every `///` dartdoc comment on public API across all packages (gotrue, postgrest, storage_client, realtime_client, functions_client, supabase, supabase_common, supabase_flutter, supabase_typegen, yet_another_json_isolate, supabase_lints).
- Fixed comments that no longer matched the current implementation: stale parameter references, wrong exception types, incorrect defaults, wrong method names, and code examples that would not compile or run correctly.
- No code logic was changed, only doc comment text.

## Test plan
- [x] `dart format` run across all touched packages, no changes needed
- [x] `dart analyze` run on each touched package, no new issues introduced (pre-existing worktree package-resolution noise unrelated to these edits)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified supported request bodies, regional routing, token expiration, MFA QR codes, and authentication behavior.
  * Improved guidance for database queries, filters, RPC calls, return options, and data conversion examples.
  * Documented Realtime messaging, unsubscribe results, heartbeat statuses, and retry examples.
  * Clarified storage bucket creation, headers, table loading, and content-type errors.
  * Updated initialization, deep-linking, client configuration, local storage, and platform information guidance.
  * Corrected outdated references, examples, terminology, and minor wording issues across the SDK.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->