### PR TITLE
chore(ci): use Blacksmith macOS runners

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,5 @@
+self-hosted-runner:
+  # Blacksmith provides these labels through its GitHub App, so actionlint
+  # cannot discover them on its own.
+  labels:
+    - blacksmith-6vcpu-macos-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,23 +71,29 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
+            runner: ubuntu-latest
             target: web
           - os: ubuntu-latest
+            runner: ubuntu-latest
             target: linux
           - os: ubuntu-latest
+            runner: ubuntu-latest
             target: apk
           - os: macos-latest
+            runner: blacksmith-6vcpu-macos-latest
             target: macos
           - os: macos-latest
+            runner: blacksmith-6vcpu-macos-latest
             target: ios
           - os: windows-latest
+            runner: windows-latest
             target: windows
 
     defaults:
       run:
         working-directory: packages/supabase_flutter
 
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.runner }}
 
     env:
       PUB_CACHE: ${{ github.workspace }}/.pub-cache

--- a/.github/workflows/example-integration-tests.yml
+++ b/.github/workflows/example-integration-tests.yml
@@ -124,8 +124,8 @@ jobs:
           - { id: linux, os: ubuntu-latest, target: linux }
           - { id: web, os: ubuntu-latest, target: web }
           - { id: android, os: ubuntu-latest, target: android }
-          - { id: macos, os: macos-latest, target: macos }
-          - { id: ios, os: macos-latest, target: ios }
+          - { id: macos, os: blacksmith-6vcpu-macos-latest, target: macos }
+          - { id: ios, os: blacksmith-6vcpu-macos-latest, target: ios }
           - { id: windows, os: windows-latest, target: windows }
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -237,12 +237,19 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         flutter-version: ['3.35.x', 'latest']
+        include:
+          - os: ubuntu-latest
+            runner: ubuntu-latest
+          - os: macos-latest
+            runner: blacksmith-6vcpu-macos-latest
+          - os: windows-latest
+            runner: windows-latest
 
     defaults:
       run:
         working-directory: packages/supabase_flutter
 
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.runner }}
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Moves every macOS CI job from GitHub-hosted `macos-latest` to `blacksmith-6vcpu-macos-latest`, mirroring supabase/supabase-swift#1185.

## Jobs migrated

- `.github/workflows/build.yml`: `Build macos`, `Build ios`
- `.github/workflows/test.yml`: `Flutter v3.35.x on macos-latest`, `Flutter Latest on macos-latest`
- `.github/workflows/example-integration-tests.yml`: `macos`, `ios`

Ubuntu and Windows jobs are untouched.

## Implementation note

In `build.yml` and `test.yml` the `os` matrix key feeds both the job display name and several step conditions, so a separate `runner` key was added and `runs-on` points at that instead. Job names stay byte-identical, so required status checks in branch protection keep matching. `example-integration-tests.yml` only conditions on `matrix.target`, so its `os` value was swapped directly.

A `.github/actionlint.yaml` registers the Blacksmith label, since actionlint cannot discover labels that come from a GitHub App and would otherwise flag every `runs-on` here.

## Measured effect

Median duration of the GitHub-hosted jobs over the last two days of runs, against this branch's first run:

| Job | GitHub-hosted (median) | Blacksmith | Change |
| --- | --- | --- | --- |
| `Build macos` | 237s | 123s | 1.9x faster |
| `Build ios` | 232s | 125s | 1.9x faster |
| `Flutter v3.35.x on macos` | 156s | 88s | 1.8x faster |
| `Flutter Latest on macos` | 183s | 93s | 2.0x faster |

Queue time went up slightly, from 2 to 4 seconds to 13 to 22 seconds, which the runtime saving absorbs several times over.

## Still unexercised

`Example integration tests` is gated behind a release title or the `integration tests` label, so the `macos` and `ios` simulator jobs did not run here. Those boot a simulator with `xcrun simctl erase`/`boot`, which is the most likely step to behave differently on a Blacksmith image, so the label is worth applying once before merge.

Closes SDK-1466


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build, test, and integration-test workflows to use explicitly mapped platform-specific runners.
  * macOS and iOS validation now runs on dedicated macOS environments, while Windows and Linux continue using their existing runners.
  * Improved workflow configuration and validation consistency across supported platforms.
  * Added configuration support for the dedicated macOS runner label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->