### PR TITLE
chore!: give each package's Constants class a package-specific name

### DIFF
--- a/packages/supabase/lib/src/supabase_client.dart
+++ b/packages/supabase/lib/src/supabase_client.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 
 import 'package:http/http.dart';
 import 'package:logging/logging.dart';
-import 'package:supabase/src/constants.dart';
+import 'package:supabase/src/supabase_constants.dart';
 import 'package:supabase/src/version.dart';
 import 'package:supabase/supabase.dart';
 import 'package:yet_another_json_isolate/yet_another_json_isolate.dart';
@@ -93,7 +93,7 @@ class SupabaseClient {
   set headers(Map<String, String> newHeaders) {
     _headers.clear();
     _headers.addAll({
-      ...Constants.defaultHeaders,
+      ...SupabaseConstants.defaultHeaders,
       ...newHeaders,
     });
 
@@ -113,7 +113,7 @@ class SupabaseClient {
       auth.headers
         ..clear()
         ..addAll({
-          ...Constants.defaultHeaders,
+          ...SupabaseConstants.defaultHeaders,
           ..._getAuthHeaders(),
           ...headers,
         });
@@ -153,7 +153,7 @@ class SupabaseClient {
        _functionsUrl = '$supabaseUrl/functions/v1',
        _postgrestOptions = postgrestOptions,
        _headers = {
-         ...Constants.defaultHeaders,
+         ...SupabaseConstants.defaultHeaders,
          ...?headers,
        },
        _httpClient = httpClient,

--- a/packages/supabase/lib/src/supabase_constants.dart
+++ b/packages/supabase/lib/src/supabase_constants.dart
@@ -3,7 +3,7 @@ import 'package:supabase_common/supabase_common.dart';
 import 'package:meta/meta.dart';
 
 @internal
-class Constants {
+class SupabaseConstants {
   static final Map<String, String> defaultHeaders = Map.unmodifiable({
     'X-Client-Info': buildClientInfoHeader(
       'supabase-dart',

--- a/packages/supabase/test/utilities_test.dart
+++ b/packages/supabase/test/utilities_test.dart
@@ -3,7 +3,7 @@ import 'dart:io';
 
 import 'package:http/http.dart' as http;
 import 'package:supabase/src/auth_http_client.dart';
-import 'package:supabase/src/constants.dart';
+import 'package:supabase/src/supabase_constants.dart';
 import 'package:supabase/src/counter.dart';
 import 'package:supabase_common/supabase_common.dart';
 import 'package:test/test.dart';
@@ -35,10 +35,10 @@ void main() {
     });
   });
 
-  group('Constants', () {
+  group('SupabaseConstants', () {
     test('should have default headers with X-Client-Info', () {
       expect(
-        Constants.defaultHeaders,
+        SupabaseConstants.defaultHeaders,
         containsPair('X-Client-Info', startsWith('supabase-dart/')),
       );
     });
@@ -48,7 +48,7 @@ void main() {
       'on web',
       () {
         if (!kIsWeb) {
-          final clientInfo = Constants.defaultHeaders['X-Client-Info']!;
+          final clientInfo = SupabaseConstants.defaultHeaders['X-Client-Info']!;
           expect(clientInfo, contains('; platform='));
           expect(clientInfo, contains('; platform-version='));
           expect(clientInfo, contains('; runtime=dart'));

--- a/packages/supabase_auth/lib/src/auth_client.dart
+++ b/packages/supabase_auth/lib/src/auth_client.dart
@@ -5,7 +5,7 @@ import 'dart:math';
 import 'package:collection/collection.dart';
 import 'package:dart_jsonwebtoken/dart_jsonwebtoken.dart';
 import 'package:supabase_auth/supabase_auth.dart';
-import 'package:supabase_auth/src/constants.dart';
+import 'package:supabase_auth/src/auth_constants.dart';
 import 'package:supabase_auth/src/fetch.dart';
 import 'package:supabase_auth/src/helper.dart';
 import 'package:supabase_auth/src/types/fetch_options.dart';
@@ -157,19 +157,19 @@ class AuthClient {
     Client? httpClient,
     AuthAsyncStorage? asyncStorage,
     AuthFlowType flowType = AuthFlowType.pkce,
-  }) : _url = url ?? Constants.defaultAuthUrl,
-       _headers = {...Constants.defaultHeaders, ...?headers},
+  }) : _url = url ?? AuthConstants.defaultAuthUrl,
+       _headers = {...AuthConstants.defaultHeaders, ...?headers},
        _httpClient = httpClient,
        _asyncStorage = asyncStorage,
        _flowType = flowType {
     _autoRefreshToken = autoRefreshToken ?? true;
 
-    final authUrl = url ?? Constants.defaultAuthUrl;
+    final authUrl = url ?? AuthConstants.defaultAuthUrl;
     _log.config(
       'Initialize AuthClient v$version with url: $_url, autoRefreshToken: '
       '$_autoRefreshToken, flowType: ${_flowType.name}, tickDuration: '
-      '${Constants.autoRefreshTickDuration}, tickThreshold: '
-      '${Constants.autoRefreshTickThreshold}',
+      '${AuthConstants.autoRefreshTickDuration}, tickThreshold: '
+      '${AuthConstants.autoRefreshTickThreshold}',
     );
     _log.finest('Initialize with headers: $_headers');
     admin = AuthAdminApi(
@@ -441,7 +441,7 @@ class AuthClient {
     );
 
     final codeVerifierRawString = await _asyncStorage!.getItem(
-      key: '${Constants.defaultStorageKey}-code-verifier',
+      key: '${AuthConstants.defaultStorageKey}-code-verifier',
     );
     if (codeVerifierRawString == null) {
       throw AuthException('Code verifier could not be found in local storage.');
@@ -461,7 +461,7 @@ class AuthClient {
     );
 
     await _asyncStorage.removeItem(
-      key: '${Constants.defaultStorageKey}-code-verifier',
+      key: '${AuthConstants.defaultStorageKey}-code-verifier',
     );
 
     final authSessionUrlResponse = AuthSessionUrlResponse(
@@ -494,7 +494,7 @@ class AuthClient {
     );
     final codeVerifier = generatePKCEVerifier();
     await _asyncStorage!.setItem(
-      key: '${Constants.defaultStorageKey}-code-verifier',
+      key: '${AuthConstants.defaultStorageKey}-code-verifier',
       value: storageEventName == null
           ? codeVerifier
           : '$codeVerifier/$storageEventName',
@@ -996,7 +996,7 @@ class AuthClient {
     final expiresAt = decoded.payload.expiresAt;
     final hasExpired =
         expiresAt == null ||
-        expiresAt <= timeNow + Constants.expiryMargin.inSeconds;
+        expiresAt <= timeNow + AuthConstants.expiryMargin.inSeconds;
 
     if (hasExpired) {
       return await _callRefreshToken(refreshToken);
@@ -1143,7 +1143,7 @@ class AuthClient {
     if (scope != SignOutScope.others) {
       _removeSession();
       await _asyncStorage?.removeItem(
-        key: '${Constants.defaultStorageKey}-code-verifier',
+        key: '${AuthConstants.defaultStorageKey}-code-verifier',
       );
       notifyAllSubscribers(
         AuthChangeEvent.signedOut,
@@ -1397,7 +1397,7 @@ class AuthClient {
 
     _log.fine('Starting auto refresh');
     _autoRefreshTicker = Timer.periodic(
-      Constants.autoRefreshTickDuration,
+      AuthConstants.autoRefreshTickDuration,
       (Timer t) => _autoRefreshTokenTick(),
     );
 
@@ -1431,13 +1431,13 @@ class AuthClient {
 
       final expiresInTicks =
           (expiresAt.difference(now).inMilliseconds /
-                  Constants.autoRefreshTickDuration.inMilliseconds)
+                  AuthConstants.autoRefreshTickDuration.inMilliseconds)
               .floor();
 
       _log.finer('Access token expires in $expiresInTicks ticks');
 
       // Only tick if the next tick comes after the retry threshold
-      if (expiresInTicks <= Constants.autoRefreshTickThreshold) {
+      if (expiresInTicks <= AuthConstants.autoRefreshTickThreshold) {
         await _callRefreshToken(refreshToken);
       }
     } catch (error) {
@@ -1478,7 +1478,7 @@ class AuthClient {
             (DateTime.now().millisecondsSinceEpoch +
                     nextBackOff.inMilliseconds -
                     startedAt.millisecondsSinceEpoch) <
-                Constants.autoRefreshTickDuration.inMilliseconds;
+                AuthConstants.autoRefreshTickDuration.inMilliseconds;
       },
       maxDelay: Duration(seconds: 10),
       randomizationFactor: 0,
@@ -1759,7 +1759,7 @@ class AuthClient {
     // jwks exists and it isn't stale
     if (cachedJwk != null &&
         _jwksCachedAt != null &&
-        _jwksCachedAt!.add(Constants.jwksTtl).isAfter(now)) {
+        _jwksCachedAt!.add(AuthConstants.jwksTtl).isAfter(now)) {
       return cachedJwk;
     }
 

--- a/packages/supabase_auth/lib/src/auth_constants.dart
+++ b/packages/supabase_auth/lib/src/auth_constants.dart
@@ -1,0 +1,33 @@
+import 'package:supabase_auth/src/version.dart';
+import 'package:meta/meta.dart';
+import 'package:supabase_common/supabase_common.dart';
+
+@internal
+class AuthConstants {
+  static const String defaultAuthUrl = 'http://localhost:9999';
+  static final Map<String, String> defaultHeaders = {
+    'X-Client-Info': buildClientInfoHeader('gotrue-dart', version),
+  };
+
+  /// storage key prefix to store code verifiers
+  static const String defaultStorageKey = 'supabase.auth.token';
+
+  /// The margin to use when checking if a token is expired.
+  static const expiryMargin = Duration(seconds: 30);
+
+  /// Current session will be checked for refresh at this interval.
+  static const autoRefreshTickDuration = Duration(seconds: 10);
+
+  /// A token refresh will be attempted this many ticks before the current
+  /// session expires.
+  static const autoRefreshTickThreshold = 3;
+
+  /// The name of the header that contains API version.
+  static const apiVersionHeaderName = 'x-supabase-api-version';
+
+  /// The API version this client speaks, sent on every request.
+  static const apiVersion = '2024-01-01';
+
+  /// The TTL for the JWKS cache.
+  static const jwksTtl = Duration(minutes: 10);
+}

--- a/packages/supabase_auth/lib/src/constants.dart
+++ b/packages/supabase_auth/lib/src/constants.dart
@@ -1,36 +1,5 @@
-import 'package:supabase_auth/src/version.dart';
 import 'package:meta/meta.dart';
 import 'package:supabase_common/supabase_common.dart';
-
-@internal
-class Constants {
-  static const String defaultAuthUrl = 'http://localhost:9999';
-  static final Map<String, String> defaultHeaders = {
-    'X-Client-Info': buildClientInfoHeader('gotrue-dart', version),
-  };
-
-  /// storage key prefix to store code verifiers
-  static const String defaultStorageKey = 'supabase.auth.token';
-
-  /// The margin to use when checking if a token is expired.
-  static const expiryMargin = Duration(seconds: 30);
-
-  /// Current session will be checked for refresh at this interval.
-  static const autoRefreshTickDuration = Duration(seconds: 10);
-
-  /// A token refresh will be attempted this many ticks before the current
-  /// session expires.
-  static const autoRefreshTickThreshold = 3;
-
-  /// The name of the header that contains API version.
-  static const apiVersionHeaderName = 'x-supabase-api-version';
-
-  /// The API version this client speaks, sent on every request.
-  static const apiVersion = '2024-01-01';
-
-  /// The TTL for the JWKS cache.
-  static const jwksTtl = Duration(minutes: 10);
-}
 
 enum AuthChangeEvent {
   initialSession,

--- a/packages/supabase_auth/lib/src/fetch.dart
+++ b/packages/supabase_auth/lib/src/fetch.dart
@@ -1,6 +1,6 @@
 import 'dart:convert';
 
-import 'package:supabase_auth/src/constants.dart';
+import 'package:supabase_auth/src/auth_constants.dart';
 import 'package:supabase_auth/src/types/auth_exception.dart';
 import 'package:supabase_auth/src/types/error_code.dart';
 import 'package:supabase_auth/src/types/fetch_options.dart';
@@ -140,9 +140,10 @@ class AuthFetch {
     final headers = {...?options?.headers};
 
     // Pin the API version rather than letting a caller override it. This client
-    // only understands the error shape of [Constants.apiVersion], so asking the
-    // server for an older one would produce responses it cannot parse.
-    headers[Constants.apiVersionHeaderName] = Constants.apiVersion;
+    // only understands the error shape of [AuthConstants.apiVersion], so
+    // asking the server for an older one would produce responses it cannot
+    // parse.
+    headers[AuthConstants.apiVersionHeaderName] = AuthConstants.apiVersion;
 
     if (options?.jwt != null) {
       headers['Authorization'] = 'Bearer ${options!.jwt}';

--- a/packages/supabase_auth/lib/src/types/session.dart
+++ b/packages/supabase_auth/lib/src/types/session.dart
@@ -1,4 +1,4 @@
-import 'package:supabase_auth/src/constants.dart';
+import 'package:supabase_auth/src/auth_constants.dart';
 import 'package:supabase_auth/src/helper.dart';
 import 'package:supabase_auth/src/types/user.dart';
 import 'package:meta/meta.dart';
@@ -97,11 +97,11 @@ class Session {
   bool get isExpired {
     final expiresAt = this.expiresAt;
     if (expiresAt == null) return false;
-    return DateTime.now().add(Constants.expiryMargin).isAfter(expiresAt);
+    return DateTime.now().add(AuthConstants.expiryMargin).isAfter(expiresAt);
   }
 
   /// Returns `true` if the token is expired right now, without applying the
-  /// [Constants.expiryMargin] buffer used by [isExpired].
+  /// [AuthConstants.expiryMargin] buffer used by [isExpired].
   @internal
   bool get isExpiredWithoutMargin {
     final expiresAt = this.expiresAt;

--- a/packages/supabase_auth/lib/supabase_auth.dart
+++ b/packages/supabase_auth/lib/supabase_auth.dart
@@ -4,7 +4,7 @@ library;
 export 'package:supabase_common/supabase_common.dart'
     show SupabaseApiException, SupabaseException;
 
-export 'src/constants.dart' hide Constants;
+export 'src/constants.dart';
 export 'src/auth_admin_api.dart';
 export 'src/auth_client.dart';
 export 'src/helper.dart' show decodeJwt, validateExpiration;

--- a/packages/supabase_auth/test/fetch_test.dart
+++ b/packages/supabase_auth/test/fetch_test.dart
@@ -1,7 +1,7 @@
 import 'dart:convert';
 
 import 'package:supabase_auth/supabase_auth.dart';
-import 'package:supabase_auth/src/constants.dart';
+import 'package:supabase_auth/src/auth_constants.dart';
 import 'package:supabase_auth/src/fetch.dart';
 import 'package:supabase_auth/src/types/fetch_options.dart';
 import 'package:http/http.dart';
@@ -77,7 +77,7 @@ void main() {
           },
         },
         headers: {
-          Constants.apiVersionHeaderName: '2024-01-01',
+          AuthConstants.apiVersionHeaderName: '2024-01-01',
         },
         statusCode: 400,
       );
@@ -92,8 +92,8 @@ void main() {
       await AuthFetch(client).request(_mockUrl, HttpMethod.get);
 
       expect(
-        client.lastHeaders?[Constants.apiVersionHeaderName],
-        Constants.apiVersion,
+        client.lastHeaders?[AuthConstants.apiVersionHeaderName],
+        AuthConstants.apiVersion,
       );
     });
 
@@ -104,13 +104,13 @@ void main() {
         _mockUrl,
         HttpMethod.get,
         options: AuthRequestOptions(
-          headers: {Constants.apiVersionHeaderName: '2023-01-01'},
+          headers: {AuthConstants.apiVersionHeaderName: '2023-01-01'},
         ),
       );
 
       expect(
-        client.lastHeaders?[Constants.apiVersionHeaderName],
-        Constants.apiVersion,
+        client.lastHeaders?[AuthConstants.apiVersionHeaderName],
+        AuthConstants.apiVersion,
       );
     });
   });
@@ -123,7 +123,7 @@ void main() {
           'message': 'Error sending confirmation email',
         },
         headers: {
-          Constants.apiVersionHeaderName: '2024-01-01',
+          AuthConstants.apiVersionHeaderName: '2024-01-01',
         },
         statusCode: 500,
       );

--- a/packages/supabase_auth/test/otp_mock_test.dart
+++ b/packages/supabase_auth/test/otp_mock_test.dart
@@ -1,5 +1,5 @@
 import 'package:supabase_auth/supabase_auth.dart';
-import 'package:supabase_auth/src/constants.dart' show Constants;
+import 'package:supabase_auth/src/auth_constants.dart' show AuthConstants;
 import 'package:test/test.dart';
 
 import 'mocks/otp_mock_client.dart';
@@ -422,7 +422,7 @@ void main() {
         await client.updateUser(UserAttributes(email: testEmail));
 
         final storedVerifier = await asyncStorage.getItem(
-          key: '${Constants.defaultStorageKey}-code-verifier',
+          key: '${AuthConstants.defaultStorageKey}-code-verifier',
         );
         expect(
           storedVerifier?.split('/').last,

--- a/packages/supabase_auth/test/src/constants_test.dart
+++ b/packages/supabase_auth/test/src/constants_test.dart
@@ -1,47 +1,51 @@
+import 'package:supabase_auth/src/auth_constants.dart';
 import 'package:supabase_auth/src/constants.dart';
 import 'package:supabase_auth/src/version.dart';
 import 'package:supabase_common/supabase_common.dart';
 import 'package:test/test.dart';
 
 void main() {
-  group('Constants', () {
+  group('AuthConstants', () {
     test('has correct default GoTrue URL', () {
-      expect(Constants.defaultAuthUrl, equals('http://localhost:9999'));
+      expect(AuthConstants.defaultAuthUrl, equals('http://localhost:9999'));
     });
 
     test('has correct default headers', () {
-      expect(Constants.defaultHeaders, isA<Map<String, String>>());
+      expect(AuthConstants.defaultHeaders, isA<Map<String, String>>());
       expect(
-        Constants.defaultHeaders['X-Client-Info'],
+        AuthConstants.defaultHeaders['X-Client-Info'],
         equals('gotrue-dart/$version'),
       );
     });
 
     test('has correct default storage key', () {
-      expect(Constants.defaultStorageKey, equals('supabase.auth.token'));
+      expect(AuthConstants.defaultStorageKey, equals('supabase.auth.token'));
     });
 
     test('has correct expiry margin duration', () {
-      expect(Constants.expiryMargin, equals(const Duration(seconds: 30)));
+      expect(AuthConstants.expiryMargin, equals(const Duration(seconds: 30)));
     });
 
     test('has correct auto refresh tick duration', () {
       expect(
-        Constants.autoRefreshTickDuration,
+        AuthConstants.autoRefreshTickDuration,
         equals(const Duration(seconds: 10)),
       );
     });
 
     test('has correct auto refresh tick threshold', () {
-      expect(Constants.autoRefreshTickThreshold, equals(3));
+      expect(AuthConstants.autoRefreshTickThreshold, equals(3));
     });
 
     test('has correct API version header name', () {
-      expect(Constants.apiVersionHeaderName, equals('x-supabase-api-version'));
+      expect(
+        AuthConstants.apiVersionHeaderName,
+        equals('x-supabase-api-version'),
+      );
     });
 
     test('has correct API version', () {
-      expect(Constants.apiVersion, equals('2024-01-01'));
+      expect(AuthConstants.apiVersion, equals('2024-01-01'));
     });
   });
 

--- a/packages/supabase_auth/test/src/set_session_test.dart
+++ b/packages/supabase_auth/test/src/set_session_test.dart
@@ -116,7 +116,7 @@ void main() {
     test('access token with exp within the 30-second expiry margin is treated '
         'as expired and falls back to the refresh-token path', () async {
       final timeNow = DateTime.now().millisecondsSinceEpoch ~/ 1000;
-      // exp is 20 s in the future, inside the 30 s Constants.expiryMargin.
+      // exp is 20 s in the future, inside the 30 s AuthConstants.expiryMargin.
       final accessToken = _makeRawJwt({
         'exp': timeNow + 20,
         'iat': timeNow - 3580,

--- a/packages/supabase_auth/test/src/types/session_test.dart
+++ b/packages/supabase_auth/test/src/types/session_test.dart
@@ -1,6 +1,6 @@
 import 'dart:convert';
 
-import 'package:supabase_auth/src/constants.dart';
+import 'package:supabase_auth/src/auth_constants.dart';
 import 'package:supabase_auth/src/types/session.dart';
 import 'package:supabase_auth/src/types/user.dart';
 import 'package:test/test.dart';
@@ -297,7 +297,7 @@ void main() {
       });
 
       test('uses correct expiry margin from constants', () {
-        final marginalTime = DateTime.now().add(Constants.expiryMargin);
+        final marginalTime = DateTime.now().add(AuthConstants.expiryMargin);
         final expiresAt = (marginalTime.millisecondsSinceEpoch / 1000).floor();
         final header = base64Encode(utf8.encode('{"alg":"HS256","typ":"JWT"}'));
         final payload = base64Encode(utf8.encode('{"exp":$expiresAt}'));

--- a/packages/supabase_flutter/lib/src/supabase.dart
+++ b/packages/supabase_flutter/lib/src/supabase.dart
@@ -7,7 +7,7 @@ import 'package:http/http.dart';
 import 'package:logging/logging.dart';
 import 'package:supabase/supabase.dart';
 import 'package:supabase_common/supabase_common.dart';
-import 'package:supabase_flutter/src/constants.dart';
+import 'package:supabase_flutter/src/supabase_flutter_constants.dart';
 import 'package:supabase_flutter/src/flutter_auth_client_options.dart';
 import 'package:supabase_flutter/src/local_storage.dart';
 import 'package:supabase_flutter/src/supabase_auth.dart';
@@ -278,7 +278,7 @@ class Supabase {
     required Future<String?> Function()? accessToken,
   }) {
     final headers = {
-      ...Constants.defaultHeaders,
+      ...SupabaseFlutterConstants.defaultHeaders,
       ...?customHeaders,
     };
     final newClient = _client = SupabaseClient(

--- a/packages/supabase_flutter/lib/src/supabase_flutter_constants.dart
+++ b/packages/supabase_flutter/lib/src/supabase_flutter_constants.dart
@@ -3,7 +3,7 @@ import 'package:supabase_flutter/src/version.dart';
 import 'package:meta/meta.dart';
 
 @internal
-class Constants {
+class SupabaseFlutterConstants {
   static final Map<String, String> defaultHeaders = Map.unmodifiable({
     'X-Client-Info': buildClientInfoHeader(
       'supabase-flutter',

--- a/packages/supabase_flutter/test/version_test.dart
+++ b/packages/supabase_flutter/test/version_test.dart
@@ -1,5 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:supabase_flutter/src/constants.dart';
+import 'package:supabase_flutter/src/supabase_flutter_constants.dart';
 import 'package:supabase_flutter/src/version.dart';
 
 void main() {
@@ -10,10 +10,16 @@ void main() {
     });
   });
 
-  group('Constants', () {
+  group('SupabaseFlutterConstants', () {
     test('defaultHeaders contains expected keys', () {
-      expect(Constants.defaultHeaders, isA<Map<String, String>>());
-      expect(Constants.defaultHeaders.keys, contains('X-Client-Info'));
+      expect(
+        SupabaseFlutterConstants.defaultHeaders,
+        isA<Map<String, String>>(),
+      );
+      expect(
+        SupabaseFlutterConstants.defaultHeaders.keys,
+        contains('X-Client-Info'),
+      );
     });
   });
 }

--- a/packages/supabase_functions/lib/src/functions_client.dart
+++ b/packages/supabase_functions/lib/src/functions_client.dart
@@ -1,7 +1,7 @@
 import 'dart:convert';
 import 'dart:typed_data';
 
-import 'package:supabase_functions/src/constants.dart';
+import 'package:supabase_functions/src/functions_constants.dart';
 import 'package:supabase_functions/src/types.dart';
 import 'package:supabase_functions/src/version.dart';
 import 'package:http/http.dart' as http;
@@ -28,7 +28,7 @@ class FunctionsClient {
     YAJsonIsolate? isolate,
     String? region,
   }) : _url = url,
-       _headers = {...Constants.defaultHeaders, ...headers},
+       _headers = {...FunctionsConstants.defaultHeaders, ...headers},
        _isolate = isolate ?? (YAJsonIsolate()..initialize()),
        _hasCustomIsolate = isolate != null,
        _httpClient = httpClient,

--- a/packages/supabase_functions/lib/src/functions_constants.dart
+++ b/packages/supabase_functions/lib/src/functions_constants.dart
@@ -3,7 +3,7 @@ import 'package:supabase_common/supabase_common.dart';
 import 'package:meta/meta.dart';
 
 @internal
-class Constants {
+class FunctionsConstants {
   static final defaultHeaders = {
     'X-Client-Info': buildClientInfoHeader('functions-dart', version),
   };

--- a/packages/supabase_realtime/lib/src/constants.dart
+++ b/packages/supabase_realtime/lib/src/constants.dart
@@ -2,17 +2,21 @@ import 'package:meta/meta.dart';
 import 'package:supabase_realtime/src/version.dart';
 import 'package:supabase_common/supabase_common.dart';
 
-class Constants {
+class RealtimeConstants {
   static const Duration defaultTimeout = Duration(milliseconds: 10000);
   static const Duration defaultConnectionCloseTimeout = Duration(seconds: 6);
+
+  @internal
   static const Duration defaultHeartbeatInterval = Duration(seconds: 25);
+
+  @internal
   static const int webSocketCloseNormal = 1000;
+
+  @internal
   static final Map<String, String> defaultHeaders = {
     'X-Client-Info': buildClientInfoHeader('realtime-dart', version),
   };
 }
-
-typedef RealtimeConstants = Constants;
 
 enum RealtimeProtocolVersion {
   /// Legacy protocol: object-shaped JSON text frames only.

--- a/packages/supabase_realtime/lib/src/constants.dart
+++ b/packages/supabase_realtime/lib/src/constants.dart
@@ -1,22 +1,4 @@
 import 'package:meta/meta.dart';
-import 'package:supabase_realtime/src/version.dart';
-import 'package:supabase_common/supabase_common.dart';
-
-class RealtimeConstants {
-  static const Duration defaultTimeout = Duration(milliseconds: 10000);
-  static const Duration defaultConnectionCloseTimeout = Duration(seconds: 6);
-
-  @internal
-  static const Duration defaultHeartbeatInterval = Duration(seconds: 25);
-
-  @internal
-  static const int webSocketCloseNormal = 1000;
-
-  @internal
-  static final Map<String, String> defaultHeaders = {
-    'X-Client-Info': buildClientInfoHeader('realtime-dart', version),
-  };
-}
 
 enum RealtimeProtocolVersion {
   /// Legacy protocol: object-shaped JSON text frames only.

--- a/packages/supabase_realtime/lib/src/push.dart
+++ b/packages/supabase_realtime/lib/src/push.dart
@@ -38,7 +38,7 @@ class Push {
     this._channel,
     this._event, [
     this.payload = const {},
-    this._timeout = Constants.defaultTimeout,
+    this._timeout = RealtimeConstants.defaultTimeout,
   ]);
 
   String get ref => _ref;

--- a/packages/supabase_realtime/lib/src/realtime_client.dart
+++ b/packages/supabase_realtime/lib/src/realtime_client.dart
@@ -111,7 +111,7 @@ class RealtimeClient {
   final WebSocketTransport transport;
   final Client? httpClient;
   final _log = Logger('supabase.realtime');
-  Duration heartbeatInterval = Constants.defaultHeartbeatInterval;
+  Duration heartbeatInterval = RealtimeConstants.defaultHeartbeatInterval;
   @internal
   Timer? heartbeatTimer;
 
@@ -211,9 +211,10 @@ class RealtimeClient {
   RealtimeClient(
     String endpoint, {
     WebSocketTransport? transport,
-    this.timeout = Constants.defaultTimeout,
-    this.connectionCloseTimeout = Constants.defaultConnectionCloseTimeout,
-    this.heartbeatInterval = Constants.defaultHeartbeatInterval,
+    this.timeout = RealtimeConstants.defaultTimeout,
+    this.connectionCloseTimeout =
+        RealtimeConstants.defaultConnectionCloseTimeout,
+    this.heartbeatInterval = RealtimeConstants.defaultHeartbeatInterval,
     Duration? disconnectOnEmptyChannelsAfter,
     this.logger,
     RealtimeEncode? encode,
@@ -233,7 +234,7 @@ class RealtimeClient {
            )
            .toString(),
        headers = {
-         ...Constants.defaultHeaders,
+         ...RealtimeConstants.defaultHeaders,
          ...?headers,
        },
        transport = transport ?? createWebSocketClient,
@@ -638,7 +639,7 @@ class RealtimeClient {
       if (tokenToSend != null) {
         channel.updateJoinPayload({
           'access_token': tokenToSend,
-          'version': Constants.defaultHeaders['X-Client-Info'],
+          'version': RealtimeConstants.defaultHeaders['X-Client-Info'],
         });
       }
       if (channel.joinedOnce && channel.isJoined) {
@@ -796,7 +797,7 @@ class RealtimeClient {
       _heartbeatController.add(RealtimeHeartbeatStatus.timeout);
       unawaited(
         connection?.sink.close(
-          Constants.webSocketCloseNormal,
+          RealtimeConstants.webSocketCloseNormal,
           'heartbeat timeout',
         ),
       );

--- a/packages/supabase_realtime/lib/src/realtime_constants.dart
+++ b/packages/supabase_realtime/lib/src/realtime_constants.dart
@@ -1,0 +1,19 @@
+import 'package:meta/meta.dart';
+import 'package:supabase_realtime/src/version.dart';
+import 'package:supabase_common/supabase_common.dart';
+
+class RealtimeConstants {
+  static const Duration defaultTimeout = Duration(milliseconds: 10000);
+  static const Duration defaultConnectionCloseTimeout = Duration(seconds: 6);
+
+  @internal
+  static const Duration defaultHeartbeatInterval = Duration(seconds: 25);
+
+  @internal
+  static const int webSocketCloseNormal = 1000;
+
+  @internal
+  static final Map<String, String> defaultHeaders = {
+    'X-Client-Info': buildClientInfoHeader('realtime-dart', version),
+  };
+}

--- a/packages/supabase_realtime/lib/supabase_realtime.dart
+++ b/packages/supabase_realtime/lib/supabase_realtime.dart
@@ -3,13 +3,10 @@
 library;
 
 export 'src/constants.dart'
-    show
-        RealtimeConstants,
-        RealtimeLogLevel,
-        RealtimeProtocolVersion,
-        SocketState;
+    show RealtimeLogLevel, RealtimeProtocolVersion, SocketState;
 export 'src/realtime_channel.dart';
 export 'src/realtime_client.dart';
+export 'src/realtime_constants.dart';
 export 'src/realtime_presence.dart';
 export 'src/transformers.dart' show PostgresColumn, PostgresType;
 export 'src/types.dart' hide ChannelFilter, RealtimeListenType;

--- a/packages/supabase_realtime/test/channel_test.dart
+++ b/packages/supabase_realtime/test/channel_test.dart
@@ -4,7 +4,6 @@ import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:supabase_realtime/supabase_realtime.dart';
-import 'package:supabase_realtime/src/constants.dart';
 import 'package:supabase_realtime/src/push.dart';
 import 'package:supabase_realtime/src/types.dart';
 import 'package:test/test.dart';
@@ -115,7 +114,7 @@ void main() {
       const newTimeout = Duration(milliseconds: 2000);
       final joinPush = channel.joinPush;
 
-      expect(joinPush.timeout, Constants.defaultTimeout);
+      expect(joinPush.timeout, RealtimeConstants.defaultTimeout);
 
       channel.subscribe((_, [_]) {}, newTimeout);
 

--- a/packages/supabase_realtime/test/mock_test.dart
+++ b/packages/supabase_realtime/test/mock_test.dart
@@ -3,7 +3,6 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:supabase_realtime/supabase_realtime.dart';
-import 'package:supabase_realtime/src/constants.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -313,7 +312,7 @@ void main() {
 
       await Future.delayed(Duration(milliseconds: 200));
       await webSocket?.close(
-        Constants.webSocketCloseNormal,
+        RealtimeConstants.webSocketCloseNormal,
         "heartbeat timeout",
       );
     });

--- a/packages/supabase_realtime/test/socket_test.dart
+++ b/packages/supabase_realtime/test/socket_test.dart
@@ -91,7 +91,10 @@ void main() {
         'message': [],
       });
       expect(socket.timeout, const Duration(milliseconds: 10000));
-      expect(socket.heartbeatInterval, Constants.defaultHeartbeatInterval);
+      expect(
+        socket.heartbeatInterval,
+        RealtimeConstants.defaultHeartbeatInterval,
+      );
       expect(
         socket.logger
             is void Function(
@@ -646,7 +649,7 @@ void main() {
       final socket = RealtimeClient(socketEndpoint);
       expect(
         socket.disconnectOnEmptyChannelsAfter,
-        Constants.defaultHeartbeatInterval * 2,
+        RealtimeConstants.defaultHeartbeatInterval * 2,
       );
 
       final customSocket = RealtimeClient(
@@ -1068,7 +1071,7 @@ void main() {
     final token = generateJwt();
     final updateJoinPayload = {
       'access_token': token,
-      'version': Constants.defaultHeaders['X-Client-Info'],
+      'version': RealtimeConstants.defaultHeaders['X-Client-Info'],
     };
     final pushPayload = {'access_token': token};
 
@@ -1162,7 +1165,7 @@ void main() {
         final expectedPushPayload = {'access_token': authToken};
         final expectedUpdateJoinPayload = {
           'access_token': authToken,
-          'version': Constants.defaultHeaders['X-Client-Info'],
+          'version': RealtimeConstants.defaultHeaders['X-Client-Info'],
         };
 
         await mockedSocket.setAccessToken(authToken);

--- a/packages/supabase_storage/lib/src/storage_client.dart
+++ b/packages/supabase_storage/lib/src/storage_client.dart
@@ -1,6 +1,6 @@
 import 'package:logging/logging.dart';
 import 'package:meta/meta.dart';
-import 'package:supabase_storage/src/constants.dart';
+import 'package:supabase_storage/src/storage_constants.dart';
 import 'package:supabase_storage/src/iceberg/iceberg_rest_catalog.dart';
 import 'package:supabase_storage/src/iceberg/iceberg_types.dart';
 import 'package:supabase_storage/src/storage_bucket_api.dart';
@@ -55,7 +55,7 @@ class SupabaseStorageClient extends StorageBucketApi {
        _defaultRetryAttempts = retryAttempts,
        super(
          useNewHostname ? _transformStorageUrl(url) : url,
-         {...Constants.defaultHeaders, ...headers},
+         {...StorageConstants.defaultHeaders, ...headers},
        ) {
     _log.config(
       'Initialize SupabaseStorageClient v$version with url: $url, '

--- a/packages/supabase_storage/lib/src/storage_constants.dart
+++ b/packages/supabase_storage/lib/src/storage_constants.dart
@@ -3,7 +3,7 @@ import 'package:supabase_common/supabase_common.dart';
 import 'package:meta/meta.dart';
 
 @internal
-class Constants {
+class StorageConstants {
   static final Map<String, String> defaultHeaders = {
     'X-Client-Info': buildClientInfoHeader('storage-dart', version),
   };

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -1653,12 +1653,11 @@ features:
   realtime.client.disconnect:
     status: implemented
     symbols:
-      - Constants.defaultConnectionCloseTimeout
       - RealtimeClient.connectionCloseTimeout
       - RealtimeClient.disconnect
       - RealtimeClientOptions.connectionCloseTimeout
+      - RealtimeConstants.defaultConnectionCloseTimeout
     supporting_symbols:
-      - Constants.webSocketCloseNormal
       - RealtimeClient.onClose
       - RealtimeCloseEvent
       - RealtimeCloseEvent.RealtimeCloseEvent
@@ -1881,8 +1880,6 @@ features:
     status: implemented
     symbols:
       - RealtimeClient.heartbeatInterval
-    supporting_symbols:
-      - Constants.defaultHeartbeatInterval
   realtime.configuration.access_token_callback:
     status: implemented
     note: "On connect the access token is resolved before the send buffer is flushed; buffered channel join payloads are patched with the token and re-sent so subscriptions authenticate correctly when the token resolves asynchronously (e.g. read from async storage)."
@@ -2035,7 +2032,6 @@ features:
     symbols:
       - SupabaseClient.headers
     supporting_symbols:
-      - Constants.defaultHeaders
       - FunctionsClient.headers
       - AuthClient.headers
       - PostgrestBuilder.setHeader
@@ -2145,8 +2141,6 @@ supporting_symbols:
   - BucketOptions.allowedMimeTypes
   - BucketOptions.fileSizeLimit
   - BucketOptions.public
-  - Constants
-  - Constants.defaultTimeout
   - CountOption
   - ErrorCode
   - ErrorCode.ErrorCode
@@ -2376,6 +2370,7 @@ supporting_symbols:
   - RealtimeClientOptions.RealtimeClientOptions
   - RealtimeClientOptions.timeout
   - RealtimeConstants
+  - RealtimeConstants.defaultTimeout
   - RealtimeSubscribeException
   - RealtimeSubscribeException.RealtimeSubscribeException
   - RealtimeSubscribeException.details


### PR DESCRIPTION
Stacked on #1673, addressing https://github.com/supabase/supabase-flutter/pull/1673#discussion_r3747503513.

## Why

Six packages declared a class named `Constants`: `functions_client`, `gotrue`, `realtime_client`, `storage_client`, `supabase` and `supabase_flutter`. The capability matrix keys symbols by bare name, so an entry like `Constants.defaultHeaders` could not say which package it meant. The same ambiguity applies to anyone reading the code across packages.

## What changed

Each class is named after its package, and the file declaring it is named to match:

| Package | Class | File |
|---|---|---|
| `functions_client` | `FunctionsConstants` | `src/functions_constants.dart` |
| `gotrue` | `GoTrueConstants` | `src/gotrue_constants.dart` |
| `realtime_client` | `RealtimeConstants` | `src/realtime_constants.dart` |
| `storage_client` | `StorageConstants` | `src/storage_constants.dart` |
| `supabase` | `SupabaseConstants` | `src/supabase_constants.dart` |
| `supabase_flutter` | `SupabaseFlutterConstants` | `src/supabase_flutter_constants.dart` |

`gotrue` and `realtime_client` keep a `constants.dart`, since both also declare enums there. Only the class moved out into its own file, so `constants.dart` now holds exactly the enums and, for `gotrue`, `ApiVersions`. `gotrue.dart` no longer needs `hide Constants` on its export as a result.

`realtime_client` holds the only public class of the six, so it changed the most:

- The `typedef RealtimeConstants = Constants` is gone and the class carries that name directly. `realtime_client.dart` only ever exported the alias, so the name consumers write is unchanged.
- `defaultHeaders`, `defaultHeartbeatIntervalMs` and `wsCloseNormal` are now `@internal`. Nothing outside the package reads them, and the other five packages' default header maps were already internal. This is the breaking part: code outside the package that reached for them will now get `invalid_use_of_internal_member`.
- `defaultTimeout` and `defaultConnectionCloseTimeout` stay public, because `supabase` reads both when filling in unset `RealtimeClientOptions`.

In `sdk-compliance.yaml`, the three now-internal symbols are dropped, `realtime.configuration.heartbeat_interval` loses its `supporting_symbols` list along with them, the duplicated `Constants` and `Constants.defaultTimeout` pair is removed from the top-level list, and `RealtimeConstants.defaultConnectionCloseTimeout` and `RealtimeConstants.defaultTimeout` are registered under the new name.

## Verification

- `dart analyze` clean across all packages and examples.
- Full suites pass against a local Supabase stack, at the `--concurrency=1` the workflow uses: `gotrue` (479), `realtime_client` (205, integration included), `storage_client` (210), `supabase` (134), `supabase_flutter` (65), `functions_client` (48).
- The compliance symbol, drift and schema checks pass locally against this branch's base.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Realtime configuration constants are now available through the public library interface.

* **Refactor**
  * Standardized configuration naming across authentication, database, functions, realtime, storage, and Flutter integrations.
  * Centralized default headers, timeouts, session settings, and client metadata under clearer service-specific constants.
  * Preserved existing defaults and runtime behavior.

* **Tests**
  * Updated automated coverage to validate the renamed configuration references and existing expected values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->