### PR TITLE
chore!: remove the v1 to v2 migration paths and expose defaultPersistSessionKey

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -358,7 +358,9 @@ drop preferences your own code wrote through the legacy API. So if your code sti
 as well. The snippet below is the way out if you cannot do that yet.
 
 If you would rather keep the session in the legacy store for now, pass a `LocalStorage` that reads
-and writes it:
+and writes it. Supplying your own storage is also where the session key comes in: `initialize()`
+derives `sb-<project-ref>-auth-token` from your project URL for the default storage, so you only
+name the key when you construct a `LocalStorage` yourself.
 
 ```dart
 class LegacySharedPreferencesLocalStorage extends LocalStorage {

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -359,8 +359,8 @@ as well. The snippet below is the way out if you cannot do that yet.
 
 If you would rather keep the session in the legacy store for now, pass a `LocalStorage` that reads
 and writes it. Supplying your own storage is also where the session key comes in: `initialize()`
-derives `sb-<project-ref>-auth-token` from your project URL for the default storage, so you only
-name the key when you construct a `LocalStorage` yourself.
+derives it from your project URL for the default storage, so you only name the key when you
+construct a `LocalStorage` yourself, and `defaultPersistSessionKey` hands you the same one.
 
 ```dart
 class LegacySharedPreferencesLocalStorage extends LocalStorage {
@@ -397,8 +397,7 @@ await Supabase.initialize(
   publishableKey: publishableKey,
   authOptions: FlutterAuthClientOptions(
     localStorage: LegacySharedPreferencesLocalStorage(
-      persistSessionKey:
-          'sb-${Uri.parse(url).host.split('.').first}-auth-token',
+      persistSessionKey: defaultPersistSessionKey(url),
     ),
   ),
 );
@@ -437,7 +436,7 @@ await Supabase.initialize(
   publishableKey: publishableKey,
   authOptions: FlutterAuthClientOptions(
     localStorage: MySecureStorage(
-      persistSessionKey: 'sb-${Uri.parse(url).host.split('.').first}-auth-token',
+      persistSessionKey: defaultPersistSessionKey(url),
     ),
   ),
 );

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -401,3 +401,50 @@ await Supabase.initialize(
   ),
 );
 ```
+
+### `supabasePersistSessionKey` is gone
+
+The constant existed for the v1 to v2 migration from Hive, which v3 no longer carries, and the SDK
+itself never read it. The session is stored under the key you pass to `LocalStorage`, which for the
+default storage is `sb-<project-ref>-auth-token`.
+
+The `LocalStorage` examples in the README used the constant as their storage key, so if you copied
+one of those, take the key as a parameter instead:
+
+```dart
+// Before
+class MySecureStorage extends LocalStorage {
+  @override
+  Future<String?> accessToken() => storage.read(key: supabasePersistSessionKey);
+  // ...
+}
+
+// After
+class MySecureStorage extends LocalStorage {
+  MySecureStorage({required this.persistSessionKey});
+
+  final String persistSessionKey;
+
+  @override
+  Future<String?> accessToken() => storage.read(key: persistSessionKey);
+  // ...
+}
+
+await Supabase.initialize(
+  url: url,
+  publishableKey: publishableKey,
+  authOptions: FlutterAuthClientOptions(
+    localStorage: MySecureStorage(
+      persistSessionKey: 'sb-${Uri.parse(url).host.split('.').first}-auth-token',
+    ),
+  ),
+);
+```
+
+Passing the key you already store under keeps your users signed in; switching to a different key
+signs them out once. To keep the old value, pass `'SUPABASE_PERSIST_SESSION_KEY'`, which is what the
+constant held.
+
+The `MigrationLocalStorage` and `HiveLocalStorage` snippets that migrated a v1 session out of
+[hive](https://pub.dev/packages/hive) are gone from the README along with it. If you are still on
+v1, upgrade to v2 first and let it migrate the session, then move to v3.

--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -1514,8 +1514,7 @@ class GoTrueClient {
   void _mayStartBroadcastChannel() {
     if (const bool.fromEnvironment('dart.library.js_interop')) {
       // Used by the js library as well
-      final broadcastKey =
-          "sb-${Uri.parse(_url).host.split(".").first}-auth-token";
+      final broadcastKey = defaultPersistSessionKey(_url);
 
       assert(
         _broadcastChannel == null,

--- a/packages/supabase_common/lib/src/persist_session_key.dart
+++ b/packages/supabase_common/lib/src/persist_session_key.dart
@@ -1,0 +1,11 @@
+/// The key the user session is persisted under for the project at
+/// [supabaseUrl].
+///
+/// This is the key `Supabase.initialize` passes to the default `LocalStorage`,
+/// so pass it to your own `LocalStorage` implementation to keep reading and
+/// writing the session the SDK already persisted.
+///
+/// The other Supabase client libraries derive the key the same way, so a
+/// session written by one of them is found by the others.
+String defaultPersistSessionKey(String supabaseUrl) =>
+    'sb-${Uri.parse(supabaseUrl).host.split('.').first}-auth-token';

--- a/packages/supabase_common/lib/supabase_common.dart
+++ b/packages/supabase_common/lib/supabase_common.dart
@@ -10,6 +10,7 @@ export 'src/client_info.dart';
 export 'src/fetch_options.dart';
 export 'src/http_method.dart';
 export 'src/http_status.dart';
+export 'src/persist_session_key.dart';
 export 'src/pkce.dart';
 export 'src/platform/platform_info.dart';
 export 'src/replay_subject.dart';

--- a/packages/supabase_common/test/persist_session_key_test.dart
+++ b/packages/supabase_common/test/persist_session_key_test.dart
@@ -1,0 +1,27 @@
+import 'package:supabase_common/supabase_common.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('defaultPersistSessionKey', () {
+    test('derives the key from the project ref', () {
+      expect(
+        defaultPersistSessionKey('https://abcdefghijklmnop.supabase.co'),
+        'sb-abcdefghijklmnop-auth-token',
+      );
+    });
+
+    test('ignores the port and the path', () {
+      expect(
+        defaultPersistSessionKey('http://localhost:54321/rest/v1'),
+        'sb-localhost-auth-token',
+      );
+    });
+
+    test('handles a custom domain', () {
+      expect(
+        defaultPersistSessionKey('https://auth.example.com'),
+        'sb-auth-auth-token',
+      );
+    });
+  });
+}

--- a/packages/supabase_flutter/README.md
+++ b/packages/supabase_flutter/README.md
@@ -511,6 +511,9 @@ However, you can use any other methods by creating a `LocalStorage` implementati
 ```dart
 // Define the custom LocalStorage implementation
 class MySecureStorage extends LocalStorage {
+  MySecureStorage({required this.persistSessionKey});
+
+  final String persistSessionKey;
 
   final storage = FlutterSecureStorage();
 
@@ -519,22 +522,22 @@ class MySecureStorage extends LocalStorage {
 
   @override
   Future<String?> accessToken() async {
-    return storage.read(key: supabasePersistSessionKey);
+    return storage.read(key: persistSessionKey);
   }
 
   @override
   Future<bool> hasAccessToken() async {
-    return storage.containsKey(key: supabasePersistSessionKey);
+    return storage.containsKey(key: persistSessionKey);
   }
 
   @override
   Future<void> persistSession(String persistSessionString) async {
-    return storage.write(key: supabasePersistSessionKey, value: persistSessionString);
+    return storage.write(key: persistSessionKey, value: persistSessionString);
   }
 
   @override
   Future<void> removePersistedSession() async {
-    return storage.delete(key: supabasePersistSessionKey);
+    return storage.delete(key: persistSessionKey);
   }
 }
 
@@ -542,7 +545,9 @@ class MySecureStorage extends LocalStorage {
 Supabase.initialize(
   ...
   authOptions: FlutterAuthClientOptions(
-    localStorage: MySecureStorage(),
+    localStorage: MySecureStorage(
+      persistSessionKey: "sb-${Uri.parse(supabaseUrl).host.split(".").first}-auth-token",
+    ),
   ),
 );
 ```
@@ -554,160 +559,6 @@ Supabase.initialize(
   // ...
   authOptions: FlutterAuthClientOptions(
     localStorage: const EmptyLocalStorage(),
-  ),
-);
-```
-
-### Persisting the user session from supabase_flutter v1
-
-supabase_flutter v1 used hive to persist the user session. In the current version of supabase_flutter it uses shared_preferences. If you are updating your app from v1 to v2, you can use the following custom `LocalStorage` implementation to automatically migrate the user session from [hive](https://pub.dev/packages/hive) to [shared_preferences](https://pub.dev/packages/shared_preferences).
-
-```dart
-const _hiveBoxName = 'supabase_authentication';
-
-class MigrationLocalStorage extends LocalStorage {
-  final SharedPreferencesLocalStorage sharedPreferencesLocalStorage;
-  late final HiveLocalStorage hiveLocalStorage;
-
-  MigrationLocalStorage({required String persistSessionKey})
-      : sharedPreferencesLocalStorage =
-            SharedPreferencesLocalStorage(persistSessionKey: persistSessionKey);
-
-  @override
-  Future<void> initialize() async {
-    await Hive.initFlutter('auth');
-    hiveLocalStorage = const HiveLocalStorage();
-    await sharedPreferencesLocalStorage.initialize();
-    try {
-      await migrate();
-    } on TimeoutException {
-      // Ignore TimeoutException thrown by Hive methods
-      // https://github.com/supabase/supabase-flutter/issues/794
-    }
-  }
-
-  @visibleForTesting
-  Future<void> migrate() async {
-    // Migrate from Hive to SharedPreferences
-    if (await Hive.boxExists(_hiveBoxName)) {
-      await hiveLocalStorage.initialize();
-
-      final hasHive = await hiveLocalStorage.hasAccessToken();
-      if (hasHive) {
-        final accessToken = await hiveLocalStorage.accessToken();
-        final session =
-            Session.fromJson(jsonDecode(accessToken!)['currentSession']);
-        if (session == null) {
-          return;
-        }
-        await sharedPreferencesLocalStorage
-            .persistSession(jsonEncode(session.toJson()));
-        await hiveLocalStorage.removePersistedSession();
-      }
-      if (Hive.box(_hiveBoxName).isEmpty) {
-        final boxPath = Hive.box(_hiveBoxName).path;
-        await Hive.deleteBoxFromDisk(_hiveBoxName);
-
-        //Delete `auth` folder if it's empty
-        if (!kIsWeb && boxPath != null) {
-          final boxDir = File(boxPath).parent;
-          final dirIsEmpty = await boxDir.list().length == 0;
-          if (dirIsEmpty) {
-            await boxDir.delete();
-          }
-        }
-      }
-    }
-  }
-
-  @override
-  Future<String?> accessToken() {
-    return sharedPreferencesLocalStorage.accessToken();
-  }
-
-  @override
-  Future<bool> hasAccessToken() {
-    return sharedPreferencesLocalStorage.hasAccessToken();
-  }
-
-  @override
-  Future<void> persistSession(String persistSessionString) {
-    return sharedPreferencesLocalStorage.persistSession(persistSessionString);
-  }
-
-  @override
-  Future<void> removePersistedSession() {
-    return sharedPreferencesLocalStorage.removePersistedSession();
-  }
-}
-
-/// A [LocalStorage] implementation that implements Hive as the
-/// storage method.
-class HiveLocalStorage extends LocalStorage {
-  /// Creates a LocalStorage instance that implements the Hive Database
-  const HiveLocalStorage();
-
-  /// The encryption key used by Hive. If null, the box is not encrypted
-  ///
-  /// This value should not be redefined in runtime, otherwise the user may
-  /// not be fetched correctly
-  ///
-  /// See also:
-  ///
-  ///   * <https://docs.hivedb.dev/#/advanced/encrypted_box?id=encrypted-box>
-  static String? encryptionKey;
-
-  @override
-  Future<void> initialize() async {
-    HiveCipher? encryptionCipher;
-    if (encryptionKey != null) {
-      encryptionCipher = HiveAesCipher(base64Url.decode(encryptionKey!));
-    }
-    await Hive.initFlutter('auth');
-    await Hive.openBox(_hiveBoxName, encryptionCipher: encryptionCipher)
-        .timeout(const Duration(seconds: 1));
-  }
-
-  @override
-  Future<bool> hasAccessToken() {
-    return Future.value(
-      Hive.box(_hiveBoxName).containsKey(
-        supabasePersistSessionKey,
-      ),
-    );
-  }
-
-  @override
-  Future<String?> accessToken() {
-    return Future.value(
-      Hive.box(_hiveBoxName).get(supabasePersistSessionKey) as String?,
-    );
-  }
-
-  @override
-  Future<void> removePersistedSession() {
-    return Hive.box(_hiveBoxName).delete(supabasePersistSessionKey);
-  }
-
-  @override
-  Future<void> persistSession(String persistSessionString) {
-    // Flush after X amount of writes
-    return Hive.box(_hiveBoxName)
-        .put(supabasePersistSessionKey, persistSessionString);
-  }
-}
-```
-
-You can then initialize Supabase with `MigrationLocalStorage` and it will automatically migrate the session from Hive to SharedPreferences.
-
-```dart
-Supabase.initialize(
-  // ...
-  authOptions: FlutterAuthClientOptions(
-    localStorage: const MigrationLocalStorage(
-      persistSessionKey:
-              "sb-${Uri.parse(url).host.split(".").first}-auth-token",
-    ),
   ),
 );
 ```
@@ -746,8 +597,8 @@ supabaseLogger.onRecord.listen((record) {
 
 ## Migrating Guide
 
-You can find the migration guide to migrate from v1 to v2 here:
-https://supabase.com/docs/reference/dart/upgrade-guide
+The breaking changes of each major version, and what to do about them, are documented in
+[MIGRATION.md](https://github.com/supabase/supabase-flutter/blob/main/MIGRATION.md).
 
 ## Contributing
 

--- a/packages/supabase_flutter/README.md
+++ b/packages/supabase_flutter/README.md
@@ -508,6 +508,8 @@ By default, `supabase_flutter` uses the `SharedPreferencesAsync` API of [`shared
 
 However, you can use any other methods by creating a `LocalStorage` implementation. For example, we can use [`flutter_secure_storage`](https://pub.dev/packages/flutter_secure_storage) plugin to store the user session in a secure storage.
 
+The key the session is stored under, `sb-<project-ref>-auth-token`, is derived from your project URL by `Supabase.initialize`. You only pass it yourself when you construct a `LocalStorage`, as below.
+
 ```dart
 // Define the custom LocalStorage implementation
 class MySecureStorage extends LocalStorage {

--- a/packages/supabase_flutter/README.md
+++ b/packages/supabase_flutter/README.md
@@ -508,7 +508,7 @@ By default, `supabase_flutter` uses the `SharedPreferencesAsync` API of [`shared
 
 However, you can use any other methods by creating a `LocalStorage` implementation. For example, we can use [`flutter_secure_storage`](https://pub.dev/packages/flutter_secure_storage) plugin to store the user session in a secure storage.
 
-The key the session is stored under, `sb-<project-ref>-auth-token`, is derived from your project URL by `Supabase.initialize`. You only pass it yourself when you construct a `LocalStorage`, as below.
+The key the session is stored under is derived from your project URL by `Supabase.initialize`. You only pass it yourself when you construct a `LocalStorage`, as below, and `defaultPersistSessionKey` gives you the same key the default storage uses.
 
 ```dart
 // Define the custom LocalStorage implementation
@@ -548,7 +548,7 @@ Supabase.initialize(
   ...
   authOptions: FlutterAuthClientOptions(
     localStorage: MySecureStorage(
-      persistSessionKey: "sb-${Uri.parse(supabaseUrl).host.split(".").first}-auth-token",
+      persistSessionKey: defaultPersistSessionKey(supabaseUrl),
     ),
   ),
 );

--- a/packages/supabase_flutter/lib/src/local_storage.dart
+++ b/packages/supabase_flutter/lib/src/local_storage.dart
@@ -7,17 +7,14 @@ import './local_storage_stub.dart'
     if (dart.library.js_interop) './local_storage_web.dart'
     as web;
 
-/// Only used for migration from Hive to SharedPreferences. Not actually in use.
-const supabasePersistSessionKey = 'SUPABASE_PERSIST_SESSION_KEY';
-
 /// LocalStorage is used to persist the user session in the device.
 ///
 /// See also:
 ///
 ///   * [SupabaseAuth], the instance used to manage authentication
 ///   * [EmptyLocalStorage], used to disable session persistence
-///   * [SharedPreferencesLocalStorage], that implements SharedPreferences as
-///     storage method
+///   * [SharedPreferencesLocalStorage], that implements SharedPreferencesAsync
+///     as storage method
 abstract class LocalStorage {
   const LocalStorage();
 

--- a/packages/supabase_flutter/lib/src/supabase.dart
+++ b/packages/supabase_flutter/lib/src/supabase.dart
@@ -127,8 +127,7 @@ class Supabase {
       authOptions = authOptions.copyWith(
         localStorage: authOptions.persistSession
             ? SharedPreferencesLocalStorage(
-                persistSessionKey:
-                    "sb-${Uri.parse(url).host.split(".").first}-auth-token",
+                persistSessionKey: defaultPersistSessionKey(url),
               )
             : const EmptyLocalStorage(),
       );

--- a/packages/supabase_flutter/lib/supabase_flutter.dart
+++ b/packages/supabase_flutter/lib/supabase_flutter.dart
@@ -2,6 +2,8 @@
 library;
 
 export 'package:supabase/supabase.dart';
+export 'package:supabase_common/supabase_common.dart'
+    show defaultPersistSessionKey;
 export 'package:url_launcher/url_launcher.dart' show LaunchMode;
 
 export 'src/flutter_go_true_client_options.dart';

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -2022,6 +2022,7 @@ features:
       - GoTrueClient.setInitialSession
     supporting_symbols:
       - SharedPreferencesLocalStorage.persistSessionKey
+      - defaultPersistSessionKey
   client.request_configuration.custom_http_client:
     status: implemented
     symbols:

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -2022,7 +2022,6 @@ features:
       - GoTrueClient.setInitialSession
     supporting_symbols:
       - SharedPreferencesLocalStorage.persistSessionKey
-      - supabasePersistSessionKey
   client.request_configuration.custom_http_client:
     status: implemented
     symbols:


### PR DESCRIPTION
Stacked on #1680, review that one first.

## What kind of change does this PR introduce?

Cleanup and a small feature, breaking change.

## What is the current behavior?

`supabase_flutter` still carries the leftovers of the v1 to v2 migration:

- `supabasePersistSessionKey`, a public constant whose own dartdoc says "Only used for migration from Hive to SharedPreferences. Not actually in use." The SDK never reads it. It is only the key v1 stored the session under.
- A README section with `MigrationLocalStorage` and `HiveLocalStorage` snippets to copy, which move a session out of [hive](https://pub.dev/packages/hive) on the first launch after upgrading from v1.

The README's `MySecureStorage` example used the constant as its storage key, which was wrong for anything but a v1 leftover: the session lives under the key that is passed to `LocalStorage`, `sb-<project-ref>-auth-token` for the default storage. That key was derived in two places (`Supabase.initialize` and, for the broadcast channel name, `GoTrueClient`) with nothing public to call, so a custom `LocalStorage` had no way to name the same key other than writing the format out by hand.

## What is the new behavior?

Both leftovers are gone. Anyone still on v1 can upgrade to v2, let it migrate the session, and then move to v3.

`defaultPersistSessionKey(url)` replaces the hand-written format. It lives in `supabase_common`, which gotrue and supabase_flutter both already depend on, and `supabase_flutter` exports it the way `postgrest` and `functions_client` export `HttpMethod`:

```dart
authOptions: FlutterAuthClientOptions(
  localStorage: MySecureStorage(
    persistSessionKey: defaultPersistSessionKey(supabaseUrl),
  ),
),
```

The derivation now exists in exactly one place, and both call sites use it. Nothing changes for the default path: `Supabase.initialize` still fills the key in, so `Supabase.initialize(url:, publishableKey:)` remains all a caller writes.

The `Migrating Guide` section of the README pointed at the v1 to v2 upgrade guide on the docs site, and now points at `MIGRATION.md`, which is where the v2 to v3 changes are written down. Both docs also say explicitly that the key is derived for you and only needs naming when you supply your own storage, which was easy to misread before.

## Additional context

`MIGRATION.md` documents the removal, including the literal value of the constant for anyone who copied the old example and needs to keep reading the same key.

`sdk-compliance.yaml` drops `supabasePersistSessionKey` and registers `defaultPersistSessionKey` under `client.session_management.persist_session`. The capability itself stays `implemented`. The symbol, drift and schema checks were run locally against the base and PR symbol dumps.
