### PR TITLE
chore: register SearchOptions and SortBy in the capability matrix

### DIFF
--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -766,6 +766,18 @@ features:
       - PaginatedSearchOptions.sortBy
       - PaginatedSearchOptions.toMap
       - PaginatedSearchOptions.withDelimiter
+      - SearchOptions
+      - SearchOptions.SearchOptions
+      - SearchOptions.limit
+      - SearchOptions.offset
+      - SearchOptions.search
+      - SearchOptions.sortBy
+      - SearchOptions.toMap
+      - SortBy
+      - SortBy.SortBy
+      - SortBy.column
+      - SortBy.order
+      - SortBy.toMap
   storage.file_buckets.move:
     status: implemented
     symbols:


### PR DESCRIPTION
## Summary

`SearchOptions` is the options type `StorageFileApi.list` takes, and `SortBy` is the type of its `sortBy` field. Neither was registered anywhere in `sdk-compliance.yaml`, so 12 public symbols went unaccounted for, while the paginated equivalents sitting right next to them (`PaginatedSearchOptions`, `FileSort`) were listed in full.

Both are supporting types rather than entry points, so they go under `supporting_symbols` on `storage.file_buckets.list_files`, alongside the paginated ones.

```yaml
storage.file_buckets.list_files:
  status: implemented
  symbols:
    - StorageFileApi.list
    - StorageFileApi.listPaginated
  supporting_symbols:
    # ...
    - SearchOptions
    - SearchOptions.limit
    - SearchOptions.offset
    - SearchOptions.search
    - SearchOptions.sortBy
    - SearchOptions.toMap
    - SortBy
    - SortBy.column
    - SortBy.order
    - SortBy.toMap
```

Verified `SortBy` is referenced only by `SearchOptions.sortBy`, and `SearchOptions` only by `StorageFileApi.list`, so neither is shared with another capability.

Found while reconciling the merged `list_files` entry in #1667.

## Test plan

- [x] `validate-compliance`: `OK — compliance file is valid.`
- [x] `check-drift`: `✅ No capability matrix drift detected.`
- [x] Registered symbol count 887 → 899, exactly the 12 added.

## Note on the wider gap

This fixes the case that surfaced in review, but it is one instance of a much larger pattern. Against the current public surface:

| | count |
|---|---|
| Public symbols extracted | 1952 |
| Registered in `sdk-compliance.yaml` | 899 |
| **Unregistered** | **1051** |

By package: gotrue 463, realtime_client 230, storage_client 121, supabase_flutter 73, postgrest 71, supabase 64, functions_client 16, yet_another_json_isolate 13.

This is not a regression and does not fail CI, because `check-api-symbols` only fires on symbols a PR *adds*, diffing base against head. Everything already present is grandfathered in. But it does mean the matrix currently accounts for under half the public API, which weakens the guarantee the check is meant to provide.

Worth deciding separately whether to backfill, and if so whether some of that surface should be `@internal` instead (`Fetch`, `Constants`, `ToQueryParams` and similar look like they were never meant to be public). Not attempting that here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for search options and symbol-based sorting when listing files in storage buckets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->