### PR TITLE
ci: pin supabase/sdk reusable workflows to v1.0.0, add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,4 +3,4 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/sync-compliance.yml
+++ b/.github/workflows/sync-compliance.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: supabase/sdk/.github/workflows/sync-sdk-compliance.yml@d9f43f5be4056adc33c65fe54f1c9ed1714d67e0
+    uses: supabase/sdk/.github/workflows/sync-sdk-compliance.yml@93b52588ffda761e61b22cebfc3e5e29aa3cb3f4 # v1.0.0
     secrets:
       app-id: ${{ secrets.APP_ID }}
       private-key: ${{ secrets.PRIVATE_KEY }}

--- a/.github/workflows/validate-capabilities.yml
+++ b/.github/workflows/validate-capabilities.yml
@@ -13,4 +13,4 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    uses: supabase/sdk/.github/workflows/validate-sdk-compliance-dart.yml@main
+    uses: supabase/sdk/.github/workflows/validate-sdk-compliance-dart.yml@93b52588ffda761e61b22cebfc3e5e29aa3cb3f4 # v1.0.0


### PR DESCRIPTION
## Summary
- supabase/sdk cut its first tagged release, v1.0.0 (github.com/supabase/sdk/releases/tag/v1.0.0).
- Pins `sync-compliance.yml` and `validate-capabilities.yml`'s `uses:` refs to that release's commit SHA with a `# v1.0.0` comment, instead of a floating `@main` ref (validate-capabilities) or an unlabeled SHA (sync-compliance).
- Adds a `github-actions` Dependabot config (this repo didn't have one). Dependabot will recognize the version comment and open PRs here as supabase/sdk cuts new releases, so this stays current automatically.

## Test plan
- [ ] Merge this PR
- [ ] Confirm `SDK Compliance` and `Sync SDK Compliance Matrix` workflows still run successfully against the pinned ref
- [ ] Confirm Dependabot picks up a future supabase/sdk release and opens a bump PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added daily checks for GitHub Actions dependency updates.
  * Updated compliance validation workflows to use stable, pinned versions for more consistent results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->