### PR TITLE
docs: add a v2 to v3 migration guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -211,5 +211,7 @@ await Supabase.initialize(
 - Run `melos analyze` and `melos format` before committing
 - Ensure tests pass for modified packages
 - Update package changelogs if making notable changes
+- Any change that breaks the public API adds its own section to `MIGRATION.md`
+  in the same pull request, under the major version it will ship in
 - Line length limit is 80 characters
 - Use `dart format` for consistent formatting

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,114 @@
+# Migration Guides
+
+This document describes the breaking changes you need to be aware of when upgrading between major
+versions of the Supabase Flutter SDK, together with the steps required to migrate your code.
+
+All packages in this repository are released together for a major version, so a single section
+covers `supabase_flutter`, `supabase`, `gotrue`, `postgrest`, `realtime_client`, `storage_client`
+and `functions_client`. Every symbol mentioned here is re-exported from `supabase_flutter`, so the
+snippets apply whether you depend on the individual package or on the Flutter one.
+
+## Migrating from v2 to v3
+
+> [!NOTE]
+> v3 has not been released yet. This section is updated as breaking changes land on `main`, so
+> treat it as the running list rather than the final one.
+
+### `RealtimeClient.connectionState` is now typed
+
+`RealtimeClient` used to expose the socket state twice: a typed `connState` field and a stringly
+typed `connectionState` getter derived from it. The getter is gone and the typed field has taken
+its name, so there is now one way to read the socket state.
+
+This one does not produce a compile error if you were only reading the string, so it is worth
+checking every use site: the name stayed the same and the type changed from `String` to
+`SocketState?`.
+
+```dart
+// Before
+if (client.connectionState == 'open') {
+  // ...
+}
+
+// After
+if (client.connectionState == SocketState.open) {
+  // ...
+}
+```
+
+If you need the string form, use `connectionState?.name`. For the common case of checking whether
+the socket is up, `RealtimeClient.isConnected` is unchanged and is the better choice.
+
+If you were using the typed field under its old name, rename it:
+
+```dart
+// Before
+final SocketStates? state = client.connState;
+
+// After
+final SocketState? state = client.connectionState;
+```
+
+### `conn` abbreviations on `RealtimeClient` spelled out
+
+The `conn` shortening on `RealtimeClient` is spelled out. The behaviour is unchanged, only the
+names are different.
+
+| Before | After |
+| --- | --- |
+| `RealtimeClient.conn` | `RealtimeClient.connection` |
+| `RealtimeClient.connState` | `RealtimeClient.connectionState` |
+| `RealtimeClient.onConnMessage` | `RealtimeClient.onConnectionMessage` |
+
+```dart
+// Before
+final WebSocketChannel? socket = client.conn;
+client.onConnMessage(rawMessage);
+
+// After
+final WebSocketChannel? socket = client.connection;
+client.onConnectionMessage(rawMessage);
+```
+
+### Plural enum names singularized
+
+A Dart enum type names one value rather than the set, so its name should be singular. Five enums
+were ports of the `realtime-js` and `gotrue-js` names instead, and one more turned up in storage.
+Three of them were never reachable from outside the package and are now marked `@internal`; the
+ones below are the renames you can actually hit.
+
+| Before | After | Package |
+| --- | --- | --- |
+| `SocketStates` | `SocketState` | `realtime_client` |
+| `PostgresTypes` | `PostgresType` | `realtime_client` |
+| `AuthenticatorAssuranceLevels` | `AuthenticatorAssuranceLevel` | `gotrue` |
+| `LoadTableSnapshots` | `TableSnapshotScope` | `storage_client` |
+
+No enum values changed, so the only work is renaming the type where you name it explicitly.
+
+```dart
+// Before
+final AuthenticatorAssuranceLevels? level =
+    supabase.auth.mfa.getAuthenticatorAssuranceLevel().currentLevel;
+
+// After
+final AuthenticatorAssuranceLevel? level =
+    supabase.auth.mfa.getAuthenticatorAssuranceLevel().currentLevel;
+```
+
+`LoadTableSnapshots` was additionally renamed to describe what it is rather than where it is used,
+since it selects which snapshots a table load returns:
+
+```dart
+// Before
+await catalog.loadTableResult(
+  id,
+  const LoadTableOptions(snapshots: LoadTableSnapshots.refs),
+);
+
+// After
+await catalog.loadTableResult(
+  id,
+  const LoadTableOptions(snapshots: TableSnapshotScope.refs),
+);
+```

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@
     <a href="https://supabase.com/docs/guides/with-flutter">Guides</a>
     ·
     <a href="https://supabase.com/docs/reference/dart/introduction">Reference Docs</a>
+    ·
+    <a href="https://github.com/supabase/supabase-flutter/blob/main/MIGRATION.md">Migration Guides</a>
   </p>
 </p>
 

--- a/packages/supabase_flutter/README.md
+++ b/packages/supabase_flutter/README.md
@@ -14,6 +14,8 @@
     <a href="https://supabase.com/docs/guides/with-flutter">Guides</a>
     ·
     <a href="https://supabase.com/docs/reference/dart/introduction">Reference Docs</a>
+    ·
+    <a href="https://github.com/supabase/supabase-flutter/blob/main/MIGRATION.md">Migration Guides</a>
   </p>
 </p>
 


### PR DESCRIPTION
Closes SDK-1425

## What

v3 is accumulating breaking changes across every package in the monorepo (#1278), and there is nowhere a user can look to find out what they have to change in their own code. The changelogs are per package, auto-generated and one line per commit, so anyone upgrading has to read seven of them and reconstruct the migration themselves. `sdk-compliance.yaml` tracks capabilities, not migrations.

This adds a `MIGRATION.md` at the repository root, modelled on [Flame's migration guide](https://github.com/flame-engine/flame/blob/main/doc/flame/migration.md):

- One section per major version step, newest first: `## Migrating from v2 to v3`.
- One `###` subsection per breaking change, titled after what changed.
- Each subsection says why the change was made and what you have to do, with a `// Before` / `// After` Dart snippet.
- Changes that keep their name but change type or behaviour are called out explicitly, since those do not surface as compile errors.

One file for the whole monorepo rather than one per package, because the packages go major in lockstep, and it gives us a single link to hand to users.

## Covered so far

The two breaking commits that have landed on `main`:

- `RealtimeClient.connectionState` changing from `String` to `SocketState?` (#1404). This is the silent one: the name is unchanged, so anyone comparing it against `'open'` gets no compile error.
- The `conn` abbreviations spelled out: `conn` → `connection`, `connState` → `connectionState`, `onConnMessage` → `onConnectionMessage` (#1404).
- The four consumer-reachable enum renames (#1654): `SocketStates` → `SocketState`, `PostgresTypes` → `PostgresType`, `AuthenticatorAssuranceLevels` → `AuthenticatorAssuranceLevel`, `LoadTableSnapshots` → `TableSnapshotScope`.

Left out on purpose: the three enums that were never exported (`ChannelStates`, `ChannelEvents`, `RealtimeListenTypes`) and the enum extensions folded in by #1654, since all of them are `@internal` and cannot break a consumer.

The section carries a note that v3 is unreleased and the list is still growing.

## Keeping it current

`AGENTS.md` now states that a change breaking the public API adds its own section to `MIGRATION.md` in the same pull request, the same way parity work reconciles `sdk-compliance.yaml`. There is no pull request template in `.github/`, so there was nothing to add a checkbox to.

Linked from the root `README.md` and `packages/supabase_flutter/README.md`, next to the existing Guides and Reference Docs links.

## Testing

Documentation only, no code changes. Every snippet in the guide was type-checked against the workspace in a scratch file (`dart analyze`, clean), which was then deleted.
