### PR TITLE
refactor!: remove analyzer ignores by fixing the underlying code

### DIFF
--- a/packages/postgrest/lib/src/postgrest_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_builder.dart
@@ -53,15 +53,13 @@ class _RetryConfig {
   final Duration Function(int attempt) delay;
 
   _RetryConfig copyWith({
-    // retry() always passes enabled, but keep the standard copyWith shape.
-    // ignore: avoid-unnecessary-nullable-parameters
-    bool? enabled,
+    required bool enabled,
     int? count,
     Set<int>? statusCodes,
     Duration Function(int attempt)? delay,
   }) {
     return _RetryConfig(
-      enabled: enabled ?? this.enabled,
+      enabled: enabled,
       count: count ?? this.count,
       statusCodes: statusCodes ?? this.statusCodes,
       delay: delay ?? this.delay,

--- a/packages/realtime_client/lib/src/realtime_channel.dart
+++ b/packages/realtime_client/lib/src/realtime_channel.dart
@@ -241,18 +241,18 @@ class RealtimeChannel {
     void Function(RealtimeSubscribeStatus status, Object? error)? callback,
   ) async {
     final serverPostgresFilters = response['postgres_changes'];
-    if (socket.accessToken != null) {
+    final accessToken = socket.accessToken;
+    if (accessToken != null) {
       try {
-        // ignore: avoid-passing-self-as-argument
-        await socket.setAuth(socket.accessToken);
-      } on FormatException catch (e) {
+        await socket.setAuth(accessToken);
+      } on FormatException catch (error) {
         // The cached access token may have expired by the time the
         // channel rejoins (e.g. after the device wakes from a long
         // sleep). Auth state listeners will re-call setAuth with a
         // fresh token shortly after, so swallow this specific error
         // to avoid surfacing it as an uncaught exception. The same
         // filter is applied in `SupabaseClient._handleTokenChanged`.
-        if (!e.message.contains('InvalidJWTToken')) {
+        if (!error.message.contains('InvalidJWTToken')) {
           rethrow;
         }
       }

--- a/packages/realtime_client/lib/src/realtime_client.dart
+++ b/packages/realtime_client/lib/src/realtime_client.dart
@@ -527,8 +527,7 @@ class RealtimeClient {
   ///
   /// If the socket is not connected, the message gets enqueued within a local
   /// buffer, and sent out when a connection is next established.
-  // ignore: function-always-returns-null
-  String? push(Message message) {
+  void push(Message message) {
     void callback() {
       connection?.sink.add(encode(message.toJson()));
     }
@@ -544,7 +543,6 @@ class RealtimeClient {
     } else {
       sendBuffer.add(callback);
     }
-    return null;
   }
 
   void onConnectionMessage(Object rawMessage) {

--- a/packages/realtime_client/lib/src/transformers.dart
+++ b/packages/realtime_client/lib/src/transformers.dart
@@ -321,8 +321,7 @@ Map<String, dynamic> getEnrichedPayload(Map<String, dynamic> payload) {
 Map<String, Map<String, dynamic>> getPayloadRecords(
   Map<String, dynamic> payload,
 ) {
-  // ignore: avoid-inferrable-type-arguments
-  final records = <String, Map<String, dynamic>>{
+  final Map<String, Map<String, dynamic>> records = {
     'new': {},
     'old': {},
   };

--- a/packages/supabase_flutter/test/widget_test_stubs.dart
+++ b/packages/supabase_flutter/test/widget_test_stubs.dart
@@ -122,36 +122,27 @@ void mockAppLink({
 
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  // ignore: invalid_null_aware_operator
-  TestDefaultBinaryMessengerBinding.instance?.defaultBinaryMessenger
-      .setMockMethodCallHandler(
-        channel,
-        (call) async => mockMethodChannel ? initialLink : null,
-      );
+  final binaryMessenger =
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
 
-  // Mock event channel using method channel, to keep supporting older versions
-  // of flutter_test in which setMockStreamHandler is not yet available.
+  binaryMessenger.setMockMethodCallHandler(
+    channel,
+    (call) async => mockMethodChannel ? initialLink : null,
+  );
+
   if (mockEventChannel) {
-    // ignore: invalid_null_aware_operator
-    TestDefaultBinaryMessengerBinding.instance?.defaultBinaryMessenger
-        .setMockMethodCallHandler(
-          eventChannel,
-          // ignore: function-always-returns-null
-          (MethodCall methodCall) async {
-            await TestDefaultBinaryMessengerBinding
-                .instance
-                // ignore: invalid_null_aware_operator
-                ?.defaultBinaryMessenger
-                .handlePlatformMessage(
-                  eventChannel.name,
-                  const StandardMethodCodec().encodeSuccessEnvelope(
-                    initialLink,
-                  ),
-                  (ByteData? data) {},
-                );
-            return null;
-          },
-        );
+    Future<void> handleEventChannelCall(MethodCall methodCall) async {
+      await binaryMessenger.handlePlatformMessage(
+        eventChannel.name,
+        const StandardMethodCodec().encodeSuccessEnvelope(initialLink),
+        (ByteData? data) {},
+      );
+    }
+
+    binaryMessenger.setMockMethodCallHandler(
+      eventChannel,
+      handleEventChannelCall,
+    );
   }
 }
 

--- a/packages/yet_another_json_isolate/lib/src/_isolates_io.dart
+++ b/packages/yet_another_json_isolate/lib/src/_isolates_io.dart
@@ -124,33 +124,29 @@ class YAJsonIsolate {
   }
 }
 
-void _compute(SendPort p) async {
+List<dynamic> _computeResponse(dynamic input, {required bool isEncoding}) {
+  try {
+    return _buildSuccessResponse(
+      isEncoding ? jsonEncode(input) : jsonDecode(input),
+    );
+  } catch (error, stackTrace) {
+    return _buildErrorResponse(error, stackTrace);
+  }
+}
+
+void _compute(SendPort sendPort) async {
   final commandPort = ReceivePort();
-  p.send(commandPort.sendPort);
+  sendPort.send(commandPort.sendPort);
 
   await for (final event in commandPort) {
-    // [event] is a list of [input,method]
+    // [event] is a list of [input, isEncoding]
     if (event is List) {
       final input = event.first;
 
       /// `true` for encoding and `false` for decoding
-      final bool method = event.last;
-      // ignore: avoid-unnecessary-local-late
-      late final List<dynamic> computationResult;
+      final bool isEncoding = event.last;
 
-      try {
-        final dynamic res;
-        if (method == true) {
-          res = jsonEncode(input);
-        } else {
-          res = jsonDecode(input);
-        }
-        computationResult = _buildSuccessResponse(res);
-      } catch (e, s) {
-        computationResult = _buildErrorResponse(e, s);
-      }
-
-      p.send(computationResult);
+      sendPort.send(_computeResponse(input, isEncoding: isEncoding));
     } else if (event == null) {
       break;
     }


### PR DESCRIPTION
Several `// ignore:` comments across the packages were suppressing lints that point at real code smells rather than false positives. Now that v3 allows breaking changes, the underlying signatures and code are fixed instead of silenced.

Closes SDK-1448

## Breaking

`RealtimeClient.push` was declared `String? push(Message message)` but only ever did `return null;`, a leftover from the JavaScript port. It is now `void push(Message message)`. No caller used the return value, and `realtime-js` returns void as well. This removes `// ignore: function-always-returns-null`.

Callers that stored the result can drop it:

```dart
// before
final ref = client.push(message); // always null

// after
client.push(message);
```

## Non-breaking cleanups

- **`packages/supabase_flutter/test/widget_test_stubs.dart`** — `TestDefaultBinaryMessengerBinding.instance` is non-nullable and the package already requires Flutter `>=3.35.0`, so the three `// ignore: invalid_null_aware_operator` comments and their `?.` operators are gone. The binary messenger is hoisted into a local, and the event channel handler became a named `Future<void>` local function, which also drops a second `function-always-returns-null` ignore. Dart function literals cannot carry a return type annotation, hence the named local function.
- **`packages/realtime_client/lib/src/realtime_channel.dart`** — `socket.accessToken` is hoisted into a local so the null check promotes it, removing `// ignore: avoid-passing-self-as-argument`.
- **`packages/yet_another_json_isolate/lib/src/_isolates_io.dart`** — the try/catch is extracted into `_computeResponse` so the `late final` local is no longer needed, removing `// ignore: avoid-unnecessary-local-late`. A plain `final` local does not work here because Dart rejects assigning it in both the `try` and the `catch`.
- **`packages/realtime_client/lib/src/transformers.dart`** — type arguments moved onto the variable declaration, removing `// ignore: avoid-inferrable-type-arguments`.
- **`packages/postgrest/lib/src/postgrest_builder.dart`** — `_RetryConfig.copyWith` now takes `required bool enabled`, since its only caller (`retry()`) always passes it. Removes `// ignore: avoid-unnecessary-nullable-parameters`. `_RetryConfig` is private, so this is not a public API change.
- Abbreviated identifiers in the touched code are spelled out: `e`/`s` to `error`/`stackTrace`, `p` to `sendPort`, `method` to `isEncoding`.

## Ignores intentionally kept

These suppress lints that are correct to silence, so they stay:

| Ignore | Why it stays |
| --- | --- |
| `avoid_print` | Example apps and one test that prints deliberately |
| `invalid_use_of_internal_member` | Deliberate cross-package `@internal` access |
| `experimental_member_use` | Upstream `passkeys` package API |
| `constant_identifier_names` | `snake_case_test.dart`, where snake_case names are the subject under test |
| `avoid-duplicate-constant-values` | `serializer.dart`, where two semantically distinct protocol constants happen to share the value `4` |
| `avoid-unnecessary-nullable-return-type` | `local_storage_stub.dart` must match the signature of the web implementation it is conditionally imported against |
| `avoid-shadowing` | `FunctionsClient.invoke`'s public `headers` parameter shadows the `headers` getter, but is the correct public API name |
| `avoid-unnecessary-nullable-parameters` | `raw_postgrest_builder.dart`, where null is the copyWith "unset" sentinel |
| `match-getter-setter-field-names` | Test fake in `lifecycle_test.dart` |

The file-level `public_member_api_docs` / `sort_constructors_first` ignores in `realtime_presence.dart` and `types.dart` also stay for now. Those hide genuinely missing dartdoc on public API and deserve their own follow-up rather than being bundled here.

## Testing

`dart analyze` is clean across all packages and `flutter analyze` is clean for `supabase_flutter`. Test suites pass for `realtime_client` (205), `supabase_flutter` (65), `yet_another_json_isolate` (27), and `postgrest`'s `retry_test.dart` (26). The remaining `postgrest` integration tests need a running PostgREST instance and fail identically on `main` in this environment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved consistency and reliability across realtime messaging, authentication, and JSON processing.
  - Simplified the realtime message-sending API by clarifying that sending messages does not return a value.
  - Strengthened handling of retry configuration and realtime authentication updates.
- **Testing**
  - Updated Flutter platform-channel test utilities for more reliable app-link and event handling.
- **Maintenance**
  - Improved type clarity and streamlined internal processing without changing expected runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->