### PR TITLE
test(gotrue): give the list-users fixture a created_at

### DIFF
--- a/packages/gotrue/test/admin_list_users_test.dart
+++ b/packages/gotrue/test/admin_list_users_test.dart
@@ -28,7 +28,10 @@ class ListUsersMockClient extends BaseClient {
         utf8.encode(
           jsonEncode({
             'users': [
-              {'id': '2fa5b8b0-4f1a-4a5c-9d47-1cf3dbb9f7e1'},
+              {
+                'id': '2fa5b8b0-4f1a-4a5c-9d47-1cf3dbb9f7e1',
+                'created_at': '2024-01-01T00:00:00Z',
+              },
             ],
             'aud': ?audience,
           }),


### PR DESCRIPTION
## What kind of change does this PR introduce?

Test fix.

## What is the current behavior?

`main` is red. Every test in `packages/gotrue/test/admin_list_users_test.dart` throws:

```
FormatException: Expected created_at to be a string, got Null
  package:supabase_common/src/timestamp.dart 16:5  parseIso8601
  package:gotrue/src/types/user.dart 72:18         User.fromJson
  package:gotrue/src/gotrue_admin_api.dart 179:54  GoTrueAdminApi.listUsers.<fn>
```

#1663 made `User.createdAt` a non-nullable `DateTime` parsed with `parseIso8601`, which throws when the field is absent. The mock list-users response in that file only carries an `id`, so `listUsers()` fails to parse the page before any of the pagination assertions run. It fails on all three Dart channels, see [run 31509351637](https://github.com/supabase/supabase-flutter/actions/runs/31509351637).

## What is the new behavior?

The fixture user has a `created_at`, which is what the GoTrue server always sends for a user. The five tests in the file pass again, and the rest of the gotrue suite is unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the user listing test data to include account creation timestamps, improving coverage of returned user information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->