### PR TITLE
refactor!: apply Dart 3 class modifiers to the core public types

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -326,3 +326,69 @@ unaffected. For `functions.invoke`, two things changed:
   (3 to 5). This one is not a compile error, so replace any persisted `index` with `name`.
 
 The enum also exposes `value`, the uppercase wire form, in place of `method.name.toUpperCase()`.
+
+### Core types declare their subtyping intent with class modifiers
+
+The core public types now carry Dart 3 class modifiers that state whether they are meant to be
+extended, implemented, or neither. Nothing about their behaviour changed, but subtyping them in a
+way the modifier disallows is now a compile error.
+
+The clients and the request builders are `interface class`, so they can still be implemented (this
+is what `mockito` and `mocktail` need) but no longer extended:
+
+| Type | Modifier |
+| --- | --- |
+| `SupabaseClient` | `interface class` |
+| `GoTrueClient` | `interface class` |
+| `PostgrestClient` | `interface class` |
+| `PostgrestBuilder` | `interface class` |
+| `RealtimeClient` | `interface class` |
+| `FunctionsClient` | `interface class` |
+| `SupabaseStorageClient` | `interface class` |
+| `StorageFileApi` | `interface class` |
+
+If you were extending one of these to change its behaviour, wrap it instead:
+
+```dart
+// Before
+class LoggingSupabaseClient extends SupabaseClient {
+  LoggingSupabaseClient(super.url, super.key);
+}
+
+// After
+class LoggingSupabaseClient {
+  LoggingSupabaseClient(this._inner);
+
+  final SupabaseClient _inner;
+
+  SupabaseQueryBuilder from(String table) {
+    print('from($table)');
+    return _inner.from(table);
+  }
+}
+```
+
+Mocks are unaffected, because `implements` is still allowed:
+
+```dart
+// Still compiles
+class MockSupabaseClient extends Mock implements SupabaseClient {}
+```
+
+The two storage abstractions you are meant to plug your own implementation into are
+`abstract interface class`, so they must be implemented rather than extended. Both declare only
+abstract members, so this is a one-word change at the use site:
+
+```dart
+// Before
+class MyLocalStorage extends LocalStorage { /* ... */ }
+class MyPkceStorage extends GotrueAsyncStorage { /* ... */ }
+
+// After
+class MyLocalStorage implements LocalStorage { /* ... */ }
+class MyPkceStorage implements GotrueAsyncStorage { /* ... */ }
+```
+
+Finally, `AuthState` is a `final class`. It is a plain value carrying an `AuthChangeEvent` and a
+`Session`, and `AuthChangeEvent` is already an enum, so switching over auth state changes is
+unchanged.

--- a/packages/functions_client/lib/src/functions_client.dart
+++ b/packages/functions_client/lib/src/functions_client.dart
@@ -10,7 +10,7 @@ import 'package:logging/logging.dart';
 import 'package:supabase_common/supabase_common.dart';
 import 'package:yet_another_json_isolate/yet_another_json_isolate.dart';
 
-class FunctionsClient {
+interface class FunctionsClient {
   final String _url;
   final Map<String, String> _headers;
   final http.Client? _httpClient;

--- a/packages/gotrue/lib/src/fetch.dart
+++ b/packages/gotrue/lib/src/fetch.dart
@@ -11,7 +11,7 @@ import 'package:meta/meta.dart';
 import 'package:supabase_common/supabase_common.dart';
 
 @internal
-class GotrueFetch {
+final class GotrueFetch {
   final Client? httpClient;
 
   const GotrueFetch([this.httpClient]);

--- a/packages/gotrue/lib/src/gotrue_client.dart
+++ b/packages/gotrue/lib/src/gotrue_client.dart
@@ -49,7 +49,7 @@ class _SessionState {
 ///
 /// Set [flowType] to [AuthFlowType.implicit] to perform old implicit auth flow.
 /// {@endtemplate}
-class GoTrueClient {
+interface class GoTrueClient {
   /// Namespace for the GoTrue API methods. These can be used for example to get
   /// a user from a JWT in a server environment or reset a user's password.
   late final GoTrueAdminApi admin;

--- a/packages/gotrue/lib/src/types/auth_state.dart
+++ b/packages/gotrue/lib/src/types/auth_state.dart
@@ -2,7 +2,7 @@ import 'package:gotrue/src/constants.dart';
 import 'package:gotrue/src/types/session.dart';
 import 'package:gotrue/src/types/sign_out_reason.dart';
 
-class AuthState {
+final class AuthState {
   final AuthChangeEvent event;
   final Session? session;
 

--- a/packages/gotrue/lib/src/types/gotrue_async_storage.dart
+++ b/packages/gotrue/lib/src/types/gotrue_async_storage.dart
@@ -1,5 +1,5 @@
 /// Interface to provide async storage to store pkce tokens.
-abstract class GotrueAsyncStorage {
+abstract interface class GotrueAsyncStorage {
   const GotrueAsyncStorage();
 
   /// Retrieves an item asynchronously from the storage with the key.

--- a/packages/gotrue/test/utils.dart
+++ b/packages/gotrue/test/utils.dart
@@ -81,7 +81,7 @@ const sessionDataUserId = '4d2583da-8de4-49d3-9cd1-37a9a74f55bd';
   return (accessToken: accessToken, sessionString: sessionString);
 }
 
-class TestAsyncStorage extends GotrueAsyncStorage {
+class TestAsyncStorage implements GotrueAsyncStorage {
   final Map<String, String> _map = {};
   @override
   Future<String?> getItem({required String key}) async {

--- a/packages/postgrest/lib/src/postgrest.dart
+++ b/packages/postgrest/lib/src/postgrest.dart
@@ -7,7 +7,7 @@ import 'package:yet_another_json_isolate/yet_another_json_isolate.dart';
 
 /// A PostgREST api client written in Dartlang. The goal of this library is to
 /// make an "ORM-like" restful interface.
-class PostgrestClient {
+interface class PostgrestClient {
   /// HTTP status codes that trigger an automatic retry by default.
   static const Set<int> defaultRetryableStatusCodes = {503, 520};
 

--- a/packages/postgrest/lib/src/postgrest_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_builder.dart
@@ -134,7 +134,7 @@ String? _emptyPreferAsNull(String? prefer) =>
 /// When using [_converter], [R] is the input and [S] is the output
 /// Otherwise [S] and [R] are the same
 @immutable
-class PostgrestBuilder<T, S, R> implements Future<T> {
+interface class PostgrestBuilder<T, S, R> implements Future<T> {
   final _RequestConfig _config;
   final PostgrestConverter<S, R>? _converter;
   final _log = Logger('supabase.postgrest');

--- a/packages/realtime_client/lib/src/realtime_client.dart
+++ b/packages/realtime_client/lib/src/realtime_client.dart
@@ -97,7 +97,7 @@ enum RealtimeHeartbeatStatus {
 /// **Platform notes:**
 /// - Works on all Dart platforms (Flutter mobile/desktop, web, server).
 /// - On web, the underlying [WebSocketChannel] uses the browser WebSocket API.
-class RealtimeClient {
+interface class RealtimeClient {
   String? accessToken;
   List<RealtimeChannel> channels = [];
   final String endPoint;

--- a/packages/realtime_client/test/channel_test.dart
+++ b/packages/realtime_client/test/channel_test.dart
@@ -3,11 +3,14 @@ import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
 
+import 'package:mocktail/mocktail.dart';
 import 'package:realtime_client/realtime_client.dart';
 import 'package:realtime_client/src/constants.dart';
 import 'package:realtime_client/src/push.dart';
 import 'package:realtime_client/src/types.dart';
 import 'package:test/test.dart';
+
+const _expiredToken = 'expired-token';
 
 void main() {
   late RealtimeClient socket;
@@ -132,15 +135,13 @@ void main() {
     // https://github.com/supabase/supabase-flutter/issues/1363.
     test("swallows FormatException with 'InvalidJWTToken' from setAuth and "
         "still emits 'subscribed' status", () async {
-      final throwingSocket = _SetAuthThrowingSocket(
-        '/socket',
-        thrown: const FormatException(
+      final throwingSocket = _setAuthThrowingSocket(
+        const FormatException(
           'InvalidJWTToken: Invalid value for JWT claim "exp" with value 0',
         ),
       );
-      throwingSocket.accessToken = 'expired-token';
 
-      final localChannel = throwingSocket.channel('topic');
+      final localChannel = RealtimeChannel('topic', throwingSocket);
 
       RealtimeSubscribeStatus? status;
       localChannel.subscribe((s, _) => status = s);
@@ -150,7 +151,7 @@ void main() {
       await Future<void>.value();
       await Future<void>.value();
 
-      expect(throwingSocket.setAuthCalls, 1);
+      verify(() => throwingSocket.setAuth(_expiredToken)).called(1);
       expect(
         status,
         RealtimeSubscribeStatus.subscribed,
@@ -162,13 +163,11 @@ void main() {
 
     test("non-InvalidJWTToken FormatExceptions from setAuth still abort the "
         "rejoin handler", () async {
-      final throwingSocket = _SetAuthThrowingSocket(
-        '/socket',
-        thrown: const FormatException('some other parsing failure'),
+      final throwingSocket = _setAuthThrowingSocket(
+        const FormatException('some other parsing failure'),
       );
-      throwingSocket.accessToken = 'some-token';
 
-      final localChannel = throwingSocket.channel('topic');
+      final localChannel = RealtimeChannel('topic', throwingSocket);
 
       RealtimeSubscribeStatus? status;
       // Use runZonedGuarded so the rethrown async error does not pollute
@@ -185,7 +184,7 @@ void main() {
         },
       );
 
-      expect(throwingSocket.setAuthCalls, 1);
+      verify(() => throwingSocket.setAuth(_expiredToken)).called(1);
       expect(
         status,
         isNull,
@@ -1365,23 +1364,21 @@ void main() {
   });
 }
 
-class _SetAuthThrowingSocket extends RealtimeClient {
-  _SetAuthThrowingSocket(super.endPoint, {required this.thrown});
+class _MockSocket extends Mock implements RealtimeClient {}
 
-  final FormatException thrown;
-  int setAuthCalls = 0;
-
-  @override
-  Future<void> connect() async {
-    // No-op: avoid opening a real WebSocket so async transport failures
-    // don't leak into the test runner zone.
-  }
-
-  @override
-  Future<void> setAuth(String? token) async {
-    setAuthCalls++;
-    throw thrown;
-  }
+/// A socket whose [RealtimeClient.setAuth] throws [thrown]. It reports itself
+/// as already connected so no real WebSocket is opened and async transport
+/// failures don't leak into the test runner zone.
+_MockSocket _setAuthThrowingSocket(FormatException thrown) {
+  final socket = _MockSocket();
+  when(() => socket.endPoint).thenReturn('/socket');
+  when(() => socket.timeout).thenReturn(Constants.defaultTimeout);
+  when(() => socket.reconnectAfterMs).thenReturn((_) => 0);
+  when(() => socket.isConnected).thenReturn(true);
+  when(() => socket.accessToken).thenReturn(_expiredToken);
+  when(() => socket.makeRef()).thenReturn('1');
+  when(() => socket.setAuth(any())).thenThrow(thrown);
+  return socket;
 }
 
 class _OptsCapturingChannel extends RealtimeChannel {

--- a/packages/realtime_client/test/socket_test.dart
+++ b/packages/realtime_client/test/socket_test.dart
@@ -595,23 +595,14 @@ void main() {
       final mockedChannel2 = MockChannel();
       when(() => mockedChannel2.joinRef).thenReturn('2');
 
-      const tTopic1 = 'topic-1';
-      const tTopic2 = 'topic-2';
+      final mockedSocket = RealtimeClient(socketEndpoint);
+      mockedSocket.channels.addAll([mockedChannel1, mockedChannel2]);
 
-      final mockedSocket = SocketWithMockedChannel(socketEndpoint);
-      mockedSocket.mockedChannelLooker.addAll({
-        tTopic1: mockedChannel1,
-        tTopic2: mockedChannel2,
-      });
-
-      final channel1 = mockedSocket.channel(tTopic1);
-      final channel2 = mockedSocket.channel(tTopic2);
-
-      mockedSocket.remove(channel1);
+      mockedSocket.remove(mockedChannel1);
       expect(mockedSocket.channels, hasLength(1));
 
       final foundChannel = mockedSocket.channels[0];
-      expect(foundChannel, channel2);
+      expect(foundChannel, mockedChannel2);
     });
 
     test('keeps the other channels when none of them have joined', () {
@@ -1090,29 +1081,24 @@ void main() {
           () => mockedChannel2.push(ChannelEvent.accessToken, pushPayload),
         ).thenReturn(MockPush());
 
-        const tTopic1 = 'topic-1';
-        const tTopic2 = 'topic-2';
-
-        final mockedSocket = SocketWithMockedChannel(socketEndpoint);
-        mockedSocket.mockedChannelLooker.addAll({
-          tTopic1: mockedChannel1,
-          tTopic2: mockedChannel2,
-        });
-
-        final channel1 = mockedSocket.channel(tTopic1);
-        final channel2 = mockedSocket.channel(tTopic2);
+        final mockedSocket = RealtimeClient(socketEndpoint);
+        mockedSocket.channels.addAll([mockedChannel1, mockedChannel2]);
 
         await mockedSocket.setAuth(token);
 
         expect(mockedSocket.accessToken, token);
 
-        verify(() => channel1.updateJoinPayload(updateJoinPayload)).called(1);
-        verify(() => channel2.updateJoinPayload(updateJoinPayload)).called(1);
         verify(
-          () => channel1.push(ChannelEvent.accessToken, pushPayload),
+          () => mockedChannel1.updateJoinPayload(updateJoinPayload),
         ).called(1);
         verify(
-          () => channel2.push(ChannelEvent.accessToken, pushPayload),
+          () => mockedChannel2.updateJoinPayload(updateJoinPayload),
+        ).called(1);
+        verify(
+          () => mockedChannel1.push(ChannelEvent.accessToken, pushPayload),
+        ).called(1);
+        verify(
+          () => mockedChannel2.push(ChannelEvent.accessToken, pushPayload),
         ).called(1);
       },
     );
@@ -1143,20 +1129,12 @@ void main() {
           () => mockedChannel3.push(ChannelEvent.accessToken, any()),
         ).thenReturn(MockPush());
 
-        const tTopic1 = 'test-topic1';
-        const tTopic2 = 'test-topic2';
-        const tTopic3 = 'test-topic3';
-
-        final mockedSocket = SocketWithMockedChannel(socketEndpoint);
-        mockedSocket.mockedChannelLooker.addAll({
-          tTopic1: mockedChannel1,
-          tTopic2: mockedChannel2,
-          tTopic3: mockedChannel3,
-        });
-
-        final channel1 = mockedSocket.channel(tTopic1);
-        final channel2 = mockedSocket.channel(tTopic2);
-        final channel3 = mockedSocket.channel(tTopic3);
+        final mockedSocket = RealtimeClient(socketEndpoint);
+        mockedSocket.channels.addAll([
+          mockedChannel1,
+          mockedChannel2,
+          mockedChannel3,
+        ]);
 
         const authToken = 'sb-key';
         final expectedPushPayload = {'access_token': authToken};
@@ -1170,23 +1148,32 @@ void main() {
         expect(mockedSocket.accessToken, authToken);
 
         verify(
-          () => channel1.updateJoinPayload(expectedUpdateJoinPayload),
+          () => mockedChannel1.updateJoinPayload(expectedUpdateJoinPayload),
         ).called(1);
         verify(
-          () => channel2.updateJoinPayload(expectedUpdateJoinPayload),
+          () => mockedChannel2.updateJoinPayload(expectedUpdateJoinPayload),
         ).called(1);
         verify(
-          () => channel3.updateJoinPayload(expectedUpdateJoinPayload),
+          () => mockedChannel3.updateJoinPayload(expectedUpdateJoinPayload),
         ).called(1);
 
         verify(
-          () => channel1.push(ChannelEvent.accessToken, expectedPushPayload),
+          () => mockedChannel1.push(
+            ChannelEvent.accessToken,
+            expectedPushPayload,
+          ),
         ).called(1);
         verifyNever(
-          () => channel2.push(ChannelEvent.accessToken, expectedPushPayload),
+          () => mockedChannel2.push(
+            ChannelEvent.accessToken,
+            expectedPushPayload,
+          ),
         );
         verify(
-          () => channel3.push(ChannelEvent.accessToken, expectedPushPayload),
+          () => mockedChannel3.push(
+            ChannelEvent.accessToken,
+            expectedPushPayload,
+          ),
         ).called(1);
       },
     );

--- a/packages/realtime_client/test/socket_test_stubs.dart
+++ b/packages/realtime_client/test/socket_test_stubs.dart
@@ -11,21 +11,3 @@ class MockWebSocketSink extends Mock implements WebSocketSink {}
 class MockChannel extends Mock implements RealtimeChannel {}
 
 class MockPush extends Mock implements Push {}
-
-class SocketWithMockedChannel extends RealtimeClient {
-  SocketWithMockedChannel(super.endPoint);
-
-  Map<String, RealtimeChannel> mockedChannelLooker = {};
-
-  @override
-  RealtimeChannel channel(
-    String topic, [
-    RealtimeChannelConfig config = const RealtimeChannelConfig(),
-  ]) {
-    if (mockedChannelLooker.containsKey(topic)) {
-      channels.add(mockedChannelLooker[topic]!);
-      return mockedChannelLooker[topic]!;
-    }
-    return super.channel(topic, config);
-  }
-}

--- a/packages/storage_client/lib/src/fetch.dart
+++ b/packages/storage_client/lib/src/fetch.dart
@@ -13,7 +13,7 @@ import 'package:supabase_common/supabase_common.dart';
 import 'file_stub.dart' if (dart.library.io) './file_io.dart';
 
 @internal
-class Fetch {
+final class Fetch {
   final Client? httpClient;
   final _log = Logger('supabase.storage');
 

--- a/packages/storage_client/lib/src/storage_client.dart
+++ b/packages/storage_client/lib/src/storage_client.dart
@@ -9,7 +9,7 @@ import 'package:storage_client/src/storage_file_api.dart';
 import 'package:storage_client/src/vector_client.dart';
 import 'package:storage_client/src/version.dart';
 
-class SupabaseStorageClient extends StorageBucketApi {
+interface class SupabaseStorageClient extends StorageBucketApi {
   final int _defaultRetryAttempts;
   final Client? _httpClient;
   final _log = Logger('supabase.storage');

--- a/packages/storage_client/lib/src/storage_file_api.dart
+++ b/packages/storage_client/lib/src/storage_file_api.dart
@@ -6,7 +6,7 @@ import 'package:supabase_common/supabase_common.dart';
 
 import 'file_stub.dart' if (dart.library.io) './file_io.dart';
 
-class StorageFileApi {
+interface class StorageFileApi {
   final String url;
   Map<String, String> _headers;
   final String? bucketId;

--- a/packages/supabase/lib/src/supabase_client.dart
+++ b/packages/supabase/lib/src/supabase_client.dart
@@ -48,7 +48,7 @@ import 'trace_http_client.dart';
 /// [authOptions] and set its `authFlowType` field to `AuthFlowType.pkce` in
 /// order to perform auth actions with pkce flow.
 /// {@endtemplate}
-class SupabaseClient {
+interface class SupabaseClient {
   final String _supabaseKey;
   final PostgrestClientOptions _postgrestOptions;
   final FunctionsClientOptions _functionsOptions;

--- a/packages/supabase_flutter/lib/src/local_storage.dart
+++ b/packages/supabase_flutter/lib/src/local_storage.dart
@@ -20,7 +20,7 @@ const supabasePersistSessionKey = 'SUPABASE_PERSIST_SESSION_KEY';
 ///   * [EmptyLocalStorage], used to disable session persistence
 ///   * [SharedPreferencesLocalStorage], that implements SharedPreferences as
 ///     storage method
-abstract class LocalStorage {
+abstract interface class LocalStorage {
   const LocalStorage();
 
   /// Initialize the storage to persist session.
@@ -116,7 +116,7 @@ class SharedPreferencesLocalStorage extends LocalStorage {
 }
 
 /// local storage to store pkce flow code verifier.
-class SharedPreferencesGotrueAsyncStorage extends GotrueAsyncStorage {
+class SharedPreferencesGotrueAsyncStorage implements GotrueAsyncStorage {
   SharedPreferencesGotrueAsyncStorage() {
     unawaited(_initialize());
   }

--- a/packages/supabase_flutter/lib/src/supabase_auth.dart
+++ b/packages/supabase_flutter/lib/src/supabase_auth.dart
@@ -57,7 +57,7 @@ import 'clear_auth_url_parameters_stub.dart'
 ///   since browser navigation triggers a full page load rather than a
 ///   stream event.
 @internal
-class SupabaseAuth with WidgetsBindingObserver {
+final class SupabaseAuth with WidgetsBindingObserver {
   static WidgetsBinding get _widgetsBindingInstance => WidgetsBinding.instance;
 
   late LocalStorage _localStorage;

--- a/packages/supabase_flutter/test/widget_test_stubs.dart
+++ b/packages/supabase_flutter/test/widget_test_stubs.dart
@@ -57,7 +57,7 @@ class _MockWidgetState extends State<MockWidget> {
 }
 
 /// Local storage that returns an expired session
-class MockExpiredStorage extends LocalStorage {
+class MockExpiredStorage implements LocalStorage {
   const MockExpiredStorage();
   @override
   Future<void> initialize() async {}
@@ -76,7 +76,7 @@ class MockExpiredStorage extends LocalStorage {
   Future<void> removePersistedSession() async {}
 }
 
-class MockLocalStorage extends LocalStorage {
+class MockLocalStorage implements LocalStorage {
   const MockLocalStorage();
   @override
   Future<void> initialize() async {}
@@ -95,7 +95,7 @@ class MockLocalStorage extends LocalStorage {
   Future<void> removePersistedSession() async {}
 }
 
-class MockEmptyLocalStorage extends LocalStorage {
+class MockEmptyLocalStorage implements LocalStorage {
   const MockEmptyLocalStorage();
   @override
   Future<void> initialize() async {}
@@ -184,7 +184,7 @@ class GetUserHttpClient extends BaseClient {
   }
 }
 
-class MockAsyncStorage extends GotrueAsyncStorage {
+class MockAsyncStorage implements GotrueAsyncStorage {
   final Map<String, String> _map = {};
 
   @override


### PR DESCRIPTION
Closes SDK-819.

Most public classes in the SDK were plain `class`, so consumers could extend or implement any of them, including internal plumbing. This declares the intent explicitly with Dart 3 class modifiers.

## What changed

### `interface class` — implementable, not extendable

The client entry points and the request builder base. `interface class` closes off `extends` while leaving `implements` open, so the standard mocking idiom keeps compiling:

```dart
// Still compiles
class MockSupabaseClient extends Mock implements SupabaseClient {}

// No longer compiles
class MyClient extends SupabaseClient { /* ... */ }
```

`SupabaseClient`, `GoTrueClient`, `PostgrestClient`, `PostgrestBuilder`, `RealtimeClient`, `FunctionsClient`, `SupabaseStorageClient`, `StorageFileApi`.

The ticket proposed `final class` for these. `final` also blocks `implements`, which would break every consumer test suite that mocks a client with no escape hatch, so `interface` is the narrower break that still delivers "not designed for extension".

### `abstract interface class` — the two consumer extension points

`LocalStorage` and `GotrueAsyncStorage`. Both declare only abstract members, so callers change one word:

```dart
- class MyLocalStorage extends LocalStorage { /* ... */ }
+ class MyLocalStorage implements LocalStorage { /* ... */ }
```

### `final class` — fully closed

`AuthState`, plus the internal `GotrueFetch`, `Fetch` and `SupabaseAuth` helpers.

## Notes on the rest of the ticket's proposal

- **The `AuthException` hierarchy is deliberately untouched.** The ticket asks for `base class AuthException` with `final` subclasses, but the exceptions are being restructured by a separate chain of PRs, so the modifiers belong there rather than here where they would just conflict.
- `AuthChangeEvent` is already an `enum`, so the proposed `sealed class` treatment is moot; exhaustive switches over auth events are unchanged. `AuthState` is a single class rather than a hierarchy, so it is `final` rather than `sealed`.
- `StorageBucketApi` is not exported from `package:storage_client`, so consumers cannot name it and its modifier would have no public effect. Closing it would also force `SupabaseStorageClient` to be `base`/`final` and lose mockability, so it stays a plain class.
- The concrete postgrest builders (`PostgrestQueryBuilder` and friends) stay open. `PostgrestQueryBuilder` is extended across package boundaries by `SupabaseQueryBuilder`, and marking the chain `base`/`final` would make the whole `from(...)` chain unmockable.

## Test changes

Two realtime test stubs extended `RealtimeClient` and had to go:

- The setAuth error-handling tests in `channel_test.dart` now use a mocktail mock of the socket, which is exactly the escape hatch `interface class` preserves.
- The `remove` and `setAuth` tests in `socket_test.dart` register their mock channels on `RealtimeClient.channels` directly rather than overriding `channel()` to hand them back.

The `LocalStorage` and `GotrueAsyncStorage` test stubs switched from `extends` to `implements`.

## Verification

- `dart analyze packages`: no issues
- `dart format`: no changes
- Full test suites pass for gotrue (479), postgrest (196), realtime_client (205), storage_client (210), supabase (134), functions_client (48) and supabase_flutter (65), with the local Supabase stack running for the backend-dependent ones
- The extracted public symbol set is byte-identical to `main` (1754 symbols, no additions or removals), so `sdk-compliance.yaml` needs no changes

`MIGRATION.md` documents each modifier under the v2 to v3 section.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added migration guidance for Dart 3 class modifiers and updated inheritance examples.

* **API Updates**
  * Clarified which public classes can be extended, implemented, or neither through interface, abstract interface, and final declarations.
  * Preserved existing members, method signatures, and runtime behavior.

* **Tests**
  * Updated storage and realtime test implementations to follow the new class-modifier rules.
  * Refined realtime authentication and channel test coverage using mocks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->