### PR TITLE
refactor(realtime)!: remove the automatic REST fallback in send()

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -70,6 +70,46 @@ final WebSocketChannel? socket = client.connection;
 client.onConnectionMessage(rawMessage);
 ```
 
+### Broadcasts no longer fall back to the REST API
+
+`sendBroadcastMessage()` used to silently post to the REST broadcast endpoint whenever the channel
+could not push over the WebSocket, logging a warning that the fallback would go away. It has gone
+away: the message is only ever sent over the WebSocket, and calling it on a channel that was never
+subscribed throws instead.
+
+The fallback made delivery depend on socket timing, so the same call could take two different
+transports with two different sets of failure modes. `httpSend()` is the explicit REST path, and it
+works without subscribing at all.
+
+```dart
+// Before
+final channel = supabase.channel('room');
+// Delivered over REST because the channel was never subscribed.
+await channel.sendBroadcastMessage(
+  event: 'cursor-pos',
+  payload: {'x': 12, 'y': 34},
+);
+
+// After, over REST
+final channel = supabase.channel('room');
+await channel.httpSend(
+  event: 'cursor-pos',
+  payload: {'x': 12, 'y': 34},
+);
+
+// After, over the WebSocket
+final channel = supabase.channel('room')..subscribe();
+await channel.sendBroadcastMessage(
+  event: 'cursor-pos',
+  payload: {'x': 12, 'y': 34},
+);
+```
+
+Messages sent between `subscribe()` and the channel actually joining are still buffered and
+flushed once the join succeeds, so only channels that were never subscribed throw.
+
+`httpSend()` requires a Realtime server running v2.97.0 or newer.
+
 ### Plural enum names singularized
 
 A Dart enum type names one value rather than the set, so its name should be singular. Five enums

--- a/packages/realtime_client/lib/src/realtime_channel.dart
+++ b/packages/realtime_client/lib/src/realtime_channel.dart
@@ -663,8 +663,8 @@ class RealtimeChannel {
   /// Sends a broadcast message explicitly via REST API.
   ///
   /// This method always uses the REST API endpoint regardless of WebSocket
-  /// connection state. Useful when you want to guarantee REST delivery or when
-  /// gradually migrating from implicit REST fallback.
+  /// connection state, so it is the way to broadcast without subscribing to
+  /// the channel first.
   ///
   /// [payload] must be either a `Map<String, dynamic>`, which is JSON-encoded,
   /// or binary data ([TypedData] such as [Uint8List], or [ByteBuffer]), which
@@ -760,7 +760,10 @@ class RealtimeChannel {
     return typed.buffer.asUint8List(typed.offsetInBytes, typed.lengthInBytes);
   }
 
-  /// Sends a realtime broadcast message.
+  /// Sends a realtime broadcast message over the WebSocket.
+  ///
+  /// The channel has to be subscribed first, otherwise this throws. Use
+  /// [httpSend] to broadcast over the REST API without subscribing.
   ///
   /// With protocol `2.0.0` the message is sent as a positional JSON text frame.
   ///
@@ -799,59 +802,36 @@ class RealtimeChannel {
       payload['event'] = event;
     }
 
-    if (!canPush && type == RealtimeListenType.broadcast) {
-      socket.log(
-        'channel',
-        'send() is automatically falling back to REST API. This behavior will '
-            'be deprecated in the future. Please use httpSend() explicitly '
-            'for REST delivery.',
-      );
+    final push = this.push(
+      ChannelEvent.fromType(payload['type']),
+      payload,
+      opts['timeout'] ?? _timeout,
+    );
 
-      try {
-        final response = await (socket.httpClient?.post ?? post)(
-          Uri.parse(broadcastEndpointURL),
-          headers: _broadcastHeaders,
-          body: json.encode(_broadcastBody(event, payload)),
-        );
-        if (200 <= response.statusCode && response.statusCode < 300) {
-          completer.complete(ChannelResponse.ok);
-        } else {
-          completer.complete(ChannelResponse.error);
-        }
-      } catch (e) {
+    if (payload['type'] == 'broadcast' &&
+        (params['config']?['broadcast']?['ack'] == null ||
+            params['config']?['broadcast']?['ack'] == false)) {
+      if (!completer.isCompleted) {
+        completer.complete(ChannelResponse.ok);
+      }
+    }
+
+    push.receive('ok', (_) {
+      if (!completer.isCompleted) {
+        completer.complete(ChannelResponse.ok);
+      }
+    });
+    push.receive('error', (_) {
+      if (!completer.isCompleted) {
         completer.complete(ChannelResponse.error);
       }
-    } else {
-      final push = this.push(
-        ChannelEvent.fromType(payload['type']),
-        payload,
-        opts['timeout'] ?? _timeout,
-      );
-
-      if (payload['type'] == 'broadcast' &&
-          (params['config']?['broadcast']?['ack'] == null ||
-              params['config']?['broadcast']?['ack'] == false)) {
-        if (!completer.isCompleted) {
-          completer.complete(ChannelResponse.ok);
-        }
+    });
+    push.receive('timeout', (_) {
+      if (!completer.isCompleted) {
+        completer.complete(ChannelResponse.timedOut);
       }
+    });
 
-      push.receive('ok', (_) {
-        if (!completer.isCompleted) {
-          completer.complete(ChannelResponse.ok);
-        }
-      });
-      push.receive('error', (_) {
-        if (!completer.isCompleted) {
-          completer.complete(ChannelResponse.error);
-        }
-      });
-      push.receive('timeout', (_) {
-        if (!completer.isCompleted) {
-          completer.complete(ChannelResponse.timedOut);
-        }
-      });
-    }
     return completer.future;
   }
 
@@ -862,22 +842,6 @@ class RealtimeChannel {
     if (socket.accessToken != null)
       'Authorization': 'Bearer ${socket.accessToken}',
   };
-
-  Map<String, dynamic> _broadcastBody(
-    String? event,
-    Map<String, dynamic> payload,
-  ) {
-    return {
-      'messages': [
-        {
-          'topic': subTopic,
-          'event': event,
-          'payload': payload,
-          'private': _private,
-        },
-      ],
-    };
-  }
 
   @internal
   void updateJoinPayload(Map<String, dynamic> payload) {

--- a/packages/realtime_client/lib/src/realtime_channel.dart
+++ b/packages/realtime_client/lib/src/realtime_channel.dart
@@ -794,7 +794,7 @@ class RealtimeChannel {
     String? event,
     required Map<String, dynamic> payload,
     Map<String, dynamic> opts = const {},
-  }) async {
+  }) {
     final completer = Completer<ChannelResponse>();
 
     payload['type'] = type.toType();
@@ -802,11 +802,16 @@ class RealtimeChannel {
       payload['event'] = event;
     }
 
-    final push = this.push(
-      ChannelEvent.fromType(payload['type']),
-      payload,
-      opts['timeout'] ?? _timeout,
-    );
+    final Push push;
+    try {
+      push = this.push(
+        ChannelEvent.fromType(payload['type']),
+        payload,
+        opts['timeout'] ?? _timeout,
+      );
+    } catch (error, stackTrace) {
+      return Future.error(error, stackTrace);
+    }
 
     if (payload['type'] == 'broadcast' &&
         (params['config']?['broadcast']?['ack'] == null ||

--- a/packages/realtime_client/test/channel_test.dart
+++ b/packages/realtime_client/test/channel_test.dart
@@ -766,31 +766,50 @@ void main() {
       expect(message[4], containsPair('myKey', 'myValue'));
     });
 
-    test(
-      'send message via http request to Broadcast endpoint when not subscribed '
-      'to channel',
-      () async {
-        final requestFuture = mockServer.first;
-        final sendFuture = channel.send(
+    test('buffers the message while the channel is still joining', () async {
+      channel.subscribe();
+      unawaited(
+        channel.send(
           type: RealtimeListenType.broadcast,
           payload: {'myKey': 'myValue'},
-        );
+        ),
+      );
 
-        final request = await requestFuture;
-        expect(request.uri.toString(), '/realtime/v1/api/broadcast');
-        expect(request.headers.value('apikey'), 'supabaseKey');
+      final serverSocket = await mockServer.first.then(
+        WebSocketTransformer.upgrade,
+      );
+      final broadcast = Completer<List<dynamic>>();
+      serverSocket.listen((frame) {
+        final message = jsonDecode(frame as String) as List;
+        switch (message[3]) {
+          case 'phx_join':
+            serverSocket.add(
+              jsonEncode([
+                message[0],
+                message[1],
+                message[2],
+                'phx_reply',
+                {'status': 'ok', 'response': <String, dynamic>{}},
+              ]),
+            );
+          case 'broadcast':
+            broadcast.complete(message);
+        }
+      });
 
-        final body = json.decode(await utf8.decodeStream(request));
-        final message = body['messages'].first;
-        expect(message['payload'], containsPair('myKey', 'myValue'));
-        expect(message, containsPair('topic', 'myTopic'));
-        expect(message['private'], isTrue);
+      final message = await broadcast.future;
+      expect(message[4], containsPair('myKey', 'myValue'));
+    });
 
-        await request.response.close();
-
-        expect(await sendFuture, ChannelResponse.ok);
-      },
-    );
+    test('throws instead of falling back to REST when not subscribed', () {
+      return expectLater(
+        channel.send(
+          type: RealtimeListenType.broadcast,
+          payload: {'myKey': 'myValue'},
+        ),
+        throwsA(contains('before joining')),
+      );
+    });
   });
 
   group('presence', () {

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -1627,7 +1627,6 @@ features:
       - RealtimeChannel.unsubscribe
   realtime.channel.broadcast:
     status: implemented
-    note: "sendBroadcastMessage only sends over the WebSocket and throws when the channel was never subscribed; it does not fall back to the REST endpoint the way supabase-js send() still does. Use httpSend for REST delivery."
     symbols:
       - RealtimeChannel.sendBroadcastMessage
     supporting_symbols:

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -1627,14 +1627,13 @@ features:
       - RealtimeChannel.unsubscribe
   realtime.channel.broadcast:
     status: implemented
+    note: "sendBroadcastMessage only sends over the WebSocket and throws when the channel was never subscribed; it does not fall back to the REST endpoint the way supabase-js send() still does. Use httpSend for REST delivery."
     symbols:
       - RealtimeChannel.sendBroadcastMessage
     supporting_symbols:
       - ChannelResponse
   realtime.channel.broadcast_http:
     status: implemented
-    note: "httpSend posts to the legacy /api/broadcast endpoint with a messages array and returns Future<void>, not the newer per-channel endpoint returning {success}."
-
     symbols:
       - RealtimeChannel.httpSend
   # realtime — client


### PR DESCRIPTION
## What

`RealtimeChannel.send()` used to silently post the broadcast to the legacy `/api/broadcast` endpoint whenever the channel could not push over the socket (`canPush == false`), logging a warning that the fallback would be deprecated. It is gone.

- `sendBroadcastMessage()` only ever sends over the WebSocket.
- Calling it on a channel that was never subscribed now throws instead of quietly switching transport.
- Messages sent between `subscribe()` and the join completing are still buffered and flushed on join.
- `httpSend()` is the explicit REST path and works without subscribing.

The dead `_broadcastBody()` helper went with it. `broadcastEndpointURL` and `_broadcastHeaders` are still used by `httpSend()`.

## Why

The fallback made delivery depend on socket timing, so the same call could take two different transports with two different sets of failure modes. Now that `httpSend()` exists as the explicit REST delivery path, the implicit one is not needed.

## Changes

- `packages/realtime_client/lib/src/realtime_channel.dart`: drop the fallback branch and the `_broadcastBody()` helper, and document that `sendBroadcastMessage()` requires a subscribed channel while `httpSend()` does not.
- `packages/realtime_client/test/channel_test.dart`: the fallback test is replaced by one asserting `send()` throws when the channel was never subscribed, plus a new test covering the buffered-while-joining path.
- `MIGRATION.md`: v2 to v3 entry with the before/after for both transports.
- `sdk-compliance.yaml`: note the deviation from `supabase-js`, which still has the fallback in `send()`. Also drops the stale note on `realtime.channel.broadcast_http`, which described the endpoint shape from before `httpSend()` moved to the per-event URL.

## Breaking change

Code that called `sendBroadcastMessage()` on a channel it never subscribed to relied on the REST fallback and now throws. Switch those calls to `httpSend()`, which requires a Realtime server running v2.97.0 or newer.

Closes #1600

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Broadcast messages now use WebSocket delivery through subscribed channels.
  * Added explicit REST delivery through `httpSend()`, requiring Realtime server v2.97.0 or newer.

* **Bug Fixes**
  * Messages sent while a channel is joining are buffered and delivered after connection.
  * Sending through an unsubscribed channel now reports an error instead of falling back to REST.

* **Documentation**
  * Added migration guidance covering the updated delivery behavior and server requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->