### PR TITLE
chore: reconcile sdk-compliance.yaml with capability matrix renames and splits

### DIFF
--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -723,24 +723,20 @@ features:
       - StorageFileApi.downloadStream
   storage.file_buckets.list_files:
     status: implemented
+    note: "Cursor-based pagination is exposed as listPaginated (paired with descriptive Dart type names) rather than the supabase-js listV2 name."
     symbols:
       - StorageFileApi.list
       - StorageFileApi.listPaginated
-      - PaginatedSearchOptions
-      - PaginatedSearchOptions.PaginatedSearchOptions
-      - PaginatedSearchOptions.cursor
-      - PaginatedSearchOptions.limit
-      - PaginatedSearchOptions.prefix
-      - PaginatedSearchOptions.sortBy
-      - PaginatedSearchOptions.toMap
-      - PaginatedSearchOptions.withDelimiter
-      - PaginatedListResult
-      - PaginatedListResult.PaginatedListResult
-      - PaginatedListResult.folders
-      - PaginatedListResult.fromJson
-      - PaginatedListResult.hasNext
-      - PaginatedListResult.nextCursor
-      - PaginatedListResult.objects
+    supporting_symbols:
+      - FileSort
+      - FileSort.FileSort
+      - FileSort.column
+      - FileSort.order
+      - FileSort.toMap
+      - FileSortColumn
+      - FileSortOrder
+      - FileSortOrder.FileSortOrder
+      - FileSortOrder.value
       - PaginatedFile
       - PaginatedFile.PaginatedFile
       - PaginatedFile.createdAt
@@ -755,16 +751,21 @@ features:
       - PaginatedFolder.fromJson
       - PaginatedFolder.key
       - PaginatedFolder.name
-      - FileSort
-      - FileSort.FileSort
-      - FileSort.column
-      - FileSort.order
-      - FileSort.toMap
-      - FileSortColumn
-      - FileSortOrder
-      - FileSortOrder.FileSortOrder
-      - FileSortOrder.value
-    note: Exposed as listPaginated (paired with descriptive Dart type names) rather than the supabase-js listV2 name.
+      - PaginatedListResult
+      - PaginatedListResult.PaginatedListResult
+      - PaginatedListResult.folders
+      - PaginatedListResult.fromJson
+      - PaginatedListResult.hasNext
+      - PaginatedListResult.nextCursor
+      - PaginatedListResult.objects
+      - PaginatedSearchOptions
+      - PaginatedSearchOptions.PaginatedSearchOptions
+      - PaginatedSearchOptions.cursor
+      - PaginatedSearchOptions.limit
+      - PaginatedSearchOptions.prefix
+      - PaginatedSearchOptions.sortBy
+      - PaginatedSearchOptions.toMap
+      - PaginatedSearchOptions.withDelimiter
   storage.file_buckets.move:
     status: implemented
     symbols:

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -1066,26 +1066,13 @@ features:
       - IcebergRestCatalog.loadTable
       - IcebergRestCatalog.loadTableResult
     supporting_symbols:
-      - AccessDelegation
-      - AccessDelegation.AccessDelegation
-      - AccessDelegation.value
       - LoadTableOptions
       - LoadTableOptions.LoadTableOptions
       - LoadTableOptions.ifNoneMatch
       - LoadTableOptions.snapshots
-      - LoadTableResult
-      - LoadTableResult.LoadTableResult
-      - LoadTableResult.config
-      - LoadTableResult.etag
-      - LoadTableResult.fromJson
-      - LoadTableResult.metadata
-      - LoadTableResult.metadataLocation
-      - LoadTableResult.storageCredentials
-      - StorageCredential
-      - StorageCredential.StorageCredential
-      - StorageCredential.config
-      - StorageCredential.fromJson
-      - StorageCredential.prefix
+      - TableSnapshotScope
+      - TableSnapshotScope.TableSnapshotScope
+      - TableSnapshotScope.value
   storage.analytics.update_table:
     status: implemented
     note: Data definition table updates (schema, partition spec, sort order, properties, location) are modelled as typed TableUpdate subclasses; snapshot, statistics and encryption key updates are sent through the TableUpdate.raw escape hatch.
@@ -1463,11 +1450,16 @@ features:
       - TracePropagationOptions.enabled
       - TracePropagationOptions.respectSamplingDecision
       - TracePropagationOptions.traceContextProvider
-# Public API accounted for by the matrix but not attributable to one capability:
-# the Iceberg schema and type model, the exception hierarchy, and the catalog
-# operations the canonical matrix has no feature id for yet (registerTable,
-# tableExists, loadNamespaceMetadata, namespaceExists, updateNamespaceProperties).
+
+# Public API the matrix accounts for but that no single capability owns: types
+# reachable from several features' entry points (the Iceberg schema and type
+# model), types reachable from none because they are thrown rather than passed
+# (the exception hierarchy), and the catalog operations the canonical matrix has
+# no feature id for yet. See supabase/sdk#76 for the last group.
 supporting_symbols:
+  - AccessDelegation
+  - AccessDelegation.AccessDelegation
+  - AccessDelegation.value
   - IcebergAuthenticationTimeoutException
   - IcebergAuthenticationTimeoutException.IcebergAuthenticationTimeoutException
   - IcebergCommitStateUnknownException
@@ -1509,6 +1501,14 @@ supporting_symbols:
   - ListType.elementRequired
   - ListType.fromJson
   - ListType.toJson
+  - LoadTableResult
+  - LoadTableResult.LoadTableResult
+  - LoadTableResult.config
+  - LoadTableResult.etag
+  - LoadTableResult.fromJson
+  - LoadTableResult.metadata
+  - LoadTableResult.metadataLocation
+  - LoadTableResult.storageCredentials
   - MapType
   - MapType.MapType
   - MapType.fromJson
@@ -1588,6 +1588,11 @@ supporting_symbols:
   - SortOrder.fromJson
   - SortOrder.orderId
   - SortOrder.toJson
+  - StorageCredential
+  - StorageCredential.StorageCredential
+  - StorageCredential.config
+  - StorageCredential.fromJson
+  - StorageCredential.prefix
   - StructType
   - StructType.StructType
   - StructType.fields
@@ -1638,9 +1643,6 @@ supporting_symbols:
   - TableSchema.identifierFieldIds
   - TableSchema.schemaId
   - TableSchema.toJson
-  - TableSnapshotScope
-  - TableSnapshotScope.TableSnapshotScope
-  - TableSnapshotScope.value
   - UpdateNamespacePropertiesResult
   - UpdateNamespacePropertiesResult.UpdateNamespacePropertiesResult
   - UpdateNamespacePropertiesResult.fromJson

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -1200,6 +1200,40 @@ features:
     status: implemented
     symbols:
       - IcebergRestCatalog.dropTable
+  storage.analytics.load_namespace_metadata:
+    status: implemented
+    symbols:
+      - IcebergRestCatalog.loadNamespaceMetadata
+  storage.analytics.namespace_exists:
+    status: implemented
+    symbols:
+      - IcebergRestCatalog.namespaceExists
+  storage.analytics.update_namespace_properties:
+    status: implemented
+    symbols:
+      - IcebergRestCatalog.updateNamespaceProperties
+    supporting_symbols:
+      - UpdateNamespacePropertiesResult
+      - UpdateNamespacePropertiesResult.UpdateNamespacePropertiesResult
+      - UpdateNamespacePropertiesResult.fromJson
+      - UpdateNamespacePropertiesResult.missing
+      - UpdateNamespacePropertiesResult.removed
+      - UpdateNamespacePropertiesResult.updated
+  storage.analytics.register_table:
+    status: implemented
+    symbols:
+      - IcebergRestCatalog.registerTable
+    supporting_symbols:
+      - RegisterTableRequest
+      - RegisterTableRequest.RegisterTableRequest
+      - RegisterTableRequest.metadataLocation
+      - RegisterTableRequest.name
+      - RegisterTableRequest.overwrite
+      - RegisterTableRequest.toJson
+  storage.analytics.table_exists:
+    status: implemented
+    symbols:
+      - IcebergRestCatalog.tableExists
 
   # realtime — channel
   realtime.channel.subscribe:
@@ -1451,11 +1485,10 @@ features:
       - TracePropagationOptions.respectSamplingDecision
       - TracePropagationOptions.traceContextProvider
 
-# Public API the matrix accounts for but that no single capability owns: types
-# reachable from several features' entry points (the Iceberg schema and type
-# model), types reachable from none because they are thrown rather than passed
-# (the exception hierarchy), and the catalog operations the canonical matrix has
-# no feature id for yet. See supabase/sdk#76 for the last group.
+# Public API the matrix accounts for but that no single capability owns: the
+# Iceberg schema and type model, reachable from several features' entry points,
+# and the exception hierarchy, reachable from none because it is thrown rather
+# than passed. Every catalog operation now has a feature id of its own.
 supporting_symbols:
   - AccessDelegation
   - AccessDelegation.AccessDelegation
@@ -1481,11 +1514,6 @@ supporting_symbols:
   - IcebergNotFoundException.IcebergNotFoundException
   - IcebergRestCatalog
   - IcebergRestCatalog.IcebergRestCatalog
-  - IcebergRestCatalog.loadNamespaceMetadata
-  - IcebergRestCatalog.namespaceExists
-  - IcebergRestCatalog.registerTable
-  - IcebergRestCatalog.tableExists
-  - IcebergRestCatalog.updateNamespaceProperties
   - IcebergServerException
   - IcebergServerException.IcebergServerException
   - IcebergType
@@ -1540,12 +1568,6 @@ supporting_symbols:
   - PrimitiveType.PrimitiveType
   - PrimitiveType.name
   - PrimitiveType.toJson
-  - RegisterTableRequest
-  - RegisterTableRequest.RegisterTableRequest
-  - RegisterTableRequest.metadataLocation
-  - RegisterTableRequest.name
-  - RegisterTableRequest.overwrite
-  - RegisterTableRequest.toJson
   - Snapshot
   - Snapshot.Snapshot
   - Snapshot.fromJson
@@ -1643,9 +1665,3 @@ supporting_symbols:
   - TableSchema.identifierFieldIds
   - TableSchema.schemaId
   - TableSchema.toJson
-  - UpdateNamespacePropertiesResult
-  - UpdateNamespacePropertiesResult.UpdateNamespacePropertiesResult
-  - UpdateNamespacePropertiesResult.fromJson
-  - UpdateNamespacePropertiesResult.missing
-  - UpdateNamespacePropertiesResult.removed
-  - UpdateNamespacePropertiesResult.updated

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -74,7 +74,7 @@ features:
     status: implemented
     symbols:
       - GoTrueClient.reauthenticate
-  auth.sign_in.reset_password:
+  auth.sign_in.send_password_reset_email:
     status: implemented
     symbols:
       - GoTrueClient.resetPasswordForEmail
@@ -725,10 +725,6 @@ features:
     status: implemented
     symbols:
       - StorageFileApi.list
-  storage.file_buckets.list_files_paginated:
-    status: implemented
-    note: "Exposed as listPaginated (paired with descriptive Dart type names) rather than the supabase-js listV2 name."
-    symbols:
       - StorageFileApi.listPaginated
       - PaginatedSearchOptions
       - PaginatedSearchOptions.PaginatedSearchOptions
@@ -768,6 +764,7 @@ features:
       - FileSortOrder
       - FileSortOrder.FileSortOrder
       - FileSortOrder.value
+    note: Exposed as listPaginated (paired with descriptive Dart type names) rather than the supabase-js listV2 name.
   storage.file_buckets.move:
     status: implemented
     symbols:
@@ -1010,16 +1007,16 @@ features:
     status: implemented
     symbols:
       - StorageBucketApi.deleteAnalyticsBucket
-  storage.analytics.iceberg_namespace:
+  storage.analytics.create_namespace:
     status: implemented
     symbols:
       - IcebergRestCatalog.createNamespace
       - IcebergRestCatalog.createNamespaceIfNotExists
-      - IcebergRestCatalog.dropNamespace
+  storage.analytics.list_namespaces:
+    status: implemented
+    symbols:
       - IcebergRestCatalog.listNamespaces
-      - IcebergRestCatalog.loadNamespaceMetadata
-      - IcebergRestCatalog.namespaceExists
-      - IcebergRestCatalog.updateNamespaceProperties
+    supporting_symbols:
       - ListNamespacesOptions
       - ListNamespacesOptions.ListNamespacesOptions
       - ListNamespacesOptions.pageSize
@@ -1029,23 +1026,72 @@ features:
       - ListNamespacesResult.ListNamespacesResult
       - ListNamespacesResult.namespaces
       - ListNamespacesResult.nextPageToken
-      - UpdateNamespacePropertiesResult
-      - UpdateNamespacePropertiesResult.UpdateNamespacePropertiesResult
-      - UpdateNamespacePropertiesResult.fromJson
-      - UpdateNamespacePropertiesResult.missing
-      - UpdateNamespacePropertiesResult.removed
-      - UpdateNamespacePropertiesResult.updated
-  storage.analytics.iceberg_table:
+  storage.analytics.delete_namespace:
     status: implemented
-    note: >-
-      Data definition table updates (schema, partition spec, sort order,
-      properties, location) are modelled as typed TableUpdate subclasses;
-      snapshot, statistics and encryption key updates are sent through the
-      TableUpdate.raw escape hatch.
     symbols:
+      - IcebergRestCatalog.dropNamespace
+  storage.analytics.create_table:
+    status: implemented
+    symbols:
+      - IcebergRestCatalog.createTable
+      - IcebergRestCatalog.createTableIfNotExists
+      - IcebergRestCatalog.createTableResult
+    supporting_symbols:
+      - CreateTableRequest
+      - CreateTableRequest.CreateTableRequest
+      - CreateTableRequest.location
+      - CreateTableRequest.name
+      - CreateTableRequest.partitionSpec
+      - CreateTableRequest.properties
+      - CreateTableRequest.schema
+      - CreateTableRequest.stageCreate
+      - CreateTableRequest.toJson
+      - CreateTableRequest.writeOrder
+  storage.analytics.list_tables:
+    status: implemented
+    symbols:
+      - IcebergRestCatalog.listTables
+    supporting_symbols:
+      - ListTablesOptions
+      - ListTablesOptions.ListTablesOptions
+      - ListTablesOptions.pageSize
+      - ListTablesOptions.pageToken
+      - ListTablesResult
+      - ListTablesResult.ListTablesResult
+      - ListTablesResult.identifiers
+      - ListTablesResult.nextPageToken
+  storage.analytics.load_table:
+    status: implemented
+    symbols:
+      - IcebergRestCatalog.loadTable
+      - IcebergRestCatalog.loadTableResult
+    supporting_symbols:
       - AccessDelegation
       - AccessDelegation.AccessDelegation
       - AccessDelegation.value
+      - LoadTableOptions
+      - LoadTableOptions.LoadTableOptions
+      - LoadTableOptions.ifNoneMatch
+      - LoadTableOptions.snapshots
+      - LoadTableResult
+      - LoadTableResult.LoadTableResult
+      - LoadTableResult.config
+      - LoadTableResult.etag
+      - LoadTableResult.fromJson
+      - LoadTableResult.metadata
+      - LoadTableResult.metadataLocation
+      - LoadTableResult.storageCredentials
+      - StorageCredential
+      - StorageCredential.StorageCredential
+      - StorageCredential.config
+      - StorageCredential.fromJson
+      - StorageCredential.prefix
+  storage.analytics.update_table:
+    status: implemented
+    note: Data definition table updates (schema, partition spec, sort order, properties, location) are modelled as typed TableUpdate subclasses; snapshot, statistics and encryption key updates are sent through the TableUpdate.raw escape hatch.
+    symbols:
+      - IcebergRestCatalog.updateTable
+    supporting_symbols:
       - AddPartitionSpecUpdate
       - AddPartitionSpecUpdate.AddPartitionSpecUpdate
       - AddPartitionSpecUpdate.spec
@@ -1098,125 +1144,11 @@ features:
       - CommitTableResult.CommitTableResult
       - CommitTableResult.metadata
       - CommitTableResult.metadataLocation
-      - CreateTableRequest
-      - CreateTableRequest.CreateTableRequest
-      - CreateTableRequest.location
-      - CreateTableRequest.name
-      - CreateTableRequest.partitionSpec
-      - CreateTableRequest.properties
-      - CreateTableRequest.schema
-      - CreateTableRequest.stageCreate
-      - CreateTableRequest.toJson
-      - CreateTableRequest.writeOrder
-      - IcebergAuthenticationTimeoutException
-      - IcebergAuthenticationTimeoutException.IcebergAuthenticationTimeoutException
-      - IcebergCommitStateUnknownException
-      - IcebergCommitStateUnknownException.IcebergCommitStateUnknownException
-      - IcebergConflictException
-      - IcebergConflictException.IcebergConflictException
-      - IcebergException
-      - IcebergException.IcebergException
-      - IcebergException.code
-      - IcebergException.details
-      - IcebergException.fromResponse
-      - IcebergException.message
-      - IcebergException.statusCode
-      - IcebergException.toString
-      - IcebergException.type
-      - IcebergNetworkException
-      - IcebergNetworkException.IcebergNetworkException
-      - IcebergNotFoundException
-      - IcebergNotFoundException.IcebergNotFoundException
-      - IcebergRestCatalog
-      - IcebergRestCatalog.IcebergRestCatalog
-      - IcebergRestCatalog.createTable
-      - IcebergRestCatalog.createTableIfNotExists
-      - IcebergRestCatalog.createTableResult
-      - IcebergRestCatalog.dropTable
-      - IcebergRestCatalog.listTables
-      - IcebergRestCatalog.loadTable
-      - IcebergRestCatalog.loadTableResult
-      - IcebergRestCatalog.registerTable
-      - IcebergRestCatalog.renameTable
-      - IcebergRestCatalog.tableExists
-      - IcebergRestCatalog.updateTable
-      - IcebergServerException
-      - IcebergServerException.IcebergServerException
-      - IcebergType
-      - IcebergType.IcebergType
-      - IcebergType.fromJson
-      - IcebergType.toJson
-      - IcebergUnknownException
-      - IcebergUnknownException.IcebergUnknownException
-      - ListTablesOptions
-      - ListTablesOptions.ListTablesOptions
-      - ListTablesOptions.pageSize
-      - ListTablesOptions.pageToken
-      - ListTablesResult
-      - ListTablesResult.ListTablesResult
-      - ListTablesResult.identifiers
-      - ListTablesResult.nextPageToken
-      - ListType
-      - ListType.ListType
-      - ListType.element
-      - ListType.elementId
-      - ListType.elementRequired
-      - ListType.fromJson
-      - ListType.toJson
-      - LoadTableOptions
-      - LoadTableOptions.LoadTableOptions
-      - LoadTableOptions.ifNoneMatch
-      - LoadTableOptions.snapshots
-      - LoadTableResult
-      - LoadTableResult.LoadTableResult
-      - LoadTableResult.config
-      - LoadTableResult.etag
-      - LoadTableResult.fromJson
-      - LoadTableResult.metadata
-      - LoadTableResult.metadataLocation
-      - LoadTableResult.storageCredentials
-      - MapType
-      - MapType.MapType
-      - MapType.fromJson
-      - MapType.key
-      - MapType.keyId
-      - MapType.toJson
-      - MapType.value
-      - MapType.valueId
-      - MapType.valueRequired
-      - NullOrder
-      - NullOrder.NullOrder
-      - NullOrder.fromValue
-      - NullOrder.value
-      - PartitionField
-      - PartitionField.PartitionField
-      - PartitionField.fieldId
-      - PartitionField.fromJson
-      - PartitionField.name
-      - PartitionField.sourceId
-      - PartitionField.toJson
-      - PartitionField.transform
-      - PartitionSpec
-      - PartitionSpec.PartitionSpec
-      - PartitionSpec.fields
-      - PartitionSpec.fromJson
-      - PartitionSpec.specId
-      - PartitionSpec.toJson
-      - PrimitiveType
-      - PrimitiveType.PrimitiveType
-      - PrimitiveType.name
-      - PrimitiveType.toJson
       - RawTableUpdate
       - RawTableUpdate.RawTableUpdate
       - RawTableUpdate.action
       - RawTableUpdate.body
       - RawTableUpdate.toJson
-      - RegisterTableRequest
-      - RegisterTableRequest.RegisterTableRequest
-      - RegisterTableRequest.metadataLocation
-      - RegisterTableRequest.name
-      - RegisterTableRequest.overwrite
-      - RegisterTableRequest.toJson
       - RemovePartitionSpecsUpdate
       - RemovePartitionSpecsUpdate.RemovePartitionSpecsUpdate
       - RemovePartitionSpecsUpdate.specIds
@@ -1262,109 +1194,9 @@ features:
       - SetSnapshotReferenceUpdate.reference
       - SetSnapshotReferenceUpdate.referenceName
       - SetSnapshotReferenceUpdate.toJson
-      - Snapshot
-      - Snapshot.Snapshot
-      - Snapshot.fromJson
-      - Snapshot.manifestList
-      - Snapshot.parentSnapshotId
-      - Snapshot.schemaId
-      - Snapshot.sequenceNumber
-      - Snapshot.snapshotId
-      - Snapshot.summary
-      - Snapshot.timestampMs
-      - Snapshot.toJson
-      - SnapshotReference
-      - SnapshotReference.SnapshotReference
-      - SnapshotReference.fromJson
-      - SnapshotReference.maxReferenceAgeMs
-      - SnapshotReference.maxSnapshotAgeMs
-      - SnapshotReference.minSnapshotsToKeep
-      - SnapshotReference.snapshotId
-      - SnapshotReference.toJson
-      - SnapshotReference.type
-      - SnapshotReferenceType
-      - SnapshotReferenceType.SnapshotReferenceType
-      - SnapshotReferenceType.fromValue
-      - SnapshotReferenceType.value
-      - SortDirection
-      - SortDirection.SortDirection
-      - SortDirection.fromValue
-      - SortDirection.value
-      - SortField
-      - SortField.SortField
-      - SortField.direction
-      - SortField.fromJson
-      - SortField.nullOrder
-      - SortField.sourceId
-      - SortField.toJson
-      - SortField.transform
-      - SortOrder
-      - SortOrder.SortOrder
-      - SortOrder.fields
-      - SortOrder.fromJson
-      - SortOrder.orderId
-      - SortOrder.toJson
-      - StorageCredential
-      - StorageCredential.StorageCredential
-      - StorageCredential.config
-      - StorageCredential.fromJson
-      - StorageCredential.prefix
-      - StructType
-      - StructType.StructType
-      - StructType.fields
-      - StructType.fromJson
-      - StructType.toJson
-      - SupabaseStorageClient.analyticsCatalog
-      - TableField
-      - TableField.TableField
-      - TableField.doc
-      - TableField.fromJson
-      - TableField.id
-      - TableField.initialDefault
-      - TableField.name
-      - TableField.required
-      - TableField.toJson
-      - TableField.type
-      - TableField.writeDefault
-      - TableIdentifier
-      - TableIdentifier.TableIdentifier
-      - TableIdentifier.fromJson
-      - TableIdentifier.name
-      - TableIdentifier.namespace
-      - TableIdentifier.toJson
-      - TableMetadata
-      - TableMetadata.TableMetadata
-      - TableMetadata.currentSchema
-      - TableMetadata.currentSchemaId
-      - TableMetadata.currentSnapshotId
-      - TableMetadata.defaultSortOrderId
-      - TableMetadata.defaultSpecId
-      - TableMetadata.formatVersion
-      - TableMetadata.fromJson
-      - TableMetadata.lastColumnId
-      - TableMetadata.lastUpdatedMs
-      - TableMetadata.location
-      - TableMetadata.metadataLocation
-      - TableMetadata.partitionSpecs
-      - TableMetadata.properties
-      - TableMetadata.refs
-      - TableMetadata.schemas
-      - TableMetadata.snapshots
-      - TableMetadata.sortOrders
-      - TableMetadata.tableUuid
       - TableRequirement
       - TableRequirement.TableRequirement
       - TableRequirement.toJson
-      - TableSchema
-      - TableSchema.TableSchema
-      - TableSchema.fields
-      - TableSchema.fromJson
-      - TableSchema.identifierFieldIds
-      - TableSchema.schemaId
-      - TableSchema.toJson
-      - TableSnapshotScope
-      - TableSnapshotScope.TableSnapshotScope
-      - TableSnapshotScope.value
       - TableUpdate
       - TableUpdate.TableUpdate
       - TableUpdate.raw
@@ -1373,6 +1205,14 @@ features:
       - UpgradeFormatVersionUpdate.UpgradeFormatVersionUpdate
       - UpgradeFormatVersionUpdate.formatVersion
       - UpgradeFormatVersionUpdate.toJson
+  storage.analytics.rename_table:
+    status: implemented
+    symbols:
+      - IcebergRestCatalog.renameTable
+  storage.analytics.delete_table:
+    status: implemented
+    symbols:
+      - IcebergRestCatalog.dropTable
 
   # realtime — channel
   realtime.channel.subscribe:
@@ -1383,7 +1223,7 @@ features:
     status: implemented
     symbols:
       - RealtimeChannel.unsubscribe
-  realtime.channel.send:
+  realtime.channel.broadcast:
     status: implemented
     symbols:
       - RealtimeChannel.sendBroadcastMessage
@@ -1623,3 +1463,187 @@ features:
       - TracePropagationOptions.enabled
       - TracePropagationOptions.respectSamplingDecision
       - TracePropagationOptions.traceContextProvider
+# Public API accounted for by the matrix but not attributable to one capability:
+# the Iceberg schema and type model, the exception hierarchy, and the catalog
+# operations the canonical matrix has no feature id for yet (registerTable,
+# tableExists, loadNamespaceMetadata, namespaceExists, updateNamespaceProperties).
+supporting_symbols:
+  - IcebergAuthenticationTimeoutException
+  - IcebergAuthenticationTimeoutException.IcebergAuthenticationTimeoutException
+  - IcebergCommitStateUnknownException
+  - IcebergCommitStateUnknownException.IcebergCommitStateUnknownException
+  - IcebergConflictException
+  - IcebergConflictException.IcebergConflictException
+  - IcebergException
+  - IcebergException.IcebergException
+  - IcebergException.code
+  - IcebergException.details
+  - IcebergException.fromResponse
+  - IcebergException.message
+  - IcebergException.statusCode
+  - IcebergException.toString
+  - IcebergException.type
+  - IcebergNetworkException
+  - IcebergNetworkException.IcebergNetworkException
+  - IcebergNotFoundException
+  - IcebergNotFoundException.IcebergNotFoundException
+  - IcebergRestCatalog
+  - IcebergRestCatalog.IcebergRestCatalog
+  - IcebergRestCatalog.loadNamespaceMetadata
+  - IcebergRestCatalog.namespaceExists
+  - IcebergRestCatalog.registerTable
+  - IcebergRestCatalog.tableExists
+  - IcebergRestCatalog.updateNamespaceProperties
+  - IcebergServerException
+  - IcebergServerException.IcebergServerException
+  - IcebergType
+  - IcebergType.IcebergType
+  - IcebergType.fromJson
+  - IcebergType.toJson
+  - IcebergUnknownException
+  - IcebergUnknownException.IcebergUnknownException
+  - ListType
+  - ListType.ListType
+  - ListType.element
+  - ListType.elementId
+  - ListType.elementRequired
+  - ListType.fromJson
+  - ListType.toJson
+  - MapType
+  - MapType.MapType
+  - MapType.fromJson
+  - MapType.key
+  - MapType.keyId
+  - MapType.toJson
+  - MapType.value
+  - MapType.valueId
+  - MapType.valueRequired
+  - NullOrder
+  - NullOrder.NullOrder
+  - NullOrder.fromValue
+  - NullOrder.value
+  - PartitionField
+  - PartitionField.PartitionField
+  - PartitionField.fieldId
+  - PartitionField.fromJson
+  - PartitionField.name
+  - PartitionField.sourceId
+  - PartitionField.toJson
+  - PartitionField.transform
+  - PartitionSpec
+  - PartitionSpec.PartitionSpec
+  - PartitionSpec.fields
+  - PartitionSpec.fromJson
+  - PartitionSpec.specId
+  - PartitionSpec.toJson
+  - PrimitiveType
+  - PrimitiveType.PrimitiveType
+  - PrimitiveType.name
+  - PrimitiveType.toJson
+  - RegisterTableRequest
+  - RegisterTableRequest.RegisterTableRequest
+  - RegisterTableRequest.metadataLocation
+  - RegisterTableRequest.name
+  - RegisterTableRequest.overwrite
+  - RegisterTableRequest.toJson
+  - Snapshot
+  - Snapshot.Snapshot
+  - Snapshot.fromJson
+  - Snapshot.manifestList
+  - Snapshot.parentSnapshotId
+  - Snapshot.schemaId
+  - Snapshot.sequenceNumber
+  - Snapshot.snapshotId
+  - Snapshot.summary
+  - Snapshot.timestampMs
+  - Snapshot.toJson
+  - SnapshotReference
+  - SnapshotReference.SnapshotReference
+  - SnapshotReference.fromJson
+  - SnapshotReference.maxReferenceAgeMs
+  - SnapshotReference.maxSnapshotAgeMs
+  - SnapshotReference.minSnapshotsToKeep
+  - SnapshotReference.snapshotId
+  - SnapshotReference.toJson
+  - SnapshotReference.type
+  - SnapshotReferenceType
+  - SnapshotReferenceType.SnapshotReferenceType
+  - SnapshotReferenceType.fromValue
+  - SnapshotReferenceType.value
+  - SortDirection
+  - SortDirection.SortDirection
+  - SortDirection.fromValue
+  - SortDirection.value
+  - SortField
+  - SortField.SortField
+  - SortField.direction
+  - SortField.fromJson
+  - SortField.nullOrder
+  - SortField.sourceId
+  - SortField.toJson
+  - SortField.transform
+  - SortOrder
+  - SortOrder.SortOrder
+  - SortOrder.fields
+  - SortOrder.fromJson
+  - SortOrder.orderId
+  - SortOrder.toJson
+  - StructType
+  - StructType.StructType
+  - StructType.fields
+  - StructType.fromJson
+  - StructType.toJson
+  - SupabaseStorageClient.analyticsCatalog
+  - TableField
+  - TableField.TableField
+  - TableField.doc
+  - TableField.fromJson
+  - TableField.id
+  - TableField.initialDefault
+  - TableField.name
+  - TableField.required
+  - TableField.toJson
+  - TableField.type
+  - TableField.writeDefault
+  - TableIdentifier
+  - TableIdentifier.TableIdentifier
+  - TableIdentifier.fromJson
+  - TableIdentifier.name
+  - TableIdentifier.namespace
+  - TableIdentifier.toJson
+  - TableMetadata
+  - TableMetadata.TableMetadata
+  - TableMetadata.currentSchema
+  - TableMetadata.currentSchemaId
+  - TableMetadata.currentSnapshotId
+  - TableMetadata.defaultSortOrderId
+  - TableMetadata.defaultSpecId
+  - TableMetadata.formatVersion
+  - TableMetadata.fromJson
+  - TableMetadata.lastColumnId
+  - TableMetadata.lastUpdatedMs
+  - TableMetadata.location
+  - TableMetadata.metadataLocation
+  - TableMetadata.partitionSpecs
+  - TableMetadata.properties
+  - TableMetadata.refs
+  - TableMetadata.schemas
+  - TableMetadata.snapshots
+  - TableMetadata.sortOrders
+  - TableMetadata.tableUuid
+  - TableSchema
+  - TableSchema.TableSchema
+  - TableSchema.fields
+  - TableSchema.fromJson
+  - TableSchema.identifierFieldIds
+  - TableSchema.schemaId
+  - TableSchema.toJson
+  - TableSnapshotScope
+  - TableSnapshotScope.TableSnapshotScope
+  - TableSnapshotScope.value
+  - UpdateNamespacePropertiesResult
+  - UpdateNamespacePropertiesResult.UpdateNamespacePropertiesResult
+  - UpdateNamespacePropertiesResult.fromJson
+  - UpdateNamespacePropertiesResult.missing
+  - UpdateNamespacePropertiesResult.removed
+  - UpdateNamespacePropertiesResult.updated


### PR DESCRIPTION
## Summary

Reconciles `sdk-compliance.yaml` with three upstream changes that have now landed in `supabase/sdk`:

- **supabase/sdk#74** renamed and split several canonical feature IDs.
- **supabase/sdk#75** separated symbol *evidence* from symbol *coverage*, adding `supporting_symbols`.
- **supabase/sdk#76** added the five Iceberg catalog capabilities that #74's split left without an ID.

### Renames and merges

- `auth.sign_in.reset_password` → `auth.sign_in.send_password_reset_email`
- `realtime.channel.send` → `realtime.channel.broadcast`
- `storage.file_buckets.list_files_paginated` merged into `list_files`
- `storage.analytics.iceberg_namespace` split into `create_namespace` / `list_namespaces` / `delete_namespace`
- `storage.analytics.iceberg_table` split into `create_table` / `list_tables` / `load_table` / `update_table` / `rename_table` / `delete_table`

### New capabilities declared

`load_namespace_metadata`, `namespace_exists`, `update_namespace_properties`, `register_table`, `table_exists`.

## Why the Iceberg entries look the way they do

Splitting two bundled entries into fifteen raises the question of which symbols belong where. The Iceberg surface is 352 symbols, only 18 of which are catalog entry points; the rest are option types, result types, the schema and type model, and the exception hierarchy.

`symbols` now holds **only** the methods a caller invokes, because the drift check treats every name in it as evidence the capability exists. Everything else sits under `supporting_symbols`, which counts for new-symbol coverage without claiming to implement anything.

Owners for the supporting types are derived from the source rather than assigned by hand: build the type graph from `packages/storage_client/lib/src/iceberg/`, including subtype edges since a signature naming a sealed base reaches every variant a caller can pass, then ask which entry points reach each type. A type reachable from exactly one feature belongs to that feature.

| | count |
|---|---|
| Sole natural owner | 37 of 67 |
| Genuinely shared across several features | 20 |
| Reachable from no entry point (thrown, not passed) | 10 |

So all 28 `*Update` and `Assert*` classes land on `update_table`, `ListTablesOptions`/`ListTablesResult` on `list_tables`, `RegisterTableRequest` on `register_table`. The schema and type model and the exception hierarchy stay in the top-level `supporting_symbols` list, which is the honest answer rather than a coin flip.

The alternative was to replicate the full 330-symbol list across all six table IDs and the 22-symbol list across all three namespace IDs (+1729 lines, as in the now-closed #1666). That inflates what the file claims is implemented, fans drift findings across features that do not own the symbol, and leaves attribution arbitrary, since `buildSymbolIndex` last-wins on collision. Under that shape only 2 of 9 split features resolved to their own entry point; here it is 9 of 9.

## Test plan

Validated against current `supabase/sdk@main`, with #74, #75 and #76 all merged:

- [x] `validate-compliance`: `OK — compliance file is valid.` Two features remain undeclared (`postgres_changes_multiple_filters`, `error_codes`); both are pre-existing and out of scope here.
- [x] `check-drift` against symbols extracted with the real Dart extractor: `✅ No capability matrix drift detected.`
- [x] `check-api-symbols`: all public API accounted for; 887 symbols covered, unchanged from before this PR.
- [x] Verified no unintended edits: every feature outside the rename and split scope is byte-identical to `main` after re-serialization.
- [x] CI re-run after the upstream merges: `Validate compliance file` and `Check public API against capability matrix` both green.

No SDK code changes, only capability declarations.

Context: [SDK-1439](https://linear.app/supabase/issue/SDK-1439)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Standardized capability names for password reset and realtime broadcast functionality.
  * Clarified storage file listing capabilities, including pagination and sorting support.
  * Added more granular capability definitions for Iceberg namespaces and tables.
  * Consolidated shared Iceberg models, errors, catalog access, and supporting symbols for more consistent capability descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->