### PR TITLE
feat(gotrue)!: return pagination metadata from admin listUsers

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -146,6 +146,41 @@ upgrading and leave this change out of the upgrade itself.
 
 `nullsFirst` is unchanged and still defaults to `false`.
 
+### `admin.listUsers()` returns pagination metadata
+
+`listUsers()` accepted `page` and `perPage` but returned a bare `List<User>`, so the pagination
+metadata the server reports went unused and there was no way to tell how many users or pages exist
+short of requesting pages until a short one came back. It now returns a `ListUsersResponse` that
+carries the page of users plus that metadata.
+
+```dart
+// Before
+final List<User> users = await supabase.auth.admin.listUsers(perPage: 50);
+for (final user in users) {
+  print(user.email);
+}
+
+// After
+final response = await supabase.auth.admin.listUsers(perPage: 50);
+for (final user in response.users) {
+  print(user.email);
+}
+```
+
+`total` comes from the `X-Total-Count` response header, `nextPage` and `lastPage` from the `Link`
+header, and `aud` from the body. `nextPage` is `null` on the last page, so you can walk every page
+without guessing where it ends:
+
+```dart
+var response = await supabase.auth.admin.listUsers(perPage: 50);
+while (response.nextPage != null) {
+  response = await supabase.auth.admin.listUsers(
+    page: response.nextPage,
+    perPage: 50,
+  );
+}
+```
+
 ### Every deprecated API is gone
 
 v3 drops the whole deprecated surface that accumulated over v1 and v2. Where an entry has a

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -168,8 +168,8 @@ for (final user in response.users) {
 ```
 
 `total` comes from the `X-Total-Count` response header, `nextPage` and `lastPage` from the `Link`
-header, and `aud` from the body. `nextPage` is `null` on the last page, so you can walk every page
-without guessing where it ends:
+header, and `audience` from the `aud` field of the body. `nextPage` is `null` on the last page, so
+you can walk every page without guessing where it ends:
 
 ```dart
 var response = await supabase.auth.admin.listUsers(perPage: 50);

--- a/packages/gotrue/lib/src/fetch.dart
+++ b/packages/gotrue/lib/src/fetch.dart
@@ -7,6 +7,7 @@ import 'package:gotrue/src/types/auth_exception.dart';
 import 'package:gotrue/src/types/error_code.dart';
 import 'package:gotrue/src/types/fetch_options.dart';
 import 'package:http/http.dart';
+import 'package:meta/meta.dart';
 import 'package:supabase_common/supabase_common.dart';
 
 enum RequestMethodType { get, post, put, patch, delete }
@@ -119,6 +120,20 @@ class GotrueFetch {
     RequestMethodType method, {
     GotrueRequestOptions? options,
   }) async {
+    final result = await requestWithResponse(url, method, options: options);
+    return result.body;
+  }
+
+  /// Performs the request and returns the resolved [body] alongside the raw
+  /// [response], for callers that need to read response headers.
+  ///
+  /// Use [request] unless you need the headers.
+  @internal
+  Future<({dynamic body, Response response})> requestWithResponse(
+    String url,
+    RequestMethodType method, {
+    GotrueRequestOptions? options,
+  }) async {
     // Copy the maps before mutating them. Callers pass the client's shared
     // header/query maps by reference, so writing `Authorization`, the API
     // version or `redirect_to` directly would leak into every later request.
@@ -140,15 +155,33 @@ class GotrueFetch {
     Uri uri = Uri.parse(url);
     uri = uri.replace(queryParameters: {...uri.queryParameters, ...qs});
 
-    return await _handleRequest(
+    final response = await _handleRequest(
       method: method,
       uri: uri,
       options: options,
       headers: headers,
     );
+
+    return (body: _resolveBody(response, options), response: response);
   }
 
-  Future<dynamic> _handleRequest({
+  dynamic _resolveBody(Response response, GotrueRequestOptions? options) {
+    if (options?.noResolveJson == true) {
+      return response.body;
+    }
+
+    try {
+      final bodyString = utf8.decode(response.bodyBytes);
+      if (bodyString.isEmpty) {
+        return <String, dynamic>{};
+      }
+      return json.decode(bodyString);
+    } catch (error) {
+      throw _handleError(error);
+    }
+  }
+
+  Future<Response> _handleRequest({
     required RequestMethodType method,
     required Uri uri,
     required GotrueRequestOptions? options,
@@ -196,18 +229,6 @@ class GotrueFetch {
       throw _handleError(response);
     }
 
-    if (options?.noResolveJson == true) {
-      return response.body;
-    }
-
-    try {
-      final bodyString = utf8.decode(response.bodyBytes);
-      if (bodyString.isEmpty) {
-        return <String, dynamic>{};
-      }
-      return json.decode(bodyString);
-    } catch (error) {
-      throw _handleError(error);
-    }
+    return response;
   }
 }

--- a/packages/gotrue/lib/src/gotrue_admin_api.dart
+++ b/packages/gotrue/lib/src/gotrue_admin_api.dart
@@ -17,12 +17,16 @@ final _linkHeaderPattern = RegExp(r'<([^>]+)>\s*;\s*rel="([^"]+)"');
 ///
 /// The header holds one link per relation, for example
 /// `</admin/users?page=2>; rel="next", </admin/users?page=3>; rel="last"`.
+///
+/// Links that do not parse or carry no page number are skipped, so a header the
+/// client cannot read costs the metadata rather than throwing over a request
+/// that otherwise succeeded.
 Map<String, int> _parsePaginationLinks(String? header) {
   if (header == null) return const {};
 
   final pages = <String, int>{};
   for (final match in _linkHeaderPattern.allMatches(header)) {
-    final page = Uri.parse(match.group(1)!).queryParameters['page'];
+    final page = Uri.tryParse(match.group(1)!)?.queryParameters['page'];
     final pageNumber = int.tryParse(page ?? '');
     if (pageNumber != null) {
       pages[match.group(2)!] = pageNumber;

--- a/packages/gotrue/lib/src/gotrue_admin_api.dart
+++ b/packages/gotrue/lib/src/gotrue_admin_api.dart
@@ -10,6 +10,27 @@ import 'gotrue_admin_custom_providers_api.dart';
 import 'gotrue_admin_mfa_api.dart';
 import 'gotrue_admin_oauth_api.dart';
 
+final _linkHeaderPattern = RegExp(r'<([^>]+)>\s*;\s*rel="([^"]+)"');
+
+/// Reads the page number of every link in a `Link` response header, keyed by
+/// its `rel` value.
+///
+/// The header holds one link per relation, for example
+/// `</admin/users?page=2>; rel="next", </admin/users?page=3>; rel="last"`.
+Map<String, int> _parsePaginationLinks(String? header) {
+  if (header == null) return const {};
+
+  final pages = <String, int>{};
+  for (final match in _linkHeaderPattern.allMatches(header)) {
+    final page = Uri.parse(match.group(1)!).queryParameters['page'];
+    final pageNumber = int.tryParse(page ?? '');
+    if (pageNumber != null) {
+      pages[match.group(2)!] = pageNumber;
+    }
+  }
+  return pages;
+}
+
 class GoTrueAdminApi {
   final String _url;
   final Map<String, String> _headers;
@@ -125,8 +146,15 @@ class GoTrueAdminApi {
   /// `secret` key on the client.
   ///
   /// The result is paginated. Use the [page] and [perPage] parameters to
-  /// paginate the result.
-  Future<List<User>> listUsers({int? page, int? perPage}) async {
+  /// paginate the result, and [ListUsersResponse.nextPage] to walk the pages:
+  ///
+  /// ```dart
+  /// var response = await admin.listUsers(perPage: 50);
+  /// while (response.nextPage != null) {
+  ///   response = await admin.listUsers(page: response.nextPage, perPage: 50);
+  /// }
+  /// ```
+  Future<ListUsersResponse> listUsers({int? page, int? perPage}) async {
     final options = GotrueRequestOptions(
       headers: _headers,
       query: {
@@ -134,12 +162,22 @@ class GoTrueAdminApi {
         'per_page': ?perPage?.toString(),
       },
     );
-    final response = await _fetch.request(
+    final result = await _fetch.requestWithResponse(
       '$_url/admin/users',
       RequestMethodType.get,
       options: options,
     );
-    return (response['users'] as List).map((e) => User.fromJson(e)!).toList();
+    final body = result.body;
+    final headers = result.response.headers;
+    final links = _parsePaginationLinks(headers['link']);
+
+    return ListUsersResponse(
+      users: (body['users'] as List).map((e) => User.fromJson(e)!).toList(),
+      total: int.tryParse(headers['x-total-count'] ?? ''),
+      nextPage: links['next'],
+      lastPage: links['last'],
+      aud: body['aud'] as String?,
+    );
   }
 
   /// Sends an invite link to an email address.

--- a/packages/gotrue/lib/src/gotrue_admin_api.dart
+++ b/packages/gotrue/lib/src/gotrue_admin_api.dart
@@ -176,7 +176,7 @@ class GoTrueAdminApi {
       total: int.tryParse(headers['x-total-count'] ?? ''),
       nextPage: links['next'],
       lastPage: links['last'],
-      aud: body['aud'] as String?,
+      audience: body['aud'] as String?,
     );
   }
 

--- a/packages/gotrue/lib/src/types/auth_response.dart
+++ b/packages/gotrue/lib/src/types/auth_response.dart
@@ -53,15 +53,16 @@ class ListUsersResponse {
   /// response header.
   final int? lastPage;
 
-  /// The audience the users belong to.
-  final String? aud;
+  /// The audience the users belong to, from the `aud` field of the response
+  /// body.
+  final String? audience;
 
   const ListUsersResponse({
     required this.users,
     this.total,
     this.nextPage,
     this.lastPage,
-    this.aud,
+    this.audience,
   });
 }
 

--- a/packages/gotrue/lib/src/types/auth_response.dart
+++ b/packages/gotrue/lib/src/types/auth_response.dart
@@ -35,6 +35,36 @@ class UserResponse {
   UserResponse.fromJson(Map<String, dynamic> json) : user = User.fromJson(json);
 }
 
+/// Response of [GoTrueAdminApi.listUsers], a page of users together with the
+/// pagination metadata the server reports for it.
+class ListUsersResponse {
+  /// The users on the requested page.
+  final List<User> users;
+
+  /// Total number of users across all pages, from the `X-Total-Count`
+  /// response header.
+  final int? total;
+
+  /// The page to request next, or `null` when the requested page was the last
+  /// one. Read from the `next` link of the `Link` response header.
+  final int? nextPage;
+
+  /// The number of the last page. Read from the `last` link of the `Link`
+  /// response header.
+  final int? lastPage;
+
+  /// The audience the users belong to.
+  final String? aud;
+
+  const ListUsersResponse({
+    required this.users,
+    this.total,
+    this.nextPage,
+    this.lastPage,
+    this.aud,
+  });
+}
+
 class ResendResponse {
   /// Only set for phone resend
   String? messageId;

--- a/packages/gotrue/test/admin_list_users_test.dart
+++ b/packages/gotrue/test/admin_list_users_test.dart
@@ -111,4 +111,23 @@ void main() {
     expect(response.nextPage, isNull);
     expect(response.total, isNull);
   });
+
+  test('listUsers() ignores a link holding an unparseable URI', () async {
+    // A malformed URI must cost the metadata, not fail the whole call with a
+    // FormatException from outside the AuthException hierarchy.
+    final mockClient = ListUsersMockClient(
+      link:
+          '<http://host:notaport/admin/users?page=2>; rel="next", '
+          '</admin/users?page=5>; rel="last"',
+    );
+
+    final response = await clientWith(mockClient).admin.listUsers();
+
+    expect(response.nextPage, isNull);
+    expect(
+      response.lastPage,
+      5,
+      reason: 'a readable link is still used alongside a malformed one',
+    );
+  });
 }

--- a/packages/gotrue/test/admin_list_users_test.dart
+++ b/packages/gotrue/test/admin_list_users_test.dart
@@ -7,11 +7,15 @@ import 'package:test/test.dart';
 /// Serves a fixed list-users response with the pagination headers the GoTrue
 /// server sends alongside it.
 class ListUsersMockClient extends BaseClient {
-  ListUsersMockClient({this.link, this.totalCount, this.aud = 'authenticated'});
+  ListUsersMockClient({
+    this.link,
+    this.totalCount,
+    this.audience = 'authenticated',
+  });
 
   final String? link;
   final String? totalCount;
-  final String? aud;
+  final String? audience;
 
   Uri? lastRequestUrl;
 
@@ -26,7 +30,7 @@ class ListUsersMockClient extends BaseClient {
             'users': [
               {'id': '2fa5b8b0-4f1a-4a5c-9d47-1cf3dbb9f7e1'},
             ],
-            'aud': ?aud,
+            'aud': ?audience,
           }),
         ),
       ),
@@ -63,7 +67,7 @@ void main() {
     expect(response.total, 5);
     expect(response.nextPage, 3);
     expect(response.lastPage, 5);
-    expect(response.aud, 'authenticated');
+    expect(response.audience, 'authenticated');
     expect(mockClient.lastRequestUrl?.queryParameters, {
       'page': '2',
       'per_page': '1',
@@ -86,14 +90,14 @@ void main() {
 
   test('listUsers() leaves the metadata null when omitted', () async {
     final response = await clientWith(
-      ListUsersMockClient(aud: null),
+      ListUsersMockClient(audience: null),
     ).admin.listUsers();
 
     expect(response.users, hasLength(1));
     expect(response.total, isNull);
     expect(response.nextPage, isNull);
     expect(response.lastPage, isNull);
-    expect(response.aud, isNull);
+    expect(response.audience, isNull);
   });
 
   test('listUsers() ignores links it cannot read a page number from', () async {

--- a/packages/gotrue/test/admin_list_users_test.dart
+++ b/packages/gotrue/test/admin_list_users_test.dart
@@ -1,0 +1,110 @@
+import 'dart:convert';
+
+import 'package:gotrue/gotrue.dart';
+import 'package:http/http.dart';
+import 'package:test/test.dart';
+
+/// Serves a fixed list-users response with the pagination headers the GoTrue
+/// server sends alongside it.
+class ListUsersMockClient extends BaseClient {
+  ListUsersMockClient({this.link, this.totalCount, this.aud = 'authenticated'});
+
+  final String? link;
+  final String? totalCount;
+  final String? aud;
+
+  Uri? lastRequestUrl;
+
+  @override
+  Future<StreamedResponse> send(BaseRequest request) async {
+    lastRequestUrl = request.url;
+
+    return StreamedResponse(
+      Stream.value(
+        utf8.encode(
+          jsonEncode({
+            'users': [
+              {'id': '2fa5b8b0-4f1a-4a5c-9d47-1cf3dbb9f7e1'},
+            ],
+            'aud': ?aud,
+          }),
+        ),
+      ),
+      200,
+      request: request,
+      headers: {
+        'content-type': 'application/json',
+        'link': ?link,
+        'x-total-count': ?totalCount,
+      },
+    );
+  }
+}
+
+void main() {
+  GoTrueClient clientWith(ListUsersMockClient mockClient) => GoTrueClient(
+    url: 'http://localhost:9999',
+    httpClient: mockClient,
+  );
+
+  test('listUsers() returns the metadata of a middle page', () async {
+    final mockClient = ListUsersMockClient(
+      link:
+          '</admin/users?page=3&per_page=1>; rel="next", '
+          '</admin/users?page=5&per_page=1>; rel="last"',
+      totalCount: '5',
+    );
+
+    final response = await clientWith(
+      mockClient,
+    ).admin.listUsers(page: 2, perPage: 1);
+
+    expect(response.users, hasLength(1));
+    expect(response.total, 5);
+    expect(response.nextPage, 3);
+    expect(response.lastPage, 5);
+    expect(response.aud, 'authenticated');
+    expect(mockClient.lastRequestUrl?.queryParameters, {
+      'page': '2',
+      'per_page': '1',
+    });
+  });
+
+  test('listUsers() reports no next page on the last page', () async {
+    // The server omits the `next` link once there is nothing left to fetch.
+    final mockClient = ListUsersMockClient(
+      link: '</admin/users?page=5&per_page=1>; rel="last"',
+      totalCount: '5',
+    );
+
+    final response = await clientWith(mockClient).admin.listUsers(page: 5);
+
+    expect(response.nextPage, isNull);
+    expect(response.lastPage, 5);
+    expect(response.total, 5);
+  });
+
+  test('listUsers() leaves the metadata null when omitted', () async {
+    final response = await clientWith(
+      ListUsersMockClient(aud: null),
+    ).admin.listUsers();
+
+    expect(response.users, hasLength(1));
+    expect(response.total, isNull);
+    expect(response.nextPage, isNull);
+    expect(response.lastPage, isNull);
+    expect(response.aud, isNull);
+  });
+
+  test('listUsers() ignores links it cannot read a page number from', () async {
+    final mockClient = ListUsersMockClient(
+      link: '</admin/users?per_page=1>; rel="next"',
+      totalCount: 'not a number',
+    );
+
+    final response = await clientWith(mockClient).admin.listUsers();
+
+    expect(response.nextPage, isNull);
+    expect(response.total, isNull);
+  });
+}

--- a/packages/gotrue/test/admin_test.dart
+++ b/packages/gotrue/test/admin_test.dart
@@ -48,7 +48,7 @@ void main() {
     test('listUsers() returns the pagination metadata of the page', () async {
       final firstPage = await client.admin.listUsers(perPage: 1);
       expect(firstPage.users, hasLength(1));
-      expect(firstPage.aud, 'authenticated');
+      expect(firstPage.audience, 'authenticated');
       expect(firstPage.total, greaterThan(1));
       expect(firstPage.lastPage, firstPage.total);
       expect(firstPage.nextPage, 2);

--- a/packages/gotrue/test/admin_test.dart
+++ b/packages/gotrue/test/admin_test.dart
@@ -44,6 +44,31 @@ void main() {
         expect(foundUserResponse.user?.email, email1);
       },
     );
+
+    test('listUsers() returns the pagination metadata of the page', () async {
+      final firstPage = await client.admin.listUsers(perPage: 1);
+      expect(firstPage.users, hasLength(1));
+      expect(firstPage.aud, 'authenticated');
+      expect(firstPage.total, greaterThan(1));
+      expect(firstPage.lastPage, firstPage.total);
+      expect(firstPage.nextPage, 2);
+
+      final secondPage = await client.admin.listUsers(
+        page: firstPage.nextPage,
+        perPage: 1,
+      );
+      expect(
+        secondPage.users.single.id,
+        isNot(firstPage.users.single.id),
+        reason: 'the next page holds different users',
+      );
+
+      final lastPage = await client.admin.listUsers(
+        page: firstPage.lastPage,
+        perPage: 1,
+      );
+      expect(lastPage.nextPage, isNull);
+    });
   });
 
   group('User updates', () {
@@ -121,9 +146,9 @@ void main() {
 
   group('User deletion', () {
     test('deleteUser() deletes an user', () async {
-      final userLengthBefore = (await client.admin.listUsers()).length;
+      final userLengthBefore = (await client.admin.listUsers()).users.length;
       await client.admin.deleteUser(userId1);
-      final userLengthAfter = (await client.admin.listUsers()).length;
+      final userLengthAfter = (await client.admin.listUsers()).users.length;
       expect(userLengthBefore - 1, userLengthAfter);
     });
 
@@ -142,7 +167,7 @@ void main() {
       );
       await client.admin.deleteUser(hardDeleted.user!.id);
 
-      final ids = (await client.admin.listUsers()).map((user) => user.id);
+      final ids = (await client.admin.listUsers()).users.map((user) => user.id);
       expect(
         ids,
         contains(softDeleted.user!.id),

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -260,7 +260,7 @@ features:
       - GoTrueAdminApi.listUsers
       - ListUsersResponse
       - ListUsersResponse.ListUsersResponse
-      - ListUsersResponse.aud
+      - ListUsersResponse.audience
       - ListUsersResponse.lastPage
       - ListUsersResponse.nextPage
       - ListUsersResponse.total

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -255,8 +255,16 @@ features:
     symbols:
       - GoTrueAdminApi.deleteUser
   auth.admin.list_users:
-    status: partially_implemented
-    note: "Returns the user list only; pagination metadata (total, nextPage, lastPage, aud) is not returned."
+    status: implemented
+    symbols:
+      - GoTrueAdminApi.listUsers
+      - ListUsersResponse
+      - ListUsersResponse.ListUsersResponse
+      - ListUsersResponse.aud
+      - ListUsersResponse.lastPage
+      - ListUsersResponse.nextPage
+      - ListUsersResponse.total
+      - ListUsersResponse.users
   auth.admin.invite_user:
     status: implemented
     symbols:


### PR DESCRIPTION
Closes #1602

## What

`GoTrueAdminApi.listUsers` accepted `page` and `perPage` but returned a bare `List<User>`, so the pagination metadata the server sends alongside the page was thrown away. There was no way to learn how many users or pages exist short of requesting pages until a short one came back.

It now returns a `ListUsersResponse`:

```dart
class ListUsersResponse {
  final List<User> users;
  final int? total;       // X-Total-Count header
  final int? nextPage;    // rel="next" of the Link header, null on the last page
  final int? lastPage;    // rel="last" of the Link header
  final String? audience; // `aud` field of the response body
}
```

Following the existing named-response-class convention (`UserResponse`, `GenerateLinkResponse`), the type carries only the successful payload. It deliberately does not mirror supabase-js's `{ data, error }` wrapper, since Dart gotrue throws on error.

`audience` is spelled out rather than passed through as `aud` the way supabase-js and supabase-swift do. The wire key stays `aud`; only the Dart field name differs.

Walking every page no longer needs guesswork:

```dart
var response = await supabase.auth.admin.listUsers(perPage: 50);
while (response.nextPage != null) {
  response = await supabase.auth.admin.listUsers(
    page: response.nextPage,
    perPage: 50,
  );
}
```

## How

`GotrueFetch.request` discarded the `Response` after decoding the body, so the headers were unreachable. The send/validate step is now split out into an `@internal` `requestWithResponse`, which returns the decoded body alongside the raw response; `request` delegates to it and keeps returning just the body, so every other call site is untouched.

The `Link` header is parsed with a regex over `<url>; rel="name"` pairs, reading the `page` query parameter of each link. Links without a readable page number and a non-numeric `X-Total-Count` are ignored rather than throwing.

## Breaking change

`listUsers` returns `ListUsersResponse` instead of `List<User>`; callers read the users from `.users`. Documented in `MIGRATION.md` under the v2 to v3 section.

## Tests

- `packages/gotrue/test/admin_list_users_test.dart` covers header parsing against a mock client: a middle page, the last page (no `next` link), a server that sends no pagination headers at all, and unparseable values.
- `packages/gotrue/test/admin_test.dart` gains an integration test that paginates with `perPage: 1` against the local GoTrue stack and checks `total`, `lastPage`, `nextPage` and that the next page holds different users.

Full `gotrue` suite (465 tests) and `supabase` suite (134 tests) pass against the local stack.

## Compliance matrix

`auth.admin.list_users` moves from `partially_implemented` to `implemented`, with `GoTrueAdminApi.listUsers` and the `ListUsersResponse` surface registered. The symbol, drift and schema checks were run locally and pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced admin user listing with pagination support and response metadata, including total users, next and last pages, and audience.
  * Added a structured response containing both the user list and pagination details.
  * Pagination information is now available for navigating through user-list pages.

* **Documentation**
  * Added migration guidance for the v2-to-v3 change to `listUsers()` response handling.

* **Tests**
  * Added coverage for pagination, metadata, query parameters, and missing or invalid pagination information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->