### PR TITLE
chore: mark non-public declarations @internal

### DIFF
--- a/packages/functions_client/lib/src/constants.dart
+++ b/packages/functions_client/lib/src/constants.dart
@@ -1,6 +1,8 @@
 import 'package:functions_client/src/version.dart';
 import 'package:supabase_common/supabase_common.dart';
+import 'package:meta/meta.dart';
 
+@internal
 class Constants {
   static final defaultHeaders = {
     'X-Client-Info': buildClientInfoHeader('functions-dart', version),

--- a/packages/functions_client/pubspec.yaml
+++ b/packages/functions_client/pubspec.yaml
@@ -20,6 +20,7 @@ resolution: workspace
 dependencies:
   http: ^1.6.0
   logging: ^1.3.0
+  meta: ^1.16.0
   supabase_common: 0.1.2
   yet_another_json_isolate: 2.1.1
 

--- a/packages/gotrue/lib/src/constants.dart
+++ b/packages/gotrue/lib/src/constants.dart
@@ -3,6 +3,7 @@ import 'package:gotrue/src/version.dart';
 import 'package:meta/meta.dart';
 import 'package:supabase_common/supabase_common.dart';
 
+@internal
 class Constants {
   static const String defaultGotrueUrl = 'http://localhost:9999';
   static final Map<String, String> defaultHeaders = {

--- a/packages/gotrue/lib/src/fetch.dart
+++ b/packages/gotrue/lib/src/fetch.dart
@@ -10,8 +10,10 @@ import 'package:http/http.dart';
 import 'package:meta/meta.dart';
 import 'package:supabase_common/supabase_common.dart';
 
+@internal
 enum RequestMethodType { get, post, put, patch, delete }
 
+@internal
 class GotrueFetch {
   final Client? httpClient;
 

--- a/packages/gotrue/lib/src/gotrue_admin_oauth_api.dart
+++ b/packages/gotrue/lib/src/gotrue_admin_oauth_api.dart
@@ -2,9 +2,11 @@ import 'fetch.dart';
 import 'helper.dart';
 import 'types/fetch_options.dart';
 import 'types/types.dart';
+import 'package:meta/meta.dart';
 
 /// Response type for OAuth client operations.
 /// Only relevant when the OAuth 2.1 server is enabled in Supabase Auth.
+@internal
 class OAuthClientResponse {
   final OAuthClient? client;
 
@@ -19,6 +21,7 @@ class OAuthClientResponse {
 
 /// Response type for listing OAuth clients.
 /// Only relevant when the OAuth 2.1 server is enabled in Supabase Auth.
+@internal
 class OAuthClientListResponse {
   final List<OAuthClient> clients;
   final String? aud;

--- a/packages/gotrue/lib/src/types/api_version.dart
+++ b/packages/gotrue/lib/src/types/api_version.dart
@@ -1,5 +1,6 @@
 import 'package:gotrue/src/constants.dart';
 import 'package:http/http.dart';
+import 'package:meta/meta.dart';
 
 // Parses the API version which is 2YYY-MM-DD. */
 const String _apiVersionRegex =
@@ -8,6 +9,7 @@ const String _apiVersionRegex =
 /// Represents the API versions supported by the package.
 
 /// Represents the API version specified by a [name] in the format YYYY-MM-DD.
+@internal
 class ApiVersion {
   const ApiVersion({
     required this.name,

--- a/packages/gotrue/lib/src/types/fetch_options.dart
+++ b/packages/gotrue/lib/src/types/fetch_options.dart
@@ -1,7 +1,9 @@
 import 'package:supabase_common/supabase_common.dart';
+import 'package:meta/meta.dart';
 
 export 'package:supabase_common/supabase_common.dart' show FetchOptions;
 
+@internal
 class GotrueRequestOptions extends FetchOptions {
   final String? jwt;
   final String? redirectTo;

--- a/packages/realtime_client/lib/src/message.dart
+++ b/packages/realtime_client/lib/src/message.dart
@@ -1,6 +1,8 @@
 import 'package:realtime_client/realtime_client.dart';
 import 'package:realtime_client/src/constants.dart';
+import 'package:meta/meta.dart';
 
+@internal
 class Message {
   final String topic;
   final ChannelEvent event;

--- a/packages/realtime_client/lib/src/push.dart
+++ b/packages/realtime_client/lib/src/push.dart
@@ -4,12 +4,15 @@ import 'package:realtime_client/realtime_client.dart';
 import 'package:realtime_client/src/constants.dart';
 import 'package:realtime_client/src/message.dart';
 import 'package:realtime_client/src/types.dart';
+import 'package:meta/meta.dart';
 
+@internal
 typedef Callback = void Function(dynamic response);
 
 /// {@template push}
 /// Initializes the Push
 /// {@endtemplate}
+@internal
 class Push {
   bool sent = false;
   Timer? _timeoutTimer;
@@ -139,6 +142,7 @@ class Push {
   }
 }
 
+@internal
 class Hook {
   final String status;
   final Callback callback;

--- a/packages/realtime_client/lib/src/retry_timer.dart
+++ b/packages/realtime_client/lib/src/retry_timer.dart
@@ -2,7 +2,9 @@ import 'dart:async';
 
 import 'package:meta/meta.dart';
 
+@internal
 typedef TimerCallback = void Function();
+@internal
 typedef TimerCalculation = int Function(int tries);
 
 // Need to limit doubling to avoid overflow, this limit gives 1 million times
@@ -26,6 +28,7 @@ const maxShift = 20;
 /// reconnectTimer.scheduleTimeout(); // fires after 1000
 ///
 /// ```
+@internal
 class RetryTimer {
   final TimerCallback callback;
   final TimerCalculation timerCalc;

--- a/packages/realtime_client/lib/src/serializer.dart
+++ b/packages/realtime_client/lib/src/serializer.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'dart:typed_data';
+import 'package:meta/meta.dart';
 
 /// Encodes and decodes Realtime protocol `2.0.0` frames.
 ///
@@ -12,6 +13,7 @@ import 'dart:typed_data';
 /// WebSocket frames so that raw bytes can be forwarded without JSON encoding.
 /// Incoming binary broadcast frames are decoded back into the same map shape as
 /// their JSON counterparts.
+@internal
 class Serializer {
   static const int headerLength = 1;
   static const int userBroadcastPushMetaLength = 6;

--- a/packages/storage_client/lib/src/constants.dart
+++ b/packages/storage_client/lib/src/constants.dart
@@ -1,6 +1,8 @@
 import 'package:storage_client/src/version.dart';
 import 'package:supabase_common/supabase_common.dart';
+import 'package:meta/meta.dart';
 
+@internal
 class Constants {
   static final Map<String, String> defaultHeaders = {
     'X-Client-Info': buildClientInfoHeader('storage-dart', version),

--- a/packages/storage_client/lib/src/fetch.dart
+++ b/packages/storage_client/lib/src/fetch.dart
@@ -12,6 +12,7 @@ import 'package:supabase_common/supabase_common.dart';
 
 import 'file_stub.dart' if (dart.library.io) './file_io.dart';
 
+@internal
 class Fetch {
   final Client? httpClient;
   final _log = Logger('supabase.storage');

--- a/packages/storage_client/lib/src/types.dart
+++ b/packages/storage_client/lib/src/types.dart
@@ -677,6 +677,7 @@ class TransformOptions {
   });
 }
 
+@internal
 extension ToQueryParams on TransformOptions {
   Map<String, String> get toQueryParams {
     return {

--- a/packages/supabase/lib/src/auth_http_client.dart
+++ b/packages/supabase/lib/src/auth_http_client.dart
@@ -1,6 +1,8 @@
 import 'package:http/http.dart';
 import 'package:supabase/src/api_key.dart';
+import 'package:meta/meta.dart';
 
+@internal
 class AuthHttpClient extends BaseClient {
   final Client _inner;
 

--- a/packages/supabase/lib/src/constants.dart
+++ b/packages/supabase/lib/src/constants.dart
@@ -1,6 +1,8 @@
 import 'package:supabase/src/version.dart';
 import 'package:supabase_common/supabase_common.dart';
+import 'package:meta/meta.dart';
 
+@internal
 class Constants {
   static final Map<String, String> defaultHeaders = Map.unmodifiable({
     'X-Client-Info': buildClientInfoHeader(

--- a/packages/supabase/lib/src/counter.dart
+++ b/packages/supabase/lib/src/counter.dart
@@ -1,3 +1,6 @@
+import 'package:meta/meta.dart';
+
+@internal
 class Counter {
   int _value = 0;
 

--- a/packages/supabase_flutter/lib/src/constants.dart
+++ b/packages/supabase_flutter/lib/src/constants.dart
@@ -1,6 +1,8 @@
 import 'package:supabase_common/supabase_common.dart';
 import 'package:supabase_flutter/src/version.dart';
+import 'package:meta/meta.dart';
 
+@internal
 class Constants {
   static final Map<String, String> defaultHeaders = Map.unmodifiable({
     'X-Client-Info': buildClientInfoHeader(

--- a/packages/supabase_flutter/lib/src/supabase_auth.dart
+++ b/packages/supabase_flutter/lib/src/supabase_auth.dart
@@ -8,6 +8,7 @@ import 'package:flutter/foundation.dart'
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:logging/logging.dart';
+import 'package:meta/meta.dart';
 import 'package:supabase_common/supabase_common.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -55,6 +56,7 @@ import 'clear_auth_url_parameters_stub.dart'
 ///   only the URL the app was loaded with is inspected once at startup,
 ///   since browser navigation triggers a full page load rather than a
 ///   stream event.
+@internal
 class SupabaseAuth with WidgetsBindingObserver {
   static WidgetsBinding get _widgetsBindingInstance => WidgetsBinding.instance;
 


### PR DESCRIPTION
## Summary

The capability matrix extractor treats every non-underscore name in `lib/` as public API, without following exports:

> Dart privacy is name-based, so a declaration is public when its name does not start with `_`. [...] Declarations annotated with `@internal` are excluded: the annotation is the canonical marker that a name is public by Dart's underscore rule but is not part of the package's public API.

So implementation plumbing in `lib/src/` counted as public surface that had to be either registered in `sdk-compliance.yaml` or left as an unexplained gap. This marks that plumbing `@internal`. The repo already uses the annotation on individual members; this extends it to the declarations themselves.

Annotates **24 declarations**:

| Package | Declarations |
|---|---|
| `realtime_client` | `Push`, `Hook`, `Message`, `Serializer`, `RetryTimer`, `Callback`, `TimerCallback`, `TimerCalculation` |
| `gotrue` | `GotrueFetch`, `GotrueRequestOptions`, `RequestMethodType`, `ApiVersion`, `Constants`, `OAuthClientResponse`, `OAuthClientListResponse` |
| `storage_client` | `Fetch`, `ToQueryParams`, `Constants` |
| `supabase` | `AuthHttpClient`, `Counter`, `Constants` |
| `supabase_flutter` | `SupabaseAuth`, `Constants` |
| `functions_client` | `Constants` |

## How the set was chosen

Not by eye. A declaration qualifies only if it is **unreachable from its package's public library**, resolving `export` directives transitively and honouring `show`/`hide`. That makes the annotation truthful rather than a judgement call, and keeps it analyzer-legal, since `@internal` on something in the public API is itself a diagnostic.

Candidates were then filtered against `sdk-compliance.yaml`. Annotating a class hides its **members** from the extractor too, so anything with registered symbols would silently break the drift check. That filter removed six:

| Excluded | Registered symbols |
|---|---|
| `storage_client/StorageBucketApi` | 10 (`createBucket`, `listBuckets`, ...) |
| `gotrue/GoTrueAdminCustomProvidersApi` | 7 |
| `gotrue/GoTrueAdminOAuthApi` | 6 |
| `gotrue/GoTrueAdminMFAApi` | 2 |
| `realtime_client/Constants` | 1 (`defaultConnectionCloseTimeout`) |
| `realtime_client/ChannelFilter` | 1 (`select`) |

Two more were excluded for being publicly reachable in ways a naive export scan misses:

- `storage_client/File` is a conditional-import typedef used in `StorageFileApi.upload` signatures, so it is effectively public.
- `yet_another_json_isolate/YAJsonIsolate` lives in `_isolates_web.dart` but is conditionally *exported* (`if (dart.library.js_interop)`), so it is the package's public entry point.

## Effect

| | before | after |
|---|---|---|
| Symbols reported as public API | 1952 | **1831** |
| Unregistered | 1051 | **930** |
| Matrix coverage | 46.2% | **49.2%** |

111 symbols stop being counted as public API. No symbol newly appears, and no registered symbol disappears.

This shrinks the backfill problem noted in #1670 by about a ninth. The remaining 930 are genuine public API that is simply unregistered; that is a separate task.

## Test plan

- [x] `dart analyze packages/`: **No issues found.** This is the real gate: the analyzer reports `invalid_internal_annotation` for anything annotated inside a public API, and `invalid_use_of_internal_member` for cross-package use. Neither fires.
- [x] Independent cross-package reference sweep, not trusting the lint config alone. The only hits were `Constants`, which each package declares for itself; verified `supabase_flutter/src/supabase.dart` imports its own `src/constants.dart`, so that use is same-package.
- [x] `check-drift` against a freshly extracted surface: `✅ No capability matrix drift detected.`
- [x] `dart format packages/`: 0 changed.
- [x] `gotrue` tests: `+448 -23`, **identical to unmodified `main`** (`+448 -23`). The 23 failures are integration tests needing a local GoTrue on `localhost:9999` and are unrelated to this change, which is annotation-only and cannot affect runtime behaviour.

## Note

`functions_client` gains a `meta: ^1.16.0` dependency, which it did not previously have. Every other touched package already depended on it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Clarified API boundaries across authentication, storage, realtime, functions, and Flutter integrations.
  * Internal implementation details are now explicitly identified and excluded from the supported public API.
  * Added required metadata support for improved API visibility annotations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->