### PR TITLE
chore(realtime)!: mark the transport internals @internal

### DIFF
--- a/packages/realtime_client/lib/src/realtime_channel.dart
+++ b/packages/realtime_client/lib/src/realtime_channel.dart
@@ -634,6 +634,7 @@ class RealtimeChannel {
   }
 
   /// Returns `true` if the socket is connected and the channel has been joined.
+  @internal
   bool get canPush {
     return socket.isConnected && isJoined;
   }
@@ -981,6 +982,7 @@ class RealtimeChannel {
     joinPush.resend(timeout ?? _timeout);
   }
 
+  @internal
   void trigger(String type, [dynamic payload, String? ref]) {
     final typeLower = type.toLowerCase();
 

--- a/packages/realtime_client/lib/src/realtime_client.dart
+++ b/packages/realtime_client/lib/src/realtime_client.dart
@@ -112,6 +112,7 @@ class RealtimeClient {
   final Client? httpClient;
   final _log = Logger('supabase.realtime');
   int heartbeatIntervalMs = Constants.defaultHeartbeatIntervalMs;
+  @internal
   Timer? heartbeatTimer;
 
   /// Delay before the socket is disconnected once the last channel has been
@@ -129,11 +130,14 @@ class RealtimeClient {
   /// reference ID of the most recently sent heartbeat.
   ///
   /// Used to keep track of whether the client is connected to the server.
+  @internal
   String? pendingHeartbeatRef;
 
   /// Counter used by [makeRef] to generate a unique reference ID for every
   /// pushed message, including heartbeats.
+  @internal
   int ref = 0;
+  @internal
   late RetryTimer reconnectTimer;
   void Function(String? kind, String? message, dynamic data)? logger;
   static final Serializer _serializer = Serializer();
@@ -142,7 +146,9 @@ class RealtimeClient {
   late TimerCalculation reconnectAfterMs;
   WebSocketChannel? connection;
   StreamSubscription<dynamic>? _connectionSubscription;
+  @internal
   List<dynamic> sendBuffer = [];
+  @internal
   Map<String, List<Function>> stateChangeCallbacks = {
     'open': [],
     'close': [],
@@ -528,6 +534,7 @@ class RealtimeClient {
   /// If the socket is not connected, the message gets enqueued within a local
   /// buffer, and sent out when a connection is next established.
   // ignore: function-always-returns-null
+  @internal
   String? push(Message message) {
     void callback() {
       connection?.sink.add(encode(message.toJson()));
@@ -605,6 +612,7 @@ class RealtimeClient {
   }
 
   /// Return the next message ref, accounting for overflows
+  @internal
   String makeRef() {
     final int newRef = ref + 1;
     if (newRef < 0) {

--- a/packages/realtime_client/lib/src/realtime_client.dart
+++ b/packages/realtime_client/lib/src/realtime_client.dart
@@ -533,8 +533,8 @@ class RealtimeClient {
   ///
   /// If the socket is not connected, the message gets enqueued within a local
   /// buffer, and sent out when a connection is next established.
-  // ignore: function-always-returns-null
   @internal
+  // ignore: function-always-returns-null
   String? push(Message message) {
     void callback() {
       connection?.sink.add(encode(message.toJson()));

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -1875,16 +1875,12 @@ features:
     status: implemented
     symbols:
       - RealtimeClient.reconnectAfterMs
-    supporting_symbols:
-      - RealtimeClient.reconnectTimer
   realtime.configuration.heartbeat_interval:
     status: implemented
     symbols:
       - RealtimeClient.heartbeatIntervalMs
     supporting_symbols:
       - Constants.defaultHeartbeatIntervalMs
-      - RealtimeClient.heartbeatTimer
-      - RealtimeClient.pendingHeartbeatRef
   realtime.configuration.access_token_callback:
     status: implemented
     note: "On connect the access token is resolved before the send buffer is flushed; buffered channel join payloads are patched with the token and re-sent so subscriptions authenticate correctly when the token resolves asynchronously (e.g. read from async storage)."
@@ -2366,8 +2362,6 @@ supporting_symbols:
   - RawPostgrestBuilder.withConverter
   - RealtimeChannel
   - RealtimeChannel.RealtimeChannel
-  - RealtimeChannel.canPush
-  - RealtimeChannel.trigger
   - RealtimeChannelConfig
   - RealtimeChannelConfig.RealtimeChannelConfig
   - RealtimeChannelConfig.enabled
@@ -2376,12 +2370,7 @@ supporting_symbols:
   - RealtimeClient.RealtimeClient
   - RealtimeClient.endPoint
   - RealtimeClient.endPointURL
-  - RealtimeClient.makeRef
   - RealtimeClient.params
-  - RealtimeClient.push
-  - RealtimeClient.ref
-  - RealtimeClient.sendBuffer
-  - RealtimeClient.stateChangeCallbacks
   - RealtimeClient.timeout
   - RealtimeClient.version
   - RealtimeClientOptions


### PR DESCRIPTION
Stacked on #1673. Follow-up to the audit in that PR: of the 536 entries in the top-level `supporting_symbols` list, ten were realtime transport internals that had no business being public in the first place. They were registered there for want of a better home, which was the wrong answer.

## What becomes `@internal`

| Symbol | What it is |
|---|---|
| `RealtimeClient.sendBuffer` | Queue of callbacks awaiting a connection |
| `RealtimeClient.stateChangeCallbacks` | The `open`/`close`/`error`/`message` listener registry behind `onOpen` and friends |
| `RealtimeClient.ref` | Message ref counter |
| `RealtimeClient.makeRef` | Increments the counter, handling overflow |
| `RealtimeClient.push` | Raw frame send |
| `RealtimeClient.heartbeatTimer` | The `Timer` driving heartbeats |
| `RealtimeClient.pendingHeartbeatRef` | Ref of the last unacknowledged heartbeat |
| `RealtimeClient.reconnectTimer` | The `RetryTimer` behind reconnect backoff |
| `RealtimeChannel.canPush` | Whether the socket is connected and the channel joined |
| `RealtimeChannel.trigger` | Dispatches a raw event to the channel's bindings |

`push` is the clearest case: it already took `Message`, which #1671 marked `@internal`, so it could not be called from outside the package regardless. Its signature said internal while its name said public.

The rest are fields on a class that happens to be public, so Dart's underscore rule made them public by default. None appears in any documented flow. Every one of them has a public counterpart that is the supported way in: `onOpen`/`onClose`/`onError`/`onMessage` instead of `stateChangeCallbacks`, `heartbeatIntervalMs` instead of `heartbeatTimer`, `reconnectAfterMs` instead of `reconnectTimer`, `sendBroadcastMessage` instead of `push`.

## Matrix changes

Ten symbols leave the scan, so they leave `sdk-compliance.yaml` too:

- Eight drop out of the top-level `supporting_symbols` list.
- `RealtimeClient.reconnectTimer` drops from `realtime.configuration.reconnect_backoff`, and `heartbeatTimer`/`pendingHeartbeatRef` from `realtime.configuration.heartbeat_interval`. Both features keep their real evidence (`reconnectAfterMs`, `heartbeatIntervalMs`), and `reconnect_backoff` no longer needs a `supporting_symbols` list at all.

Public surface 1774 → 1764. Coverage stays at 100%.

## Breaking

Marked `chore(realtime)!` with a `BREAKING CHANGE` footer. It is a genuine public API removal, though the practical risk is low: none of these is documented, `push` was already uncallable, and v3 is the right window. Anyone reaching for them was working around a missing public API, which is worth an issue rather than a lint suppression.

## Test plan

- [x] `dart analyze packages/`: **No issues found.** This is the gate that matters here: `invalid_use_of_internal_member` fires for any cross-package use, and the `supabase` and `supabase_flutter` packages both consume `RealtimeClient` and `RealtimeChannel`. Neither touches any of the ten.
- [x] `realtime_client` tests: 205 passed. `@internal` permits same-package use, so the existing tests that drive `makeRef`, `push` and `trigger` still compile and run.
- [x] `supabase` tests: 134 passed, including the realtime stream integration tests.
- [x] `supabase_flutter` tests: 65 passed.
- [x] `check-drift`: `✅ No capability matrix drift detected.`
- [x] `check-api-symbols` against #1673 as base: `✅ All new public API symbols are covered in the capability matrix.` This is the check that would have caught a stale registration, since the ten removed symbols were all registered on the base.
- [x] Uncovered symbol count from a fresh extraction: **0**.
- [x] `dart format packages/`: 0 changed.
