### PR TITLE
fix(realtime): remove only the given channel from the client

### DIFF
--- a/packages/realtime_client/lib/src/realtime_client.dart
+++ b/packages/realtime_client/lib/src/realtime_client.dart
@@ -459,9 +459,13 @@ class RealtimeClient {
   bool get isConnected => connectionState == SocketState.open;
 
   /// Removes a subscription from the socket.
+  ///
+  /// Matches on identity rather than on [RealtimeChannel.joinRef], which is
+  /// the empty string until a channel is subscribed and is therefore shared
+  /// by every channel that has not joined yet.
   @internal
   void remove(RealtimeChannel channel) {
-    channels = channels.where((c) => c.joinRef != channel.joinRef).toList();
+    channels = channels.where((c) => !identical(c, channel)).toList();
     if (channels.isEmpty) {
       log('transport', 'no channels remaining, scheduling disconnect');
       _schedulePendingDisconnect();

--- a/packages/realtime_client/test/socket_test.dart
+++ b/packages/realtime_client/test/socket_test.dart
@@ -613,6 +613,32 @@ void main() {
       final foundChannel = mockedSocket.channels[0];
       expect(foundChannel, channel2);
     });
+
+    test('keeps the other channels when none of them have joined', () {
+      // Channels that have never subscribed all share the empty join ref, so
+      // matching on it removed every one of them at once.
+      final socket = RealtimeClient(socketEndpoint);
+      final channel1 = socket.channel('topic-1');
+      socket.channel('topic-2');
+      socket.channel('topic-3');
+
+      socket.remove(channel1);
+
+      expect(
+        socket.channels.map((channel) => channel.topic),
+        ['realtime:topic-2', 'realtime:topic-3'],
+      );
+    });
+
+    test('removes only the given channel when topics are duplicated', () {
+      final socket = RealtimeClient(socketEndpoint);
+      final channel1 = socket.channel('topic');
+      final channel2 = socket.channel('topic');
+
+      socket.remove(channel1);
+
+      expect(socket.channels, [channel2]);
+    });
   });
 
   group('deferred disconnect', () {


### PR DESCRIPTION
`RealtimeClient.remove()` matched channels on `joinRef`, which is the empty string until a channel subscribes. Removing one channel that had never joined therefore removed every channel that had never joined.

```dart
final a = client.channel('a');
client.channel('b');
client.channel('c');

await client.removeChannel(a);

client.getChannels(); // [] instead of [b, c]
```

Two consequences beyond the wrong list:

- The dropped channels are still held by the caller but no longer known to the client, so `removeAllChannels()` will not unsubscribe them and their rejoin timers stay armed.
- `channels` going empty makes the client schedule a disconnect while channels are still in use.

`remove()` is only ever called from `RealtimeChannel`'s close handler passing `this`, so it now matches on identity.

## Tests

Two cases in the `remove` group of `socket_test.dart`, both of which fail against the old implementation:

- removing one of three never-joined channels leaves the other two.
- removing one of two channels that share a topic leaves the other.

The existing case did not catch this because it uses mocked channels with distinct `joinRef` values.

## Verification

`realtime_client` (205 tests) and `supabase` (134 tests) pass.

Found while auditing for leaks in #1668, which has the rest of that work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed channel removal so only the selected channel is removed.
  * Preserved other channels when multiple channels share the same topic or have not yet joined.

* **Tests**
  * Added coverage for removing channels with duplicate topics and unjoined channels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->