### PR TITLE
chore: fix the analyzer issues from Flutter 3.47

### DIFF
--- a/examples/authentication/analysis_options.yaml
+++ b/examples/authentication/analysis_options.yaml
@@ -1,1 +1,10 @@
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: package:supabase_lints/analysis_options_flutter.yaml

--- a/examples/authentication/analysis_options.yaml
+++ b/examples/authentication/analysis_options.yaml
@@ -1,3 +1,5 @@
+include: package:supabase_lints/analysis_options_flutter.yaml
+
 analyzer:
   exclude:
     - build/**
@@ -7,4 +9,3 @@ analyzer:
     - windows/**
     - macos/**
     - linux/**
-include: package:supabase_lints/analysis_options_flutter.yaml

--- a/examples/database_crud/analysis_options.yaml
+++ b/examples/database_crud/analysis_options.yaml
@@ -1,1 +1,10 @@
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: package:supabase_lints/analysis_options_flutter.yaml

--- a/examples/database_crud/analysis_options.yaml
+++ b/examples/database_crud/analysis_options.yaml
@@ -1,3 +1,5 @@
+include: package:supabase_lints/analysis_options_flutter.yaml
+
 analyzer:
   exclude:
     - build/**
@@ -7,4 +9,3 @@ analyzer:
     - windows/**
     - macos/**
     - linux/**
-include: package:supabase_lints/analysis_options_flutter.yaml

--- a/examples/edge_functions/analysis_options.yaml
+++ b/examples/edge_functions/analysis_options.yaml
@@ -1,1 +1,10 @@
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: package:supabase_lints/analysis_options_flutter.yaml

--- a/examples/edge_functions/analysis_options.yaml
+++ b/examples/edge_functions/analysis_options.yaml
@@ -1,3 +1,5 @@
+include: package:supabase_lints/analysis_options_flutter.yaml
+
 analyzer:
   exclude:
     - build/**
@@ -7,4 +9,3 @@ analyzer:
     - windows/**
     - macos/**
     - linux/**
-include: package:supabase_lints/analysis_options_flutter.yaml

--- a/examples/launcher/analysis_options.yaml
+++ b/examples/launcher/analysis_options.yaml
@@ -1,3 +1,5 @@
+include: package:supabase_lints/analysis_options.yaml
+
 analyzer:
   exclude:
     - build/**
@@ -7,4 +9,3 @@ analyzer:
     - windows/**
     - macos/**
     - linux/**
-include: package:supabase_lints/analysis_options.yaml

--- a/examples/launcher/analysis_options.yaml
+++ b/examples/launcher/analysis_options.yaml
@@ -1,1 +1,10 @@
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: package:supabase_lints/analysis_options.yaml

--- a/examples/passkeys/analysis_options.yaml
+++ b/examples/passkeys/analysis_options.yaml
@@ -4,3 +4,11 @@ analyzer:
   errors:
     # The passkey API is intentionally marked @experimental upstream.
     experimental_member_use: ignore
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**

--- a/examples/realtime_room/analysis_options.yaml
+++ b/examples/realtime_room/analysis_options.yaml
@@ -1,1 +1,10 @@
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: package:supabase_lints/analysis_options_flutter.yaml

--- a/examples/realtime_room/analysis_options.yaml
+++ b/examples/realtime_room/analysis_options.yaml
@@ -1,3 +1,5 @@
+include: package:supabase_lints/analysis_options_flutter.yaml
+
 analyzer:
   exclude:
     - build/**
@@ -7,4 +9,3 @@ analyzer:
     - windows/**
     - macos/**
     - linux/**
-include: package:supabase_lints/analysis_options_flutter.yaml

--- a/examples/storage_transforms/analysis_options.yaml
+++ b/examples/storage_transforms/analysis_options.yaml
@@ -1,1 +1,10 @@
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: package:supabase_lints/analysis_options_flutter.yaml

--- a/examples/storage_transforms/analysis_options.yaml
+++ b/examples/storage_transforms/analysis_options.yaml
@@ -1,3 +1,5 @@
+include: package:supabase_lints/analysis_options_flutter.yaml
+
 analyzer:
   exclude:
     - build/**
@@ -7,4 +9,3 @@ analyzer:
     - windows/**
     - macos/**
     - linux/**
-include: package:supabase_lints/analysis_options_flutter.yaml

--- a/packages/functions_client/analysis_options.yaml
+++ b/packages/functions_client/analysis_options.yaml
@@ -1,3 +1,5 @@
+include: package:supabase_lints/analysis_options.yaml
+
 analyzer:
   exclude:
     - build/**
@@ -7,4 +9,3 @@ analyzer:
     - windows/**
     - macos/**
     - linux/**
-include: package:supabase_lints/analysis_options.yaml

--- a/packages/functions_client/analysis_options.yaml
+++ b/packages/functions_client/analysis_options.yaml
@@ -1,1 +1,10 @@
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: package:supabase_lints/analysis_options.yaml

--- a/packages/gotrue/analysis_options.yaml
+++ b/packages/gotrue/analysis_options.yaml
@@ -1,3 +1,5 @@
+include: package:supabase_lints/analysis_options.yaml
+
 analyzer:
   exclude:
     - build/**
@@ -7,4 +9,3 @@ analyzer:
     - windows/**
     - macos/**
     - linux/**
-include: package:supabase_lints/analysis_options.yaml

--- a/packages/gotrue/analysis_options.yaml
+++ b/packages/gotrue/analysis_options.yaml
@@ -1,1 +1,10 @@
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: package:supabase_lints/analysis_options.yaml

--- a/packages/postgrest/analysis_options.yaml
+++ b/packages/postgrest/analysis_options.yaml
@@ -1,3 +1,5 @@
+include: package:supabase_lints/analysis_options.yaml
+
 analyzer:
   exclude:
     - build/**
@@ -7,4 +9,3 @@ analyzer:
     - windows/**
     - macos/**
     - linux/**
-include: package:supabase_lints/analysis_options.yaml

--- a/packages/postgrest/analysis_options.yaml
+++ b/packages/postgrest/analysis_options.yaml
@@ -1,1 +1,10 @@
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: package:supabase_lints/analysis_options.yaml

--- a/packages/realtime_client/analysis_options.yaml
+++ b/packages/realtime_client/analysis_options.yaml
@@ -1,3 +1,5 @@
+include: package:supabase_lints/analysis_options.yaml
+
 analyzer:
   exclude:
     - build/**
@@ -7,4 +9,3 @@ analyzer:
     - windows/**
     - macos/**
     - linux/**
-include: package:supabase_lints/analysis_options.yaml

--- a/packages/realtime_client/analysis_options.yaml
+++ b/packages/realtime_client/analysis_options.yaml
@@ -1,1 +1,10 @@
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: package:supabase_lints/analysis_options.yaml

--- a/packages/storage_client/analysis_options.yaml
+++ b/packages/storage_client/analysis_options.yaml
@@ -1,3 +1,5 @@
+include: package:supabase_lints/analysis_options.yaml
+
 analyzer:
   exclude:
     - build/**
@@ -7,4 +9,3 @@ analyzer:
     - windows/**
     - macos/**
     - linux/**
-include: package:supabase_lints/analysis_options.yaml

--- a/packages/storage_client/analysis_options.yaml
+++ b/packages/storage_client/analysis_options.yaml
@@ -1,1 +1,10 @@
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: package:supabase_lints/analysis_options.yaml

--- a/packages/storage_client/lib/src/storage_client.dart
+++ b/packages/storage_client/lib/src/storage_client.dart
@@ -1,4 +1,3 @@
-import 'package:http/http.dart';
 import 'package:logging/logging.dart';
 import 'package:meta/meta.dart';
 import 'package:storage_client/src/constants.dart';
@@ -11,7 +10,6 @@ import 'package:storage_client/src/version.dart';
 
 class SupabaseStorageClient extends StorageBucketApi {
   final int _defaultRetryAttempts;
-  final Client? _httpClient;
   final _log = Logger('supabase.storage');
 
   /// To create a [SupabaseStorageClient], you need to provide an [url] and
@@ -46,7 +44,7 @@ class SupabaseStorageClient extends StorageBucketApi {
   SupabaseStorageClient(
     String url,
     Map<String, String> headers, {
-    Client? httpClient,
+    super.httpClient,
     int retryAttempts = 0,
     bool useNewHostname = false,
   }) : assert(
@@ -54,11 +52,9 @@ class SupabaseStorageClient extends StorageBucketApi {
          'retryAttempts has to be greater than or equal to 0',
        ),
        _defaultRetryAttempts = retryAttempts,
-       _httpClient = httpClient,
        super(
          useNewHostname ? _transformStorageUrl(url) : url,
          {...Constants.defaultHeaders, ...headers},
-         httpClient: httpClient,
        ) {
     _log.config(
       'Initialize SupabaseStorageClient v$version with url: $url, '
@@ -132,7 +128,7 @@ class SupabaseStorageClient extends StorageBucketApi {
       headers: headers,
       warehouse: bucketId,
       accessDelegation: accessDelegation,
-      httpClient: _httpClient,
+      httpClient: storageFetch.httpClient,
     );
   }
 

--- a/packages/supabase/analysis_options.yaml
+++ b/packages/supabase/analysis_options.yaml
@@ -1,3 +1,5 @@
+include: package:supabase_lints/analysis_options.yaml
+
 analyzer:
   exclude:
     - build/**
@@ -7,4 +9,3 @@ analyzer:
     - windows/**
     - macos/**
     - linux/**
-include: package:supabase_lints/analysis_options.yaml

--- a/packages/supabase/analysis_options.yaml
+++ b/packages/supabase/analysis_options.yaml
@@ -1,1 +1,10 @@
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: package:supabase_lints/analysis_options.yaml

--- a/packages/supabase/example/analysis_options.yaml
+++ b/packages/supabase/example/analysis_options.yaml
@@ -1,3 +1,5 @@
+include: package:supabase_lints/analysis_options.yaml
+
 analyzer:
   exclude:
     - build/**
@@ -7,4 +9,3 @@ analyzer:
     - windows/**
     - macos/**
     - linux/**
-include: package:supabase_lints/analysis_options.yaml

--- a/packages/supabase/example/analysis_options.yaml
+++ b/packages/supabase/example/analysis_options.yaml
@@ -1,1 +1,10 @@
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: package:supabase_lints/analysis_options.yaml

--- a/packages/supabase_common/analysis_options.yaml
+++ b/packages/supabase_common/analysis_options.yaml
@@ -1,3 +1,5 @@
+include: package:supabase_lints/analysis_options.yaml
+
 analyzer:
   exclude:
     - build/**
@@ -7,4 +9,3 @@ analyzer:
     - windows/**
     - macos/**
     - linux/**
-include: package:supabase_lints/analysis_options.yaml

--- a/packages/supabase_common/analysis_options.yaml
+++ b/packages/supabase_common/analysis_options.yaml
@@ -1,1 +1,10 @@
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: package:supabase_lints/analysis_options.yaml

--- a/packages/supabase_flutter/analysis_options.yaml
+++ b/packages/supabase_flutter/analysis_options.yaml
@@ -1,1 +1,10 @@
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: package:supabase_lints/analysis_options_flutter.yaml

--- a/packages/supabase_flutter/analysis_options.yaml
+++ b/packages/supabase_flutter/analysis_options.yaml
@@ -1,3 +1,5 @@
+include: package:supabase_lints/analysis_options_flutter.yaml
+
 analyzer:
   exclude:
     - build/**
@@ -7,4 +9,3 @@ analyzer:
     - windows/**
     - macos/**
     - linux/**
-include: package:supabase_lints/analysis_options_flutter.yaml

--- a/packages/supabase_flutter/example/analysis_options.yaml
+++ b/packages/supabase_flutter/example/analysis_options.yaml
@@ -3,6 +3,13 @@ include: package:supabase_lints/analysis_options_flutter.yaml
 analyzer:
   exclude:
     - lib/generated_plugin_registrant.dart
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 
 dcm:
   rules:

--- a/packages/supabase_flutter/example/android/app/build.gradle
+++ b/packages/supabase_flutter/example/android/app/build.gradle
@@ -11,12 +11,8 @@ android {
     ndkVersion = flutter.ndkVersion
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
-    }
-
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
     defaultConfig {
@@ -36,6 +32,12 @@ android {
             // Signing with the debug keys for now, so `flutter run --release` works.
             signingConfig = signingConfigs.debug
         }
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
     }
 }
 

--- a/packages/supabase_flutter/example/android/gradle.properties
+++ b/packages/supabase_flutter/example/android/gradle.properties
@@ -1,4 +1,7 @@
-org.gradle.jvmargs=-Xmx4G -XX:MaxMetaspaceSize=2G -XX:+HeapDumpOnOutOfMemoryError
+org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
-android.enableJetifier=true
-kotlin.version=2.1.20
+# This newDsl flag was added by the Flutter template
+android.newDsl=false
+# This builtInKotlin flag was added by the Flutter template
+android.builtInKotlin=false
+kotlin.version=2.4.0

--- a/packages/supabase_flutter/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/supabase_flutter/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-all.zip

--- a/packages/supabase_flutter/example/android/settings.gradle
+++ b/packages/supabase_flutter/example/android/settings.gradle
@@ -18,8 +18,8 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version '8.13.1' apply false
-    id "org.jetbrains.kotlin.android" version "2.1.20" apply false
+    id "com.android.application" version "9.1.0" apply false
+    id "org.jetbrains.kotlin.android" version "2.4.0" apply false
 }
 
 include ":app"

--- a/packages/supabase_lints/analysis_options.yaml
+++ b/packages/supabase_lints/analysis_options.yaml
@@ -1,3 +1,5 @@
+include: package:supabase_lints/analysis_options.yaml
+
 analyzer:
   exclude:
     - build/**
@@ -7,4 +9,3 @@ analyzer:
     - windows/**
     - macos/**
     - linux/**
-include: package:supabase_lints/analysis_options.yaml

--- a/packages/supabase_lints/analysis_options.yaml
+++ b/packages/supabase_lints/analysis_options.yaml
@@ -1,1 +1,10 @@
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: package:supabase_lints/analysis_options.yaml

--- a/packages/supabase_lints/lib/analysis_options.yaml
+++ b/packages/supabase_lints/lib/analysis_options.yaml
@@ -7,6 +7,21 @@
 include: package:lints/recommended.yaml
 
 analyzer:
+  # These exclusions are repeated verbatim in every package's own
+  # analysis_options.yaml. The duplication is deliberate: flutter_tools rewrites
+  # each project's file to re-add them on every `flutter pub get`, because its
+  # AnalysisOptionsMigration does not resolve `include:` and so cannot see that
+  # they are already inherited from here. Committing the duplicates keeps the
+  # working tree clean. Drop them once the upstream issue is fixed:
+  # https://github.com/flutter/flutter/issues/191056
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
   language:
     strict-raw-types: true
 

--- a/packages/supabase_typegen/analysis_options.yaml
+++ b/packages/supabase_typegen/analysis_options.yaml
@@ -1,3 +1,5 @@
+include: package:supabase_lints/analysis_options.yaml
+
 analyzer:
   exclude:
     - build/**
@@ -7,4 +9,3 @@ analyzer:
     - windows/**
     - macos/**
     - linux/**
-include: package:supabase_lints/analysis_options.yaml

--- a/packages/supabase_typegen/analysis_options.yaml
+++ b/packages/supabase_typegen/analysis_options.yaml
@@ -1,1 +1,10 @@
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: package:supabase_lints/analysis_options.yaml

--- a/packages/yet_another_json_isolate/analysis_options.yaml
+++ b/packages/yet_another_json_isolate/analysis_options.yaml
@@ -1,3 +1,5 @@
+include: package:supabase_lints/analysis_options.yaml
+
 analyzer:
   exclude:
     - build/**
@@ -7,4 +9,3 @@ analyzer:
     - windows/**
     - macos/**
     - linux/**
-include: package:supabase_lints/analysis_options.yaml

--- a/packages/yet_another_json_isolate/analysis_options.yaml
+++ b/packages/yet_another_json_isolate/analysis_options.yaml
@@ -1,1 +1,10 @@
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: package:supabase_lints/analysis_options.yaml

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -149,10 +149,10 @@ packages:
     dependency: transitive
     description:
       name: build_web_compilers
-      sha256: c8be4b48f09289d145c7eaa3240f1e7776c529ea1cecddf483218edd3129de3f
+      sha256: ef4bc35e0e335f8520692a333b872446697adce0618cf23c3084715ace641721
       url: "https://pub.dev"
     source: hosted
-    version: "4.8.0"
+    version: "4.8.5"
   built_collection:
     dependency: transitive
     description:
@@ -507,10 +507,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "31bd099b47c10cd1aeb55146a2d46ce0277630ecef3f7dae54ad7873f36696cd"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.20"
   material_color_utilities:
     dependency: transitive
     description:
@@ -531,10 +531,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "307249ce4ff29d58a18e97f6345f539382eb9c9c29ecda628900f31de0443dd9"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.0"
   mime:
     dependency: transitive
     description:
@@ -968,26 +968,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
+      sha256: ca578dc12bb8b2f40b67b7d3bd2fac4f31c01a6ff7130a14e2597b919934507f
       url: "https://pub.dev"
     source: hosted
-    version: "1.31.0"
+    version: "1.31.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: "2a122cbe059f8b610d3a5415f42e255b6c17b1f21eee1d960f31080237fb4f11"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.12"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
+      sha256: d2e98ec12998368dc59ddd47ab709f2cd55acd6b66dc7db764455a44082f4bc5
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.17"
+    version: "0.6.18"
   timezone:
     dependency: transitive
     description:
@@ -1088,10 +1088,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
+      sha256: f36f9f3be64c6198714492bb455c11056e33e2f85d9a0b676a48301e44fdcf47
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.4.2"
   vm_service:
     dependency: transitive
     description:
@@ -1197,5 +1197,5 @@ packages:
     source: hosted
     version: "2.2.4"
 sdks:
-  dart: ">=3.12.0 <3.13.0-z"
+  dart: ">=3.13.0-107.0.dev <3.14.0-z"
   flutter: ">=3.44.0"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Chore. Fixes the two things that broke with Flutter 3.47 / Dart 3.13.

## What is the current behavior?

`dart analyze --fatal-infos .` fails, and `flutter pub get` leaves a 20-file dirty working tree.

## What is the new behavior?

### `use_super_parameters` in `SupabaseStorageClient`

Dart 3.13's analyzer started reporting:

```
info • Parameter 'httpClient' could be a super parameter • packages/storage_client/lib/src/storage_client.dart:46:3 • use_super_parameters
```

`httpClient` is now a super parameter, and the redundant private `_httpClient` field is gone. `analyticsCatalog` reads the client back from `storageFetch.httpClient`, which holds the same instance. The public parameter name is unchanged, so no call sites move. The now-unused `package:http` import is dropped.

### Committed `analyzer: exclude:` blocks

Flutter 3.47 added [`AnalysisOptionsMigration`](https://github.com/flutter/flutter/blob/master/packages/flutter_tools/lib/src/migrations/analysis_options_migration.dart), which rewrites every project's `analysis_options.yaml` to exclude `build/` and the platform directories. It runs from `ensureReadyForPlatformSpecificTooling`, so `pub get`, `analyze`, `run` and `build` all trigger it.

The natural fix is to put the exclusions in `supabase_lints` once. That does work for analysis. But the migration only reads each project's own file and never resolves `include:`, so it cannot tell the exclusions are already inherited and re-adds them to all 20 packages on every `flutter pub get`. Reverting and re-running brings them straight back.

So this commits the duplicated blocks to stop the churn, and keeps the canonical copy in `supabase_lints` with a comment pointing at the upstream issue, so the 20 duplicates can be deleted once it is fixed.

Reported upstream as https://github.com/flutter/flutter/issues/191056.

`pubspec.lock` also picks up transitive bumps required by the new SDK constraints.

## Additional context

Verified locally on Flutter 3.47.0 / Dart 3.13.0:

- `dart analyze --fatal-infos .` reports no issues
- `dart format --line-length 80 --set-exit-if-changed packages examples` reports 0 changed across 285 files
- `flutter pub get` no longer prints `Upgrading analysis_options.yaml ...` and leaves the tree clean
- `storage_client` unit tests pass (`basic_test.dart`, `fetch_test.dart`, `path_encoding_test.dart`)

The backend-dependent test suites were not run locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved analyzer behavior by excluding generated build artifacts and platform-specific directories from validation across examples and packages.
  * Preserved existing linting rules for project source code.

* **Refactor**
  * Simplified HTTP client handling in storage operations while preserving existing behavior and constructor usage.
  * Iceberg catalog operations continue using the configured HTTP client.

* **Chores**
  * Updated the Android example’s Gradle, Kotlin, Java, and JVM tooling to newer versions and configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->