### PR TITLE
fix!: release retained resources on dispose

### DIFF
--- a/examples/database_crud/lib/main.dart
+++ b/examples/database_crud/lib/main.dart
@@ -158,27 +158,9 @@ class _TasksPageState extends State<TasksPage> {
   }
 
   Future<void> _rename(Task task) async {
-    final controller = TextEditingController(text: task.title);
     final title = await showDialog<String>(
       context: context,
-      builder: (context) => AlertDialog(
-        title: const Text('Rename task'),
-        content: TextField(
-          controller: controller,
-          autofocus: true,
-          decoration: const InputDecoration(labelText: 'Title'),
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(context),
-            child: const Text('Cancel'),
-          ),
-          FilledButton(
-            onPressed: () => Navigator.pop(context, controller.text.trim()),
-            child: const Text('Save'),
-          ),
-        ],
-      ),
+      builder: (context) => _RenameDialog(initialTitle: task.title),
     );
     if (title == null || title.isEmpty) return;
     await _mutate(() => _repository.renameTask(id: task.id, title: title));
@@ -372,6 +354,52 @@ class _TaskFormResult {
   final String projectId;
   final String title;
   final Priority priority;
+}
+
+/// Asks for a new title for an existing task.
+///
+/// Owns its [TextEditingController] so that it is disposed together with the
+/// dialog. Creating the controller in the caller instead would either leak it
+/// or dispose it while the route is still animating out.
+class _RenameDialog extends StatefulWidget {
+  const _RenameDialog({required this.initialTitle});
+
+  final String initialTitle;
+
+  @override
+  State<_RenameDialog> createState() => _RenameDialogState();
+}
+
+class _RenameDialogState extends State<_RenameDialog> {
+  late final _title = TextEditingController(text: widget.initialTitle);
+
+  @override
+  void dispose() {
+    _title.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('Rename task'),
+      content: TextField(
+        controller: _title,
+        autofocus: true,
+        decoration: const InputDecoration(labelText: 'Title'),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          onPressed: () => Navigator.pop(context, _title.text.trim()),
+          child: const Text('Save'),
+        ),
+      ],
+    );
+  }
 }
 
 class _TaskDialog extends StatefulWidget {

--- a/examples/passkeys/lib/main.dart
+++ b/examples/passkeys/lib/main.dart
@@ -159,6 +159,52 @@ class _SignInViewState extends State<SignInView> {
   }
 }
 
+/// Asks for a new friendly name for an existing passkey.
+///
+/// Owns its [TextEditingController] so that it is disposed together with the
+/// dialog. Creating the controller in the caller instead would either leak it
+/// or dispose it while the route is still animating out.
+class _RenameDialog extends StatefulWidget {
+  const _RenameDialog({required this.initialName});
+
+  final String initialName;
+
+  @override
+  State<_RenameDialog> createState() => _RenameDialogState();
+}
+
+class _RenameDialogState extends State<_RenameDialog> {
+  late final _name = TextEditingController(text: widget.initialName);
+
+  @override
+  void dispose() {
+    _name.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('Rename passkey'),
+      content: TextField(
+        controller: _name,
+        autofocus: true,
+        decoration: const InputDecoration(labelText: 'Friendly name'),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          onPressed: () => Navigator.pop(context, _name.text),
+          child: const Text('Save'),
+        ),
+      ],
+    );
+  }
+}
+
 /// Lists, registers, renames and deletes passkeys for the signed in user.
 class SignedInView extends StatefulWidget {
   const SignedInView({super.key});
@@ -201,27 +247,10 @@ class _SignedInViewState extends State<SignedInView> {
   }
 
   Future<void> _rename(Passkey passkey) async {
-    final controller = TextEditingController(text: passkey.friendlyName);
     final name = await showDialog<String>(
       context: context,
-      builder: (context) => AlertDialog(
-        title: const Text('Rename passkey'),
-        content: TextField(
-          controller: controller,
-          autofocus: true,
-          decoration: const InputDecoration(labelText: 'Friendly name'),
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(context),
-            child: const Text('Cancel'),
-          ),
-          FilledButton(
-            onPressed: () => Navigator.pop(context, controller.text),
-            child: const Text('Save'),
-          ),
-        ],
-      ),
+      builder: (context) =>
+          _RenameDialog(initialName: passkey.friendlyName ?? ''),
     );
     if (name == null || name.isEmpty) return;
     try {

--- a/examples/passkeys/lib/main.dart
+++ b/examples/passkeys/lib/main.dart
@@ -197,7 +197,7 @@ class _RenameDialogState extends State<_RenameDialog> {
           child: const Text('Cancel'),
         ),
         FilledButton(
-          onPressed: () => Navigator.pop(context, _name.text),
+          onPressed: () => Navigator.pop(context, _name.text.trim()),
           child: const Text('Save'),
         ),
       ],

--- a/packages/supabase_flutter/lib/src/supabase.dart
+++ b/packages/supabase_flutter/lib/src/supabase.dart
@@ -230,6 +230,7 @@ class Supabase {
     final lifecycleListener = _lifecycleListener;
     final restoreSession = _restoreSessionCancellableOperation;
     final logSubscription = _logSubscription;
+    final pendingLifecycleOperation = _pendingLifecycleOperation;
 
     _client = null;
     _supabaseAuth = null;
@@ -240,8 +241,7 @@ class Supabase {
     _isInitialized = false;
 
     // Stop listening before anything is awaited, so no lifecycle event can be
-    // queued while the client is being torn down. Operations queued earlier
-    // see the cleared [_targetLifecycleState] and abort as stale.
+    // queued while the client is being torn down.
     _targetLifecycleState = null;
     lifecycleListener?.dispose();
 
@@ -251,6 +251,11 @@ class Supabase {
     await _disposeAll([
       () => restoreSession?.cancel(),
       () => logSubscription?.cancel(),
+      // A lifecycle operation that already passed its stale check can be
+      // half way through `realtime.connect()`. Clearing the target state
+      // stops it rejoining channels but not the connect itself, so wait for
+      // it rather than let it race the disconnect below.
+      () => pendingLifecycleOperation,
       currentClient.dispose,
       () => supabaseAuth?.dispose(),
     ]);

--- a/packages/supabase_flutter/lib/src/supabase.dart
+++ b/packages/supabase_flutter/lib/src/supabase.dart
@@ -175,14 +175,17 @@ class Supabase {
 
   /// The supabase client for this instance
   ///
-  /// Throws an error if [Supabase.initialize] was not called.
+  /// Throws a [StateError] if [Supabase.initialize] was not called, or if the
+  /// instance has since been disposed.
   SupabaseClient get client {
-    assert(
-      _client != null,
-      'You must initialize the supabase instance before calling '
-      'Supabase.instance.client',
-    );
-    return _client!;
+    final currentClient = _client;
+    if (currentClient == null) {
+      throw StateError(
+        'You must initialize the supabase instance before calling '
+        'Supabase.instance.client',
+      );
+    }
+    return currentClient;
   }
 
   SupabaseAuth? _supabaseAuth;
@@ -211,25 +214,37 @@ class Supabase {
   StreamSubscription<dynamic>? _logSubscription;
 
   /// Dispose the instance to free up resources.
+  ///
+  /// Calling this on an instance that is not initialized does nothing, so it
+  /// is safe to call more than once.
   Future<void> dispose() async {
-    _targetLifecycleState = null;
-    await _restoreSessionCancellableOperation?.cancel();
-    await _logSubscription?.cancel();
-    await client.dispose();
-    _supabaseAuth?.dispose();
-    _lifecycleListener?.dispose();
+    final currentClient = _client;
+    if (currentClient == null) return;
 
-    // Drop every reference the singleton holds. Without this the disposed
-    // client and its whole graph (auth, realtime, http clients) stay reachable
-    // from a static field for the rest of the process.
-    _restoreSessionCancellableOperation = null;
-    _logSubscription = null;
+    // Drop every reference the singleton holds before tearing anything down.
+    // Without this the disposed client and its whole graph (auth, realtime,
+    // http clients) stay reachable from a static field for the rest of the
+    // process, and doing it up front means a teardown step that throws cannot
+    // leave the singleton pinning a half-disposed client.
+    final supabaseAuth = _supabaseAuth;
+    final lifecycleListener = _lifecycleListener;
+    final restoreSession = _restoreSessionCancellableOperation;
+    final logSubscription = _logSubscription;
+
     _client = null;
     _supabaseAuth = null;
     _lifecycleListener = null;
+    _restoreSessionCancellableOperation = null;
+    _logSubscription = null;
+    _targetLifecycleState = null;
     _pendingLifecycleOperation = Future.value();
-
     _isInitialized = false;
+
+    await restoreSession?.cancel();
+    await logSubscription?.cancel();
+    await currentClient.dispose();
+    supabaseAuth?.dispose();
+    lifecycleListener?.dispose();
   }
 
   void _init(
@@ -248,7 +263,7 @@ class Supabase {
       ...Constants.defaultHeaders,
       ...?customHeaders,
     };
-    final client = _client = SupabaseClient(
+    final newClient = _client = SupabaseClient(
       supabaseUrl,
       supabaseKey,
       httpClient: httpClient,
@@ -265,7 +280,7 @@ class Supabase {
     // flutter web hot-restart.
     if (kDebugMode) {
       disposePreviousClient();
-      markClientToDispose(client);
+      markClientToDispose(newClient);
     }
 
     _setupLifecycleListener();

--- a/packages/supabase_flutter/lib/src/supabase.dart
+++ b/packages/supabase_flutter/lib/src/supabase.dart
@@ -236,15 +236,44 @@ class Supabase {
     _lifecycleListener = null;
     _restoreSessionCancellableOperation = null;
     _logSubscription = null;
-    _targetLifecycleState = null;
     _pendingLifecycleOperation = Future.value();
     _isInitialized = false;
 
-    await restoreSession?.cancel();
-    await logSubscription?.cancel();
-    await currentClient.dispose();
-    supabaseAuth?.dispose();
+    // Stop listening before anything is awaited, so no lifecycle event can be
+    // queued while the client is being torn down. Operations queued earlier
+    // see the cleared [_targetLifecycleState] and abort as stale.
+    _targetLifecycleState = null;
     lifecycleListener?.dispose();
+
+    // Every step runs even if an earlier one throws, otherwise a failure part
+    // way through would leave the rest of the graph alive. The first error is
+    // rethrown once everything has been attempted.
+    await _disposeAll([
+      () => restoreSession?.cancel(),
+      () => logSubscription?.cancel(),
+      currentClient.dispose,
+      () => supabaseAuth?.dispose(),
+    ]);
+  }
+
+  /// Runs every step, then rethrows the first error any of them threw.
+  static Future<void> _disposeAll(List<FutureOr<void> Function()> steps) async {
+    Object? firstError;
+    StackTrace? firstStackTrace;
+
+    for (final step in steps) {
+      try {
+        await step();
+      } catch (error, stackTrace) {
+        _log.warning('Error while disposing Supabase', error, stackTrace);
+        firstError ??= error;
+        firstStackTrace ??= stackTrace;
+      }
+    }
+
+    if (firstError != null) {
+      Error.throwWithStackTrace(firstError, firstStackTrace!);
+    }
   }
 
   void _init(

--- a/packages/supabase_flutter/lib/src/supabase.dart
+++ b/packages/supabase_flutter/lib/src/supabase.dart
@@ -221,11 +221,6 @@ class Supabase {
     final currentClient = _client;
     if (currentClient == null) return;
 
-    // Drop every reference the singleton holds before tearing anything down.
-    // Without this the disposed client and its whole graph (auth, realtime,
-    // http clients) stay reachable from a static field for the rest of the
-    // process, and doing it up front means a teardown step that throws cannot
-    // leave the singleton pinning a half-disposed client.
     final supabaseAuth = _supabaseAuth;
     final lifecycleListener = _lifecycleListener;
     final restoreSession = _restoreSessionCancellableOperation;
@@ -234,27 +229,17 @@ class Supabase {
 
     _client = null;
     _supabaseAuth = null;
-    _lifecycleListener = null;
     _restoreSessionCancellableOperation = null;
+    _lifecycleListener = null;
     _logSubscription = null;
-    _pendingLifecycleOperation = Future.value();
     _isInitialized = false;
 
-    // Stop listening before anything is awaited, so no lifecycle event can be
-    // queued while the client is being torn down.
     _targetLifecycleState = null;
     lifecycleListener?.dispose();
 
-    // Every step runs even if an earlier one throws, otherwise a failure part
-    // way through would leave the rest of the graph alive. The first error is
-    // rethrown once everything has been attempted.
     await _disposeAll([
       () => restoreSession?.cancel(),
       () => logSubscription?.cancel(),
-      // A lifecycle operation that already passed its stale check can be
-      // half way through `realtime.connect()`. Clearing the target state
-      // stops it rejoining channels but not the connect itself, so wait for
-      // it rather than let it race the disconnect below.
       () => pendingLifecycleOperation,
       currentClient.dispose,
       () => supabaseAuth?.dispose(),

--- a/packages/supabase_flutter/lib/src/supabase.dart
+++ b/packages/supabase_flutter/lib/src/supabase.dart
@@ -171,10 +171,19 @@ class Supabase {
   /// Whether the Supabase instance has been initialized. Useful for debugging.
   bool get isInitialized => _isInitialized;
 
+  SupabaseClient? _client;
+
   /// The supabase client for this instance
   ///
   /// Throws an error if [Supabase.initialize] was not called.
-  late SupabaseClient client;
+  SupabaseClient get client {
+    assert(
+      _client != null,
+      'You must initialize the supabase instance before calling '
+      'Supabase.instance.client',
+    );
+    return _client!;
+  }
 
   SupabaseAuth? _supabaseAuth;
 
@@ -207,8 +216,19 @@ class Supabase {
     await _restoreSessionCancellableOperation?.cancel();
     await _logSubscription?.cancel();
     await client.dispose();
-    _instance._supabaseAuth?.dispose();
+    _supabaseAuth?.dispose();
     _lifecycleListener?.dispose();
+
+    // Drop every reference the singleton holds. Without this the disposed
+    // client and its whole graph (auth, realtime, http clients) stay reachable
+    // from a static field for the rest of the process.
+    _restoreSessionCancellableOperation = null;
+    _logSubscription = null;
+    _client = null;
+    _supabaseAuth = null;
+    _lifecycleListener = null;
+    _pendingLifecycleOperation = Future.value();
+
     _isInitialized = false;
   }
 
@@ -228,7 +248,7 @@ class Supabase {
       ...Constants.defaultHeaders,
       ...?customHeaders,
     };
-    client = SupabaseClient(
+    final client = _client = SupabaseClient(
       supabaseUrl,
       supabaseKey,
       httpClient: httpClient,

--- a/packages/supabase_flutter/test/initialization_test.dart
+++ b/packages/supabase_flutter/test/initialization_test.dart
@@ -143,6 +143,23 @@ void main() {
         );
       });
 
+      test('dispose drops the reference to the client', () async {
+        await Supabase.initialize(
+          url: supabaseUrl,
+          publishableKey: supabaseKey,
+          debug: false,
+        );
+
+        // Captured while still initialized, because `Supabase.instance`
+        // itself refuses to hand out a disposed instance.
+        final supabase = Supabase.instance;
+        await supabase.dispose();
+
+        // The singleton is static, so holding on to the client here would
+        // keep it and everything it owns alive for the rest of the process.
+        expect(() => supabase.client, throwsA(isA<AssertionError>()));
+      });
+
       test('handles multiple initializations correctly', () async {
         await Supabase.initialize(
           url: supabaseUrl,

--- a/packages/supabase_flutter/test/initialization_test.dart
+++ b/packages/supabase_flutter/test/initialization_test.dart
@@ -150,13 +150,9 @@ void main() {
           debug: false,
         );
 
-        // Captured while still initialized, because `Supabase.instance`
-        // itself refuses to hand out a disposed instance.
         final supabase = Supabase.instance;
         await supabase.dispose();
 
-        // The singleton is static, so holding on to the client here would
-        // keep it and everything it owns alive for the rest of the process.
         expect(() => supabase.client, throwsStateError);
       });
 

--- a/packages/supabase_flutter/test/initialization_test.dart
+++ b/packages/supabase_flutter/test/initialization_test.dart
@@ -157,7 +157,20 @@ void main() {
 
         // The singleton is static, so holding on to the client here would
         // keep it and everything it owns alive for the rest of the process.
-        expect(() => supabase.client, throwsA(isA<AssertionError>()));
+        expect(() => supabase.client, throwsStateError);
+      });
+
+      test('dispose can be called more than once', () async {
+        await Supabase.initialize(
+          url: supabaseUrl,
+          publishableKey: supabaseKey,
+          debug: false,
+        );
+
+        final supabase = Supabase.instance;
+        await supabase.dispose();
+
+        await expectLater(supabase.dispose(), completes);
       });
 
       test('handles multiple initializations correctly', () async {

--- a/packages/supabase_flutter/test/widget_test.dart
+++ b/packages/supabase_flutter/test/widget_test.dart
@@ -15,10 +15,6 @@ void main() {
   testWidgets('Signing out triggers AuthChangeEvent.signedOut event', (
     tester,
   ) async {
-    // Initialize the Supabase singleton. `runAsync` is required because the
-    // client spawns the JSON isolate, and the fake clock of `testWidgets`
-    // would never let `Isolate.spawn` complete, which in turn would make
-    // `dispose()` wait forever.
     await tester.runAsync(
       () => Supabase.initialize(
         url: supabaseUrl,
@@ -30,8 +26,6 @@ void main() {
         ),
       ),
     );
-    // Registered before the assertions below, so a failing one cannot leave
-    // the singleton and its `AppLifecycleListener` alive for later tests.
     addTearDown(() => tester.runAsync(() => Supabase.instance.dispose()));
 
     Supabase.instance.client.auth.stopAutoRefresh();

--- a/packages/supabase_flutter/test/widget_test.dart
+++ b/packages/supabase_flutter/test/widget_test.dart
@@ -18,7 +18,7 @@ void main() {
     // Initialize the Supabase singleton. `runAsync` is required because the
     // client spawns the JSON isolate, and the fake clock of `testWidgets`
     // would never let `Isolate.spawn` complete, which in turn would make
-    // `dispose()` below wait forever.
+    // `dispose()` wait forever.
     await tester.runAsync(
       () => Supabase.initialize(
         url: supabaseUrl,
@@ -30,14 +30,14 @@ void main() {
         ),
       ),
     );
+    // Registered before the assertions below, so a failing one cannot leave
+    // the singleton and its `AppLifecycleListener` alive for later tests.
+    addTearDown(() => tester.runAsync(() => Supabase.instance.dispose()));
+
     Supabase.instance.client.auth.stopAutoRefresh();
     await tester.pumpWidget(const MaterialApp(home: MockWidget()));
     await tester.tap(find.text('Sign out'));
     await tester.pumpAndSettle();
     expect(find.text('You have signed out'), findsOneWidget);
-
-    // Tear the singleton down so the `AppLifecycleListener` it owns is
-    // disposed and leak tracking passes.
-    await tester.runAsync(() => Supabase.instance.dispose());
   });
 }

--- a/packages/supabase_flutter/test/widget_test.dart
+++ b/packages/supabase_flutter/test/widget_test.dart
@@ -15,14 +15,19 @@ void main() {
   testWidgets('Signing out triggers AuthChangeEvent.signedOut event', (
     tester,
   ) async {
-    // Initialize the Supabase singleton
-    await Supabase.initialize(
-      url: supabaseUrl,
-      publishableKey: supabaseKey,
-      debug: false,
-      authOptions: FlutterAuthClientOptions(
-        localStorage: const MockLocalStorage(),
-        pkceAsyncStorage: MockAsyncStorage(),
+    // Initialize the Supabase singleton. `runAsync` is required because the
+    // client spawns the JSON isolate, and the fake clock of `testWidgets`
+    // would never let `Isolate.spawn` complete, which in turn would make
+    // `dispose()` below wait forever.
+    await tester.runAsync(
+      () => Supabase.initialize(
+        url: supabaseUrl,
+        publishableKey: supabaseKey,
+        debug: false,
+        authOptions: FlutterAuthClientOptions(
+          localStorage: const MockLocalStorage(),
+          pkceAsyncStorage: MockAsyncStorage(),
+        ),
       ),
     );
     Supabase.instance.client.auth.stopAutoRefresh();
@@ -30,5 +35,9 @@ void main() {
     await tester.tap(find.text('Sign out'));
     await tester.pumpAndSettle();
     expect(find.text('You have signed out'), findsOneWidget);
+
+    // Tear the singleton down so the `AppLifecycleListener` it owns is
+    // disposed and leak tracking passes.
+    await tester.runAsync(() => Supabase.instance.dispose());
   });
 }

--- a/packages/supabase_flutter/test/widget_test_stubs.dart
+++ b/packages/supabase_flutter/test/widget_test_stubs.dart
@@ -19,6 +19,7 @@ class MockWidget extends StatefulWidget {
 
 class _MockWidgetState extends State<MockWidget> {
   bool isSignedIn = true;
+  StreamSubscription<AuthState>? _authSubscription;
 
   @override
   Widget build(BuildContext context) {
@@ -37,13 +38,21 @@ class _MockWidgetState extends State<MockWidget> {
   @override
   void initState() {
     super.initState();
-    Supabase.instance.client.auth.onAuthStateChange.listen((data) {
+    _authSubscription = Supabase.instance.client.auth.onAuthStateChange.listen((
+      data,
+    ) {
       if (data.event == AuthChangeEvent.signedOut) {
         setState(() {
           isSignedIn = false;
         });
       }
     });
+  }
+
+  @override
+  void dispose() {
+    unawaited(_authSubscription?.cancel());
+    super.dispose();
   }
 }
 

--- a/packages/yet_another_json_isolate/lib/src/_isolates_io.dart
+++ b/packages/yet_another_json_isolate/lib/src/_isolates_io.dart
@@ -63,9 +63,6 @@ class YAJsonIsolate {
 
   Future<void> _dispose() async {
     if (!_hasStartedInitialize) {
-      // No isolate was ever spawned, so there is nothing to shut down and
-      // [_createdIsolate] would never complete. The receive port is open from
-      // construction though, and keeps this object alive until it is closed.
       _receivePort.close();
       return;
     }

--- a/packages/yet_another_json_isolate/lib/src/_isolates_io.dart
+++ b/packages/yet_another_json_isolate/lib/src/_isolates_io.dart
@@ -20,12 +20,21 @@ class YAJsonIsolate {
   final _createdIsolate = Completer<void>();
   late final _events = StreamQueue(_receivePort);
   bool _hasStartedInitialize = false;
-  bool _isDisposed = false;
+  Future<void>? _disposal;
+
+  bool get _isDisposed => _disposal != null;
+
+  void _throwIfDisposed() {
+    if (_isDisposed) {
+      throw StateError('This YAJsonIsolate has already been disposed.');
+    }
+  }
 
   /// Initialize the isolate
   ///
   /// This method is called automatically when the first method is called. Manually initializing before first json de/encode can improve performance.
   Future<void> initialize() async {
+    _throwIfDisposed();
     assert(
       _hasStartedInitialize == false,
       'initialize() can only be called once per isolate.',
@@ -45,11 +54,12 @@ class YAJsonIsolate {
   /// Dispose the isolate
   ///
   /// This exits the isolate. Safe to call more than once, and safe to call on
-  /// an instance that was never used.
-  Future<void> dispose() async {
-    if (_isDisposed) return;
-    _isDisposed = true;
+  /// an instance that was never used. Concurrent calls all await the same
+  /// shutdown, so awaiting any of them means the isolate is gone. Using the
+  /// instance afterwards throws a [StateError].
+  Future<void> dispose() => _disposal ??= _dispose();
 
+  Future<void> _dispose() async {
     if (!_hasStartedInitialize) {
       // No isolate was ever spawned, so there is nothing to shut down and
       // [_createdIsolate] would never complete. The receive port is open from
@@ -65,6 +75,7 @@ class YAJsonIsolate {
   }
 
   Future<dynamic> decode(String json) async {
+    _throwIfDisposed();
     if (!_createdIsolate.isCompleted) {
       if (!_hasStartedInitialize) await initialize();
       await _createdIsolate.future;
@@ -74,6 +85,7 @@ class YAJsonIsolate {
   }
 
   Future<String> encode(Object? json) async {
+    _throwIfDisposed();
     if (!_createdIsolate.isCompleted) {
       if (!_hasStartedInitialize) await initialize();
       await _createdIsolate.future;

--- a/packages/yet_another_json_isolate/lib/src/_isolates_io.dart
+++ b/packages/yet_another_json_isolate/lib/src/_isolates_io.dart
@@ -20,6 +20,7 @@ class YAJsonIsolate {
   final _createdIsolate = Completer<void>();
   late final _events = StreamQueue(_receivePort);
   bool _hasStartedInitialize = false;
+  bool _isDisposed = false;
 
   /// Initialize the isolate
   ///
@@ -43,8 +44,20 @@ class YAJsonIsolate {
 
   /// Dispose the isolate
   ///
-  /// This exits the isolate
+  /// This exits the isolate. Safe to call more than once, and safe to call on
+  /// an instance that was never used.
   Future<void> dispose() async {
+    if (_isDisposed) return;
+    _isDisposed = true;
+
+    if (!_hasStartedInitialize) {
+      // No isolate was ever spawned, so there is nothing to shut down and
+      // [_createdIsolate] would never complete. The receive port is open from
+      // construction though, and keeps this object alive until it is closed.
+      _receivePort.close();
+      return;
+    }
+
     await _createdIsolate.future;
     _sendPort.send(null);
     _receivePort.close();

--- a/packages/yet_another_json_isolate/lib/src/_isolates_io.dart
+++ b/packages/yet_another_json_isolate/lib/src/_isolates_io.dart
@@ -32,7 +32,9 @@ class YAJsonIsolate {
 
   /// Initialize the isolate
   ///
-  /// This method is called automatically when the first method is called. Manually initializing before first json de/encode can improve performance.
+  /// This method is called automatically when the first method is called.
+  /// Manually initializing before the first JSON decode or encode can improve
+  /// performance.
   Future<void> initialize() async {
     _throwIfDisposed();
     assert(

--- a/packages/yet_another_json_isolate/test/yet_another_json_isolate_io_test.dart
+++ b/packages/yet_another_json_isolate/test/yet_another_json_isolate_io_test.dart
@@ -35,5 +35,39 @@ void main() {
         completes,
       );
     });
+
+    test('concurrent dispose calls all await the same shutdown', () async {
+      final isolate = YAJsonIsolate();
+      await isolate.decode('{}');
+
+      // Started before either is awaited, so a second call must not report
+      // the isolate as gone while the first is still shutting it down.
+      final first = isolate.dispose();
+      final second = isolate.dispose();
+
+      await expectLater(
+        Future.wait([first, second]).timeout(const Duration(seconds: 5)),
+        completes,
+      );
+    });
+
+    test('using the isolate after dispose throws', () async {
+      final isolate = YAJsonIsolate();
+      await isolate.decode('{}');
+      await isolate.dispose();
+
+      // Without this the calls below would spawn a replacement isolate onto a
+      // closed receive port and then wait for a reply that never arrives.
+      expect(isolate.decode('{}'), throwsStateError);
+      expect(isolate.encode({}), throwsStateError);
+      expect(isolate.initialize(), throwsStateError);
+    });
+
+    test('a never used isolate also rejects work after dispose', () async {
+      final isolate = YAJsonIsolate();
+      await isolate.dispose();
+
+      expect(isolate.decode('{}'), throwsStateError);
+    });
   });
 }

--- a/packages/yet_another_json_isolate/test/yet_another_json_isolate_io_test.dart
+++ b/packages/yet_another_json_isolate/test/yet_another_json_isolate_io_test.dart
@@ -39,8 +39,6 @@ void main() {
       final isolate = YAJsonIsolate();
       await isolate.decode('{}');
 
-      // Started before either is awaited, so a second call must not report
-      // the isolate as gone while the first is still shutting it down.
       final first = isolate.dispose();
       final second = isolate.dispose();
       expect(identical(first, second), isTrue);
@@ -56,8 +54,6 @@ void main() {
       await isolate.decode('{}');
       await dispose(isolate);
 
-      // Without this the calls below would spawn a replacement isolate onto a
-      // closed receive port and then wait for a reply that never arrives.
       expect(isolate.decode('{}'), throwsStateError);
       expect(isolate.encode({}), throwsStateError);
       expect(isolate.initialize(), throwsStateError);

--- a/packages/yet_another_json_isolate/test/yet_another_json_isolate_io_test.dart
+++ b/packages/yet_another_json_isolate/test/yet_another_json_isolate_io_test.dart
@@ -41,10 +41,14 @@ void main() {
 
       // Started before either is awaited, so a second call must not report
       // the isolate as gone while the first is still shutting it down.
-      final first = dispose(isolate);
-      final second = dispose(isolate);
+      final first = isolate.dispose();
+      final second = isolate.dispose();
+      expect(identical(first, second), isTrue);
 
-      await expectLater(Future.wait([first, second]), completes);
+      await expectLater(
+        Future.wait([first, second]).timeout(const Duration(seconds: 5)),
+        completes,
+      );
     });
 
     test('using the isolate after dispose throws', () async {

--- a/packages/yet_another_json_isolate/test/yet_another_json_isolate_io_test.dart
+++ b/packages/yet_another_json_isolate/test/yet_another_json_isolate_io_test.dart
@@ -4,12 +4,17 @@ library;
 import 'package:test/test.dart';
 import 'package:yet_another_json_isolate/yet_another_json_isolate.dart';
 
+/// Every disposal in this group is bounded, so a regression that makes
+/// `dispose()` wait forever fails the test instead of hanging the suite.
+Future<void> dispose(YAJsonIsolate isolate) =>
+    isolate.dispose().timeout(const Duration(seconds: 5));
+
 void main() {
   group('io implementation', () {
     test('throws when initialize is called twice', () async {
       final isolate = YAJsonIsolate();
       await isolate.initialize();
-      addTearDown(isolate.dispose);
+      addTearDown(() => dispose(isolate));
       expect(isolate.initialize(), throwsA(isA<AssertionError>()));
     });
 
@@ -20,20 +25,14 @@ void main() {
 
     test('dispose completes when the isolate was never used', () async {
       final isolate = YAJsonIsolate();
-      await expectLater(
-        isolate.dispose().timeout(const Duration(seconds: 5)),
-        completes,
-      );
+      await expectLater(dispose(isolate), completes);
     });
 
     test('dispose completes when called twice', () async {
       final isolate = YAJsonIsolate();
       await isolate.decode('{}');
-      await isolate.dispose();
-      await expectLater(
-        isolate.dispose().timeout(const Duration(seconds: 5)),
-        completes,
-      );
+      await dispose(isolate);
+      await expectLater(dispose(isolate), completes);
     });
 
     test('concurrent dispose calls all await the same shutdown', () async {
@@ -42,19 +41,16 @@ void main() {
 
       // Started before either is awaited, so a second call must not report
       // the isolate as gone while the first is still shutting it down.
-      final first = isolate.dispose();
-      final second = isolate.dispose();
+      final first = dispose(isolate);
+      final second = dispose(isolate);
 
-      await expectLater(
-        Future.wait([first, second]).timeout(const Duration(seconds: 5)),
-        completes,
-      );
+      await expectLater(Future.wait([first, second]), completes);
     });
 
     test('using the isolate after dispose throws', () async {
       final isolate = YAJsonIsolate();
       await isolate.decode('{}');
-      await isolate.dispose();
+      await dispose(isolate);
 
       // Without this the calls below would spawn a replacement isolate onto a
       // closed receive port and then wait for a reply that never arrives.
@@ -65,7 +61,7 @@ void main() {
 
     test('a never used isolate also rejects work after dispose', () async {
       final isolate = YAJsonIsolate();
-      await isolate.dispose();
+      await dispose(isolate);
 
       expect(isolate.decode('{}'), throwsStateError);
     });

--- a/packages/yet_another_json_isolate/test/yet_another_json_isolate_io_test.dart
+++ b/packages/yet_another_json_isolate/test/yet_another_json_isolate_io_test.dart
@@ -17,5 +17,23 @@ void main() {
       final isolate = YAJsonIsolate(debugName: 'my-isolate');
       expect(isolate.debugName, 'my-isolate');
     });
+
+    test('dispose completes when the isolate was never used', () async {
+      final isolate = YAJsonIsolate();
+      await expectLater(
+        isolate.dispose().timeout(const Duration(seconds: 5)),
+        completes,
+      );
+    });
+
+    test('dispose completes when called twice', () async {
+      final isolate = YAJsonIsolate();
+      await isolate.decode('{}');
+      await isolate.dispose();
+      await expectLater(
+        isolate.dispose().timeout(const Duration(seconds: 5)),
+        completes,
+      );
+    });
   });
 }


### PR DESCRIPTION
Fixes three leaks found by auditing the packages and the example apps with `leak_tracker`. The tracking itself was a one-off investigation and is not part of this change.

Closes SDK-1441.

## Leaks fixed

**The `Supabase` singleton pinned the disposed client graph.** `dispose()` tore everything down but never dropped its references, so the disposed `SupabaseClient` and everything under it (auth, realtime, PostgREST, storage, functions, the http clients) stayed reachable from a static field for the rest of the process.

`client` is now a getter over a nullable backing field, and `dispose()` clears `_client`, `_supabaseAuth`, `_lifecycleListener`, `_restoreSessionCancellableOperation`, `_logSubscription` and the pending lifecycle operation. Clearing happens before teardown, so a step that throws cannot leave the singleton pinning a half-disposed client, and `dispose()` returns early when there is nothing to dispose so it is safe to call more than once.

**`YAJsonIsolate.dispose()` hung forever when the isolate was never used.** It awaited `_createdIsolate.future`, which only completes inside `initialize()`, so an instance that was never exercised never finished disposing and left its `ReceivePort` open. Reachable through `PostgrestClient` and `FunctionsClient` when they are handed a custom isolate that never runs.

It now returns early after closing the port when nothing was spawned. Overlapping `dispose()` calls share a single shutdown future, and `initialize()`, `decode()` and `encode()` throw a `StateError` afterwards rather than spawning a replacement isolate onto a closed receive port and waiting for a reply that never arrives.

This one also blocked the fix above: making the existing widget test dispose the singleton turned it into a 10 minute timeout until the isolate teardown was fixed.

**Undisposed `TextEditingController` in the `database_crud` and `passkeys` examples.** Both rename dialogs built a controller in the calling method and never disposed it.

Each is now a `_RenameDialog` stateful widget that owns and disposes its controller. Disposing in the caller does not work: `whenComplete` on the `showDialog` future fires while the route is still animating out, and the `TextField` then rebuilds against a disposed controller.

## Tests

- `initialization_test.dart` gains cases asserting the singleton drops its client reference on dispose and that a second `dispose()` completes. The first captures the instance before disposing, because `Supabase.instance` itself refuses to hand out a disposed instance.
- `yet_another_json_isolate` gains cases for disposing an unused isolate, disposing twice, overlapping disposals, and using the isolate after disposal. Every disposal in that suite is bounded by a timeout so a regression fails rather than hanging.
- The existing widget test now tears the singleton down via `addTearDown`, which also covers the isolate fix in a widget test context. It needs `tester.runAsync` around both initialize and dispose, see the caveat below.
- The `MockWidget` stub now cancels its auth subscription in `dispose()`.

## Verification

- `supabase_flutter`: 65 tests pass.
- `supabase`: 134 tests pass.
- `yet_another_json_isolate`: 27, `postgrest`: 196, `functions_client`: 48, `realtime_client` and `storage_client` all pass.
- `dcm analyze packages` is clean.
- The example fixes were confirmed on an Android emulator against the local stack while the leak tracking was still wired up: `database_crud` went from one reported leak to none. `passkeys` needs real platform passkey support and does not run on an emulator, so its identical fix comes from inspection.

## Breaking change

`Supabase.instance.client` is a getter rather than a field, so it can no longer be assigned, and it throws a `StateError` after `dispose()` instead of returning the disposed client. Reads on an initialized instance are unchanged.

## Found but not fixed here

**`SupabaseClient.dispose()` cannot complete inside `testWidgets`.** The constructor eagerly spawns the JSON isolate, and `Isolate.spawn` never resolves under the fake clock, so consumers writing widget tests have to wrap both `Supabase.initialize` and `dispose` in `tester.runAsync`. Making `dispose()` non-blocking would weaken its contract, so it is a design call rather than a drive-by fix.

The other finding from this audit, `RealtimeClient.remove()` dropping unrelated channels, is fixed separately in #1669.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Renaming tasks and passkeys now opens a dedicated dialog with the current name prefilled.
  * Saved names are automatically trimmed of leading and trailing spaces.

* **Bug Fixes**
  * Improved cleanup and disposal behavior for Supabase and JSON processing resources.
  * Repeated or early disposal is now handled safely.
  * Attempts to use disposed services now provide clear state errors.
  * Improved cleanup during authentication and widget testing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->