### PR TITLE
chore: spell out abbreviations in internal code, tests, and examples

### DIFF
--- a/examples/launcher/bin/examples_launcher.dart
+++ b/examples/launcher/bin/examples_launcher.dart
@@ -2,6 +2,6 @@ import 'dart:io';
 
 import 'package:examples_launcher/launcher.dart' as launcher;
 
-Future<void> main(List<String> args) async {
-  exitCode = await launcher.run(args);
+Future<void> main(List<String> arguments) async {
+  exitCode = await launcher.run(arguments);
 }

--- a/examples/launcher/lib/launcher.dart
+++ b/examples/launcher/lib/launcher.dart
@@ -22,9 +22,9 @@ class Example {
 
 /// Boots the local Supabase stack, asks which example to run and runs it.
 ///
-/// Any [args] are forwarded to `flutter run`, replacing the default
+/// Any [arguments] are forwarded to `flutter run`, replacing the default
 /// `-d chrome`, so `dart run -- -d macos` runs the chosen example on macOS.
-Future<int> run(List<String> args) async {
+Future<int> run(List<String> arguments) async {
   _printBanner();
 
   final root = _findExamplesRoot();
@@ -96,8 +96,8 @@ Future<int> run(List<String> args) async {
 
     // Serve on a fixed origin so it matches the WebAuthn rp_origins configured
     // in supabase/config.toml, which the passkeys example relies on.
-    final flutterArgs = args.isNotEmpty
-        ? args
+    final flutterArguments = arguments.isNotEmpty
+        ? arguments
         : const [
             '-d',
             'chrome',
@@ -110,7 +110,7 @@ Future<int> run(List<String> args) async {
       'flutter',
       [
         'run',
-        ...flutterArgs,
+        ...flutterArguments,
         '--dart-define=SUPABASE_URL=$url',
         '--dart-define=SUPABASE_PUBLISHABLE_KEY=$key',
       ],
@@ -214,10 +214,10 @@ Future<Map<String, String>> _supabaseStatus(Directory root) async {
     root.path,
   ]);
   if (result.exitCode != _ok) return {};
-  return _parseEnv('${result.stdout}');
+  return _parseEnvironment('${result.stdout}');
 }
 
-Map<String, String> _parseEnv(String output) {
+Map<String, String> _parseEnvironment(String output) {
   final env = <String, String>{};
   for (final line in const LineSplitter().convert(output)) {
     final index = line.indexOf('=');

--- a/packages/functions_client/lib/src/functions_client.dart
+++ b/packages/functions_client/lib/src/functions_client.dart
@@ -104,8 +104,8 @@ class FunctionsClient {
   /// final response = await supabase.functions.invoke('sse-function');
   /// response.data
   ///     .transform(const Utf8Decoder())
-  ///     .listen((val) {
-  ///       print(val);
+  ///     .listen((value) {
+  ///       print(value);
   ///     });
   /// ```
   /// To stream SSE on the web, you can use a custom HTTP client that is able to
@@ -132,15 +132,15 @@ class FunctionsClient {
     final effectiveRegion = region ?? _region;
 
     // Merge query parameters with forceFunctionRegion if region is specified
-    final effectiveQueryParams = <String, dynamic>{
+    final effectiveQueryParameters = <String, dynamic>{
       ...?queryParameters,
       if (effectiveRegion != null && effectiveRegion != 'any')
         'forceFunctionRegion': effectiveRegion,
     };
 
     final uri = Uri.parse('$_url/$functionName').replace(
-      queryParameters: effectiveQueryParams.isNotEmpty
-          ? effectiveQueryParams
+      queryParameters: effectiveQueryParameters.isNotEmpty
+          ? effectiveQueryParameters
           : null,
     );
 
@@ -189,8 +189,8 @@ class FunctionsClient {
       } else if (body is Uint8List) {
         bodyRequest.bodyBytes = body;
       } else {
-        final bodyStr = await _isolate.encode(body);
-        bodyRequest.body = bodyStr;
+        final bodyString = await _isolate.encode(body);
+        bodyRequest.body = bodyString;
       }
       request = bodyRequest;
     }

--- a/packages/postgrest/example/main.dart
+++ b/packages/postgrest/example/main.dart
@@ -12,9 +12,9 @@ dynamic main() async {
   try {
     final response = await client.from('countries').select();
     print(response);
-  } on PostgrestApiException catch (e) {
+  } on PostgrestApiException catch (error) {
     // handle PostgrestError
-    print(e.errorCode);
-    print(e.message);
+    print(error.errorCode);
+    print(error.message);
   }
 }

--- a/packages/postgrest/lib/src/postgrest_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_builder.dart
@@ -279,8 +279,8 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
   ///   .from('table')
   ///   .select()
   ///   .abortSignal(abortSignal.future);
-  /// } on RequestAbortedException catch (e) {
-  ///  print('Request was aborted: $e');
+  /// } on RequestAbortedException catch (error) {
+  ///  print('Request was aborted: $error');
   /// }
   /// ```
   ///
@@ -292,8 +292,8 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
   ///   .from('table')
   ///   .select()
   ///   .abortSignal(Future.delayed(Duration(seconds: 5)));
-  /// } on RequestAbortedException catch (e) {
-  ///  print('Request was aborted: $e');
+  /// } on RequestAbortedException catch (error) {
+  ///  print('Request was aborted: $error');
   /// }
   /// ```
   PostgrestBuilder<T, S, R> abortSignal(Future<void> abortSignal) {
@@ -338,7 +338,7 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
     if (method != HttpMethod.get && method != HttpMethod.head) {
       execHeaders['Content-Type'] = 'application/json';
     }
-    final bodyStr = jsonEncode(_body);
+    final bodyString = jsonEncode(_body);
     _log.finest("Request: ${method.value} $_url");
 
     final requestTimeout = _requestTimeout;
@@ -375,7 +375,7 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
       request.headers.addAll(execHeaders);
       switch (method) {
         case HttpMethod.post || HttpMethod.put || HttpMethod.patch:
-          request.body = bodyStr;
+          request.body = bodyString;
         case HttpMethod.get || HttpMethod.head || HttpMethod.delete:
           break;
       }
@@ -597,30 +597,30 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
     throw error;
   }
 
-  /// Get new Uri with updated queryParams
+  /// Get new Uri with updated query parameters
   /// Uses lists to allow multiple values for the same key
   ///
   /// [url] may be used to update based on a different url than the current one
   Uri appendSearchParams(String key, String value, [Uri? url]) {
-    final searchParams = Map<String, dynamic>.of(
+    final searchParameters = Map<String, dynamic>.of(
       (url ?? _url).queryParametersAll,
     );
-    searchParams[key] = [...?searchParams[key], value];
-    return (url ?? _url).replace(queryParameters: searchParams);
+    searchParameters[key] = [...?searchParameters[key], value];
+    return (url ?? _url).replace(queryParameters: searchParameters);
   }
 
-  /// Get new Uri with overridden queryParams
+  /// Get new Uri with overridden query parameters
   ///
   /// [url] may be used to update based on a different url than the current one
   Uri overrideSearchParams(String key, String value, [Uri? url]) {
-    final searchParams = Map<String, dynamic>.of(
+    final searchParameters = Map<String, dynamic>.of(
       (url ?? _url).queryParametersAll,
     );
-    searchParams[key] = value;
-    return (url ?? _url).replace(queryParameters: searchParams);
+    searchParameters[key] = value;
+    return (url ?? _url).replace(queryParameters: searchParameters);
   }
 
-  /// Convert list filter to query params string
+  /// Convert list filter to query parameters string
   String _cleanFilterArray(List<dynamic> filter) {
     if (filter.every((element) => element is num)) {
       return filter.map((s) => '$s').join(',');
@@ -644,8 +644,8 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
       then((value) {
             controller.add(value);
           })
-          .catchError((Object error, StackTrace stack) {
-            controller.addError(error, stack);
+          .catchError((Object error, StackTrace stackTrace) {
+            controller.addError(error, stackTrace);
           })
           .whenComplete(() {
             unawaited(controller.close());
@@ -682,22 +682,22 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
     // frames are still on the stack and appear in error traces.
     final callerTrace = StackTrace.current;
 
-    StackTrace enrichStack(StackTrace stack) =>
-        StackTrace.fromString('$stack\n<async call site>\n$callerTrace');
+    StackTrace enrichStack(StackTrace stackTrace) =>
+        StackTrace.fromString('$stackTrace\n<async call site>\n$callerTrace');
 
     if (onError == null) {
       return _execute().then(
         onValue,
-        onError: (Object error, StackTrace stack) {
-          Error.throwWithStackTrace(error, enrichStack(stack));
+        onError: (Object error, StackTrace stackTrace) {
+          Error.throwWithStackTrace(error, enrichStack(stackTrace));
         },
       );
     }
 
     return _execute().then(
       onValue,
-      onError: (Object error, StackTrace stack) async {
-        final enrichedStack = enrichStack(stack);
+      onError: (Object error, StackTrace stackTrace) async {
+        final enrichedStack = enrichStack(stackTrace);
         final FutureOr<U> result;
         if (onError is Function(Object, StackTrace)) {
           result = onError(error, enrichedStack);

--- a/packages/postgrest/lib/src/postgrest_query_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_query_builder.dart
@@ -62,9 +62,9 @@ class PostgrestQueryBuilder<T> extends RawPostgrestBuilder<T, T, T> {
   PostgrestFilterBuilder<PostgrestList> select([String columns = '*']) {
     // Remove whitespaces except when quoted
     var quoted = false;
-    final re = RegExp(r'\s');
+    final whitespaceRegularExpression = RegExp(r'\s');
     final cleanedColumns = columns.split('').map((c) {
-      if (re.hasMatch(c) && !quoted) {
+      if (whitespaceRegularExpression.hasMatch(c) && !quoted) {
         return '';
       }
       if (c == '"') {

--- a/packages/postgrest/lib/src/postgrest_transform_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_transform_builder.dart
@@ -45,9 +45,9 @@ class PostgrestTransformBuilder<T> extends RawPostgrestBuilder<T, T, T> {
   PostgrestTransformBuilder<PostgrestList> select([String columns = '*']) {
     // Remove whitespaces except when quoted
     var quoted = false;
-    final re = RegExp(r'\s');
+    final whitespaceRegularExpression = RegExp(r'\s');
     final cleanedColumns = columns.split('').map((c) {
-      if (re.hasMatch(c) && !quoted) {
+      if (whitespaceRegularExpression.hasMatch(c) && !quoted) {
         return '';
       }
       if (c == '"') {
@@ -281,12 +281,12 @@ class PostgrestTransformBuilder<T> extends RawPostgrestBuilder<T, T, T> {
   /// with the data and the count.
   ///
   /// ```dart
-  /// final res = await postgrest
+  /// final response = await postgrest
   ///    .from('users')
   ///    .select()
   ///    .count(CountOption.exact);
-  /// final users = res.data;
-  /// int count = res.count;
+  /// final users = response.data;
+  /// int count = response.count;
   /// ```
   ResponsePostgrestBuilder<PostgrestResponse<T>, T, T> count([
     CountOption count = CountOption.exact,

--- a/packages/postgrest/lib/src/response_postgrest_builder.dart
+++ b/packages/postgrest/lib/src/response_postgrest_builder.dart
@@ -17,15 +17,15 @@ class ResponsePostgrestBuilder<T, S, R> extends PostgrestBuilder<T, S, R> {
   /// response.
   ///
   /// ```dart
-  /// final res = await postgrest
+  /// final response = await postgrest
   ///     .from('users')
   ///     .select()
   ///     .count(CountOption.exact)
   ///     .withConverter(
   ///       (users) => users.map(User.fromJson).toList(),
   ///     );
-  /// List<User> users = res.data;
-  /// int count = res.count;
+  /// List<User> users = response.data;
+  /// int count = response.count;
   /// ```
   PostgrestBuilder<PostgrestResponse<U>, U, R> withConverter<U>(
     PostgrestConverter<U, R> converter,

--- a/packages/realtime_client/example/main.dart
+++ b/packages/realtime_client/example/main.dart
@@ -6,8 +6,8 @@ Future<void> main() async {
     'ws://SUPABASE_API_ENDPOINT/realtime/v1',
     params: {'apikey': 'SUPABASE_API_KEY'},
     // ignore: avoid_print
-    logger: (kind, msg, data) {
-      print('$kind $msg $data');
+    logger: (kind, message, data) {
+      print('$kind $message $data');
     },
   );
 

--- a/packages/realtime_client/lib/src/push.dart
+++ b/packages/realtime_client/lib/src/push.dart
@@ -17,8 +17,8 @@ class Push {
   bool sent = false;
   Timer? _timeoutTimer;
   String _ref = '';
-  Map<String, dynamic>? _receivedResp;
-  final List<Hook> _recHooks = [];
+  Map<String, dynamic>? _receivedResponse;
+  final List<Hook> _receiveHooks = [];
   String? _refEvent;
 
   /// The channel
@@ -50,7 +50,7 @@ class Push {
     _cancelRefEvent();
     _ref = '';
     _refEvent = null;
-    _receivedResp = null;
+    _receivedResponse = null;
     sent = false;
     send();
   }
@@ -78,10 +78,10 @@ class Push {
 
   Push receive(String status, Callback callback) {
     if (_hasReceived(status)) {
-      callback(_receivedResp?['response']);
+      callback(_receivedResponse?['response']);
     }
 
-    _recHooks.add(Hook(status, callback));
+    _receiveHooks.add(Hook(status, callback));
     return this;
   }
 
@@ -95,7 +95,7 @@ class Push {
     _channel.onEvents(_refEvent!, ChannelFilter(), (dynamic response, [_]) {
       _cancelRefEvent();
       _cancelTimeout();
-      _receivedResp = response;
+      _receivedResponse = response;
       _matchReceive(response['status'] as String, response['response']);
     });
 
@@ -132,13 +132,13 @@ class Push {
     String status,
     dynamic response,
   ) {
-    _recHooks.where((h) => h.status == status).forEach((h) {
+    _receiveHooks.where((h) => h.status == status).forEach((h) {
       h.callback(response);
     });
   }
 
   bool _hasReceived(String status) {
-    return _receivedResp is Map && _receivedResp?['status'] == status;
+    return _receivedResponse is Map && _receivedResponse?['status'] == status;
   }
 }
 

--- a/packages/realtime_client/lib/src/realtime_channel.dart
+++ b/packages/realtime_client/lib/src/realtime_channel.dart
@@ -265,10 +265,10 @@ class RealtimeChannel {
       return;
     }
     final clientPostgresBindings = _bindings['postgres_changes'];
-    final bindingsLen = clientPostgresBindings?.length ?? 0;
+    final bindingsLength = clientPostgresBindings?.length ?? 0;
     final newPostgresBindings = <Binding>[];
 
-    for (var i = 0; i < bindingsLen; i++) {
+    for (var i = 0; i < bindingsLength; i++) {
       final clientPostgresBinding = clientPostgresBindings![i];
 
       final event = clientPostgresBinding.filter['event'];
@@ -332,7 +332,7 @@ class RealtimeChannel {
         'event': 'track',
         'payload': payload,
       },
-      opts: {
+      options: {
         'timeout': _timeout,
         ...opts,
       },
@@ -347,7 +347,7 @@ class RealtimeChannel {
       payload: {
         'event': 'untrack',
       },
-      opts: opts,
+      options: opts,
     );
   }
 
@@ -686,8 +686,8 @@ class RealtimeChannel {
   ///     event: 'cursor-pos',
   ///     payload: {'x': 123, 'y': 456},
   ///   );
-  /// } catch (e) {
-  ///   print('Failed to send message: $e');
+  /// } catch (error) {
+  ///   print('Failed to send message: $error');
   /// }
   /// ```
   Future<void> httpSend({
@@ -793,7 +793,7 @@ class RealtimeChannel {
     required RealtimeListenType type,
     String? event,
     required Map<String, dynamic> payload,
-    Map<String, dynamic> opts = const {},
+    Map<String, dynamic> options = const {},
   }) {
     final completer = Completer<ChannelResponse>();
 
@@ -807,7 +807,7 @@ class RealtimeChannel {
       push = this.push(
         ChannelEvent.fromType(payload['type']),
         payload,
-        opts['timeout'] ?? _timeout,
+        options['timeout'] ?? _timeout,
       );
     } catch (error, stackTrace) {
       return Future.error(error, stackTrace);
@@ -1032,14 +1032,17 @@ class RealtimeChannel {
   @internal
   bool get isLeaving => _state == ChannelState.leaving;
 
-  static bool _isEqual(Map<String, Object?> obj1, Map<String, Object?> obj2) {
-    if (obj1.keys.length != obj2.keys.length) {
+  static bool _isEqual(
+    Map<String, Object?> first,
+    Map<String, Object?> second,
+  ) {
+    if (first.keys.length != second.keys.length) {
       return false;
     }
 
     const equality = DeepCollectionEquality();
-    for (final k in obj1.keys) {
-      if (!equality.equals(obj1[k], obj2[k])) {
+    for (final k in first.keys) {
+      if (!equality.equals(first[k], second[k])) {
         return false;
       }
     }

--- a/packages/realtime_client/lib/src/realtime_client.dart
+++ b/packages/realtime_client/lib/src/realtime_client.dart
@@ -324,9 +324,9 @@ class RealtimeClient {
           _onConnectionClose();
         },
       );
-    } catch (e) {
+    } catch (error) {
       /// General error handling
-      _onConnectionError(e);
+      _onConnectionError(error);
     }
   }
 
@@ -606,7 +606,7 @@ class RealtimeClient {
   String get endPointURL {
     final queryParameters = Map<String, String>.from(params);
     queryParameters['vsn'] = version.vsn;
-    return _appendParams(endPoint, queryParameters);
+    return _appendParameters(endPoint, queryParameters);
   }
 
   /// Return the next message ref, accounting for overflows
@@ -677,8 +677,8 @@ class RealtimeClient {
           channel.rejoin();
         }
       }
-    } catch (e) {
-      log('transport', 'error while rejoining channels', e, Level.WARNING);
+    } catch (error) {
+      log('transport', 'error while rejoining channels', error, Level.WARNING);
     }
 
     for (final callback in stateChangeCallbacks['open']!) {
@@ -724,7 +724,7 @@ class RealtimeClient {
     }
   }
 
-  String _appendParams(String url, Map<String, String> queryParameters) {
+  String _appendParameters(String url, Map<String, String> queryParameters) {
     if (queryParameters.keys.isEmpty) {
       return url;
     }

--- a/packages/realtime_client/lib/src/realtime_presence.dart
+++ b/packages/realtime_client/lib/src/realtime_presence.dart
@@ -184,12 +184,12 @@ class RealtimePresence {
         final newPresenceRefs = (newPresences as List)
             .map((m) => m.presenceRef as String)
             .toList();
-        final curPresenceRefs = currentPresences
+        final currentPresenceRefs = currentPresences
             .map((m) => m.presenceRef)
             .toList();
         final joinedPresences =
             newPresences
-                    .where((m) => !curPresenceRefs.contains(m.presenceRef))
+                    .where((m) => !currentPresenceRefs.contains(m.presenceRef))
                     .toList()
                 as List<Presence>;
         final leftPresences = currentPresences
@@ -240,11 +240,11 @@ class RealtimePresence {
         final joinedPresenceRefs = state[key]!
             .map((m) => m.presenceRef)
             .toList();
-        final curPresences = currentPresences
+        final remainingPresences = currentPresences
             .where((m) => !joinedPresenceRefs.contains(m.presenceRef))
             .toList();
 
-        state[key]!.insertAll(0, curPresences);
+        state[key]!.insertAll(0, remainingPresences);
       }
 
       onJoin!(key, currentPresences, newPresences);
@@ -287,8 +287,13 @@ class RealtimePresence {
     return _map(presences, (key, presence) => chooser!(key, presence));
   }
 
-  static List<T> _map<T>(Map<String, dynamic> obj, PresenceChooser<T> func) {
-    return obj.keys.map((key) => func(key, obj[key])).toList();
+  static List<T> _map<T>(
+    Map<String, dynamic> presencesByKey,
+    PresenceChooser<T> func,
+  ) {
+    return presencesByKey.keys
+        .map((key) => func(key, presencesByKey[key]))
+        .toList();
   }
 
   /// Remove 'metas' key
@@ -336,10 +341,10 @@ class RealtimePresence {
   }
 
   static Map<String, List<Presence>> _cloneDeep(
-    Map<String, List<Presence>> obj,
+    Map<String, List<Presence>> presencesByKey,
   ) {
     return Map.fromEntries(
-      obj.entries.map(
+      presencesByKey.entries.map(
         (entry) => MapEntry(
           entry.key,
           entry.value.map((presence) => presence.deepClone()).toList(),

--- a/packages/realtime_client/lib/src/retry_timer.dart
+++ b/packages/realtime_client/lib/src/retry_timer.dart
@@ -8,7 +8,7 @@ typedef TimerCallback = void Function();
 @internal
 typedef TimerCalculation = int Function(int tries);
 
-/// Creates a timer that accepts a `timerCalc` function to perform
+/// Creates a timer that accepts a `timerCalculation` function to perform
 /// calculated timeout retries, such as exponential backoff.
 ///
 /// ```dart
@@ -28,12 +28,12 @@ typedef TimerCalculation = int Function(int tries);
 @internal
 class RetryTimer {
   final TimerCallback callback;
-  final TimerCalculation timerCalc;
+  final TimerCalculation timerCalculation;
 
   Timer? _timer;
   int _tries = 0;
 
-  RetryTimer(this.callback, this.timerCalc);
+  RetryTimer(this.callback, this.timerCalculation);
 
   /// Cancels any previous timer and reset tries
   void reset() {
@@ -52,7 +52,7 @@ class RetryTimer {
   void scheduleTimeout() {
     if (_timer != null) _timer!.cancel();
 
-    _timer = Timer(Duration(milliseconds: timerCalc(_tries + 1)), () {
+    _timer = Timer(Duration(milliseconds: timerCalculation(_tries + 1)), () {
       _tries = _tries + 1;
       callback();
     });

--- a/packages/realtime_client/lib/src/transformers.dart
+++ b/packages/realtime_client/lib/src/transformers.dart
@@ -267,24 +267,24 @@ dynamic toArray(dynamic value, String type) {
   }
 
   // trim Postgres array curly brackets
-  final lastIdx = value.length - 1;
-  final closeBrace = value[lastIdx];
+  final lastIndex = value.length - 1;
+  final closeBrace = value[lastIndex];
   final openBrace = value[0];
 
   // Confirm value is a Postgres array by checking curly brackets
   if (openBrace == '{' && closeBrace == '}') {
-    final valTrim = value.substring(1, lastIdx);
+    final trimmedValue = value.substring(1, lastIndex);
     List<dynamic> array;
 
     // TODO: find a better solution to separate Postgres array data
     try {
-      array = json.decode('[$valTrim]') as List;
+      array = json.decode('[$trimmedValue]') as List;
     } catch (_) {
       // WARNING: splitting on comma does not cover all edge cases
-      array = valTrim != '' ? valTrim.split(',') : [];
+      array = trimmedValue != '' ? trimmedValue.split(',') : [];
     }
 
-    return array.map((val) => convertCell(type, val)).toList();
+    return array.map((element) => convertCell(type, element)).toList();
   }
 
   return value;

--- a/packages/realtime_client/lib/src/types.dart
+++ b/packages/realtime_client/lib/src/types.dart
@@ -132,9 +132,9 @@ enum PresenceEvent {
   leave;
 
   @internal
-  static PresenceEvent fromString(String val) {
+  static PresenceEvent fromString(String value) {
     for (final event in PresenceEvent.values) {
-      if (event.name == val) {
+      if (event.name == value) {
         return event;
       }
     }

--- a/packages/realtime_client/test/channel_test.dart
+++ b/packages/realtime_client/test/channel_test.dart
@@ -855,24 +855,24 @@ void main() {
     });
   });
 
-  group('track opts forwarding', () {
-    late _OptsCapturingChannel capturingChannel;
+  group('track options forwarding', () {
+    late _OptionsCapturingChannel capturingChannel;
 
     setUp(() {
       socket = RealtimeClient('', timeout: const Duration(milliseconds: 1234));
-      capturingChannel = _OptsCapturingChannel('topic', socket);
+      capturingChannel = _OptionsCapturingChannel('topic', socket);
     });
 
-    test('track forwards a custom non-timeout opt to send', () async {
+    test('track forwards a custom non-timeout option to send', () async {
       await capturingChannel.track({'id': 123}, {'ack': true});
 
-      expect(capturingChannel.capturedOpts, containsPair('ack', true));
+      expect(capturingChannel.capturedOptions, containsPair('ack', true));
     });
 
-    test('track forwards a custom timeout opt to send', () async {
+    test('track forwards a custom timeout option to send', () async {
       await capturingChannel.track({'id': 123}, {'timeout': 2500});
 
-      expect(capturingChannel.capturedOpts, containsPair('timeout', 2500));
+      expect(capturingChannel.capturedOptions, containsPair('timeout', 2500));
     });
 
     test(
@@ -881,17 +881,17 @@ void main() {
         await capturingChannel.track({'id': 123});
 
         expect(
-          capturingChannel.capturedOpts,
+          capturingChannel.capturedOptions,
           containsPair('timeout', const Duration(milliseconds: 1234)),
         );
       },
     );
 
-    test('track keeps custom opts alongside the default timeout', () async {
+    test('track keeps custom options alongside the default timeout', () async {
       await capturingChannel.track({'id': 123}, {'ack': true});
 
       expect(
-        capturingChannel.capturedOpts,
+        capturingChannel.capturedOptions,
         allOf(
           containsPair('ack', true),
           containsPair('timeout', const Duration(milliseconds: 1234)),
@@ -1403,19 +1403,19 @@ class _SetAuthThrowingSocket extends RealtimeClient {
   }
 }
 
-class _OptsCapturingChannel extends RealtimeChannel {
-  _OptsCapturingChannel(super.topic, super.socket);
+class _OptionsCapturingChannel extends RealtimeChannel {
+  _OptionsCapturingChannel(super.topic, super.socket);
 
-  Map<String, dynamic>? capturedOpts;
+  Map<String, dynamic>? capturedOptions;
 
   @override
   Future<ChannelResponse> send({
     required RealtimeListenType type,
     String? event,
     required Map<String, dynamic> payload,
-    Map<String, dynamic> opts = const {},
+    Map<String, dynamic> options = const {},
   }) async {
-    capturedOpts = opts;
+    capturedOptions = options;
     return ChannelResponse.ok;
   }
 }

--- a/packages/realtime_client/test/socket_test.dart
+++ b/packages/realtime_client/test/socket_test.dart
@@ -545,7 +545,7 @@ void main() {
 
   group('channel', () {
     const tTopic = 'topic';
-    const tParams = RealtimeChannelConfig();
+    const channelConfig = RealtimeChannelConfig();
     late RealtimeClient socket;
     setUp(() {
       socket = RealtimeClient(socketEndpoint);
@@ -558,7 +558,7 @@ void main() {
     test('returns channel with given topic and params', () {
       final channel = socket.channel(
         tTopic,
-        tParams,
+        channelConfig,
       );
 
       expect(channel.socket, socket);
@@ -577,7 +577,7 @@ void main() {
 
       final channel = socket.channel(
         tTopic,
-        tParams,
+        channelConfig,
       );
 
       expect(socket.channels, hasLength(1));

--- a/packages/storage_client/lib/src/fetch.dart
+++ b/packages/storage_client/lib/src/fetch.dart
@@ -26,14 +26,14 @@ class Fetch {
 
   StorageException _handleError(
     dynamic error,
-    StackTrace stack,
+    StackTrace stackTrace,
     Uri? url,
     FetchOptions? options,
   ) {
     if (error is! http.Response) {
       // No response was received, so there is neither a status nor a service
       // error code to report. The error's own toString names its type.
-      _log.fine('StorageException for $url', error, stack);
+      _log.fine('StorageException for $url', error, stackTrace);
       return StorageException(error.toString());
     }
 
@@ -50,7 +50,7 @@ class Fetch {
     }
 
     if (data == null) {
-      _log.fine('StorageException for $url', error.body, stack);
+      _log.fine('StorageException for $url', error.body, stackTrace);
       return StorageApiException(
         error.body.isEmpty ? (error.reasonPhrase ?? '') : error.body,
         statusCode: error.statusCode,
@@ -58,7 +58,7 @@ class Fetch {
     }
 
     final exception = StorageApiException.fromJson(data, error.statusCode);
-    _log.fine('StorageException for $url', exception, stack);
+    _log.fine('StorageException for $url', exception, stackTrace);
     return exception;
   }
 

--- a/packages/storage_client/lib/src/storage_file_api.dart
+++ b/packages/storage_client/lib/src/storage_file_api.dart
@@ -592,8 +592,8 @@ class StorageFileApi {
         options: options,
       );
       return true;
-    } on StorageApiException catch (e) {
-      if (e.statusCode == 400 || e.statusCode == 404) {
+    } on StorageApiException catch (error) {
+      if (error.statusCode == 400 || error.statusCode == 404) {
         return false;
       }
       rethrow;

--- a/packages/storage_client/test/client_test.dart
+++ b/packages/storage_client/test/client_test.dart
@@ -636,8 +636,8 @@ void main() {
           ),
         );
 
-    final objectInfo = await storage.from(newBucketName).info(path);
-    expect(objectInfo.metadata, metadata);
+    final objectMetadata = await storage.from(newBucketName).info(path);
+    expect(objectMetadata.metadata, metadata);
   });
 
   test('check if object exists', () async {

--- a/packages/supabase/lib/src/supabase_client.dart
+++ b/packages/supabase/lib/src/supabase_client.dart
@@ -423,8 +423,8 @@ class SupabaseClient {
         event == AuthChangeEvent.signedIn) {
       try {
         await realtime.setAuth(token);
-      } on FormatException catch (e) {
-        if (e.message.contains('InvalidJWTToken')) {
+      } on FormatException catch (error) {
+        if (error.message.contains('InvalidJWTToken')) {
           // The exception is thrown by RealtimeClient when the token is
           // expired for example on app launch after the app has been closed
           // for a while.

--- a/packages/supabase_auth/lib/src/auth_client.dart
+++ b/packages/supabase_auth/lib/src/auth_client.dart
@@ -423,7 +423,7 @@ class AuthClient {
       url: '$_url/authorize',
       redirectTo: redirectTo,
       scopes: scopes,
-      queryParams: queryParams,
+      queryParameters: queryParams,
     );
   }
 
@@ -781,7 +781,7 @@ class AuthClient {
 
     final codeChallenge = await _generatePKCECodeChallenge();
 
-    final res = await _fetch.request(
+    final response = await _fetch.request(
       '$_url/sso',
       HttpMethod.post,
       options: AuthRequestOptions(
@@ -799,7 +799,7 @@ class AuthClient {
       ),
     );
 
-    return res['url'] as String;
+    return response['url'] as String;
   }
 
   /// Returns a new session, regardless of expiry status. Takes in an optional
@@ -988,9 +988,10 @@ class AuthClient {
 
     // Throws AuthInvalidJwtException if the token is malformed.
     final decoded = decodeJwt(accessToken);
-    final exp = decoded.payload.exp;
+    final expiresAt = decoded.payload.exp;
     final hasExpired =
-        exp == null || exp <= timeNow + Constants.expiryMargin.inSeconds;
+        expiresAt == null ||
+        expiresAt <= timeNow + Constants.expiryMargin.inSeconds;
 
     if (hasExpired) {
       return await _callRefreshToken(refreshToken);
@@ -1002,13 +1003,13 @@ class AuthClient {
       throw AuthSessionMissingException();
     }
 
-    final iat = decoded.payload.iat;
+    final issuedAt = decoded.payload.iat;
     final session = Session(
       accessToken: accessToken,
       refreshToken: refreshToken,
       user: user,
       tokenType: 'bearer',
-      expiresIn: (iat != null) ? exp - iat : null,
+      expiresIn: (issuedAt != null) ? expiresAt - issuedAt : null,
     );
 
     _saveSession(session);
@@ -1193,8 +1194,8 @@ class AuthClient {
 
   /// Gets all the identities linked to a user.
   Future<List<UserIdentity>> getUserIdentities() async {
-    final res = await getUser();
-    return res.user?.identities ?? [];
+    final response = await getUser();
+    return response.user?.identities ?? [];
   }
 
   /// Link an identity to the current user using an ID token.
@@ -1258,10 +1259,10 @@ class AuthClient {
       url: '$_url/user/identities/authorize',
       redirectTo: redirectTo,
       scopes: scopes,
-      queryParams: queryParams,
+      queryParameters: queryParams,
       skipBrowserRedirect: true,
     );
-    final res = await _fetch.request(
+    final response = await _fetch.request(
       urlResponse.url,
       HttpMethod.get,
       options: AuthRequestOptions(
@@ -1269,7 +1270,7 @@ class AuthClient {
         jwt: _currentSession?.accessToken,
       ),
     );
-    return OAuthResponse(provider: provider, url: res['url']);
+    return OAuthResponse(provider: provider, url: response['url']);
   }
 
   /// Unlinks an identity from a user by deleting it.
@@ -1487,15 +1488,15 @@ class AuthClient {
     required String url,
     required String? scopes,
     required String? redirectTo,
-    required Map<String, String>? queryParams,
+    required Map<String, String>? queryParameters,
     bool skipBrowserRedirect = false,
   }) async {
     final codeChallenge = await _generatePKCECodeChallenge();
-    final urlParams = {
+    final urlParameters = {
       'provider': provider.name,
       'scopes': ?scopes,
       'redirect_to': ?redirectTo,
-      ...?queryParams,
+      ...?queryParameters,
       if (codeChallenge != null) ...{
         'flow_type': _flowType.name,
         'code_challenge': codeChallenge,
@@ -1503,7 +1504,7 @@ class AuthClient {
       },
       if (skipBrowserRedirect) 'skip_http_redirect': 'true',
     };
-    final oauthUrl = '$url?${Uri(queryParameters: urlParams).query}';
+    final oauthUrl = '$url?${Uri(queryParameters: urlParameters).query}';
     return OAuthResponse(provider: provider, url: oauthUrl);
   }
 
@@ -1620,8 +1621,10 @@ class AuthClient {
             (response) {
               if (!completer.isCompleted) completer.complete(response);
             },
-            onError: (Object error, StackTrace stack) {
-              if (!completer.isCompleted) completer.completeError(error, stack);
+            onError: (Object error, StackTrace stackTrace) {
+              if (!completer.isCompleted) {
+                completer.completeError(error, stackTrace);
+              }
             },
           )
           .whenComplete(() => _pendingRefreshes.remove(refreshToken)),
@@ -1842,8 +1845,8 @@ class AuthClient {
         header: decoded.header,
         signature: decoded.signature,
       );
-    } catch (e) {
-      throw AuthInvalidJwtException('Invalid JWT signature: $e');
+    } catch (error) {
+      throw AuthInvalidJwtException('Invalid JWT signature: $error');
     }
   }
 }

--- a/packages/supabase_auth/lib/src/constants.dart
+++ b/packages/supabase_auth/lib/src/constants.dart
@@ -45,9 +45,9 @@ enum AuthChangeEvent {
   const AuthChangeEvent(this.jsName);
 
   @internal
-  static AuthChangeEvent? fromString(String? val) {
+  static AuthChangeEvent? fromString(String? value) {
     for (final event in AuthChangeEvent.values) {
-      if (event.name == val) {
+      if (event.name == value) {
         return event;
       }
     }
@@ -65,9 +65,9 @@ enum GenerateLinkType {
   unknown;
 
   @internal
-  static GenerateLinkType fromString(String? val) {
+  static GenerateLinkType fromString(String? value) {
     for (final type in GenerateLinkType.values) {
-      if (type.snakeCase == val) {
+      if (type.snakeCase == value) {
         return type;
       }
     }

--- a/packages/supabase_auth/lib/src/fetch.dart
+++ b/packages/supabase_auth/lib/src/fetch.dart
@@ -148,12 +148,14 @@ class AuthFetch {
       headers['Authorization'] = 'Bearer ${options!.jwt}';
     }
 
-    final qs = {...?options?.query};
+    final queryParameters = {...?options?.query};
     if (options?.redirectTo != null) {
-      qs['redirect_to'] = options!.redirectTo!;
+      queryParameters['redirect_to'] = options!.redirectTo!;
     }
     Uri uri = Uri.parse(url);
-    uri = uri.replace(queryParameters: {...uri.queryParameters, ...qs});
+    uri = uri.replace(
+      queryParameters: {...uri.queryParameters, ...queryParameters},
+    );
 
     final response = await _handleRequest(
       method: method,
@@ -187,7 +189,7 @@ class AuthFetch {
     required AuthRequestOptions? options,
     required Map<String, String> headers,
   }) async {
-    final bodyStr = json.encode(options?.body ?? {});
+    final bodyString = json.encode(options?.body ?? {});
 
     if (method != HttpMethod.get && method != HttpMethod.head) {
       headers['Content-Type'] = 'application/json';
@@ -200,27 +202,27 @@ class AuthFetch {
         HttpMethod.post => (httpClient?.post ?? post)(
           uri,
           headers: headers,
-          body: bodyStr,
+          body: bodyString,
         ),
         HttpMethod.put => (httpClient?.put ?? put)(
           uri,
           headers: headers,
-          body: bodyStr,
+          body: bodyString,
         ),
         HttpMethod.patch => (httpClient?.patch ?? patch)(
           uri,
           headers: headers,
-          body: bodyStr,
+          body: bodyString,
         ),
         HttpMethod.delete => (httpClient?.delete ?? delete)(
           uri,
           headers: headers,
-          body: bodyStr,
+          body: bodyString,
         ),
       };
-    } catch (e) {
+    } catch (error) {
       // fetch failed, likely due to a network or CORS error
-      throw AuthRetryableFetchException(message: e.toString());
+      throw AuthRetryableFetchException(message: error.toString());
     }
 
     if (!isSuccessStatusCode(response.statusCode)) {

--- a/packages/supabase_auth/lib/src/helper.dart
+++ b/packages/supabase_auth/lib/src/helper.dart
@@ -44,11 +44,11 @@ DecodedJwt decodeJwt(String token) {
         signature: rawSignature,
       ),
     );
-  } catch (e) {
-    if (e is AuthInvalidJwtException) {
+  } catch (error) {
+    if (error is AuthInvalidJwtException) {
       rethrow;
     }
-    throw AuthInvalidJwtException('Failed to decode JWT: $e');
+    throw AuthInvalidJwtException('Failed to decode JWT: $error');
   }
 }
 
@@ -68,11 +68,11 @@ JwtPayload decodeJwtPayload(String token) {
   try {
     final payloadJson = Base64Url.decodeToString(parts[1]);
     return JwtPayload.fromJson(json.decode(payloadJson));
-  } catch (e) {
-    if (e is AuthInvalidJwtException) {
+  } catch (error) {
+    if (error is AuthInvalidJwtException) {
       rethrow;
     }
-    throw AuthInvalidJwtException('Failed to decode JWT: $e');
+    throw AuthInvalidJwtException('Failed to decode JWT: $error');
   }
 }
 

--- a/packages/supabase_auth/test/get_claims_test.dart
+++ b/packages/supabase_auth/test/get_claims_test.dart
@@ -356,19 +356,19 @@ void main() {
 
     test('validateExp() throws on expired token', () {
       final pastTime = DateTime.now().subtract(Duration(hours: 1));
-      final exp = pastTime.millisecondsSinceEpoch ~/ 1000;
+      final expiresAt = pastTime.millisecondsSinceEpoch ~/ 1000;
 
       expect(
-        () => validateExp(exp),
+        () => validateExp(expiresAt),
         throwsA(isA<AuthException>()),
       );
     });
 
     test('validateExp() succeeds on valid token', () {
       final futureTime = DateTime.now().add(Duration(hours: 1));
-      final exp = futureTime.millisecondsSinceEpoch ~/ 1000;
+      final expiresAt = futureTime.millisecondsSinceEpoch ~/ 1000;
 
-      expect(() => validateExp(exp), returnsNormally);
+      expect(() => validateExp(expiresAt), returnsNormally);
     });
 
     test('validateExp() throws on null exp', () {

--- a/packages/supabase_auth/test/src/auth_oauth_api_test.dart
+++ b/packages/supabase_auth/test/src/auth_oauth_api_test.dart
@@ -182,42 +182,44 @@ void main() {
 
   group('OAuth server', () {
     test('get authorization details', () async {
-      final sut = await fixture.build();
+      final client = await fixture.build();
       final clientParameters = CreateOAuthClientParams(
         clientName: 'Test OAuth Client',
         redirectUris: ['http://127.0.0.1:3000/oauth/callback'],
         responseTypes: [OAuthClientResponseType.code],
         scope: 'email',
       );
-      final client = await fixture.sutCreatesOAuthClient(clientParameters);
-      final auth = await fixture.sutLogsIn(password: password, email: email1);
-      final authorizationId = await fixture.sutAuthorizesClient(client);
+      final oauthClient = await fixture.createOAuthClient(clientParameters);
+      final auth = await fixture.logIn(password: password, email: email1);
+      final authorizationId = await fixture.authorizeClient(oauthClient);
 
-      final response = await sut.oauth.getAuthorizationDetails(authorizationId);
+      final response = await client.oauth.getAuthorizationDetails(
+        authorizationId,
+      );
 
       expect(response, isA<OAuthAuthorizationDetailsResponse>());
       final details = response as OAuthAuthorizationDetailsResponse;
       expect(details.authorizationId, equals(authorizationId));
       expect(details.scope, equals(clientParameters.scope));
       expect(details.redirectUri, equals(clientParameters.redirectUris.first));
-      expect(details.client.clientId, equals(client.clientId));
-      expect(details.client.clientName, equals(client.clientName));
+      expect(details.client.clientId, equals(oauthClient.clientId));
+      expect(details.client.clientName, equals(oauthClient.clientName));
       expect(details.user.id, equals(auth.user?.id));
       expect(details.user.email, equals(email1));
     });
 
     test('approve authorization request', () async {
-      final sut = await fixture.build();
+      final client = await fixture.build();
       final clientParameters = CreateOAuthClientParams(
         clientName: 'Test OAuth Client',
         redirectUris: ['http://127.0.0.1:3000/oauth/callback'],
       );
-      final client = await fixture.sutCreatesOAuthClient(clientParameters);
-      final authorizationId = await fixture.sutAuthorizesClient(client);
-      await fixture.sutLogsIn(password: password, email: email1);
+      final oauthClient = await fixture.createOAuthClient(clientParameters);
+      final authorizationId = await fixture.authorizeClient(oauthClient);
+      await fixture.logIn(password: password, email: email1);
 
-      await sut.oauth.getAuthorizationDetails(authorizationId);
-      final response = await sut.oauth.approveAuthorization(authorizationId);
+      await client.oauth.getAuthorizationDetails(authorizationId);
+      final response = await client.oauth.approveAuthorization(authorizationId);
 
       expect(
         response.redirectUrl,
@@ -227,17 +229,17 @@ void main() {
     });
 
     test('denies authorization request', () async {
-      final sut = await fixture.build();
+      final client = await fixture.build();
       final clientParameters = CreateOAuthClientParams(
         clientName: 'Test OAuth Client',
         redirectUris: ['http://127.0.0.1:3000/oauth/callback'],
       );
-      final client = await fixture.sutCreatesOAuthClient(clientParameters);
-      final authorizationId = await fixture.sutAuthorizesClient(client);
-      await fixture.sutLogsIn(password: password, email: email1);
+      final oauthClient = await fixture.createOAuthClient(clientParameters);
+      final authorizationId = await fixture.authorizeClient(oauthClient);
+      await fixture.logIn(password: password, email: email1);
 
-      await sut.oauth.getAuthorizationDetails(authorizationId);
-      final response = await sut.oauth.denyAuthorization(authorizationId);
+      await client.oauth.getAuthorizationDetails(authorizationId);
+      final response = await client.oauth.denyAuthorization(authorizationId);
 
       expect(
         response.redirectUrl,
@@ -251,17 +253,17 @@ void main() {
     });
 
     test('approving authorization without getting details throws', () async {
-      final sut = await fixture.build();
+      final client = await fixture.build();
       final clientParameters = CreateOAuthClientParams(
         clientName: 'Test OAuth Client',
         redirectUris: ['http://127.0.0.1:3000/oauth/callback'],
       );
-      final client = await fixture.sutCreatesOAuthClient(clientParameters);
-      final authorizationId = await fixture.sutAuthorizesClient(client);
-      await fixture.sutLogsIn(password: password, email: email1);
+      final oauthClient = await fixture.createOAuthClient(clientParameters);
+      final authorizationId = await fixture.authorizeClient(oauthClient);
+      await fixture.logIn(password: password, email: email1);
 
       await expectLater(
-        () async => sut.oauth.approveAuthorization(authorizationId),
+        () async => client.oauth.approveAuthorization(authorizationId),
         throwsA(
           isAnAuthApiException(
             statusCode: equals(404),
@@ -272,69 +274,71 @@ void main() {
     });
 
     test('lists grants after approving an authorization', () async {
-      final sut = await fixture.build();
+      final client = await fixture.build();
       final clientParameters = CreateOAuthClientParams(
         clientName: 'Test OAuth Client',
         redirectUris: ['http://127.0.0.1:3000/oauth/callback'],
         responseTypes: [OAuthClientResponseType.code],
         scope: 'email',
       );
-      final client = await fixture.sutCreatesOAuthClient(clientParameters);
-      await fixture.sutLogsIn(password: password, email: email1);
-      final authorizationId = await fixture.sutAuthorizesClient(client);
-      await sut.oauth.getAuthorizationDetails(authorizationId);
-      await sut.oauth.approveAuthorization(authorizationId);
+      final oauthClient = await fixture.createOAuthClient(clientParameters);
+      await fixture.logIn(password: password, email: email1);
+      final authorizationId = await fixture.authorizeClient(oauthClient);
+      await client.oauth.getAuthorizationDetails(authorizationId);
+      await client.oauth.approveAuthorization(authorizationId);
 
-      final grants = await sut.oauth.listGrants();
+      final grants = await client.oauth.listGrants();
 
       expect(grants, hasLength(1));
-      expect(grants.first.client.clientId, equals(client.clientId));
+      expect(grants.first.client.clientId, equals(oauthClient.clientId));
       expect(grants.first.scopes, contains('email'));
     });
 
     test('revokes a grant', () async {
-      final sut = await fixture.build();
+      final client = await fixture.build();
       final clientParameters = CreateOAuthClientParams(
         clientName: 'Test OAuth Client',
         redirectUris: ['http://127.0.0.1:3000/oauth/callback'],
         responseTypes: [OAuthClientResponseType.code],
         scope: 'email',
       );
-      final client = await fixture.sutCreatesOAuthClient(clientParameters);
-      await fixture.sutLogsIn(password: password, email: email1);
-      final authorizationId = await fixture.sutAuthorizesClient(client);
-      await sut.oauth.getAuthorizationDetails(authorizationId);
-      await sut.oauth.approveAuthorization(authorizationId);
-      expect(await sut.oauth.listGrants(), hasLength(1));
+      final oauthClient = await fixture.createOAuthClient(clientParameters);
+      await fixture.logIn(password: password, email: email1);
+      final authorizationId = await fixture.authorizeClient(oauthClient);
+      await client.oauth.getAuthorizationDetails(authorizationId);
+      await client.oauth.approveAuthorization(authorizationId);
+      expect(await client.oauth.listGrants(), hasLength(1));
 
-      await sut.oauth.revokeGrant(client.clientId);
+      await client.oauth.revokeGrant(oauthClient.clientId);
 
-      expect(await sut.oauth.listGrants(), isEmpty);
+      expect(await client.oauth.listGrants(), isEmpty);
     });
 
     test(
       'getting details for a new authorization after the client was already '
       'approved does not throw',
       () async {
-        final sut = await fixture.build();
+        final client = await fixture.build();
         final clientParameters = CreateOAuthClientParams(
           clientName: 'Test OAuth Client',
           redirectUris: ['http://127.0.0.1:3000/oauth/callback'],
           responseTypes: [OAuthClientResponseType.code],
           scope: 'email',
         );
-        final client = await fixture.sutCreatesOAuthClient(clientParameters);
-        await fixture.sutLogsIn(password: password, email: email1);
+        final oauthClient = await fixture.createOAuthClient(clientParameters);
+        await fixture.logIn(password: password, email: email1);
 
         // First authorization: fetch details and approve to record consent.
-        final firstAuthorizationId = await fixture.sutAuthorizesClient(client);
-        await sut.oauth.getAuthorizationDetails(firstAuthorizationId);
-        await sut.oauth.approveAuthorization(firstAuthorizationId);
+        final firstAuthorizationId = await fixture.authorizeClient(oauthClient);
+        await client.oauth.getAuthorizationDetails(firstAuthorizationId);
+        await client.oauth.approveAuthorization(firstAuthorizationId);
 
         // Second authorization for the same client, by the same user.
-        final secondAuthorizationId = await fixture.sutAuthorizesClient(client);
+        final secondAuthorizationId = await fixture.authorizeClient(
+          oauthClient,
+        );
 
-        final response = await sut.oauth.getAuthorizationDetails(
+        final response = await client.oauth.getAuthorizationDetails(
           secondAuthorizationId,
         );
 
@@ -372,13 +376,13 @@ class AuthOauthApiFixture {
   late final String _authUrl;
   late final String _serviceRoleToken;
 
-  Future<OAuthClient> sutCreatesOAuthClient(CreateOAuthClientParams request) {
+  Future<OAuthClient> createOAuthClient(CreateOAuthClientParams request) {
     return _client.admin.oauth
         .createClient(request)
         .then((response) => response.client!);
   }
 
-  Future<String> sutAuthorizesClient(OAuthClient client) async {
+  Future<String> authorizeClient(OAuthClient client) async {
     // Don't follow redirects: the authorize endpoint returns a 302 to the
     // consent page with authorization_id as a query parameter.
     final httpClient = http.Client();
@@ -406,7 +410,7 @@ class AuthOauthApiFixture {
     return Uri.parse(location).queryParameters['authorization_id']!;
   }
 
-  Future<AuthResponse> sutLogsIn({
+  Future<AuthResponse> logIn({
     required String email,
     required String password,
   }) {

--- a/packages/supabase_auth/test/src/set_session_test.dart
+++ b/packages/supabase_auth/test/src/set_session_test.dart
@@ -41,11 +41,11 @@ class _SetSessionMockClient extends BaseClient {
 
     if (request.url.path.contains('/token')) {
       // Refresh-token fallback response with a freshly minted access token.
-      final exp = DateTime.now().millisecondsSinceEpoch ~/ 1000 + 3600;
-      final iat = exp - 3600;
+      final expiresAt = DateTime.now().millisecondsSinceEpoch ~/ 1000 + 3600;
+      final issuedAt = expiresAt - 3600;
       final freshAccessToken = _makeRawJwt({
-        'exp': exp,
-        'iat': iat,
+        'exp': expiresAt,
+        'iat': issuedAt,
         'sub': 'mock-user-id',
       });
       return StreamedResponse(
@@ -98,10 +98,10 @@ void main() {
   group('setSession — validation edge cases', () {
     test('empty refresh token with a non-null access token throws before '
         'inspecting the access token', () async {
-      final exp = DateTime.now().millisecondsSinceEpoch ~/ 1000 + 3600;
+      final expiresAt = DateTime.now().millisecondsSinceEpoch ~/ 1000 + 3600;
       final accessToken = _makeRawJwt({
-        'exp': exp,
-        'iat': exp - 3600,
+        'exp': expiresAt,
+        'iat': expiresAt - 3600,
         'sub': 'mock-user-id',
       });
 
@@ -158,11 +158,11 @@ void main() {
     test(
       'expiresIn equals exp minus iat when both claims are present',
       () async {
-        final iat = DateTime.now().millisecondsSinceEpoch ~/ 1000 - 60;
-        final exp = iat + 3600;
+        final issuedAt = DateTime.now().millisecondsSinceEpoch ~/ 1000 - 60;
+        final expiresAt = issuedAt + 3600;
         final accessToken = _makeRawJwt({
-          'exp': exp,
-          'iat': iat,
+          'exp': expiresAt,
+          'iat': issuedAt,
           'sub': 'mock-user-id',
         });
 
@@ -172,14 +172,17 @@ void main() {
         );
 
         // expiresIn should be the total token lifetime (exp - iat = 3600).
-        expect(response.session?.expiresIn, equals(exp - iat));
+        expect(response.session?.expiresIn, equals(expiresAt - issuedAt));
       },
     );
 
     test('expiresIn is null when iat claim is absent', () async {
-      final exp = DateTime.now().millisecondsSinceEpoch ~/ 1000 + 3600;
+      final expiresAt = DateTime.now().millisecondsSinceEpoch ~/ 1000 + 3600;
       // JWT without iat.
-      final accessToken = _makeRawJwt({'exp': exp, 'sub': 'mock-user-id'});
+      final accessToken = _makeRawJwt({
+        'exp': expiresAt,
+        'sub': 'mock-user-id',
+      });
 
       final response = await client.setSession(
         'some-refresh-token',
@@ -190,11 +193,11 @@ void main() {
     });
 
     test('expiresAt matches the exp claim in the JWT', () async {
-      final iat = DateTime.now().millisecondsSinceEpoch ~/ 1000 - 60;
-      final exp = iat + 3600;
+      final issuedAt = DateTime.now().millisecondsSinceEpoch ~/ 1000 - 60;
+      final expiresAt = issuedAt + 3600;
       final accessToken = _makeRawJwt({
-        'exp': exp,
-        'iat': iat,
+        'exp': expiresAt,
+        'iat': issuedAt,
         'sub': 'mock-user-id',
       });
 
@@ -206,19 +209,21 @@ void main() {
       // expiresAt is re-derived from the JWT's own exp, not from expiresIn.
       expect(
         response.session?.expiresAt,
-        equals(DateTime.fromMillisecondsSinceEpoch(exp * 1000, isUtc: true)),
+        equals(
+          DateTime.fromMillisecondsSinceEpoch(expiresAt * 1000, isUtc: true),
+        ),
       );
     });
 
     test(
       'returned session preserves the supplied access and refresh tokens',
       () async {
-        final iat = DateTime.now().millisecondsSinceEpoch ~/ 1000 - 60;
-        final exp = iat + 3600;
+        final issuedAt = DateTime.now().millisecondsSinceEpoch ~/ 1000 - 60;
+        final expiresAt = issuedAt + 3600;
         const refreshToken = 'my-refresh-token';
         final accessToken = _makeRawJwt({
-          'exp': exp,
-          'iat': iat,
+          'exp': expiresAt,
+          'iat': issuedAt,
           'sub': 'mock-user-id',
         });
 
@@ -236,11 +241,11 @@ void main() {
 
   group('setSession — auth state events', () {
     test('fast path emits signedIn (not tokenRefreshed)', () async {
-      final iat = DateTime.now().millisecondsSinceEpoch ~/ 1000 - 60;
-      final exp = iat + 3600;
+      final issuedAt = DateTime.now().millisecondsSinceEpoch ~/ 1000 - 60;
+      final expiresAt = issuedAt + 3600;
       final accessToken = _makeRawJwt({
-        'exp': exp,
-        'iat': iat,
+        'exp': expiresAt,
+        'iat': issuedAt,
         'sub': 'mock-user-id',
       });
 

--- a/packages/supabase_auth/test/src/token_refresh_race_test.dart
+++ b/packages/supabase_auth/test/src/token_refresh_race_test.dart
@@ -35,9 +35,9 @@ String _makeRawJwt(Map<String, dynamic> payload) {
 }
 
 String _freshAccessToken({String sub = 'mock-user-id'}) {
-  final exp = DateTime.now().millisecondsSinceEpoch ~/ 1000 + 3600;
-  final iat = exp - 3600;
-  return _makeRawJwt({'exp': exp, 'iat': iat, 'sub': sub});
+  final expiresAt = DateTime.now().millisecondsSinceEpoch ~/ 1000 + 3600;
+  final issuedAt = expiresAt - 3600;
+  return _makeRawJwt({'exp': expiresAt, 'iat': issuedAt, 'sub': sub});
 }
 
 String _tokenResponseJson({

--- a/packages/supabase_auth/test/src/types/session_test.dart
+++ b/packages/supabase_auth/test/src/types/session_test.dart
@@ -114,9 +114,9 @@ void main() {
     group('toJson', () {
       test('serializes session correctly', () {
         final now = DateTime.now();
-        final exp = (now.millisecondsSinceEpoch / 1000).floor() + 3600;
+        final expiresAt = (now.millisecondsSinceEpoch / 1000).floor() + 3600;
         final header = base64Encode(utf8.encode('{"alg":"HS256","typ":"JWT"}'));
-        final payload = base64Encode(utf8.encode('{"exp":$exp}'));
+        final payload = base64Encode(utf8.encode('{"exp":$expiresAt}'));
         final jwt = '$header.$payload.signature';
 
         final session = Session(
@@ -186,9 +186,9 @@ void main() {
 
       test('returns the exp claim of the JWT as a UTC DateTime', () {
         final now = DateTime.now();
-        final exp = (now.millisecondsSinceEpoch / 1000).floor() + 3600;
+        final expiresAt = (now.millisecondsSinceEpoch / 1000).floor() + 3600;
         final header = base64Encode(utf8.encode('{"alg":"HS256","typ":"JWT"}'));
-        final payload = base64Encode(utf8.encode('{"exp":$exp}'));
+        final payload = base64Encode(utf8.encode('{"exp":$expiresAt}'));
         final jwt = '$header.$payload.signature';
 
         final session = Session(
@@ -199,7 +199,9 @@ void main() {
 
         expect(
           session.expiresAt,
-          equals(DateTime.fromMillisecondsSinceEpoch(exp * 1000, isUtc: true)),
+          equals(
+            DateTime.fromMillisecondsSinceEpoch(expiresAt * 1000, isUtc: true),
+          ),
         );
         expect(session.expiresAt!.isUtc, isTrue);
       });
@@ -228,9 +230,9 @@ void main() {
 
       test('returns true when token is expired', () {
         final pastTime = DateTime.now().subtract(const Duration(hours: 1));
-        final exp = (pastTime.millisecondsSinceEpoch / 1000).floor();
+        final expiresAt = (pastTime.millisecondsSinceEpoch / 1000).floor();
         final header = base64Encode(utf8.encode('{"alg":"HS256","typ":"JWT"}'));
-        final payload = base64Encode(utf8.encode('{"exp":$exp}'));
+        final payload = base64Encode(utf8.encode('{"exp":$expiresAt}'));
         final jwt = '$header.$payload.signature';
 
         final session = Session(
@@ -244,9 +246,9 @@ void main() {
 
       test('returns true when token expires within margin', () {
         final futureTime = DateTime.now().add(const Duration(seconds: 20));
-        final exp = (futureTime.millisecondsSinceEpoch / 1000).floor();
+        final expiresAt = (futureTime.millisecondsSinceEpoch / 1000).floor();
         final header = base64Encode(utf8.encode('{"alg":"HS256","typ":"JWT"}'));
-        final payload = base64Encode(utf8.encode('{"exp":$exp}'));
+        final payload = base64Encode(utf8.encode('{"exp":$expiresAt}'));
         final jwt = '$header.$payload.signature';
 
         final session = Session(
@@ -260,9 +262,9 @@ void main() {
 
       test('returns false when token is not expired', () {
         final futureTime = DateTime.now().add(const Duration(hours: 1));
-        final exp = (futureTime.millisecondsSinceEpoch / 1000).floor();
+        final expiresAt = (futureTime.millisecondsSinceEpoch / 1000).floor();
         final header = base64Encode(utf8.encode('{"alg":"HS256","typ":"JWT"}'));
-        final payload = base64Encode(utf8.encode('{"exp":$exp}'));
+        final payload = base64Encode(utf8.encode('{"exp":$expiresAt}'));
         final jwt = '$header.$payload.signature';
 
         final session = Session(
@@ -276,9 +278,9 @@ void main() {
 
       test('uses correct expiry margin from constants', () {
         final marginalTime = DateTime.now().add(Constants.expiryMargin);
-        final exp = (marginalTime.millisecondsSinceEpoch / 1000).floor();
+        final expiresAt = (marginalTime.millisecondsSinceEpoch / 1000).floor();
         final header = base64Encode(utf8.encode('{"alg":"HS256","typ":"JWT"}'));
-        final payload = base64Encode(utf8.encode('{"exp":$exp}'));
+        final payload = base64Encode(utf8.encode('{"exp":$expiresAt}'));
         final jwt = '$header.$payload.signature';
 
         final session = Session(

--- a/packages/supabase_common/lib/src/retry.dart
+++ b/packages/supabase_common/lib/src/retry.dart
@@ -40,10 +40,10 @@ class RetryOptions {
     );
   }
 
-  /// Calls [fn], retrying so long as [retryIf] returns `true` for the thrown
-  /// [Exception], up to [maxAttempts] times.
+  /// Calls [action], retrying so long as [retryIf] returns `true` for the
+  /// thrown [Exception], up to [maxAttempts] times.
   Future<T> retry<T>(
-    FutureOr<T> Function() fn, {
+    FutureOr<T> Function() action, {
     FutureOr<bool> Function(Exception)? retryIf,
     FutureOr<void> Function(Exception)? onRetry,
   }) async {
@@ -51,7 +51,7 @@ class RetryOptions {
     while (true) {
       attempt++;
       try {
-        return await fn();
+        return await action();
       } on Exception catch (error) {
         if (attempt >= maxAttempts ||
             (retryIf != null && !(await retryIf(error)))) {
@@ -66,10 +66,10 @@ class RetryOptions {
   }
 }
 
-/// Calls [fn], retrying so long as [retryIf] returns `true` for the thrown
+/// Calls [action], retrying so long as [retryIf] returns `true` for the thrown
 /// [Exception], up to [maxAttempts] times.
 Future<T> retry<T>(
-  FutureOr<T> Function() fn, {
+  FutureOr<T> Function() action, {
   Duration delayFactor = const Duration(milliseconds: 200),
   double randomizationFactor = 0.25,
   Duration maxDelay = const Duration(seconds: 30),
@@ -81,4 +81,4 @@ Future<T> retry<T>(
   randomizationFactor: randomizationFactor,
   maxDelay: maxDelay,
   maxAttempts: maxAttempts,
-).retry(fn, retryIf: retryIf, onRetry: onRetry);
+).retry(action, retryIf: retryIf, onRetry: onRetry);

--- a/packages/supabase_common/lib/src/snake_case.dart
+++ b/packages/supabase_common/lib/src/snake_case.dart
@@ -5,10 +5,10 @@ extension ToSnakeCase on Enum {
     final A = 'A'.codeUnitAt(0), Z = 'Z'.codeUnitAt(0);
     final result = StringBuffer()..write(name[0].toLowerCase());
     for (var i = 1; i < name.length; i++) {
-      final char = name.codeUnitAt(i);
-      if (A <= char && char <= Z) {
-        final pChar = name.codeUnitAt(i - 1);
-        if (a <= pChar && pChar <= z) {
+      final character = name.codeUnitAt(i);
+      if (A <= character && character <= Z) {
+        final previousCharacter = name.codeUnitAt(i - 1);
+        if (a <= previousCharacter && previousCharacter <= z) {
           result.write('_');
         }
       }

--- a/packages/supabase_common/test/supabase_common_test.dart
+++ b/packages/supabase_common/test/supabase_common_test.dart
@@ -146,10 +146,10 @@ void main() {
       subject.onPause = () {};
       subject.onResume = () {};
 
-      final sub = subject.stream.listen((_) {});
+      final subscription = subject.stream.listen((_) {});
       await Future<void>.delayed(Duration.zero);
       expect(listened, isTrue);
-      await sub.cancel();
+      await subscription.cancel();
       await Future<void>.delayed(Duration.zero);
       expect(cancelled, isTrue);
       await subject.close();
@@ -170,10 +170,10 @@ void main() {
         onListen: () => listened = true,
         onCancel: () => cancelled = true,
       );
-      final sub = subject.stream.listen((_) {});
+      final subscription = subject.stream.listen((_) {});
       await Future<void>.delayed(Duration.zero);
       expect(listened, isTrue);
-      await sub.cancel();
+      await subscription.cancel();
       await Future<void>.delayed(Duration.zero);
       expect(cancelled, isTrue);
       await subject.close();
@@ -182,12 +182,12 @@ void main() {
     test('forwards an added stream', () async {
       final subject = ReplaySubject<int>();
       final events = <int>[];
-      final sub = subject.stream.listen(events.add);
+      final subscription = subject.stream.listen(events.add);
       await subject.addStream(Stream.fromIterable([1, 2, 3]));
       await Future<void>.delayed(Duration.zero);
       expect(events, [1, 2, 3]);
       expect(subject.isClosed, isFalse);
-      await sub.cancel();
+      await subscription.cancel();
       await subject.close();
     });
   });

--- a/packages/supabase_common/test/timestamp_test.dart
+++ b/packages/supabase_common/test/timestamp_test.dart
@@ -32,7 +32,7 @@ void main() {
 
     test('throws when the value is missing', () {
       expect(
-        () => parseIso8601(<String, dynamic>{}, 'created_at'),
+        () => parseIso8601({}, 'created_at'),
         throwsA(
           isA<FormatException>().having(
             (exception) => exception.message,
@@ -146,7 +146,7 @@ void main() {
     });
 
     test('returns null when the value is absent', () {
-      expect(tryParseIso8601(<String, dynamic>{}, 'created_at'), isNull);
+      expect(tryParseIso8601({}, 'created_at'), isNull);
     });
 
     test('parses a present value', () {

--- a/packages/supabase_flutter/example/lib/main.dart
+++ b/packages/supabase_flutter/example/lib/main.dart
@@ -98,7 +98,7 @@ class _LoginFormState extends State<_LoginForm> {
         email: _emailController.text,
         password: _passwordController.text,
       );
-    } catch (e) {
+    } catch (_) {
       scaffoldMessenger.showSnackBar(
         const SnackBar(
           content: Text('Login failed'),
@@ -123,7 +123,7 @@ class _LoginFormState extends State<_LoginForm> {
         email: _emailController.text,
         password: _passwordController.text,
       );
-    } catch (e) {
+    } catch (_) {
       scaffoldMessenger.showSnackBar(
         const SnackBar(
           content: Text('Signup failed'),
@@ -211,7 +211,7 @@ class _ProfileFormState extends State<_ProfileForm> {
           _websiteController.text = data['website'];
         });
       }
-    } catch (e) {
+    } catch (_) {
       scaffoldMessenger.showSnackBar(
         const SnackBar(
           content: Text('Error occurred while getting profile'),
@@ -243,7 +243,7 @@ class _ProfileFormState extends State<_ProfileForm> {
           content: Text('Saved profile'),
         ),
       );
-    } catch (e) {
+    } catch (_) {
       scaffoldMessenger.showSnackBar(
         const SnackBar(
           content: Text('Error saving profile'),

--- a/packages/supabase_flutter/lib/src/supabase_auth.dart
+++ b/packages/supabase_flutter/lib/src/supabase_auth.dart
@@ -358,13 +358,13 @@ extension AuthClientSignInProvider on AuthClient {
     LaunchMode authScreenLaunchMode = LaunchMode.platformDefault,
     Map<String, String>? queryParams,
   }) async {
-    final res = await getOAuthSignInUrl(
+    final response = await getOAuthSignInUrl(
       provider: provider,
       redirectTo: redirectTo,
       scopes: scopes,
       queryParams: queryParams,
     );
-    return _launchAuthUrl(res.url, provider, authScreenLaunchMode);
+    return _launchAuthUrl(response.url, provider, authScreenLaunchMode);
   }
 
   /// Launches the [url] for an OAuth or identity-linking flow, forcing an
@@ -451,12 +451,12 @@ extension AuthClientSignInProvider on AuthClient {
     LaunchMode authScreenLaunchMode = LaunchMode.platformDefault,
     Map<String, String>? queryParams,
   }) async {
-    final res = await getLinkIdentityUrl(
+    final response = await getLinkIdentityUrl(
       provider,
       redirectTo: redirectTo,
       scopes: scopes,
       queryParams: queryParams,
     );
-    return _launchAuthUrl(res.url, provider, authScreenLaunchMode);
+    return _launchAuthUrl(response.url, provider, authScreenLaunchMode);
   }
 }

--- a/packages/yet_another_json_isolate/example/yet_another_json_isolate_example.dart
+++ b/packages/yet_another_json_isolate/example/yet_another_json_isolate_example.dart
@@ -8,7 +8,7 @@ void main() async {
   final json = await isolate.decode('{"a": 1, "b": 2}');
   print(json);
 
-  final str = await isolate.encode(json);
-  print(str);
+  final jsonString = await isolate.encode(json);
+  print(jsonString);
   await isolate.dispose();
 }

--- a/packages/yet_another_json_isolate/lib/src/_isolates_io.dart
+++ b/packages/yet_another_json_isolate/lib/src/_isolates_io.dart
@@ -80,7 +80,7 @@ class YAJsonIsolate {
       await _createdIsolate.future;
     }
     _sendPort.send([json, false]);
-    return _handleRes(await _events.next);
+    return _handleResponse(await _events.next);
   }
 
   Future<String> encode(Object? json) async {
@@ -90,10 +90,10 @@ class YAJsonIsolate {
       await _createdIsolate.future;
     }
     _sendPort.send([json, true]);
-    return _handleRes(await _events.next);
+    return _handleResponse(await _events.next);
   }
 
-  Future<R> _handleRes<R>(List<dynamic> response) async {
+  Future<R> _handleResponse<R>(List<dynamic> response) async {
     final int type = response.length;
     assert(1 <= type && type <= 3);
 
@@ -168,8 +168,8 @@ List<R> _buildSuccessResponse<R>(R result) {
 /// We wrap a caught error in a 3 element [List]. Where the last element is
 /// always null. We do this so we have a way to know if an error was one we
 /// caught or one thrown by the library code.
-List<dynamic> _buildErrorResponse(Object error, StackTrace stack) {
+List<dynamic> _buildErrorResponse(Object error, StackTrace stackTrace) {
   return List<dynamic>.filled(3, null)
     ..[0] = error
-    ..[1] = stack;
+    ..[1] = stackTrace;
 }


### PR DESCRIPTION
## What

Non-breaking counterpart to SDK-1479: spells out abbreviations in private members, `@internal` declarations, tests, and example apps.

No public API changes, so no `MIGRATION.md` entry and no `sdk-compliance.yaml` reconciliation. The three `fromString` methods, `RealtimeChannel.send` and `GotrueFetch` touched here are all `@internal`; everything else is a local, a private member, a positional parameter, a test, or an example.

Wire format is untouched throughout: JSON claim keys (`exp`, `iat`, `sub`), error keys (`msg`), Phoenix `ref`, and query keys all keep their literal spelling. Only the Dart identifiers around them changed.

## Package internals

| Current | New | Where |
| -- | -- | -- |
| `StackTrace stack` | `stackTrace` | postgrest, storage, gotrue, yet_another_json_isolate |
| `catch (e)` | `catch (error)` | gotrue `helper.dart`, `fetch.dart`, `gotrue_client.dart`, supabase, storage, realtime, plus doc-comment examples |
| `res` | `response` | `gotrue_client.dart`, `supabase_auth.dart` |
| `bodyStr` | `bodyString` | gotrue, postgrest, functions |
| `opts` | `options` | `@internal` `RealtimeChannel.send` |
| `val` | `value` | `@internal` `fromString` methods in gotrue and realtime |
| `fn` | `action` | supabase_common `retry.dart` |
| `_receivedResp`, `_recHooks` | `_receivedResponse`, `_receiveHooks` | realtime `push.dart` |
| `timerCalc` | `timerCalculation` | realtime `retry_timer.dart` |
| `bindingsLen` | `bindingsLength` | `realtime_channel.dart` |
| `lastIdx`, `valTrim` | `lastIndex`, `trimmedValue` | realtime `transformers.dart` |
| `obj1`, `obj2` | `first`, `second` | `RealtimeChannel._isEqual` |
| `obj` | `presencesByKey` | `RealtimePresence._map` and `_cloneDeep` |
| `curPresenceRefs` | `currentPresenceRefs` | `realtime_presence.dart` |
| `_handleRes` | `_handleResponse` | yet_another_json_isolate `_isolates_io.dart` |
| `pChar`, `char` | `previousCharacter`, `character` | supabase_common `snake_case.dart` |
| `_appendParams`, `urlParams`, `searchParams`, `effectiveQueryParams` | `…Parameters` | realtime, gotrue, postgrest, functions |
| `exp`, `iat` locals | `expiresAt`, `issuedAt` | `gotrue_client.dart` |
| `re` | `whitespaceRegularExpression` | postgrest query and transform builders |

## Tests

| Current | New | Where |
| -- | -- | -- |
| `sut`, `sut*` helpers | `client`, `createOAuthClient`, `authorizeClient`, `logIn` | `gotrue/test/src/gotrue_oauth_api_test.dart` |
| `exp`, `iat` | `expiresAt`, `issuedAt` | gotrue session, claims, and token refresh tests |
| `capturedOpts`, `opts` | `capturedOptions`, `options` | `realtime_client/test/channel_test.dart` |
| `tParams` | `channelConfig` | `realtime_client/test/socket_test.dart` |
| `sub` | `subscription` | `supabase_common/test/supabase_common_test.dart` |
| `objectInfo` | `objectMetadata` | `storage_client/test/client_test.dart` |

## Examples

| Current | New | Where |
| -- | -- | -- |
| `args`, `flutterArgs` | `arguments`, `flutterArguments` | `examples/launcher` |
| `_parseEnv` | `_parseEnvironment` | `examples/launcher/lib/launcher.dart` |
| `msg` | `message` | `packages/realtime_client/example/main.dart` |
| `str` | `jsonString` | yet_another_json_isolate example |

## Deviations from the ticket

* **`curPresences` is `remainingPresences`, not `currentPresences`.** In `syncDiff` the enclosing scope already declares `currentPresences`, and `curPresences` is the filtered subset of it that has to be re-inserted, so the ticket's name would have been a self-referencing redeclaration. `remainingPresences` says what it holds.
* **The four `catch (e)` clauses in the supabase_flutter example never read the caught value**, so they became `catch (_)` rather than declaring an unused `error`.
* **Three abbreviations outside the ticket's inventory** were included because they sit squarely in its stated scope: `qs` to `queryParameters` in gotrue `fetch.dart`, and the `(val)` closure parameters in realtime `transformers.dart` and a functions_client doc comment.

Left alone as out of scope: the public `opts` on `SupabaseClient.channel` / `RealtimeChannel.track` / `untrack`, `rpc(String fn)`, `JwtPayload.exp` / `iat`, `validateExp`, test `env` locals, single-letter closure parameters, and wire or third-party names.

## Testing

`dart analyze` is clean across `packages` and `examples`, and all nine test suites pass against a local Supabase stack: gotrue (458), storage_client (220), realtime_client (211), postgrest (196), supabase (134), supabase_common (79), supabase_flutter (76), functions_client (48), yet_another_json_isolate (27).

Resolves SDK-1480.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved naming consistency and readability across authentication, database, realtime, storage, networking, and JSON utilities.
  * Clarified parameter names in public APIs without changing their behavior.
  * Standardized error, response, query-parameter, and JWT terminology.

* **Tests**
  * Updated test fixtures, variables, and assertions to match the clearer terminology.
  * Existing coverage and runtime behavior remain unchanged.

* **Documentation**
  * Refined examples and inline documentation for consistency and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->