### PR TITLE
docs(supabase_common): document HttpMethod and cover it with a test

### DIFF
--- a/packages/supabase_common/lib/src/http_method.dart
+++ b/packages/supabase_common/lib/src/http_method.dart
@@ -1,3 +1,4 @@
+/// The HTTP methods the Supabase client packages send requests with.
 enum HttpMethod {
   get,
   head,
@@ -6,5 +7,6 @@ enum HttpMethod {
   patch,
   delete;
 
+  /// The method as it appears on the wire, for example `GET`.
   String get value => name.toUpperCase();
 }

--- a/packages/supabase_common/test/http_method_test.dart
+++ b/packages/supabase_common/test/http_method_test.dart
@@ -1,0 +1,19 @@
+import 'package:supabase_common/supabase_common.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('HttpMethod', () {
+    test('value is the uppercase method name', () {
+      expect(HttpMethod.get.value, 'GET');
+      expect(HttpMethod.head.value, 'HEAD');
+      expect(HttpMethod.post.value, 'POST');
+      expect(HttpMethod.put.value, 'PUT');
+      expect(HttpMethod.patch.value, 'PATCH');
+      expect(HttpMethod.delete.value, 'DELETE');
+    });
+
+    test('covers every method the client packages send', () {
+      expect(HttpMethod.values, hasLength(6));
+    });
+  });
+}


### PR DESCRIPTION
Salvaged from #1645, which #1678 superseded. Those two items are the only things #1645 carried that #1678 did not.

## Why

The shared `HttpMethod` enum landed in `supabase_common` with no doc comments and no test of its own. It is exercised indirectly through the gotrue, postgrest, storage and functions suites, but nothing pins the `value` getter's contract directly.

## What changed

- Doc comments on the enum and on `value`.
- `packages/supabase_common/test/http_method_test.dart`: asserts each of the six wire strings and that the enum still has exactly six values, so adding a seventh is a deliberate act rather than a silent one.

No behaviour change.

## Verification

`dart test test/http_method_test.dart` passes (2 tests). `dart format` reports no changes and `dart analyze` is clean for `supabase_common`.