### PR TITLE
docs: document the shared HttpMethod enum in the migration guide

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -313,3 +313,16 @@ supabase.auth.onAuthStateChange.listen((data) {
 
 For the PKCE case, `AuthSessionUrlResponse.redirectType` is `'userUpdated'` instead of `null`, so
 you can also branch on the response of `exchangeCodeForSession()` directly.
+
+### `HttpMethod` is one shared enum
+
+`functions_client` and `postgrest` each declared their own `HttpMethod`. There is now one, shaped
+like postgrest's and re-exported from both, so imports are unchanged and postgrest callers are
+unaffected. For `functions.invoke`, two things changed:
+
+- `head` was added, so an exhaustive `switch` over `HttpMethod` no longer compiles until you handle
+  it.
+- The values were reordered, so `index` shifted for `post` (1 to 2), `put` (2 to 3) and `delete`
+  (3 to 5). This one is not a compile error, so replace any persisted `index` with `name`.
+
+The enum also exposes `value`, the uppercase wire form, in place of `method.name.toUpperCase()`.


### PR DESCRIPTION
Follow-up to #1678, which landed without a migration note.

## Why

Merging the two `HttpMethod` enums changed the one that `functions_client` exported, and both effects are things a caller can hit:

- `head` joined the enum, so an exhaustive `switch` over `HttpMethod` in user code stops compiling. Verified: the analyzer reports `non_exhaustive_switch_expression`.
- The declaration order changed, so `index` moved for `post`, `put` and `delete`. That one is silent, which is exactly the kind of change this guide flags.

Nothing changes for callers who only used postgrest's enum, and no import paths change, since the shared enum is re-exported from both packages.

## What changed

One section added to the v3 list in `MIGRATION.md`: 13 lines, two bullets, no snippets. The shifted indices were read off the runtime output of iterating the merged enum (`get=0 head=1 post=2 put=3 patch=4 delete=5`) rather than derived by hand.

Docs only, no code changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the `HEAD` HTTP method.
  * Standardized HTTP method handling across Functions and PostgREST integrations.
  * Added uppercase wire-format values for HTTP methods.
  * Improved compatibility for sharing HTTP method definitions across integrations.

* **Documentation**
  * Added migration guidance for updating method-based switches.
  * Documented replacing persisted numeric method indices with stable method names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->