### PR TITLE
refactor(storage): move toQueryParams onto TransformOptions

### DIFF
--- a/packages/storage_client/lib/src/types.dart
+++ b/packages/storage_client/lib/src/types.dart
@@ -675,9 +675,9 @@ class TransformOptions {
     this.quality,
     this.format,
   });
-}
 
-extension ToQueryParams on TransformOptions {
+  /// The transformation options as `transform` query parameters.
+  @internal
   Map<String, String> get toQueryParams {
     return {
       if (width != null) 'width': '$width',

--- a/packages/storage_client/lib/storage_client.dart
+++ b/packages/storage_client/lib/storage_client.dart
@@ -8,6 +8,6 @@ export 'src/iceberg/table_requirement.dart';
 export 'src/iceberg/table_update.dart';
 export 'src/storage_client.dart';
 export 'src/storage_file_api.dart';
-export 'src/types.dart' hide ToQueryParams;
+export 'src/types.dart';
 export 'src/vector_client.dart';
 export 'src/vector_types.dart';


### PR DESCRIPTION
`ToQueryParams` was an extension on `TransformOptions` declared in the same library as the class it extended, so it did not need to be an extension at all. It is now a plain getter on the class.

To keep it out of the public API (it was previously hidden via `export 'src/types.dart' hide ToQueryParams;`) the getter is marked `@internal`, which matches how `DownloadBehavior.queryValue` is handled in the same file. Since `@internal` symbols are skipped by the compliance matrix symbol check, no matrix update is needed.

I also checked the three other extensions in the repository, and all of them are necessary:

- `ToSnakeCase on Enum` in `supabase_common`, extends a built-in type.
- `GoTrueClientPasskey on GoTrueClient` in `supabase_flutter`, adds Flutter-only behavior to a class that lives in the pure Dart `gotrue` package.
- `GoTrueClientSignInProvider on GoTrueClient`, same reason.

## Testing

`dart analyze` and the full `storage_client` test suite pass. The existing `TransformOptions.toQueryParams` tests cover the getter unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Made the query-parameter conversion utility publicly available through the storage client package.
* **Documentation**
  * Added documentation clarifying the utility’s role in converting transformation options into query parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->