### PR TITLE
refactor!: spell out abbreviations in the public API

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -810,3 +810,77 @@ try {
 
 Exhaustive switches over the sealed hierarchy still compile with the same set of cases, since the
 new base is sealed and every concrete subtype is unchanged.
+
+### Abbreviations in the public API are spelled out
+
+Public identifiers that still used abbreviations are spelled out, continuing the precedent set by
+`conn` to `connection` above. The wire format is unchanged throughout: where a JSON key, query
+parameter or URL path matched the abbreviation, only the Dart identifier is renamed.
+
+Across every package:
+
+| Before | After |
+| --- | --- |
+| `setAuth()` | `setAccessToken()` |
+| `queryParams:` | `queryParameters:` |
+| `opts:` | `options:` |
+| `PresenceOpts` | `PresenceOptions` |
+| `appendSearchParams` | `appendSearchParameters` |
+| `overrideSearchParams` | `overrideSearchParameters` |
+| `toQueryParams` | `toQueryParameters` |
+
+`realtime_client`:
+
+| Before | After |
+| --- | --- |
+| `RealtimeClient.params` | `RealtimeClient.parameters` |
+| `RealtimeClient.endPoint` | `RealtimeClient.endpoint` |
+| `RealtimeClient.endPointURL` | `RealtimeClient.endpointUrl` |
+| `RealtimeConstants.wsCloseNormal` | `RealtimeConstants.webSocketCloseNormal` |
+| `RealtimeProtocolVersion.vsn` | `RealtimeProtocolVersion.wireVersion` |
+| `RealtimeChannel(topic, socket, params: …)` | `RealtimeChannel(topic, socket, config: …)` |
+| `Presence.presenceRef` | `Presence.presenceReference` |
+
+`supabase_auth`:
+
+| Before | After |
+| --- | --- |
+| `JwtPayload.iss/sub/aud/exp/nbf/iat/jti` | `issuer`, `subject`, `audience`, `expiresAt`, `notBefore`, `issuedAt`, `jwtId` |
+| `JwtHeader.alg/kid/typ` | `algorithm`, `keyId`, `type` |
+| `JWK.kty/keyOps/alg/kid` | `keyType`, `keyOperations`, `algorithm`, `keyId` |
+| `User.aud` | `User.audience` |
+| `CreateOAuthClientParams` / `UpdateOAuthClientParams` | `…Options` |
+| `CreateCustomProviderParams` / `UpdateCustomProviderParams` | `…Options` |
+| `authorizationParams` | `authorizationParameters` |
+| `supportedIdTokenSigningAlgs` | `supportedIdTokenSigningAlgorithms` |
+| `tokenEndpointAuthMethod` | `tokenEndpointAuthenticationMethod` |
+| `userinfoEndpoint` / `userinfoUrl` | `userInfoEndpoint` / `userInfoUrl` |
+| `validateExp(int? exp)` | `validateExpiration(int? expiresAt)` |
+| `AMRMethod` / `AMREntry` | `AuthenticationMethodReference` / `…Entry` |
+| `AuthChangeEvent.jsName` | `AuthChangeEvent.value` |
+| `AuthenticationMethodReference.code` | `AuthenticationMethodReference.value` |
+| `GenerateLinkType.fromString` | `GenerateLinkType.fromValue` |
+| `OAuthClientType.fromString` | `OAuthClientType.fromValue` |
+| `OAuthClientRegistrationType.fromString` | `OAuthClientRegistrationType.fromValue` |
+| `CustomProviderType.fromString` | `CustomProviderType.fromValue` |
+
+`storage_client`:
+
+| Before | After |
+| --- | --- |
+| `StorageFileApi.info()` | `StorageFileApi.getMetadata()` |
+| `VectorBucketEncryption.sseType` | `serverSideEncryptionType` |
+| `PartitionSpec` and the Iceberg `spec` cluster | `PartitionSpecification`, `…Specification…` |
+| `TableMetadata.refs` | `TableMetadata.references` |
+| `TableField.doc` | `TableField.documentation` |
+| `TableSnapshotScope.value` | `TableSnapshotScope.name` |
+
+These renames also change a type:
+
+| Before | After |
+| --- | --- |
+| `RealtimeClient.heartbeatIntervalMs` (`int`) | `heartbeatInterval` (`Duration`) |
+| `RealtimeConstants.defaultHeartbeatIntervalMs` (`int`) | `defaultHeartbeatInterval` (`Duration`) |
+| `RealtimeClient.reconnectAfterMs` (`int` return) | `reconnectAfter` (`Duration` return) |
+| `SnapshotReference.maxReferenceAgeMs` / `maxSnapshotAgeMs` (`int?`) | `maxReferenceAge` / `maxSnapshotAge` (`Duration?`) |
+| `Snapshot.timestampMs` / `TableMetadata.lastUpdatedMs` (`int`) | `timestamp` / `lastUpdated` (`DateTime`, UTC) |

--- a/examples/realtime_room/lib/room_channel.dart
+++ b/examples/realtime_room/lib/room_channel.dart
@@ -31,7 +31,10 @@ class RoomChannel {
          // the replication backing Postgres Changes is live. Without it, a row
          // inserted right after joining can be missed, because replication is
          // set up asynchronously after the join is confirmed.
-         opts: const RealtimeChannelConfig(self: true, replicationReady: true),
+         options: const RealtimeChannelConfig(
+           self: true,
+           replicationReady: true,
+         ),
        );
 
   final SupabaseClient _client;

--- a/packages/functions_client/lib/src/functions_client.dart
+++ b/packages/functions_client/lib/src/functions_client.dart
@@ -48,7 +48,7 @@ class FunctionsClient {
   /// Updates the authorization header
   ///
   /// [token] - the new jwt token sent in the authorization header
-  void setAuth(String token) {
+  void setAccessToken(String token) {
     _headers['Authorization'] = 'Bearer $token';
   }
 

--- a/packages/functions_client/test/functions_dart_test.dart
+++ b/packages/functions_client/test/functions_dart_test.dart
@@ -420,8 +420,8 @@ void main() {
     });
 
     group('Headers', () {
-      test('setAuth updates authorization header', () async {
-        functionsCustomHttpClient.setAuth('new-token');
+      test('setAccessToken updates authorization header', () async {
+        functionsCustomHttpClient.setAccessToken('new-token');
 
         await functionsCustomHttpClient.invoke('function');
 
@@ -430,7 +430,7 @@ void main() {
       });
 
       test('headers getter returns current headers', () {
-        functionsCustomHttpClient.setAuth('test-token');
+        functionsCustomHttpClient.setAccessToken('test-token');
 
         final headers = functionsCustomHttpClient.headers;
         expect(headers['Authorization'], 'Bearer test-token');

--- a/packages/postgrest/lib/src/postgrest.dart
+++ b/packages/postgrest/lib/src/postgrest.dart
@@ -86,8 +86,8 @@ class PostgrestClient {
   /// Authenticates the request with JWT.
   ///
   /// Passing `null` clears the `Authorization` header.
-  PostgrestClient setAuth(String? token) {
-    _log.finest("setAuth with: $token");
+  PostgrestClient setAccessToken(String? token) {
+    _log.finest("setAccessToken with: $token");
     if (token != null) {
       headers['Authorization'] = 'Bearer $token';
     } else {

--- a/packages/postgrest/lib/src/postgrest_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_builder.dart
@@ -603,7 +603,7 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
   /// Uses lists to allow multiple values for the same key
   ///
   /// [url] may be used to update based on a different url than the current one
-  Uri appendSearchParams(String key, String value, [Uri? url]) {
+  Uri appendSearchParameters(String key, String value, [Uri? url]) {
     final searchParameters = Map<String, dynamic>.of(
       (url ?? _url).queryParametersAll,
     );
@@ -614,7 +614,7 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
   /// Get new Uri with overridden query parameters
   ///
   /// [url] may be used to update based on a different url than the current one
-  Uri overrideSearchParams(String key, String value, [Uri? url]) {
+  Uri overrideSearchParameters(String key, String value, [Uri? url]) {
     final searchParameters = Map<String, dynamic>.of(
       (url ?? _url).queryParametersAll,
     );

--- a/packages/postgrest/lib/src/postgrest_filter_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_filter_builder.dart
@@ -19,18 +19,18 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
     final Uri url;
     if (value is List) {
       if (operator == "in") {
-        url = appendSearchParams(
+        url = appendSearchParameters(
           column,
           'not.$operator.(${_cleanFilterArray(value)})',
         );
       } else {
-        url = appendSearchParams(
+        url = appendSearchParameters(
           column,
           'not.$operator.{${_cleanFilterArray(value)}}',
         );
       }
     } else {
-      url = appendSearchParams(column, 'not.$operator.$value');
+      url = appendSearchParameters(column, 'not.$operator.$value');
     }
     return copyWithUrl(url);
   }
@@ -45,7 +45,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   /// ```
   PostgrestFilterBuilder<T> or(String filters, {String? referencedTable}) {
     final key = referencedTable != null ? '$referencedTable.or' : 'or';
-    final url = appendSearchParams(key, '($filters)');
+    final url = appendSearchParameters(key, '($filters)');
     return copyWithUrl(url);
   }
 
@@ -63,9 +63,9 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   PostgrestFilterBuilder<T> eq(String column, Object value) {
     final Uri url;
     if (value is List) {
-      url = appendSearchParams(column, 'eq.{${_cleanFilterArray(value)}}');
+      url = appendSearchParameters(column, 'eq.{${_cleanFilterArray(value)}}');
     } else {
-      url = appendSearchParams(column, 'eq.$value');
+      url = appendSearchParameters(column, 'eq.$value');
     }
     return copyWithUrl(url);
   }
@@ -82,9 +82,9 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   PostgrestFilterBuilder<T> neq(String column, Object value) {
     final Uri url;
     if (value is List) {
-      url = appendSearchParams(column, 'neq.{${_cleanFilterArray(value)}}');
+      url = appendSearchParameters(column, 'neq.{${_cleanFilterArray(value)}}');
     } else {
-      url = appendSearchParams(column, 'neq.$value');
+      url = appendSearchParameters(column, 'neq.$value');
     }
     return copyWithUrl(url);
   }
@@ -99,7 +99,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   ///     .gt('id', 1);
   /// ```
   PostgrestFilterBuilder<T> gt(String column, Object value) {
-    return copyWithUrl(appendSearchParams(column, 'gt.$value'));
+    return copyWithUrl(appendSearchParameters(column, 'gt.$value'));
   }
 
   /// Finds all rows whose value on the stated [column] is greater than or equal
@@ -112,7 +112,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   ///     .gte('id', 1);
   /// ```
   PostgrestFilterBuilder<T> gte(String column, Object value) {
-    return copyWithUrl(appendSearchParams(column, 'gte.$value'));
+    return copyWithUrl(appendSearchParameters(column, 'gte.$value'));
   }
 
   /// Finds all rows whose value on the stated [column] is less than the
@@ -125,7 +125,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   ///     .lt('id', 2);
   /// ```
   PostgrestFilterBuilder<T> lt(String column, Object value) {
-    return copyWithUrl(appendSearchParams(column, 'lt.$value'));
+    return copyWithUrl(appendSearchParameters(column, 'lt.$value'));
   }
 
   /// Finds all rows whose value on the stated [column] is less than or equal to
@@ -138,7 +138,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   ///     .lte('id', 2);
   /// ```
   PostgrestFilterBuilder<T> lte(String column, Object value) {
-    return copyWithUrl(appendSearchParams(column, 'lte.$value'));
+    return copyWithUrl(appendSearchParameters(column, 'lte.$value'));
   }
 
   /// Finds all rows whose value in the stated [column] matches the supplied
@@ -151,7 +151,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   ///     .like('username', '%supa%');
   /// ```
   PostgrestFilterBuilder<T> like(String column, String pattern) {
-    return copyWithUrl(appendSearchParams(column, 'like.$pattern'));
+    return copyWithUrl(appendSearchParameters(column, 'like.$pattern'));
   }
 
   /// Match only rows where [column] matches all of [patterns] case-sensitively.
@@ -164,7 +164,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   /// ```
   PostgrestFilterBuilder<T> likeAllOf(String column, List<String> patterns) {
     return copyWithUrl(
-      appendSearchParams(column, 'like(all).{${patterns.join(',')}}'),
+      appendSearchParameters(column, 'like(all).{${patterns.join(',')}}'),
     );
   }
 
@@ -178,7 +178,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   /// ```
   PostgrestFilterBuilder<T> likeAnyOf(String column, List<String> patterns) {
     return copyWithUrl(
-      appendSearchParams(column, 'like(any).{${patterns.join(',')}}'),
+      appendSearchParameters(column, 'like(any).{${patterns.join(',')}}'),
     );
   }
 
@@ -192,7 +192,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   ///     .ilike('username', '%SUPA%');
   /// ```
   PostgrestFilterBuilder<T> ilike(String column, String pattern) {
-    return copyWithUrl(appendSearchParams(column, 'ilike.$pattern'));
+    return copyWithUrl(appendSearchParameters(column, 'ilike.$pattern'));
   }
 
   /// Match only rows where [column] matches all of [patterns]
@@ -206,7 +206,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   /// ```
   PostgrestFilterBuilder<T> ilikeAllOf(String column, List<String> patterns) {
     return copyWithUrl(
-      appendSearchParams(column, 'ilike(all).{${patterns.join(',')}}'),
+      appendSearchParameters(column, 'ilike(all).{${patterns.join(',')}}'),
     );
   }
 
@@ -221,7 +221,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   /// ```
   PostgrestFilterBuilder<T> ilikeAnyOf(String column, List<String> patterns) {
     return copyWithUrl(
-      appendSearchParams(column, 'ilike(any).{${patterns.join(',')}}'),
+      appendSearchParameters(column, 'ilike(any).{${patterns.join(',')}}'),
     );
   }
 
@@ -236,7 +236,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   ///     .isFilter('data', null);
   /// ```
   PostgrestFilterBuilder<T> isFilter(String column, bool? value) {
-    return copyWithUrl(appendSearchParams(column, 'is.$value'));
+    return copyWithUrl(appendSearchParameters(column, 'is.$value'));
   }
 
   /// Finds all rows whose value on the stated [column] is found on the
@@ -250,7 +250,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   /// ```
   PostgrestFilterBuilder<T> inFilter(String column, List<dynamic> values) {
     return copyWithUrl(
-      appendSearchParams(column, 'in.(${_cleanFilterArray(values)})'),
+      appendSearchParameters(column, 'in.(${_cleanFilterArray(values)})'),
     );
   }
 
@@ -285,13 +285,13 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
     if (value is String) {
       // range types can be inclusive '[', ']' or exclusive '(', ')' so just
       // keep it simple and accept a string
-      url = appendSearchParams(column, 'cs.$value');
+      url = appendSearchParameters(column, 'cs.$value');
     } else if (value is List) {
       // array
-      url = appendSearchParams(column, 'cs.{${_cleanFilterArray(value)}}');
+      url = appendSearchParameters(column, 'cs.{${_cleanFilterArray(value)}}');
     } else {
       // json
-      url = appendSearchParams(column, 'cs.${json.encode(value)}');
+      url = appendSearchParameters(column, 'cs.${json.encode(value)}');
     }
     return copyWithUrl(url);
   }
@@ -327,13 +327,13 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
     if (value is String) {
       // range types can be inclusive '[', ']' or exclusive '(', ')' so just
       // keep it simple and accept a string
-      url = appendSearchParams(column, 'cd.$value');
+      url = appendSearchParameters(column, 'cd.$value');
     } else if (value is List) {
       // array
-      url = appendSearchParams(column, 'cd.{${_cleanFilterArray(value)}}');
+      url = appendSearchParameters(column, 'cd.{${_cleanFilterArray(value)}}');
     } else {
       // json
-      url = appendSearchParams(column, 'cd.${json.encode(value)}');
+      url = appendSearchParameters(column, 'cd.${json.encode(value)}');
     }
     return copyWithUrl(url);
   }
@@ -348,7 +348,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   ///     .rangeLt('age_range', '[2,25)');
   /// ```
   PostgrestFilterBuilder<T> rangeLt(String column, String range) {
-    return copyWithUrl(appendSearchParams(column, 'sl.$range'));
+    return copyWithUrl(appendSearchParameters(column, 'sl.$range'));
   }
 
   /// Finds all rows whose range value on the stated [column] is strictly to the
@@ -361,7 +361,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   ///     .rangeGt('age_range', '[2,25)');
   /// ```
   PostgrestFilterBuilder<T> rangeGt(String column, String range) {
-    return copyWithUrl(appendSearchParams(column, 'sr.$range'));
+    return copyWithUrl(appendSearchParameters(column, 'sr.$range'));
   }
 
   /// Finds all rows whose range value on the stated [column] does not extend to
@@ -374,7 +374,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   ///     .rangeGte('age_range', '[2,25)');
   /// ```
   PostgrestFilterBuilder<T> rangeGte(String column, String range) {
-    return copyWithUrl(appendSearchParams(column, 'nxl.$range'));
+    return copyWithUrl(appendSearchParameters(column, 'nxl.$range'));
   }
 
   /// Finds all rows whose range value on the stated [column] does not extend to
@@ -387,7 +387,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   ///     .rangeLte('age_range', '[2,25)');
   /// ```
   PostgrestFilterBuilder<T> rangeLte(String column, String range) {
-    return copyWithUrl(appendSearchParams(column, 'nxr.$range'));
+    return copyWithUrl(appendSearchParameters(column, 'nxr.$range'));
   }
 
   /// Finds all rows whose range value on the stated [column] is adjacent to the
@@ -400,7 +400,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   ///     .rangeAdjacent('age_range', '[2,25)');
   /// ```
   PostgrestFilterBuilder<T> rangeAdjacent(String column, String range) {
-    return copyWithUrl(appendSearchParams(column, 'adj.$range'));
+    return copyWithUrl(appendSearchParameters(column, 'adj.$range'));
   }
 
   /// Finds all rows whose array or range value on the stated [column] overlaps
@@ -416,11 +416,11 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
     final Uri url;
     if (value is List) {
       // array
-      url = appendSearchParams(column, 'ov.{${_cleanFilterArray(value)}}');
+      url = appendSearchParameters(column, 'ov.{${_cleanFilterArray(value)}}');
     } else {
       // range types can be inclusive '[', ']' or exclusive '(', ')' so just
       // keep it simple and accept a string
-      url = appendSearchParams(column, 'ov.$value');
+      url = appendSearchParameters(column, 'ov.$value');
     }
     return copyWithUrl(url);
   }
@@ -452,7 +452,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
     };
     final configPart = config == null ? '' : '($config)';
     return copyWithUrl(
-      appendSearchParams(column, '${typePart}fts$configPart.$query'),
+      appendSearchParameters(column, '${typePart}fts$configPart.$query'),
     );
   }
 
@@ -472,18 +472,18 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
     final Uri url;
     if (value is List) {
       if (operator == "in") {
-        url = appendSearchParams(
+        url = appendSearchParameters(
           column,
           '$operator.(${_cleanFilterArray(value)})',
         );
       } else {
-        url = appendSearchParams(
+        url = appendSearchParameters(
           column,
           '$operator.{${_cleanFilterArray(value)}}',
         );
       }
     } else {
-      url = appendSearchParams(column, '$operator.$value');
+      url = appendSearchParameters(column, '$operator.$value');
     }
     return copyWithUrl(url);
   }
@@ -500,7 +500,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   PostgrestFilterBuilder<T> match(Map<String, Object> query) {
     var url = _url;
     for (final entry in query.entries) {
-      url = appendSearchParams(entry.key, 'eq.${entry.value}', url);
+      url = appendSearchParameters(entry.key, 'eq.${entry.value}', url);
     }
     return copyWithUrl(url);
   }
@@ -515,7 +515,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   ///     .matchRegex('username', '^sup.*');
   /// ```
   PostgrestFilterBuilder<T> matchRegex(String column, String pattern) {
-    return copyWithUrl(appendSearchParams(column, 'match.$pattern'));
+    return copyWithUrl(appendSearchParameters(column, 'match.$pattern'));
   }
 
   /// Finds all rows whose value in the stated [column] matches the supplied
@@ -528,7 +528,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   ///     .imatchRegex('username', '^SUP.*');
   /// ```
   PostgrestFilterBuilder<T> imatchRegex(String column, String pattern) {
-    return copyWithUrl(appendSearchParams(column, 'imatch.$pattern'));
+    return copyWithUrl(appendSearchParameters(column, 'imatch.$pattern'));
   }
 
   /// Finds all rows whose value on the stated [column] is not equal to the
@@ -543,7 +543,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   ///     .isDistinct('age', null);
   /// ```
   PostgrestFilterBuilder<T> isDistinct(String column, Object? value) {
-    return copyWithUrl(appendSearchParams(column, 'isdistinct.$value'));
+    return copyWithUrl(appendSearchParameters(column, 'isdistinct.$value'));
   }
 
   @override

--- a/packages/postgrest/lib/src/postgrest_query_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_query_builder.dart
@@ -73,7 +73,7 @@ class PostgrestQueryBuilder<T> extends RawPostgrestBuilder<T, T, T> {
       return c;
     }).join();
 
-    final url = overrideSearchParams('select', cleanedColumns);
+    final url = overrideSearchParameters('select', cleanedColumns);
     return PostgrestFilterBuilder(
       _copyWithType(
         url: url,
@@ -274,7 +274,7 @@ class PostgrestQueryBuilder<T> extends RawPostgrestBuilder<T, T, T> {
     final columns = [for (final element in newValues) ...element.keys];
     if (newValues.isNotEmpty) {
       final uniqueColumns = {...columns}.map((e) => '"$e"').join(',');
-      return appendSearchParams("columns", uniqueColumns);
+      return appendSearchParameters("columns", uniqueColumns);
     }
     return _url;
   }

--- a/packages/postgrest/lib/src/postgrest_rpc_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_rpc_builder.dart
@@ -55,7 +55,7 @@ class PostgrestRpcBuilder
           final formattedValue = value is List
               ? '{${_cleanFilterArray(value)}}'
               : value;
-          newUrl = appendSearchParams(
+          newUrl = appendSearchParameters(
             key.toString(),
             '$formattedValue',
             newUrl,

--- a/packages/postgrest/lib/src/postgrest_transform_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_transform_builder.dart
@@ -57,7 +57,7 @@ class PostgrestTransformBuilder<T> extends RawPostgrestBuilder<T, T, T> {
     }).join();
     final newHeaders = {..._headers};
 
-    final url = overrideSearchParams('select', cleanedColumns);
+    final url = overrideSearchParameters('select', cleanedColumns);
     final prefer = _emptyPreferAsNull(newHeaders['Prefer']);
     newHeaders['Prefer'] = [
       ?prefer,
@@ -115,7 +115,7 @@ class PostgrestTransformBuilder<T> extends RawPostgrestBuilder<T, T, T> {
         '${existingOrder == null ? '' : '$existingOrder,'}$column.'
         '${ascending ? 'asc' : 'desc'}.'
         '${nullsFirst ? 'nullsfirst' : 'nullslast'}';
-    final url = overrideSearchParams(key, value);
+    final url = overrideSearchParameters(key, value);
     return PostgrestTransformBuilder(copyWithUrl(url));
   }
 
@@ -136,7 +136,7 @@ class PostgrestTransformBuilder<T> extends RawPostgrestBuilder<T, T, T> {
   PostgrestTransformBuilder<T> limit(int count, {String? referencedTable}) {
     final key = referencedTable == null ? 'limit' : '$referencedTable.limit';
 
-    final url = overrideSearchParams(key, '$count');
+    final url = overrideSearchParameters(key, '$count');
     return PostgrestTransformBuilder(copyWithUrl(url));
   }
 
@@ -169,8 +169,8 @@ class PostgrestTransformBuilder<T> extends RawPostgrestBuilder<T, T, T> {
         ? 'limit'
         : '$referencedTable.limit';
 
-    var url = overrideSearchParams(keyOffset, '$from');
-    url = overrideSearchParams(keyLimit, '${to - from + 1}', url);
+    var url = overrideSearchParameters(keyOffset, '$from');
+    url = overrideSearchParameters(keyLimit, '${to - from + 1}', url);
     return PostgrestTransformBuilder(copyWithUrl(url));
   }
 

--- a/packages/postgrest/test/basic_test.dart
+++ b/packages/postgrest/test/basic_test.dart
@@ -112,7 +112,7 @@ void main() {
     });
 
     test('auth', () async {
-      postgrest = PostgrestClient(localStackRestUrl).setAuth('foo');
+      postgrest = PostgrestClient(localStackRestUrl).setAccessToken('foo');
       expect(
         postgrest.headers['Authorization'],
         'Bearer foo',

--- a/packages/realtime_client/example/main.dart
+++ b/packages/realtime_client/example/main.dart
@@ -4,7 +4,7 @@ import 'package:realtime_client/realtime_client.dart';
 Future<void> main() async {
   final socket = RealtimeClient(
     'ws://SUPABASE_API_ENDPOINT/realtime/v1',
-    params: {'apikey': 'SUPABASE_API_KEY'},
+    parameters: {'apikey': 'SUPABASE_API_KEY'},
     // ignore: avoid_print
     logger: (kind, message, data) {
       print('$kind $message $data');

--- a/packages/realtime_client/lib/src/constants.dart
+++ b/packages/realtime_client/lib/src/constants.dart
@@ -5,8 +5,8 @@ import 'package:supabase_common/supabase_common.dart';
 class Constants {
   static const Duration defaultTimeout = Duration(milliseconds: 10000);
   static const Duration defaultConnectionCloseTimeout = Duration(seconds: 6);
-  static const int defaultHeartbeatIntervalMs = 25000;
-  static const int wsCloseNormal = 1000;
+  static const Duration defaultHeartbeatInterval = Duration(seconds: 25);
+  static const int webSocketCloseNormal = 1000;
   static final Map<String, String> defaultHeaders = {
     'X-Client-Info': buildClientInfoHeader('realtime-dart', version),
   };
@@ -21,10 +21,10 @@ enum RealtimeProtocolVersion {
   /// Positional JSON array text frames plus binary frames.
   v2('2.0.0');
 
-  const RealtimeProtocolVersion(this.vsn);
+  const RealtimeProtocolVersion(this.wireVersion);
 
   /// The value sent as the `vsn` connection parameter.
-  final String vsn;
+  final String wireVersion;
 }
 
 enum SocketState {
@@ -60,7 +60,7 @@ enum ChannelEvent {
   presence,
   postgresChanges;
 
-  static ChannelEvent fromType(String type) {
+  static ChannelEvent fromValue(String type) {
     for (final event in ChannelEvent.values) {
       if (event.name == type || event.eventName() == type) {
         return event;

--- a/packages/realtime_client/lib/src/realtime_channel.dart
+++ b/packages/realtime_client/lib/src/realtime_channel.dart
@@ -24,13 +24,13 @@ class RealtimeChannel {
   List<Push> _pushBuffer = [];
   late RealtimePresence presence;
   @internal
-  late final String broadcastEndpointURL;
+  late final String broadcastEndpointUrl;
   @internal
   final String subTopic;
   @internal
   final String topic;
   @internal
-  Map<String, dynamic> params;
+  Map<String, dynamic> parameters;
   @internal
   final RealtimeClient socket;
 
@@ -41,25 +41,25 @@ class RealtimeChannel {
   RealtimeChannel(
     this.topic,
     this.socket, {
-    RealtimeChannelConfig params = const RealtimeChannelConfig(),
+    RealtimeChannelConfig config = const RealtimeChannelConfig(),
   }) : _timeout = socket.timeout,
-       params = params.toMap(),
+       parameters = config.toMap(),
        subTopic = topic.replaceFirst(
          RegExp(r"^realtime:", caseSensitive: false),
          "",
        ) {
-    broadcastEndpointURL = '${httpEndpointURL(socket.endPoint)}/api/broadcast';
-    _private = params.private;
+    broadcastEndpointUrl = '${httpEndpointUrl(socket.endpoint)}/api/broadcast';
+    _private = config.private;
 
     joinPush = Push(
       this,
       ChannelEvent.join,
-      this.params,
+      parameters,
       _timeout,
     );
     _rejoinTimer = RetryTimer(
       () => rejoinUntilConnected(),
-      socket.reconnectAfterMs,
+      socket.reconnectAfter,
     );
     joinPush.receive('ok', (_) {
       _state = ChannelState.joined;
@@ -115,19 +115,20 @@ class RealtimeChannel {
 
   bool _shouldEnablePresence() {
     return (_bindings['presence']?.isNotEmpty == true) ||
-        (params['config']['presence']['enabled'] == true);
+        (parameters['config']['presence']['enabled'] == true);
   }
 
   void _handlePresenceUpdate() {
     if (joinedOnce && isJoined) {
-      final currentPresenceEnabled = params['config']['presence']['enabled'];
+      final currentPresenceEnabled =
+          parameters['config']['presence']['enabled'];
       final shouldEnablePresence = _shouldEnablePresence();
 
       if (!currentPresenceEnabled && shouldEnablePresence) {
-        final config = Map<String, dynamic>.from(params['config']);
+        final config = Map<String, dynamic>.from(parameters['config']);
         config['presence'] = Map<String, dynamic>.from(config['presence']);
         config['presence']['enabled'] = true;
-        params['config'] = config;
+        parameters['config'] = config;
         updateJoinPayload({'config': config});
         rejoin();
       }
@@ -151,9 +152,9 @@ class RealtimeChannel {
       throw "tried to subscribe multiple times. 'subscribe' can only be "
           "called a single time per channel instance";
     }
-    final broadcast = params['config']['broadcast'];
-    final presenceConfig = params['config']['presence'];
-    final isPrivate = params['config']['private'];
+    final broadcast = parameters['config']['broadcast'];
+    final presenceConfig = parameters['config']['presence'];
+    final isPrivate = parameters['config']['private'];
 
     _onError((e) {
       if (callback != null) callback(RealtimeSubscribeStatus.channelError, e);
@@ -244,11 +245,11 @@ class RealtimeChannel {
     final accessToken = socket.accessToken;
     if (accessToken != null) {
       try {
-        await socket.setAuth(accessToken);
+        await socket.setAccessToken(accessToken);
       } on FormatException catch (error) {
         // The cached access token may have expired by the time the
         // channel rejoins (e.g. after the device wakes from a long
-        // sleep). Auth state listeners will re-call setAuth with a
+        // sleep). Auth state listeners will re-call setAccessToken with a
         // fresh token shortly after, so swallow this specific error
         // to avoid surfacing it as an uncaught exception. The same
         // filter is applied in `SupabaseClient._handleTokenChanged`.
@@ -324,7 +325,7 @@ class RealtimeChannel {
 
   Future<ChannelResponse> track(
     Map<String, dynamic> payload, [
-    Map<String, dynamic> opts = const {},
+    Map<String, dynamic> options = const {},
   ]) {
     return send(
       type: RealtimeListenType.presence,
@@ -334,20 +335,20 @@ class RealtimeChannel {
       },
       options: {
         'timeout': _timeout,
-        ...opts,
+        ...options,
       },
     );
   }
 
   Future<ChannelResponse> untrack([
-    Map<String, dynamic> opts = const {},
+    Map<String, dynamic> options = const {},
   ]) {
     return send(
       type: RealtimeListenType.presence,
       payload: {
         'event': 'untrack',
       },
-      options: opts,
+      options: options,
     );
   }
 
@@ -567,7 +568,7 @@ class RealtimeChannel {
   /// ```dart
   /// final channel = supabase.channel(
   ///   'room1',
-  ///   opts: const RealtimeChannelConfig(replicationReady: true),
+  ///   options: const RealtimeChannelConfig(replicationReady: true),
   /// );
   /// channel
   ///     .onPostgresChanges(
@@ -711,7 +712,7 @@ class RealtimeChannel {
     };
 
     final url = Uri.parse(
-      '$broadcastEndpointURL/${Uri.encodeComponent(subTopic)}/events/'
+      '$broadcastEndpointUrl/${Uri.encodeComponent(subTopic)}/events/'
       '${Uri.encodeComponent(event)}${_private ? '?private=true' : ''}',
     );
 
@@ -805,7 +806,7 @@ class RealtimeChannel {
     final Push push;
     try {
       push = this.push(
-        ChannelEvent.fromType(payload['type']),
+        ChannelEvent.fromValue(payload['type']),
         payload,
         options['timeout'] ?? _timeout,
       );
@@ -814,8 +815,8 @@ class RealtimeChannel {
     }
 
     if (payload['type'] == 'broadcast' &&
-        (params['config']?['broadcast']?['ack'] == null ||
-            params['config']?['broadcast']?['ack'] == false)) {
+        (parameters['config']?['broadcast']?['ack'] == null ||
+            parameters['config']?['broadcast']?['ack'] == false)) {
       if (!completer.isCompleted) {
         completer.complete(ChannelResponse.ok);
       }
@@ -842,7 +843,8 @@ class RealtimeChannel {
 
   Map<String, String> get _broadcastHeaders => {
     'Content-Type': 'application/json',
-    if (socket.params['apikey'] != null) 'apikey': socket.params['apikey']!,
+    if (socket.parameters['apikey'] != null)
+      'apikey': socket.parameters['apikey']!,
     ...socket.headers,
     if (socket.accessToken != null)
       'Authorization': 'Bearer ${socket.accessToken}',

--- a/packages/realtime_client/lib/src/realtime_client.dart
+++ b/packages/realtime_client/lib/src/realtime_client.dart
@@ -70,7 +70,7 @@ enum RealtimeHeartbeatStatus {
 /// subscriptions over a single connection.
 ///
 /// **Responsibilities:**
-/// - Establishes and maintains the WebSocket connection to [endPoint].
+/// - Establishes and maintains the WebSocket connection to [endpoint].
 /// - Sends periodic heartbeat messages to detect stale connections and
 ///   reconnects automatically when a heartbeat goes unanswered.
 /// - Encodes outgoing messages and decodes incoming messages (JSON by default).
@@ -100,10 +100,10 @@ enum RealtimeHeartbeatStatus {
 class RealtimeClient {
   String? accessToken;
   List<RealtimeChannel> channels = [];
-  final String endPoint;
+  final String endpoint;
 
   final Map<String, String> headers;
-  final Map<String, dynamic> params;
+  final Map<String, dynamic> parameters;
 
   final RealtimeProtocolVersion version;
   final Duration connectionCloseTimeout;
@@ -111,7 +111,7 @@ class RealtimeClient {
   final WebSocketTransport transport;
   final Client? httpClient;
   final _log = Logger('supabase.realtime');
-  int heartbeatIntervalMs = Constants.defaultHeartbeatIntervalMs;
+  Duration heartbeatInterval = Constants.defaultHeartbeatInterval;
   @internal
   Timer? heartbeatTimer;
 
@@ -143,7 +143,7 @@ class RealtimeClient {
   static final Serializer _serializer = Serializer();
   final RealtimeEncode encode;
   final RealtimeDecode decode;
-  late TimerCalculation reconnectAfterMs;
+  late TimerCalculation reconnectAfter;
   WebSocketChannel? connection;
   StreamSubscription<dynamic>? _connectionSubscription;
   @internal
@@ -165,7 +165,7 @@ class RealtimeClient {
 
   /// Initializes the Socket
   ///
-  /// [endPoint] The string WebSocket endpoint, ie, "ws://example.com/socket",
+  /// [endpoint] The string WebSocket endpoint, ie, "ws://example.com/socket",
   /// "wss://example.com", or "/socket" (which inherits the host and protocol).
   ///
   /// [transport] The Websocket Transport, for example WebSocket.
@@ -175,11 +175,11 @@ class RealtimeClient {
   /// [connectionCloseTimeout] The timeout to wait for the connection to close
   /// before dismissing the result. Defaults to 6 seconds.
   ///
-  /// [params] The optional params to pass when connecting.
+  /// [parameters] The optional parameters to pass when connecting.
   ///
   /// [headers] The optional headers to pass when connecting.
   ///
-  /// [heartbeatIntervalMs] The millisec interval to send a heartbeat message.
+  /// [heartbeatInterval] The interval at which to send a heartbeat message.
   ///
   /// [disconnectOnEmptyChannelsAfter] The delay before disconnecting the socket
   /// once the last channel is removed. If a new channel is created before the
@@ -199,8 +199,8 @@ class RealtimeClient {
   /// [decode] Overrides how incoming frames are deserialized. Defaults to the
   /// codec for [version].
   ///
-  /// [reconnectAfterMs] The optional function that returns the millisec
-  /// reconnect interval. Defaults to the stepped backoff of
+  /// [reconnectAfter] The optional function that returns the reconnect
+  /// interval. Defaults to the stepped backoff of
   /// [RetryTimer.createRetryFunction].
   ///
   /// [logLevel] Specifies the log level for the connection on the server.
@@ -209,23 +209,23 @@ class RealtimeClient {
   /// [RealtimeProtocolVersion.v2]; pass [RealtimeProtocolVersion.v1] for the
   /// legacy object-shaped JSON frames.
   RealtimeClient(
-    String endPoint, {
+    String endpoint, {
     WebSocketTransport? transport,
     this.timeout = Constants.defaultTimeout,
     this.connectionCloseTimeout = Constants.defaultConnectionCloseTimeout,
-    this.heartbeatIntervalMs = Constants.defaultHeartbeatIntervalMs,
+    this.heartbeatInterval = Constants.defaultHeartbeatInterval,
     Duration? disconnectOnEmptyChannelsAfter,
     this.logger,
     RealtimeEncode? encode,
     RealtimeDecode? decode,
-    TimerCalculation? reconnectAfterMs,
+    TimerCalculation? reconnectAfter,
     Map<String, String>? headers,
-    this.params = const {},
+    this.parameters = const {},
     RealtimeLogLevel? logLevel,
     this.httpClient,
     this.customAccessToken,
     this.version = RealtimeProtocolVersion.v2,
-  }) : endPoint = Uri.parse('$endPoint/websocket')
+  }) : endpoint = Uri.parse('$endpoint/websocket')
            .replace(
              queryParameters: logLevel == null
                  ? null
@@ -248,22 +248,21 @@ class RealtimeClient {
                ? _decodeLegacy
                : _serializer.decode) {
     _log.config(
-      'Initialize RealtimeClient with endpoint: $endPoint, timeout: $timeout, '
-      'heartbeatIntervalMs: $heartbeatIntervalMs, logLevel: ${logLevel?.name}',
+      'Initialize RealtimeClient with endpoint: $endpoint, timeout: $timeout, '
+      'heartbeatInterval: $heartbeatInterval, '
+      'logLevel: ${logLevel?.name}',
     );
-    _log.finest('Initialize with headers: $headers, params: $params');
+    _log.finest('Initialize with headers: $headers, parameters: $parameters');
     final customJWT = this.headers['Authorization']?.split(' ').last;
-    accessToken = customJWT ?? params['apikey'];
+    accessToken = customJWT ?? parameters['apikey'];
 
     this.disconnectOnEmptyChannelsAfter =
-        disconnectOnEmptyChannelsAfter ??
-        Duration(milliseconds: 2 * heartbeatIntervalMs);
+        disconnectOnEmptyChannelsAfter ?? (heartbeatInterval * 2);
 
-    this.reconnectAfterMs =
-        reconnectAfterMs ?? RetryTimer.createRetryFunction();
+    this.reconnectAfter = reconnectAfter ?? RetryTimer.createRetryFunction();
     reconnectTimer = RetryTimer(
       () => unawaited(_reconnect()),
-      this.reconnectAfterMs,
+      this.reconnectAfter,
     );
   }
 
@@ -278,10 +277,10 @@ class RealtimeClient {
     }
 
     try {
-      log('transport', 'connecting to $endPointURL', null);
+      log('transport', 'connecting to $endpointUrl', null);
       log('transport', 'connecting', null, Level.FINE);
       connectionState = SocketState.connecting;
-      final WebSocketChannel localConnection = transport(endPointURL, headers);
+      final WebSocketChannel localConnection = transport(endpointUrl, headers);
       connection = localConnection;
 
       try {
@@ -482,7 +481,7 @@ class RealtimeClient {
     String topic, [
     RealtimeChannelConfig config = const RealtimeChannelConfig(),
   ]) {
-    final newChannel = RealtimeChannel('realtime:$topic', this, params: config);
+    final newChannel = RealtimeChannel('realtime:$topic', this, config: config);
     _cancelPendingDisconnect();
     channels.add(newChannel);
     return newChannel;
@@ -603,10 +602,10 @@ class RealtimeClient {
       Map.from(jsonDecode(rawMessage as String) as Map);
 
   /// Returns the URL of the websocket.
-  String get endPointURL {
-    final queryParameters = Map<String, String>.from(params);
-    queryParameters['vsn'] = version.vsn;
-    return _appendParameters(endPoint, queryParameters);
+  String get endpointUrl {
+    final queryParameters = Map<String, String>.from(parameters);
+    queryParameters['vsn'] = version.wireVersion;
+    return _appendParameters(endpoint, queryParameters);
   }
 
   /// Return the next message ref, accounting for overflows
@@ -625,7 +624,7 @@ class RealtimeClient {
   /// Realtime RLS.
   ///
   /// `token` A JWT strings.
-  Future<void> setAuth(String? token) async {
+  Future<void> setAccessToken(String? token) async {
     final tokenToSend =
         token ?? (await customAccessToken?.call()) ?? accessToken;
 
@@ -661,13 +660,13 @@ class RealtimeClient {
   }
 
   void _onConnectionOpen() {
-    log('transport', 'connected to $endPointURL');
+    log('transport', 'connected to $endpointUrl');
     log('transport', 'connected', null, Level.FINE);
     unawaited(_resolveAccessTokenAndFlush());
     reconnectTimer.reset();
     if (heartbeatTimer != null) heartbeatTimer!.cancel();
     heartbeatTimer = Timer.periodic(
-      Duration(milliseconds: heartbeatIntervalMs),
+      heartbeatInterval,
       (Timer t) => unawaited(sendHeartbeat()),
     );
 
@@ -729,15 +728,15 @@ class RealtimeClient {
       return url;
     }
 
-    var endpoint = Uri.parse(url);
-    endpoint = endpoint.replace(
+    var uri = Uri.parse(url);
+    uri = uri.replace(
       queryParameters: {
-        ...endpoint.queryParameters,
+        ...uri.queryParameters,
         ...queryParameters,
       },
     );
 
-    return endpoint.toString();
+    return uri.toString();
   }
 
   void _flushSendBuffer() {
@@ -761,7 +760,7 @@ class RealtimeClient {
   Future<void> _resolveAccessTokenAndFlush() async {
     try {
       if (customAccessToken != null) {
-        await setAuth(null);
+        await setAccessToken(null);
         if (accessToken != null) {
           for (final channel in channels) {
             channel.updateJoinPayload({'access_token': accessToken!});
@@ -796,7 +795,10 @@ class RealtimeClient {
       );
       _heartbeatController.add(RealtimeHeartbeatStatus.timeout);
       unawaited(
-        connection?.sink.close(Constants.wsCloseNormal, 'heartbeat timeout'),
+        connection?.sink.close(
+          Constants.webSocketCloseNormal,
+          'heartbeat timeout',
+        ),
       );
       return;
     }
@@ -810,6 +812,6 @@ class RealtimeClient {
       ),
     );
     _heartbeatController.add(RealtimeHeartbeatStatus.sent);
-    await setAuth(accessToken);
+    await setAccessToken(accessToken);
   }
 }

--- a/packages/realtime_client/lib/src/realtime_presence.dart
+++ b/packages/realtime_client/lib/src/realtime_presence.dart
@@ -5,13 +5,13 @@ import 'package:realtime_client/src/types.dart';
 /// A single shared state between users with Realtime Presence.
 class Presence {
   /// Reference to the presence object.
-  final String presenceRef;
+  final String presenceReference;
 
   /// The payload shared by users.
   final Map<String, dynamic> payload;
 
   const Presence({
-    required this.presenceRef,
+    required this.presenceReference,
     required this.payload,
   });
 
@@ -20,20 +20,21 @@ class Presence {
     // Create a new map without presence_ref to avoid mutating the input
     final payload = Map<String, dynamic>.of(map)..remove('presence_ref');
     return Presence(
-      presenceRef: ref as String? ?? '',
+      presenceReference: ref as String? ?? '',
       payload: payload,
     );
   }
 
   Presence deepClone() {
     return Presence.fromJson({
-      'presence_ref': presenceRef,
+      'presence_ref': presenceReference,
       ...payload,
     });
   }
 
   @override
-  String toString() => 'Presence(presenceRef: $presenceRef, payload: $payload)';
+  String toString() =>
+      'Presence(presenceReference: $presenceReference, payload: $payload)';
 }
 
 typedef PresenceChooser<T> = T Function(String key, dynamic presence);
@@ -44,10 +45,10 @@ typedef PresenceOnJoinCallback =
 typedef PresenceOnLeaveCallback =
     void Function(String? key, dynamic currentPresences, dynamic newPresences);
 
-class PresenceOpts {
+class PresenceOptions {
   final PresenceEvents events;
 
-  const PresenceOpts({required this.events});
+  const PresenceOptions({required this.events});
 }
 
 class PresenceEvents {
@@ -73,11 +74,11 @@ class RealtimePresence {
   ///
   /// `channel` - The RealtimeChannel
   ///
-  /// `opts` - The options, for example `PresenceOpts(events:
+  /// `options` - The options, for example `PresenceOptions(events:
   /// PresenceEvents(state: 'state', diff: 'diff'))`
-  RealtimePresence(this.channel, [PresenceOpts? opts]) {
+  RealtimePresence(this.channel, [PresenceOptions? options]) {
     final events =
-        opts?.events ??
+        options?.events ??
         PresenceEvents(state: 'presence_state', diff: 'presence_diff');
 
     channel.onEvents(events.state, ChannelFilter(), (newState, [_]) {
@@ -181,19 +182,23 @@ class RealtimePresence {
       final currentPresences = state[key];
 
       if (currentPresences != null) {
-        final newPresenceRefs = (newPresences as List)
-            .map((m) => m.presenceRef as String)
+        final newPresenceReferences = (newPresences as List)
+            .map((m) => m.presenceReference as String)
             .toList();
-        final currentPresenceRefs = currentPresences
-            .map((m) => m.presenceRef)
+        final currentPresenceReferences = currentPresences
+            .map((m) => m.presenceReference)
             .toList();
         final joinedPresences =
             newPresences
-                    .where((m) => !currentPresenceRefs.contains(m.presenceRef))
+                    .where(
+                      (m) => !currentPresenceReferences.contains(
+                        m.presenceReference,
+                      ),
+                    )
                     .toList()
                 as List<Presence>;
         final leftPresences = currentPresences
-            .where((m) => !newPresenceRefs.contains(m.presenceRef))
+            .where((m) => !newPresenceReferences.contains(m.presenceReference))
             .toList();
 
         if (joinedPresences.isNotEmpty) {
@@ -237,11 +242,13 @@ class RealtimePresence {
       }).toList();
 
       if (currentPresences.isNotEmpty) {
-        final joinedPresenceRefs = state[key]!
-            .map((m) => m.presenceRef)
+        final joinedPresenceReferences = state[key]!
+            .map((m) => m.presenceReference)
             .toList();
         final remainingPresences = currentPresences
-            .where((m) => !joinedPresenceRefs.contains(m.presenceRef))
+            .where(
+              (m) => !joinedPresenceReferences.contains(m.presenceReference),
+            )
             .toList();
 
         state[key]!.insertAll(0, remainingPresences);
@@ -255,13 +262,15 @@ class RealtimePresence {
 
       if (currentPresences == null) return;
 
-      final presenceRefsToRemove = (leftPresences as List)
-          .map((leftPresence) => leftPresence.presenceRef as String)
+      final presenceReferencesToRemove = (leftPresences as List)
+          .map((leftPresence) => leftPresence.presenceReference as String)
           .toList();
 
       currentPresences = currentPresences
           .where(
-            (presence) => !presenceRefsToRemove.contains(presence.presenceRef),
+            (presence) => !presenceReferencesToRemove.contains(
+              presence.presenceReference,
+            ),
           )
           .toList();
 

--- a/packages/realtime_client/lib/src/retry_timer.dart
+++ b/packages/realtime_client/lib/src/retry_timer.dart
@@ -6,15 +6,21 @@ import 'package:supabase_common/supabase_common.dart';
 @internal
 typedef TimerCallback = void Function();
 @internal
-typedef TimerCalculation = int Function(int tries);
+typedef TimerCalculation = Duration Function(int tries);
 
 /// Creates a timer that accepts a `timerCalculation` function to perform
 /// calculated timeout retries, such as exponential backoff.
 ///
 /// ```dart
-/// int calculateRetryDuration(int tries) {
-///   const delays = [1000, 5000, 10000];
-///   return tries <= delays.length ? delays[tries - 1] : 10000;
+/// Duration calculateRetryDuration(int tries) {
+///   const delays = [
+///     Duration(seconds: 1),
+///     Duration(seconds: 5),
+///     Duration(seconds: 10),
+///   ];
+///   return tries <= delays.length
+///       ? delays[tries - 1]
+///       : const Duration(seconds: 10);
 /// }
 ///
 /// final reconnectTimer = RetryTimer(connect, calculateRetryDuration);
@@ -52,23 +58,22 @@ class RetryTimer {
   void scheduleTimeout() {
     if (_timer != null) _timer!.cancel();
 
-    _timer = Timer(Duration(milliseconds: timerCalculation(_tries + 1)), () {
+    _timer = Timer(timerCalculation(_tries + 1), () {
       _tries = _tries + 1;
       callback();
     });
   }
 
-  /// Generates an exponential backoff function with first and max delays, both
-  /// in milliseconds.
+  /// Generates an exponential backoff function with first and max delays.
   static TimerCalculation createRetryFunction({
-    int firstDelay = 1000,
-    int maxDelay = 10000,
+    Duration firstDelay = const Duration(seconds: 1),
+    Duration maxDelay = const Duration(seconds: 10),
   }) {
     return (int tries) => exponentialBackoff(
       // `tries` counts the attempt this delay precedes, so the first one is 1.
       tries - 1,
-      initialDelay: Duration(milliseconds: firstDelay),
-      maxDelay: Duration(milliseconds: maxDelay),
-    ).inMilliseconds;
+      initialDelay: firstDelay,
+      maxDelay: maxDelay,
+    );
   }
 }

--- a/packages/realtime_client/lib/src/transformers.dart
+++ b/packages/realtime_client/lib/src/transformers.dart
@@ -358,7 +358,7 @@ Map<String, Map<String, dynamic>> getPayloadRecords(
 
 /// Converts a WebSocket URL to an HTTP URL.
 @internal
-String httpEndpointURL(String socketUrl) {
+String httpEndpointUrl(String socketUrl) {
   var url = socketUrl;
 
   // Replace 'ws' or 'wss' with 'http' or 'https' respectively

--- a/packages/realtime_client/lib/src/types.dart
+++ b/packages/realtime_client/lib/src/types.dart
@@ -55,13 +55,13 @@ enum PostgresChangeEvent {
   }
 
   @internal
-  static PostgresChangeEvent fromString(String event) => switch (event) {
+  static PostgresChangeEvent fromValue(String event) => switch (event) {
     'INSERT' => PostgresChangeEvent.insert,
     'UPDATE' => PostgresChangeEvent.update,
     'DELETE' => PostgresChangeEvent.delete,
     _ => throw ArgumentError(
       'Only "INSERT", "UPDATE", or "DELETE" can be passed to the '
-      '`fromString()` method.',
+      '`fromValue()` method.',
     ),
   };
 }
@@ -132,14 +132,14 @@ enum PresenceEvent {
   leave;
 
   @internal
-  static PresenceEvent fromString(String value) {
+  static PresenceEvent fromValue(String value) {
     for (final event in PresenceEvent.values) {
       if (event.name == value) {
         return event;
       }
     }
     throw ArgumentError(
-      'Only "sync", "join", or "leave" can be passed to the `fromString()` '
+      'Only "sync", "join", or "leave" can be passed to the `fromValue()` '
       'method.',
     );
   }
@@ -321,7 +321,7 @@ class PostgresChangePayload {
       schema: payload['schema'] as String,
       table: payload['table'] as String,
       commitTimestamp: commitTimestamp,
-      eventType: PostgresChangeEvent.fromString(
+      eventType: PostgresChangeEvent.fromValue(
         payload['eventType'] as String,
       ),
       newRecord: newData is Map ? Map.from(newData) : {},
@@ -507,7 +507,7 @@ abstract class RealtimePresencePayload {
   });
 
   RealtimePresencePayload.fromJson(Map<String, dynamic> json)
-    : event = PresenceEvent.fromString(json['event']);
+    : event = PresenceEvent.fromValue(json['event']);
 
   @override
   String toString() => 'PresencePayload(event: ${event.name})';
@@ -521,7 +521,7 @@ class RealtimePresenceSyncPayload extends RealtimePresencePayload {
 
   factory RealtimePresenceSyncPayload.fromJson(Map<String, dynamic> json) {
     return RealtimePresenceSyncPayload(
-      event: PresenceEvent.fromString(json['event']),
+      event: PresenceEvent.fromValue(json['event']),
     );
   }
 
@@ -551,7 +551,7 @@ class RealtimePresenceJoinPayload extends RealtimePresencePayload {
 
   factory RealtimePresenceJoinPayload.fromJson(Map<String, dynamic> json) {
     return RealtimePresenceJoinPayload(
-      event: PresenceEvent.fromString(json['event']),
+      event: PresenceEvent.fromValue(json['event']),
       key: json['key'] as String,
       newPresences: (json['newPresences'] as List).cast(),
       currentPresences: (json['currentPresences'] as List).cast(),
@@ -586,7 +586,7 @@ class RealtimePresenceLeavePayload extends RealtimePresencePayload {
 
   factory RealtimePresenceLeavePayload.fromJson(Map<String, dynamic> json) {
     return RealtimePresenceLeavePayload(
-      event: PresenceEvent.fromString(json['event']),
+      event: PresenceEvent.fromValue(json['event']),
       key: json['key'] as String,
       leftPresences: (json['leftPresences'] as List).cast(),
       currentPresences: (json['currentPresences'] as List).cast(),

--- a/packages/realtime_client/test/channel_test.dart
+++ b/packages/realtime_client/test/channel_test.dart
@@ -28,14 +28,14 @@ void main() {
       channel = RealtimeChannel(
         'topic',
         socket,
-        params: RealtimeChannelConfig(),
+        config: RealtimeChannelConfig(),
       );
     });
 
     test('sets defaults', () {
       expect(channel.isClosed, isTrue);
       expect(channel.topic, 'topic');
-      expect(channel.params, {
+      expect(channel.parameters, {
         'config': {
           'broadcast': {'ack': false, 'self': false},
           'presence': {'key': '', 'enabled': false},
@@ -49,7 +49,7 @@ void main() {
       channel = RealtimeChannel(
         'topic',
         socket,
-        params: RealtimeChannelConfig(
+        config: RealtimeChannelConfig(
           private: true,
         ),
       );
@@ -68,10 +68,10 @@ void main() {
       channel = RealtimeChannel(
         'topic',
         socket,
-        params: RealtimeChannelConfig(replicationReady: true),
+        config: RealtimeChannelConfig(replicationReady: true),
       );
 
-      expect(channel.params, {
+      expect(channel.parameters, {
         'config': {
           'broadcast': {
             'ack': false,
@@ -123,77 +123,83 @@ void main() {
     });
   });
 
-  group("joinPush 'ok' setAuth error handling", () {
+  group("joinPush 'ok' setAccessToken error handling", () {
     // Re-authorizing the channel on rejoin can throw `FormatException`
     // ('InvalidJWTToken: ...') when the cached access token has expired
     // by the time the server responds with 'ok'. The handler must swallow
     // that specific message so it does not escape as an unhandled async
     // error (which Sentry/Crashlytics surface as a fatal). See
     // https://github.com/supabase/supabase-flutter/issues/1363.
-    test("swallows FormatException with 'InvalidJWTToken' from setAuth and "
-        "still emits 'subscribed' status", () async {
-      final throwingSocket = _SetAuthThrowingSocket(
-        '/socket',
-        thrown: const FormatException(
-          'InvalidJWTToken: Invalid value for JWT claim "exp" with value 0',
-        ),
-      );
-      throwingSocket.accessToken = 'expired-token';
+    test(
+      "swallows FormatException with 'InvalidJWTToken' from setAccessToken and "
+      "still emits 'subscribed' status",
+      () async {
+        final throwingSocket = _SetAuthThrowingSocket(
+          '/socket',
+          thrown: const FormatException(
+            'InvalidJWTToken: Invalid value for JWT claim "exp" with value 0',
+          ),
+        );
+        throwingSocket.accessToken = 'expired-token';
 
-      final localChannel = throwingSocket.channel('topic');
+        final localChannel = throwingSocket.channel('topic');
 
-      RealtimeSubscribeStatus? status;
-      localChannel.subscribe((s, _) => status = s);
-      localChannel.joinPush.trigger('ok', {});
+        RealtimeSubscribeStatus? status;
+        localChannel.subscribe((s, _) => status = s);
+        localChannel.joinPush.trigger('ok', {});
 
-      // Drain the microtask queue so the async 'ok' callback completes.
-      await Future<void>.value();
-      await Future<void>.value();
+        // Drain the microtask queue so the async 'ok' callback completes.
+        await Future<void>.value();
+        await Future<void>.value();
 
-      expect(throwingSocket.setAuthCalls, 1);
-      expect(
-        status,
-        RealtimeSubscribeStatus.subscribed,
-        reason:
-            "If the catch is missing the 'ok' callback aborts at setAuth and "
-            "the subscribed status is never emitted.",
-      );
-    });
+        expect(throwingSocket.setAuthCalls, 1);
+        expect(
+          status,
+          RealtimeSubscribeStatus.subscribed,
+          reason:
+              "If the catch is missing the 'ok' callback aborts at "
+              "setAccessToken and the subscribed status is never emitted.",
+        );
+      },
+    );
 
-    test("non-InvalidJWTToken FormatExceptions from setAuth still abort the "
-        "rejoin handler", () async {
-      final throwingSocket = _SetAuthThrowingSocket(
-        '/socket',
-        thrown: const FormatException('some other parsing failure'),
-      );
-      throwingSocket.accessToken = 'some-token';
+    test(
+      "non-InvalidJWTToken FormatExceptions from setAccessToken still abort "
+      "the rejoin handler",
+      () async {
+        final throwingSocket = _SetAuthThrowingSocket(
+          '/socket',
+          thrown: const FormatException('some other parsing failure'),
+        );
+        throwingSocket.accessToken = 'some-token';
 
-      final localChannel = throwingSocket.channel('topic');
+        final localChannel = throwingSocket.channel('topic');
 
-      RealtimeSubscribeStatus? status;
-      // Use runZonedGuarded so the rethrown async error does not pollute
-      // the test runner zone.
-      await runZonedGuarded(
-        () async {
-          localChannel.subscribe((s, _) => status = s);
-          localChannel.joinPush.trigger('ok', {});
-          await Future<void>.value();
-          await Future<void>.value();
-        },
-        (_, _) {
-          /* expected: rethrown FormatException */
-        },
-      );
+        RealtimeSubscribeStatus? status;
+        // Use runZonedGuarded so the rethrown async error does not pollute
+        // the test runner zone.
+        await runZonedGuarded(
+          () async {
+            localChannel.subscribe((s, _) => status = s);
+            localChannel.joinPush.trigger('ok', {});
+            await Future<void>.value();
+            await Future<void>.value();
+          },
+          (_, _) {
+            /* expected: rethrown FormatException */
+          },
+        );
 
-      expect(throwingSocket.setAuthCalls, 1);
-      expect(
-        status,
-        isNull,
-        reason:
-            'A non-InvalidJWTToken FormatException should propagate out of the '
-            'callback before subscribed is emitted.',
-      );
-    });
+        expect(throwingSocket.setAuthCalls, 1);
+        expect(
+          status,
+          isNull,
+          reason:
+              'A non-InvalidJWTToken FormatException should propagate out of '
+              'the callback before subscribed is emitted.',
+        );
+      },
+    );
   });
 
   group('join with postgres_changes filter matching', () {
@@ -700,7 +706,7 @@ void main() {
       socket = RealtimeClient(
         'ws://${mockServer.address.host}:${mockServer.port}/realtime/v1',
         headers: {'apikey': 'supabaseKey'},
-        params: {'apikey': 'supabaseKey'},
+        parameters: {'apikey': 'supabaseKey'},
       );
 
       channel = socket.channel('myTopic', RealtimeChannelConfig(private: true));
@@ -713,7 +719,7 @@ void main() {
 
     test('sets endpoint', () {
       expect(
-        channel.broadcastEndpointURL,
+        channel.broadcastEndpointUrl,
         'http://${mockServer.address.host}:${mockServer.port}/realtime/v1/api/broadcast',
       );
       expect(channel.subTopic, 'myTopic');
@@ -818,7 +824,7 @@ void main() {
       channel = RealtimeChannel(
         'topic',
         socket,
-        params: RealtimeChannelConfig(),
+        config: RealtimeChannelConfig(),
       );
     });
 
@@ -912,7 +918,7 @@ void main() {
         channel = RealtimeChannel(
           'topic',
           socket,
-          params: const RealtimeChannelConfig(enabled: true),
+          config: const RealtimeChannelConfig(enabled: true),
         );
 
         channel.subscribe();
@@ -926,7 +932,7 @@ void main() {
       channel = RealtimeChannel(
         'topic',
         socket,
-        params: const RealtimeChannelConfig(),
+        config: const RealtimeChannelConfig(),
       );
 
       channel.onPresenceSync((payload) {});
@@ -943,7 +949,7 @@ void main() {
         channel = RealtimeChannel(
           'topic',
           socket,
-          params: const RealtimeChannelConfig(enabled: true),
+          config: const RealtimeChannelConfig(enabled: true),
         );
 
         channel.onPresenceSync((payload) {});
@@ -961,7 +967,7 @@ void main() {
         channel = RealtimeChannel(
           'topic',
           socket,
-          params: const RealtimeChannelConfig(),
+          config: const RealtimeChannelConfig(),
         );
 
         channel.subscribe();
@@ -975,7 +981,7 @@ void main() {
       channel = RealtimeChannel(
         'topic',
         socket,
-        params: const RealtimeChannelConfig(),
+        config: const RealtimeChannelConfig(),
       );
 
       channel.onPresenceJoin((payload) {});
@@ -989,7 +995,7 @@ void main() {
       channel = RealtimeChannel(
         'topic',
         socket,
-        params: const RealtimeChannelConfig(),
+        config: const RealtimeChannelConfig(),
       );
 
       channel.onPresenceLeave((payload) {});
@@ -1012,16 +1018,16 @@ void main() {
         channel = RealtimeChannel(
           'topic',
           socket,
-          params: const RealtimeChannelConfig(),
+          config: const RealtimeChannelConfig(),
         );
 
         channel.subscribe();
         channel.joinPush.trigger('ok', {});
-        expect(channel.params['config']['presence']['enabled'], isFalse);
+        expect(channel.parameters['config']['presence']['enabled'], isFalse);
 
         channel.onPresenceSync((payload) {});
 
-        expect(channel.params['config']['presence']['enabled'], isTrue);
+        expect(channel.parameters['config']['presence']['enabled'], isTrue);
       },
     );
 
@@ -1032,17 +1038,17 @@ void main() {
         channel = RealtimeChannel(
           'topic',
           socket,
-          params: const RealtimeChannelConfig(enabled: true),
+          config: const RealtimeChannelConfig(enabled: true),
         );
 
         channel.subscribe();
         channel.joinPush.trigger('ok', {});
-        final initialPayload = Map.from(channel.params);
+        final initialPayload = Map.from(channel.parameters);
 
         channel.onPresenceSync((payload) {});
 
-        expect(channel.params['config']['presence']['enabled'], isTrue);
-        expect(channel.params, equals(initialPayload));
+        expect(channel.parameters['config']['presence']['enabled'], isTrue);
+        expect(channel.parameters, equals(initialPayload));
       },
     );
 
@@ -1052,22 +1058,22 @@ void main() {
         channel = RealtimeChannel(
           'topic',
           socket,
-          params: const RealtimeChannelConfig(),
+          config: const RealtimeChannelConfig(),
         );
 
         channel.subscribe();
         channel.joinPush.trigger('ok', {});
-        expect(channel.params['config']['presence']['enabled'], isFalse);
+        expect(channel.parameters['config']['presence']['enabled'], isFalse);
 
         channel.onPresenceSync((payload) {});
-        expect(channel.params['config']['presence']['enabled'], isTrue);
+        expect(channel.parameters['config']['presence']['enabled'], isTrue);
 
-        final payloadAfterFirst = Map.from(channel.params);
+        final payloadAfterFirst = Map.from(channel.parameters);
 
         channel.onPresenceJoin((payload) {});
         channel.onPresenceLeave((payload) {});
 
-        expect(channel.params, equals(payloadAfterFirst));
+        expect(channel.parameters, equals(payloadAfterFirst));
       },
     );
 
@@ -1078,14 +1084,14 @@ void main() {
         channel = RealtimeChannel(
           'topic',
           socket,
-          params: const RealtimeChannelConfig(),
+          config: const RealtimeChannelConfig(),
         );
 
         expect(channel.joinedOnce, isFalse);
 
         channel.onPresenceSync((payload) {});
 
-        expect(channel.params['config']['presence']['enabled'], isFalse);
+        expect(channel.parameters['config']['presence']['enabled'], isFalse);
       },
     );
 
@@ -1096,7 +1102,7 @@ void main() {
         channel = RealtimeChannel(
           'topic',
           socket,
-          params: const RealtimeChannelConfig(),
+          config: const RealtimeChannelConfig(),
         );
 
         channel.subscribe();
@@ -1117,32 +1123,32 @@ void main() {
       channel = RealtimeChannel(
         'topic',
         socket,
-        params: const RealtimeChannelConfig(),
+        config: const RealtimeChannelConfig(),
       );
 
       channel.subscribe();
       channel.joinPush.trigger('ok', {});
-      expect(channel.params['config']['presence']['enabled'], isFalse);
+      expect(channel.parameters['config']['presence']['enabled'], isFalse);
 
       channel.onPresenceJoin((payload) {});
 
-      expect(channel.params['config']['presence']['enabled'], isTrue);
+      expect(channel.parameters['config']['presence']['enabled'], isTrue);
     });
 
     test('should handle presence leave callback resubscription', () {
       channel = RealtimeChannel(
         'topic',
         socket,
-        params: const RealtimeChannelConfig(),
+        config: const RealtimeChannelConfig(),
       );
 
       channel.subscribe();
       channel.joinPush.trigger('ok', {});
-      expect(channel.params['config']['presence']['enabled'], isFalse);
+      expect(channel.parameters['config']['presence']['enabled'], isFalse);
 
       channel.onPresenceLeave((payload) {});
 
-      expect(channel.params['config']['presence']['enabled'], isTrue);
+      expect(channel.parameters['config']['presence']['enabled'], isTrue);
     });
   });
 
@@ -1163,7 +1169,7 @@ void main() {
         socket = RealtimeClient(
           'ws://${mockServer.address.host}:${mockServer.port}/realtime/v1',
           headers: {'apikey': 'supabaseKey'},
-          params: {'apikey': 'supabaseKey'},
+          parameters: {'apikey': 'supabaseKey'},
         );
         channel = socket.channel(
           'myTopic',
@@ -1199,7 +1205,7 @@ void main() {
       socket = RealtimeClient(
         'ws://${mockServer.address.host}:${mockServer.port}/realtime/v1',
         headers: {'apikey': 'supabaseKey'},
-        params: {'apikey': 'supabaseKey'},
+        parameters: {'apikey': 'supabaseKey'},
       );
       channel = socket.channel('myTopic');
 
@@ -1226,7 +1232,7 @@ void main() {
       socket = RealtimeClient(
         'ws://${mockServer.address.host}:${mockServer.port}/realtime/v1',
         headers: {'apikey': 'supabaseKey'},
-        params: {'apikey': 'supabaseKey'},
+        parameters: {'apikey': 'supabaseKey'},
       );
       channel = socket.channel('room:42');
 
@@ -1252,7 +1258,7 @@ void main() {
       socket = RealtimeClient(
         'ws://${mockServer.address.host}:${mockServer.port}/realtime/v1',
         headers: {'apikey': 'supabaseKey'},
-        params: {'apikey': 'supabaseKey'},
+        parameters: {'apikey': 'supabaseKey'},
       );
       channel = socket.channel('myTopic');
 
@@ -1280,7 +1286,7 @@ void main() {
       socket = RealtimeClient(
         'ws://${mockServer.address.host}:${mockServer.port}/realtime/v1',
         headers: {'apikey': 'supabaseKey'},
-        params: {'apikey': 'supabaseKey'},
+        parameters: {'apikey': 'supabaseKey'},
       );
       channel = socket.channel('myTopic');
 
@@ -1306,10 +1312,10 @@ void main() {
     test('sends with Authorization header when access token is set', () async {
       socket = RealtimeClient(
         'ws://${mockServer.address.host}:${mockServer.port}/realtime/v1',
-        params: {'apikey': 'abc123'},
+        parameters: {'apikey': 'abc123'},
         customAccessToken: () async => 'token123',
       );
-      await socket.setAuth('token123');
+      await socket.setAccessToken('token123');
       channel = socket.channel('topic');
 
       final requestFuture = mockServer.first;
@@ -1331,7 +1337,7 @@ void main() {
     test('throws error on non-202 status', () async {
       socket = RealtimeClient(
         'ws://${mockServer.address.host}:${mockServer.port}/realtime/v1',
-        params: {'apikey': 'abc123'},
+        parameters: {'apikey': 'abc123'},
       );
       channel = socket.channel('topic');
 
@@ -1359,7 +1365,7 @@ void main() {
     test('handles timeout', () async {
       socket = RealtimeClient(
         'ws://${mockServer.address.host}:${mockServer.port}/realtime/v1',
-        params: {'apikey': 'abc123'},
+        parameters: {'apikey': 'abc123'},
       );
       channel = socket.channel('topic');
 
@@ -1385,7 +1391,7 @@ void main() {
 }
 
 class _SetAuthThrowingSocket extends RealtimeClient {
-  _SetAuthThrowingSocket(super.endPoint, {required this.thrown});
+  _SetAuthThrowingSocket(super.endpoint, {required this.thrown});
 
   final FormatException thrown;
   int setAuthCalls = 0;
@@ -1397,7 +1403,7 @@ class _SetAuthThrowingSocket extends RealtimeClient {
   }
 
   @override
-  Future<void> setAuth(String? token) async {
+  Future<void> setAccessToken(String? token) async {
     setAuthCalls++;
     throw thrown;
   }

--- a/packages/realtime_client/test/mock_test.dart
+++ b/packages/realtime_client/test/mock_test.dart
@@ -180,7 +180,7 @@ void main() {
       mockServer = await HttpServer.bind('localhost', 0);
       client = RealtimeClient(
         'ws://${mockServer.address.host}:${mockServer.port}/realtime/v1',
-        params: {'apikey': 'supabaseKey'},
+        parameters: {'apikey': 'supabaseKey'},
       );
       hasListener = false;
       hasSentData = false;
@@ -312,7 +312,10 @@ void main() {
       channel.subscribe(subscribeCallback);
 
       await Future.delayed(Duration(milliseconds: 200));
-      await webSocket?.close(Constants.wsCloseNormal, "heartbeat timeout");
+      await webSocket?.close(
+        Constants.webSocketCloseNormal,
+        "heartbeat timeout",
+      );
     });
   });
 
@@ -443,7 +446,7 @@ void main() {
       mockServer = await HttpServer.bind('localhost', 0);
       client = RealtimeClient(
         'ws://${mockServer.address.host}:${mockServer.port}/realtime/v1',
-        params: {'apikey': 'supabaseKey'},
+        parameters: {'apikey': 'supabaseKey'},
       );
       hasListener = false;
       hasSentData = false;

--- a/packages/realtime_client/test/realtime_integration_test.dart
+++ b/packages/realtime_client/test/realtime_integration_test.dart
@@ -22,7 +22,7 @@ void main() {
   });
 
   for (final version in RealtimeProtocolVersion.values) {
-    group('Realtime protocol ${version.vsn}', () {
+    group('Realtime protocol ${version.wireVersion}', () {
       late RealtimeClient client;
 
       setUp(() {
@@ -48,8 +48,8 @@ void main() {
         final heartbeatClient = RealtimeClient(
           localStackRealtimeUrl,
           version: version,
-          params: {'apikey': generateRealtimeToken()},
-          heartbeatIntervalMs: 500,
+          parameters: {'apikey': generateRealtimeToken()},
+          heartbeatInterval: const Duration(milliseconds: 500),
         );
         final statuses = <RealtimeHeartbeatStatus>[];
         final acknowledged = Completer<void>();
@@ -73,14 +73,14 @@ void main() {
       });
 
       test('subscribes to a channel', () async {
-        final channel = client.channel('subscribe-${version.vsn}');
+        final channel = client.channel('subscribe-${version.wireVersion}');
         final status = await _subscribe(channel);
         expect(status, RealtimeSubscribeStatus.subscribed);
         expect(channel.isJoined, isTrue);
       });
 
       test('unsubscribes from a channel', () async {
-        final channel = client.channel('unsubscribe-${version.vsn}');
+        final channel = client.channel('unsubscribe-${version.wireVersion}');
         await _subscribe(channel);
         final result = await channel.unsubscribe();
         expect(result, 'ok');
@@ -89,7 +89,7 @@ void main() {
 
       test('receives its own broadcast when self is enabled', () async {
         final channel = client.channel(
-          'broadcast-self-${version.vsn}',
+          'broadcast-self-${version.wireVersion}',
           const RealtimeChannelConfig(self: true),
         );
         final received = Completer<Map<String, dynamic>>();
@@ -115,7 +115,7 @@ void main() {
       });
 
       test('broadcasts between two clients', () async {
-        final topic = 'broadcast-cross-${version.vsn}';
+        final topic = 'broadcast-cross-${version.wireVersion}';
         final receiver = client;
         final sender = createRealtimeClient(version);
         addTearDown(() async {
@@ -150,7 +150,7 @@ void main() {
 
       test('tracks and syncs presence', () async {
         final channel = client.channel(
-          'presence-${version.vsn}',
+          'presence-${version.wireVersion}',
           const RealtimeChannelConfig(key: 'user-1'),
         );
 
@@ -187,7 +187,7 @@ void main() {
 
       test('removes presence on untrack', () async {
         final channel = client.channel(
-          'presence-untrack-${version.vsn}',
+          'presence-untrack-${version.wireVersion}',
           const RealtimeChannelConfig(key: 'user-2'),
         );
 
@@ -226,7 +226,7 @@ void main() {
           final updates = Completer<PostgresChangePayload>();
           final deletes = Completer<PostgresChangePayload>();
 
-          final channel = client.channel('db-changes-${version.vsn}');
+          final channel = client.channel('db-changes-${version.wireVersion}');
           channel.onPostgresChanges(
             event: PostgresChangeEvent.all,
             schema: 'public',
@@ -281,7 +281,7 @@ void main() {
         test('applies a postgres changes filter', () async {
           final matched = Completer<PostgresChangePayload>();
 
-          final channel = client.channel('db-filter-${version.vsn}');
+          final channel = client.channel('db-filter-${version.wireVersion}');
           channel.onPostgresChanges(
             event: PostgresChangeEvent.insert,
             schema: 'public',

--- a/packages/realtime_client/test/retry_timer_test.dart
+++ b/packages/realtime_client/test/retry_timer_test.dart
@@ -3,17 +3,19 @@ import 'package:test/test.dart';
 
 void main() {
   test('retry function should stop at maxDelay', () {
-    final backoff = RetryTimer.createRetryFunction(maxDelay: 5000);
-    expect(backoff(100), 5000);
+    final backoff = RetryTimer.createRetryFunction(
+      maxDelay: const Duration(seconds: 5),
+    );
+    expect(backoff(100), const Duration(seconds: 5));
   });
 
   test('retry function should return first delay on tries == 1', () {
     final backoff = RetryTimer.createRetryFunction();
-    expect(backoff(1), 1000);
+    expect(backoff(1), const Duration(seconds: 1));
   });
 
   test('retry function should return firstDelay * 4 for tries 3', () {
     final backoff = RetryTimer.createRetryFunction();
-    expect(backoff(3), 1000 * 4);
+    expect(backoff(3), const Duration(seconds: 1) * 4);
   });
 }

--- a/packages/realtime_client/test/socket_test.dart
+++ b/packages/realtime_client/test/socket_test.dart
@@ -78,12 +78,12 @@ void main() {
     test('sets defaults', () async {
       final socket = RealtimeClient(
         'wss://example.com/socket',
-        params: {'apikey': '123'},
+        parameters: {'apikey': '123'},
       );
       expect(socket.channels, isEmpty);
       expect(socket.sendBuffer, isEmpty);
       expect(socket.ref, 0);
-      expect(socket.endPoint, 'wss://example.com/socket/websocket');
+      expect(socket.endpoint, 'wss://example.com/socket/websocket');
       expect(socket.stateChangeCallbacks, {
         'open': [],
         'close': [],
@@ -91,7 +91,7 @@ void main() {
         'message': [],
       });
       expect(socket.timeout, const Duration(milliseconds: 10000));
-      expect(socket.heartbeatIntervalMs, Constants.defaultHeartbeatIntervalMs);
+      expect(socket.heartbeatInterval, Constants.defaultHeartbeatInterval);
       expect(
         socket.logger
             is void Function(
@@ -112,7 +112,7 @@ void main() {
       final socket = RealtimeClient(
         'wss://example.com/socket',
         timeout: const Duration(milliseconds: 40000),
-        heartbeatIntervalMs: 60000,
+        heartbeatInterval: const Duration(seconds: 60),
         // ignore: avoid_print
         logger: (kind, message, data) => print('[$kind] $message $data'),
         headers: {'X-Client-Info': 'supabase-dart/0.0.0'},
@@ -120,7 +120,7 @@ void main() {
       expect(socket.channels, isEmpty);
       expect(socket.sendBuffer, isEmpty);
       expect(socket.ref, 0);
-      expect(socket.endPoint, 'wss://example.com/socket/websocket');
+      expect(socket.endpoint, 'wss://example.com/socket/websocket');
       expect(socket.stateChangeCallbacks, {
         'open': [],
         'close': [],
@@ -128,7 +128,7 @@ void main() {
         'message': [],
       });
       expect(socket.timeout, const Duration(milliseconds: 40000));
-      expect(socket.heartbeatIntervalMs, 60000);
+      expect(socket.heartbeatInterval, const Duration(seconds: 60));
       expect(
         socket.logger
             is void Function(
@@ -146,7 +146,7 @@ void main() {
     test('returns endpoint for given full url', () {
       final socket = RealtimeClient('wss://example.org/chat');
       expect(
-        socket.endPointURL,
+        socket.endpointUrl,
         'wss://example.org/chat/websocket?vsn=2.0.0',
       );
     });
@@ -154,10 +154,10 @@ void main() {
     test('returns endpoint with parameters', () {
       final socket = RealtimeClient(
         'ws://example.org/chat',
-        params: {'foo': 'bar'},
+        parameters: {'foo': 'bar'},
       );
       expect(
-        socket.endPointURL,
+        socket.endpointUrl,
         'ws://example.org/chat/websocket?foo=bar&vsn=2.0.0',
       );
     });
@@ -165,12 +165,12 @@ void main() {
     test('returns endpoint with apikey', () {
       final socket = RealtimeClient(
         'ws://example.org/chat',
-        params: {
+        parameters: {
           'apikey': '123456789',
         },
       );
       expect(
-        socket.endPointURL,
+        socket.endpointUrl,
         'ws://example.org/chat/websocket?apikey=123456789&vsn=2.0.0',
       );
     });
@@ -181,7 +181,7 @@ void main() {
         version: RealtimeProtocolVersion.v1,
       );
       expect(
-        socket.endPointURL,
+        socket.endpointUrl,
         'wss://example.org/chat/websocket?vsn=1.0.0',
       );
     });
@@ -347,7 +347,7 @@ void main() {
         socketEndpoint,
         // Reconnect almost immediately so the test doesn't wait for the
         // default backoff.
-        reconnectAfterMs: (tries) => 20,
+        reconnectAfter: (tries) => const Duration(milliseconds: 20),
         transport: (url, headers) {
           connectCount++;
           return mockedSocketChannel;
@@ -407,7 +407,7 @@ void main() {
         socketEndpoint,
         // Large delay so the automatic reconnect stays dormant during the
         // test and the manual reconnect below is what reopens the socket.
-        reconnectAfterMs: (tries) => 100000,
+        reconnectAfter: (tries) => const Duration(seconds: 100),
         transport: (url, headers) {
           connectCount++;
           return connectCount == 1 ? firstChannel : secondChannel;
@@ -467,9 +467,9 @@ void main() {
 
       final mockedSocket = RealtimeClient(
         socketEndpoint,
-        reconnectAfterMs: (tries) {
+        reconnectAfter: (tries) {
           triesSeen.add(tries);
-          return 10;
+          return const Duration(milliseconds: 10);
         },
         transport: (url, headers) {
           attempt++;
@@ -555,7 +555,7 @@ void main() {
       await socket.disconnect();
     });
 
-    test('returns channel with given topic and params', () {
+    test('returns channel with given topic and parameters', () {
       final channel = socket.channel(
         tTopic,
         channelConfig,
@@ -563,7 +563,7 @@ void main() {
 
       expect(channel.socket, socket);
       expect(channel.topic, 'realtime:topic');
-      expect(channel.params, {
+      expect(channel.parameters, {
         'config': {
           'broadcast': {'ack': false, 'self': false},
           'presence': {'key': '', 'enabled': false},
@@ -646,12 +646,12 @@ void main() {
       final socket = RealtimeClient(socketEndpoint);
       expect(
         socket.disconnectOnEmptyChannelsAfter,
-        Duration(milliseconds: 2 * Constants.defaultHeartbeatIntervalMs),
+        Constants.defaultHeartbeatInterval * 2,
       );
 
       final customSocket = RealtimeClient(
         socketEndpoint,
-        heartbeatIntervalMs: 5000,
+        heartbeatInterval: const Duration(seconds: 5),
       );
       expect(
         customSocket.disconnectOnEmptyChannelsAfter,
@@ -1064,7 +1064,7 @@ void main() {
     });
   });
 
-  group('setAuth', () {
+  group('setAccessToken', () {
     final token = generateJwt();
     final updateJoinPayload = {
       'access_token': token,
@@ -1102,7 +1102,7 @@ void main() {
         final channel1 = mockedSocket.channel(tTopic1);
         final channel2 = mockedSocket.channel(tTopic2);
 
-        await mockedSocket.setAuth(token);
+        await mockedSocket.setAccessToken(token);
 
         expect(mockedSocket.accessToken, token);
 
@@ -1165,7 +1165,7 @@ void main() {
           'version': Constants.defaultHeaders['X-Client-Info'],
         };
 
-        await mockedSocket.setAuth(authToken);
+        await mockedSocket.setAccessToken(authToken);
 
         expect(mockedSocket.accessToken, authToken);
 

--- a/packages/realtime_client/test/socket_test_stubs.dart
+++ b/packages/realtime_client/test/socket_test_stubs.dart
@@ -13,7 +13,7 @@ class MockChannel extends Mock implements RealtimeChannel {}
 class MockPush extends Mock implements Push {}
 
 class SocketWithMockedChannel extends RealtimeClient {
-  SocketWithMockedChannel(super.endPoint);
+  SocketWithMockedChannel(super.endpoint);
 
   Map<String, RealtimeChannel> mockedChannelLooker = {};
 

--- a/packages/realtime_client/test/transformers_test.dart
+++ b/packages/realtime_client/test/transformers_test.dart
@@ -252,16 +252,16 @@ void main() {
     });
   });
 
-  group('httpEndpointURL', () {
+  group('httpEndpointUrl', () {
     test('Converts a hosted Supabase WS URL', () {
       expect(
-        httpEndpointURL('wss://example.supabase.co/realtime/v1'),
+        httpEndpointUrl('wss://example.supabase.co/realtime/v1'),
         equals('https://example.supabase.co/realtime/v1'),
       );
     });
     test('Converts a custom domain WS URL', () {
       expect(
-        httpEndpointURL('wss://custom-domain.com/realtime/v1'),
+        httpEndpointUrl('wss://custom-domain.com/realtime/v1'),
         equals('https://custom-domain.com/realtime/v1'),
       );
     });

--- a/packages/realtime_client/test/utils/realtime_test_utils.dart
+++ b/packages/realtime_client/test/utils/realtime_test_utils.dart
@@ -61,8 +61,8 @@ RealtimeClient createRealtimeClient(
   return RealtimeClient(
     localStackRealtimeUrl,
     version: version,
-    params: {'apikey': apikey},
-    heartbeatIntervalMs: 5000,
+    parameters: {'apikey': apikey},
+    heartbeatInterval: const Duration(seconds: 5),
   );
 }
 

--- a/packages/storage_client/lib/src/iceberg/iceberg_rest_catalog.dart
+++ b/packages/storage_client/lib/src/iceberg/iceberg_rest_catalog.dart
@@ -397,7 +397,7 @@ class IcebergRestCatalog {
   ]) async {
     final prefix = await _resolvePrefix();
     final query = <String, String>{
-      if (options?.snapshots != null) 'snapshots': options!.snapshots!.value,
+      if (options?.snapshots != null) 'snapshots': options!.snapshots!.name,
     };
     final response = await _request(
       HttpMethod.get,

--- a/packages/storage_client/lib/src/iceberg/iceberg_types.dart
+++ b/packages/storage_client/lib/src/iceberg/iceberg_types.dart
@@ -1,3 +1,5 @@
+import 'package:supabase_common/supabase_common.dart';
+
 /// Identifies a table by its namespace and name.
 class TableIdentifier {
   /// The multi level namespace the table belongs to.
@@ -69,14 +71,7 @@ enum AccessDelegation {
 }
 
 /// Which snapshots the server should include when loading a table.
-enum TableSnapshotScope {
-  all('all'),
-  refs('refs');
-
-  const TableSnapshotScope(this.value);
-
-  final String value;
-}
+enum TableSnapshotScope { all, refs }
 
 /// A type in the Iceberg type system. Either a [PrimitiveType] represented by
 /// a type string, or one of the nested types [StructType], [ListType] and
@@ -121,7 +116,7 @@ class TableField {
   final String name;
   final IcebergType type;
   final bool required;
-  final String? doc;
+  final String? documentation;
   final Object? initialDefault;
   final Object? writeDefault;
 
@@ -130,7 +125,7 @@ class TableField {
     required this.name,
     required this.type,
     required this.required,
-    this.doc,
+    this.documentation,
     this.initialDefault,
     this.writeDefault,
   });
@@ -141,7 +136,7 @@ class TableField {
       name: json['name'] as String,
       type: IcebergType.fromJson(json['type'] as Object),
       required: json['required'] as bool,
-      doc: json['doc'] as String?,
+      documentation: json['doc'] as String?,
       initialDefault: json['initial-default'],
       writeDefault: json['write-default'],
     );
@@ -152,7 +147,7 @@ class TableField {
     'name': name,
     'type': type.toJson(),
     'required': required,
-    'doc': ?doc,
+    'doc': ?documentation,
     'initial-default': ?initialDefault,
     'write-default': ?writeDefault,
   };
@@ -277,7 +272,7 @@ class TableSchema {
   };
 }
 
-/// A single field of a [PartitionSpec].
+/// A single field of a [PartitionSpecification].
 class PartitionField {
   final int sourceId;
   final int? fieldId;
@@ -309,15 +304,15 @@ class PartitionField {
 }
 
 /// Describes how a table is partitioned.
-class PartitionSpec {
-  final int? specId;
+class PartitionSpecification {
+  final int? specificationId;
   final List<PartitionField> fields;
 
-  const PartitionSpec({required this.fields, this.specId});
+  const PartitionSpecification({required this.fields, this.specificationId});
 
-  factory PartitionSpec.fromJson(Map<String, dynamic> json) {
-    return PartitionSpec(
-      specId: json['spec-id'] as int?,
+  factory PartitionSpecification.fromJson(Map<String, dynamic> json) {
+    return PartitionSpecification(
+      specificationId: json['spec-id'] as int?,
       fields: (json['fields'] as List)
           .map(
             (field) => PartitionField.fromJson(field as Map<String, dynamic>),
@@ -327,7 +322,7 @@ class PartitionSpec {
   }
 
   Map<String, dynamic> toJson() => {
-    'spec-id': ?specId,
+    'spec-id': ?specificationId,
     'fields': fields.map((field) => field.toJson()).toList(),
   };
 }
@@ -389,15 +384,15 @@ class SortOrder {
 class SnapshotReference {
   final SnapshotReferenceType type;
   final int snapshotId;
-  final int? maxReferenceAgeMs;
-  final int? maxSnapshotAgeMs;
+  final Duration? maxReferenceAge;
+  final Duration? maxSnapshotAge;
   final int? minSnapshotsToKeep;
 
   const SnapshotReference({
     required this.type,
     required this.snapshotId,
-    this.maxReferenceAgeMs,
-    this.maxSnapshotAgeMs,
+    this.maxReferenceAge,
+    this.maxSnapshotAge,
     this.minSnapshotsToKeep,
   });
 
@@ -405,8 +400,11 @@ class SnapshotReference {
     return SnapshotReference(
       type: SnapshotReferenceType.fromValue(json['type'] as String),
       snapshotId: json['snapshot-id'] as int,
-      maxReferenceAgeMs: json['max-ref-age-ms'] as int?,
-      maxSnapshotAgeMs: json['max-snapshot-age-ms'] as int?,
+      maxReferenceAge: tryParseMillisecondsDuration(json, 'max-ref-age-ms'),
+      maxSnapshotAge: tryParseMillisecondsDuration(
+        json,
+        'max-snapshot-age-ms',
+      ),
       minSnapshotsToKeep: json['min-snapshots-to-keep'] as int?,
     );
   }
@@ -414,8 +412,8 @@ class SnapshotReference {
   Map<String, dynamic> toJson() => {
     'type': type.value,
     'snapshot-id': snapshotId,
-    'max-ref-age-ms': ?maxReferenceAgeMs,
-    'max-snapshot-age-ms': ?maxSnapshotAgeMs,
+    'max-ref-age-ms': ?maxReferenceAge?.inMilliseconds,
+    'max-snapshot-age-ms': ?maxSnapshotAge?.inMilliseconds,
     'min-snapshots-to-keep': ?minSnapshotsToKeep,
   };
 }
@@ -425,14 +423,14 @@ class Snapshot {
   final int snapshotId;
   final int? parentSnapshotId;
   final int? sequenceNumber;
-  final int timestampMs;
+  final DateTime timestamp;
   final String manifestList;
   final Map<String, String> summary;
   final int? schemaId;
 
   const Snapshot({
     required this.snapshotId,
-    required this.timestampMs,
+    required this.timestamp,
     required this.manifestList,
     required this.summary,
     this.parentSnapshotId,
@@ -445,7 +443,7 @@ class Snapshot {
       snapshotId: json['snapshot-id'] as int,
       parentSnapshotId: json['parent-snapshot-id'] as int?,
       sequenceNumber: json['sequence-number'] as int?,
-      timestampMs: json['timestamp-ms'] as int,
+      timestamp: parseUnixMilliseconds(json, 'timestamp-ms'),
       manifestList: json['manifest-list'] as String,
       summary: Map.from(json['summary'] as Map? ?? const {}),
       schemaId: json['schema-id'] as int?,
@@ -456,7 +454,7 @@ class Snapshot {
     'snapshot-id': snapshotId,
     'parent-snapshot-id': ?parentSnapshotId,
     'sequence-number': ?sequenceNumber,
-    'timestamp-ms': timestampMs,
+    'timestamp-ms': timestamp.millisecondsSinceEpoch,
     'manifest-list': manifestList,
     'summary': summary,
     'schema-id': ?schemaId,
@@ -469,55 +467,59 @@ class TableMetadata {
   final int formatVersion;
   final String tableUuid;
   final String? location;
-  final int? lastUpdatedMs;
+  final DateTime? lastUpdated;
   final int? lastColumnId;
   final List<TableSchema> schemas;
   final int currentSchemaId;
-  final List<PartitionSpec> partitionSpecs;
-  final int? defaultSpecId;
+  final List<PartitionSpecification> partitionSpecifications;
+  final int? defaultSpecificationId;
   final List<SortOrder> sortOrders;
   final int? defaultSortOrderId;
   final Map<String, String> properties;
   final String? metadataLocation;
   final int? currentSnapshotId;
   final List<Snapshot> snapshots;
-  final Map<String, SnapshotReference>? refs;
+  final Map<String, SnapshotReference>? references;
 
   const TableMetadata({
     required this.formatVersion,
     required this.tableUuid,
     required this.schemas,
     required this.currentSchemaId,
-    required this.partitionSpecs,
+    required this.partitionSpecifications,
     required this.sortOrders,
     required this.properties,
     this.location,
-    this.lastUpdatedMs,
+    this.lastUpdated,
     this.lastColumnId,
-    this.defaultSpecId,
+    this.defaultSpecificationId,
     this.defaultSortOrderId,
     this.metadataLocation,
     this.currentSnapshotId,
     this.snapshots = const [],
-    this.refs,
+    this.references,
   });
 
   factory TableMetadata.fromJson(Map<String, dynamic> json) {
-    final refs = json['refs'] as Map<String, dynamic>?;
+    final references = json['refs'] as Map<String, dynamic>?;
     return TableMetadata(
       formatVersion: json['format-version'] as int,
       tableUuid: json['table-uuid'] as String,
       location: json['location'] as String?,
-      lastUpdatedMs: json['last-updated-ms'] as int?,
+      lastUpdated: tryParseUnixMilliseconds(json, 'last-updated-ms'),
       lastColumnId: json['last-column-id'] as int?,
       schemas: (json['schemas'] as List? ?? [])
           .map((schema) => TableSchema.fromJson(schema as Map<String, dynamic>))
           .toList(),
       currentSchemaId: json['current-schema-id'] as int,
-      partitionSpecs: (json['partition-specs'] as List? ?? [])
-          .map((spec) => PartitionSpec.fromJson(spec as Map<String, dynamic>))
+      partitionSpecifications: (json['partition-specs'] as List? ?? [])
+          .map(
+            (specification) => PartitionSpecification.fromJson(
+              specification as Map<String, dynamic>,
+            ),
+          )
           .toList(),
-      defaultSpecId: json['default-spec-id'] as int?,
+      defaultSpecificationId: json['default-spec-id'] as int?,
       sortOrders: (json['sort-orders'] as List? ?? [])
           .map((order) => SortOrder.fromJson(order as Map<String, dynamic>))
           .toList(),
@@ -532,7 +534,7 @@ class TableMetadata {
             (snapshot) => Snapshot.fromJson(snapshot as Map<String, dynamic>),
           )
           .toList(),
-      refs: refs?.map(
+      references: references?.map(
         (key, value) => MapEntry(
           key,
           SnapshotReference.fromJson(value as Map<String, dynamic>),
@@ -611,7 +613,7 @@ class CreateTableRequest {
   final String name;
   final TableSchema schema;
   final String? location;
-  final PartitionSpec? partitionSpec;
+  final PartitionSpecification? partitionSpecification;
   final SortOrder? writeOrder;
   final Map<String, String>? properties;
   final bool? stageCreate;
@@ -620,7 +622,7 @@ class CreateTableRequest {
     required this.name,
     required this.schema,
     this.location,
-    this.partitionSpec,
+    this.partitionSpecification,
     this.writeOrder,
     this.properties,
     this.stageCreate,
@@ -630,7 +632,7 @@ class CreateTableRequest {
     'name': name,
     'schema': schema.toJson(),
     'location': ?location,
-    'partition-spec': ?partitionSpec?.toJson(),
+    'partition-spec': ?partitionSpecification?.toJson(),
     'write-order': ?writeOrder?.toJson(),
     'properties': ?properties,
     'stage-create': ?stageCreate,

--- a/packages/storage_client/lib/src/iceberg/table_requirement.dart
+++ b/packages/storage_client/lib/src/iceberg/table_requirement.dart
@@ -72,15 +72,15 @@ class AssertLastAssignedPartitionId extends TableRequirement {
   };
 }
 
-class AssertDefaultSpecId extends TableRequirement {
-  final int defaultSpecId;
+class AssertDefaultSpecificationId extends TableRequirement {
+  final int defaultSpecificationId;
 
-  const AssertDefaultSpecId(this.defaultSpecId);
+  const AssertDefaultSpecificationId(this.defaultSpecificationId);
 
   @override
   Map<String, dynamic> toJson() => {
     'type': 'assert-default-spec-id',
-    'default-spec-id': defaultSpecId,
+    'default-spec-id': defaultSpecificationId,
   };
 }
 

--- a/packages/storage_client/lib/src/iceberg/table_update.dart
+++ b/packages/storage_client/lib/src/iceberg/table_update.dart
@@ -70,27 +70,27 @@ class SetCurrentSchemaUpdate extends TableUpdate {
   };
 }
 
-class AddPartitionSpecUpdate extends TableUpdate {
-  final PartitionSpec spec;
+class AddPartitionSpecificationUpdate extends TableUpdate {
+  final PartitionSpecification specification;
 
-  const AddPartitionSpecUpdate(this.spec);
+  const AddPartitionSpecificationUpdate(this.specification);
 
   @override
   Map<String, dynamic> toJson() => {
     'action': 'add-spec',
-    'spec': spec.toJson(),
+    'spec': specification.toJson(),
   };
 }
 
-class SetDefaultSpecUpdate extends TableUpdate {
-  final int specId;
+class SetDefaultSpecificationUpdate extends TableUpdate {
+  final int specificationId;
 
-  const SetDefaultSpecUpdate(this.specId);
+  const SetDefaultSpecificationUpdate(this.specificationId);
 
   @override
   Map<String, dynamic> toJson() => {
     'action': 'set-default-spec',
-    'spec-id': specId,
+    'spec-id': specificationId,
   };
 }
 
@@ -154,15 +154,15 @@ class RemovePropertiesUpdate extends TableUpdate {
   };
 }
 
-class RemovePartitionSpecsUpdate extends TableUpdate {
-  final List<int> specIds;
+class RemovePartitionSpecificationsUpdate extends TableUpdate {
+  final List<int> specificationIds;
 
-  const RemovePartitionSpecsUpdate(this.specIds);
+  const RemovePartitionSpecificationsUpdate(this.specificationIds);
 
   @override
   Map<String, dynamic> toJson() => {
     'action': 'remove-partition-specs',
-    'spec-ids': specIds,
+    'spec-ids': specificationIds,
   };
 }
 

--- a/packages/storage_client/lib/src/storage_client.dart
+++ b/packages/storage_client/lib/src/storage_client.dart
@@ -150,7 +150,7 @@ class SupabaseStorageClient extends StorageBucketApi {
     storageFetch,
   );
 
-  void setAuth(String jwt) {
+  void setAccessToken(String jwt) {
     headers['Authorization'] = 'Bearer $jwt';
   }
 

--- a/packages/storage_client/lib/src/storage_file_api.dart
+++ b/packages/storage_client/lib/src/storage_file_api.dart
@@ -403,7 +403,7 @@ class StorageFileApi {
       '$url/object/sign/$finalPath',
       {
         'expiresIn': expiresIn,
-        'transform': ?transform?.toQueryParams,
+        'transform': ?transform?.toQueryParameters,
       },
       options: options,
     );
@@ -484,20 +484,20 @@ class StorageFileApi {
   /// [transform] downloads a transformed variant of the image with the provided
   /// options
   ///
-  /// [queryParams] additional query parameters to be added to the URL
+  /// [queryParameters] additional query parameters to be added to the URL
   ///
   /// [cacheNonce] adds a `cacheNonce` query parameter to bypass CDN caching for
   /// a specific file version.
   Future<Uint8List> download(
     String path, {
     TransformOptions? transform,
-    Map<String, String>? queryParams,
+    Map<String, String>? queryParameters,
     String? cacheNonce,
   }) async {
     final fetchUrl = _downloadUri(
       path,
       transform: transform,
-      queryParams: queryParams,
+      queryParameters: queryParameters,
       cacheNonce: cacheNonce,
     );
 
@@ -510,21 +510,22 @@ class StorageFileApi {
 
   /// Builds the download URL shared by [download] and [downloadStream],
   /// selecting the render endpoint when an image transformation is requested
-  /// and appending transform, [queryParams] and [cacheNonce] query parameters.
+  /// and appending transform, [queryParameters] and [cacheNonce] query
+  /// parameters.
   Uri _downloadUri(
     String path, {
     TransformOptions? transform,
-    Map<String, String>? queryParams,
+    Map<String, String>? queryParameters,
     String? cacheNonce,
   }) {
-    final transformationQuery = transform?.toQueryParams ?? {};
+    final transformationQuery = transform?.toQueryParameters ?? {};
     final renderPath = transformationQuery.isNotEmpty
         ? 'render/image/authenticated'
         : 'object';
 
     final query = {
       ...transformationQuery,
-      ...?queryParams,
+      ...?queryParameters,
       'cacheNonce': ?cacheNonce,
     };
 
@@ -547,20 +548,20 @@ class StorageFileApi {
   /// [transform] downloads a transformed variant of the image with the provided
   /// options.
   ///
-  /// [queryParams] additional query parameters to be added to the URL.
+  /// [queryParameters] additional query parameters to be added to the URL.
   ///
   /// [cacheNonce] adds a `cacheNonce` query parameter to bypass CDN caching for
   /// a specific file version.
   Stream<Uint8List> downloadStream(
     String path, {
     TransformOptions? transform,
-    Map<String, String>? queryParams,
+    Map<String, String>? queryParameters,
     String? cacheNonce,
   }) {
     final fetchUrl = _downloadUri(
       path,
       transform: transform,
-      queryParams: queryParams,
+      queryParameters: queryParameters,
       cacheNonce: cacheNonce,
     );
 
@@ -571,7 +572,7 @@ class StorageFileApi {
   }
 
   /// Retrieves the details of an existing file
-  Future<FileObjectV2> info(String path) async {
+  Future<FileObjectV2> getMetadata(String path) async {
     final finalPath = _getFinalPath(path);
     final options = _fetchOptions;
     final response = await _storageFetch.get(
@@ -622,7 +623,7 @@ class StorageFileApi {
   }) {
     final finalPath = _getFinalPath(path);
 
-    final transformationQuery = transform?.toQueryParams;
+    final transformationQuery = transform?.toQueryParameters;
     final wantsTransformation =
         transformationQuery != null && transformationQuery.isNotEmpty;
     final renderPath = wantsTransformation ? 'render/image' : 'object';

--- a/packages/storage_client/lib/src/types.dart
+++ b/packages/storage_client/lib/src/types.dart
@@ -701,7 +701,7 @@ class TransformOptions {
 
   /// The transformation options as `transform` query parameters.
   @internal
-  Map<String, String> get toQueryParams {
+  Map<String, String> get toQueryParameters {
     return {
       if (width != null) 'width': '$width',
       if (height != null) 'height': '$height',

--- a/packages/storage_client/lib/src/vector_types.dart
+++ b/packages/storage_client/lib/src/vector_types.dart
@@ -62,14 +62,14 @@ class VectorBucketEncryption {
   final String? kmsKeyArn;
 
   /// The server-side encryption type applied to the bucket.
-  final String? sseType;
+  final String? serverSideEncryptionType;
 
-  const VectorBucketEncryption({this.kmsKeyArn, this.sseType});
+  const VectorBucketEncryption({this.kmsKeyArn, this.serverSideEncryptionType});
 
   factory VectorBucketEncryption.fromJson(Map<String, dynamic> json) {
     return VectorBucketEncryption(
       kmsKeyArn: json['kmsKeyArn'] as String?,
-      sseType: json['sseType'] as String?,
+      serverSideEncryptionType: json['sseType'] as String?,
     );
   }
 }

--- a/packages/storage_client/test/basic_test.dart
+++ b/packages/storage_client/test/basic_test.dart
@@ -493,7 +493,7 @@ void main() {
 
       final response = await client
           .from('public_bucket')
-          .download('b.txt', queryParams: {'version': '1'});
+          .download('b.txt', queryParameters: {'version': '1'});
       expect(response, isA<Uint8List>());
       expect(String.fromCharCodes(response), 'Updated content');
 

--- a/packages/storage_client/test/client_test.dart
+++ b/packages/storage_client/test/client_test.dart
@@ -636,7 +636,7 @@ void main() {
           ),
         );
 
-    final objectMetadata = await storage.from(newBucketName).info(path);
+    final objectMetadata = await storage.from(newBucketName).getMetadata(path);
     expect(objectMetadata.metadata, metadata);
   });
 

--- a/packages/storage_client/test/iceberg_test.dart
+++ b/packages/storage_client/test/iceberg_test.dart
@@ -341,7 +341,7 @@ void main() {
         CreateTableRequest(
           name: 'events',
           schema: schema(),
-          partitionSpec: const PartitionSpec(
+          partitionSpecification: const PartitionSpecification(
             fields: [
               PartitionField(
                 sourceId: 1,
@@ -686,7 +686,10 @@ void main() {
       expect(snapshot.snapshotId, 42);
       expect(snapshot.parentSnapshotId, 41);
       expect(snapshot.sequenceNumber, 3);
-      expect(snapshot.timestampMs, 1700000000000);
+      expect(
+        snapshot.timestamp,
+        DateTime.fromMillisecondsSinceEpoch(1700000000000, isUtc: true),
+      );
       expect(snapshot.manifestList, 's3://bucket/manifest-list.avro');
       expect(snapshot.summary['operation'], 'append');
       expect(snapshot.schemaId, 0);

--- a/packages/storage_client/test/types_test.dart
+++ b/packages/storage_client/test/types_test.dart
@@ -388,7 +388,7 @@ void main() {
     );
   });
 
-  group('TransformOptions.toQueryParams', () {
+  group('TransformOptions.toQueryParameters', () {
     test('omits null values and snake-cases the resize mode', () {
       const options = TransformOptions(
         width: 100,
@@ -398,7 +398,7 @@ void main() {
         format: RequestImageFormat.origin,
       );
 
-      expect(options.toQueryParams, {
+      expect(options.toQueryParameters, {
         'width': '100',
         'height': '200',
         'resize': 'cover',
@@ -409,7 +409,7 @@ void main() {
 
     test('is empty when nothing is set', () {
       const options = TransformOptions();
-      expect(options.toQueryParams, isEmpty);
+      expect(options.toQueryParameters, isEmpty);
     });
   });
 

--- a/packages/storage_client/test/vector_test.dart
+++ b/packages/storage_client/test/vector_test.dart
@@ -61,7 +61,7 @@ void main() {
         bucket.creationTime,
         DateTime.fromMillisecondsSinceEpoch(1700000000 * 1000, isUtc: true),
       );
-      expect(bucket.encryption?.sseType, 'AES256');
+      expect(bucket.encryption?.serverSideEncryptionType, 'AES256');
     });
 
     test('listBuckets sends filters and parses buckets and cursor', () async {

--- a/packages/supabase/lib/src/supabase_client.dart
+++ b/packages/supabase/lib/src/supabase_client.dart
@@ -259,9 +259,9 @@ class SupabaseClient {
   /// Creates a Realtime channel with Broadcast, Presence, and Postgres Changes.
   RealtimeChannel channel(
     String name, {
-    RealtimeChannelConfig opts = const RealtimeChannelConfig(),
+    RealtimeChannelConfig options = const RealtimeChannelConfig(),
   }) {
-    return realtime.channel(name, opts);
+    return realtime.channel(name, options);
   }
 
   /// Returns all Realtime channels.
@@ -378,7 +378,7 @@ class SupabaseClient {
   }) {
     return RealtimeClient(
       _realtimeUrl,
-      params: {
+      parameters: {
         'apikey': _supabaseKey,
       },
       headers: {'apikey': _supabaseKey, ...headers},
@@ -422,7 +422,7 @@ class SupabaseClient {
         event == AuthChangeEvent.tokenRefreshed ||
         event == AuthChangeEvent.signedIn) {
       try {
-        await realtime.setAuth(token);
+        await realtime.setAccessToken(token);
       } on FormatException catch (error) {
         if (error.message.contains('InvalidJWTToken')) {
           // The exception is thrown by RealtimeClient when the token is
@@ -435,7 +435,7 @@ class SupabaseClient {
     } else if (event == AuthChangeEvent.signedOut) {
       // Token is removed
 
-      await realtime.setAuth(_supabaseKey);
+      await realtime.setAccessToken(_supabaseKey);
     }
   }
 }

--- a/packages/supabase_auth/lib/src/auth_admin_api.dart
+++ b/packages/supabase_auth/lib/src/auth_admin_api.dart
@@ -257,11 +257,11 @@ class AuthAdminApi {
   }
 
   /// Gets the user by their id.
-  Future<UserResponse> getUserById(String uid) async {
-    validateUuid(uid);
+  Future<UserResponse> getUserById(String userId) async {
+    validateUuid(userId);
     final options = AuthRequestOptions(headers: _headers);
     final response = await _fetch.request(
-      '$_url/admin/users/$uid',
+      '$_url/admin/users/$userId',
       HttpMethod.get,
       options: options,
     );
@@ -270,14 +270,14 @@ class AuthAdminApi {
 
   /// Updates the user data.
   Future<UserResponse> updateUserById(
-    String uid, {
+    String userId, {
     required AdminUserAttributes attributes,
   }) async {
-    validateUuid(uid);
+    validateUuid(userId);
     final body = attributes.toJson();
     final options = AuthRequestOptions(headers: _headers, body: body);
     final response = await _fetch.request(
-      '$_url/admin/users/$uid',
+      '$_url/admin/users/$userId',
       HttpMethod.put,
       options: options,
     );

--- a/packages/supabase_auth/lib/src/auth_admin_custom_providers_api.dart
+++ b/packages/supabase_auth/lib/src/auth_admin_custom_providers_api.dart
@@ -58,14 +58,14 @@ class AuthAdminCustomProvidersApi {
   /// This function should only be called on a server. Never expose your
   /// `service_role` key in the browser.
   Future<CustomOAuthProvider> createProvider(
-    CreateCustomProviderParams params,
+    CreateCustomProviderOptions options,
   ) async {
     final data = await _fetch.request(
       '$_url/admin/custom-providers',
       HttpMethod.post,
       options: AuthRequestOptions(
         headers: _headers,
-        body: params.toJson(),
+        body: options.toJson(),
       ),
     );
 
@@ -99,14 +99,14 @@ class AuthAdminCustomProvidersApi {
   /// `service_role` key in the browser.
   Future<CustomOAuthProvider> updateProvider(
     String identifier,
-    UpdateCustomProviderParams params,
+    UpdateCustomProviderOptions options,
   ) async {
     final data = await _fetch.request(
       '$_url/admin/custom-providers/$identifier',
       HttpMethod.put,
       options: AuthRequestOptions(
         headers: _headers,
-        body: params.toJson(),
+        body: options.toJson(),
       ),
     );
 

--- a/packages/supabase_auth/lib/src/auth_admin_oauth_api.dart
+++ b/packages/supabase_auth/lib/src/auth_admin_oauth_api.dart
@@ -25,14 +25,14 @@ class OAuthClientResponse {
 @internal
 class OAuthClientListResponse {
   final List<OAuthClient> clients;
-  final String? aud;
+  final String? audience;
   final int? nextPage;
   final int? lastPage;
   final int total;
 
   const OAuthClientListResponse({
     required this.clients,
-    this.aud,
+    this.audience,
     this.nextPage,
     this.lastPage,
     this.total = 0,
@@ -43,7 +43,7 @@ class OAuthClientListResponse {
       clients: (json['clients'] as List)
           .map((e) => OAuthClient.fromJson(e as Map<String, dynamic>))
           .toList(),
-      aud: json['aud'] as String?,
+      audience: json['aud'] as String?,
       nextPage: json['nextPage'] as int?,
       lastPage: json['lastPage'] as int?,
       total: json['total'] as int? ?? 0,
@@ -96,14 +96,14 @@ class AuthAdminOAuthApi {
   /// This function should only be called on a server. Never expose your
   /// `secret` key in the browser.
   Future<OAuthClientResponse> createClient(
-    CreateOAuthClientParams params,
+    CreateOAuthClientOptions options,
   ) async {
     final data = await _fetch.request(
       '$_url/admin/oauth/clients',
       HttpMethod.post,
       options: AuthRequestOptions(
         headers: _headers,
-        body: params.toJson(),
+        body: options.toJson(),
       ),
     );
 
@@ -136,7 +136,7 @@ class AuthAdminOAuthApi {
   /// `secret` key in the browser.
   Future<OAuthClientResponse> updateClient(
     String clientId,
-    UpdateOAuthClientParams params,
+    UpdateOAuthClientOptions options,
   ) async {
     validateUuid(clientId);
 
@@ -145,7 +145,7 @@ class AuthAdminOAuthApi {
       HttpMethod.put,
       options: AuthRequestOptions(
         headers: _headers,
-        body: params.toJson(),
+        body: options.toJson(),
       ),
     );
 

--- a/packages/supabase_auth/lib/src/auth_client.dart
+++ b/packages/supabase_auth/lib/src/auth_client.dart
@@ -416,14 +416,14 @@ class AuthClient {
     required OAuthProvider provider,
     String? redirectTo,
     String? scopes,
-    Map<String, String>? queryParams,
+    Map<String, String>? queryParameters,
   }) {
     return _getUrlForProvider(
       provider,
       url: '$_url/authorize',
       redirectTo: redirectTo,
       scopes: scopes,
-      queryParameters: queryParams,
+      queryParameters: queryParameters,
     );
   }
 
@@ -447,7 +447,7 @@ class AuthClient {
     }
     final codeVerifier = codeVerifierRawString.split('/').first;
     final eventName = codeVerifierRawString.split('/').last;
-    final redirectType = AuthChangeEvent.fromString(eventName);
+    final redirectType = AuthChangeEvent.fromValue(eventName);
 
     final Map<String, dynamic> response = await _fetch.request(
       '$_url/token',
@@ -988,7 +988,7 @@ class AuthClient {
 
     // Throws AuthInvalidJwtException if the token is malformed.
     final decoded = decodeJwt(accessToken);
-    final expiresAt = decoded.payload.exp;
+    final expiresAt = decoded.payload.expiresAt;
     final hasExpired =
         expiresAt == null ||
         expiresAt <= timeNow + Constants.expiryMargin.inSeconds;
@@ -1003,7 +1003,7 @@ class AuthClient {
       throw AuthSessionMissingException();
     }
 
-    final issuedAt = decoded.payload.iat;
+    final issuedAt = decoded.payload.issuedAt;
     final session = Session(
       accessToken: accessToken,
       refreshToken: refreshToken,
@@ -1252,14 +1252,14 @@ class AuthClient {
     OAuthProvider provider, {
     String? redirectTo,
     String? scopes,
-    Map<String, String>? queryParams,
+    Map<String, String>? queryParameters,
   }) async {
     final urlResponse = await _getUrlForProvider(
       provider,
       url: '$_url/user/identities/authorize',
       redirectTo: redirectTo,
       scopes: scopes,
-      queryParameters: queryParams,
+      queryParameters: queryParameters,
       skipBrowserRedirect: true,
     );
     final response = await _fetch.request(
@@ -1289,8 +1289,8 @@ class AuthClient {
   }
 
   /// Set the initial session to the session obtained from local storage
-  Future<void> setInitialSession(String jsonStr) async {
-    final session = Session.fromJson(json.decode(jsonStr));
+  Future<void> setInitialSession(String jsonString) async {
+    final session = Session.fromJson(json.decode(jsonString));
     if (session == null) {
       // sign out to delete the local storage from supabase_flutter
       await _signOut(
@@ -1310,10 +1310,10 @@ class AuthClient {
   }
 
   /// Recover session from stringified [Session].
-  Future<AuthResponse> recoverSession(String jsonStr) async {
+  Future<AuthResponse> recoverSession(String jsonString) async {
     final String refreshToken;
     try {
-      final session = Session.fromJson(json.decode(jsonStr));
+      final session = Session.fromJson(json.decode(jsonString));
       if (session == null) {
         _log.warning("Can't recover session from string, session is null");
         await _signOut(
@@ -1433,8 +1433,7 @@ class AuthClient {
         await _callRefreshToken(refreshToken);
       }
     } catch (error) {
-      // Do nothing. JS client prints here, but error is already tracked via
-      // [notifyException]
+      // Do nothing, the error is already tracked via [notifyException].
     }
   }
 
@@ -1522,7 +1521,6 @@ class AuthClient {
 
   void _mayStartBroadcastChannel() {
     if (const bool.fromEnvironment('dart.library.js_interop')) {
-      // Used by the js library as well
       final broadcastKey = defaultPersistSessionKey(_url);
 
       assert(
@@ -1537,21 +1535,7 @@ class AuthClient {
           final rawEvent = messageEvent['event'];
           _log.finest('Received broadcast message: $messageEvent');
           _log.info('Received broadcast event: $rawEvent');
-          final event = switch (rawEvent) {
-            // This library sends the js name of the event to be compatible with
-            // the js library, so we need to convert it back to the dart name
-            'INITIAL_SESSION' => AuthChangeEvent.initialSession,
-            'PASSWORD_RECOVERY' => AuthChangeEvent.passwordRecovery,
-            'SIGNED_IN' => AuthChangeEvent.signedIn,
-            'SIGNED_OUT' => AuthChangeEvent.signedOut,
-            'TOKEN_REFRESHED' => AuthChangeEvent.tokenRefreshed,
-            'USER_UPDATED' => AuthChangeEvent.userUpdated,
-            'MFA_CHALLENGE_VERIFIED' => AuthChangeEvent.mfaChallengeVerified,
-            // This case should never happen though
-            _ => AuthChangeEvent.values.firstWhereOrNull(
-              (changeEvent) => changeEvent.name == rawEvent,
-            ),
-          };
+          final event = AuthChangeEvent.fromValue(rawEvent);
 
           if (event != null) {
             Session? session;
@@ -1713,7 +1697,7 @@ class AuthClient {
     session ??= currentSession;
     if (broadcast && event != AuthChangeEvent.initialSession) {
       _broadcastChannel?.postMessage({
-        'event': event.jsName,
+        'event': event.value,
         'session': session?.toJson(),
       });
     }
@@ -1741,7 +1725,7 @@ class AuthClient {
 
   Future<JWK?> _fetchJwk(String kid, JWKSet suppliedJwks) async {
     // try fetching from the supplied jwks
-    final jwk = suppliedJwks.keys.firstWhereOrNull((key) => key.kid == kid);
+    final jwk = suppliedJwks.keys.firstWhereOrNull((key) => key.keyId == kid);
     if (jwk != null) {
       return jwk;
     }
@@ -1749,7 +1733,7 @@ class AuthClient {
     final now = DateTime.now();
 
     // try fetching from cache
-    final cachedJwk = _jwks?.keys.firstWhereOrNull((key) => key.kid == kid);
+    final cachedJwk = _jwks?.keys.firstWhereOrNull((key) => key.keyId == kid);
 
     // jwks exists and it isn't stale
     if (cachedJwk != null &&
@@ -1776,7 +1760,7 @@ class AuthClient {
     _jwksCachedAt = now;
 
     // find the signing key
-    return jwks.keys.firstWhereOrNull((key) => key.kid == kid);
+    return jwks.keys.firstWhereOrNull((key) => key.keyId == kid);
   }
 
   /// Extracts the JWT claims present in the access token by first verifying the
@@ -1820,13 +1804,17 @@ class AuthClient {
 
     // Validate expiration unless allowExpired is true
     if (!(options?.allowExpired ?? false)) {
-      validateExp(decoded.payload.exp);
+      validateExpiration(decoded.payload.expiresAt);
     }
 
     final signingKey =
-        (decoded.header.alg.startsWith('HS') || decoded.header.kid == null)
+        (decoded.header.algorithm.startsWith('HS') ||
+            decoded.header.keyId == null)
         ? null
-        : await _fetchJwk(decoded.header.kid!, _jwks ?? JWKSet(keys: []));
+        : await _fetchJwk(
+            decoded.header.keyId!,
+            _jwks ?? JWKSet(keys: []),
+          );
 
     // If symmetric algorithm, fallback to getUser()
     if (signingKey == null) {

--- a/packages/supabase_auth/lib/src/auth_mfa_api.dart
+++ b/packages/supabase_auth/lib/src/auth_mfa_api.dart
@@ -246,7 +246,7 @@ class AuthMFAApi {
     }
 
     final amr = (payload['amr'] as List? ?? [])
-        .map((e) => AMREntry.fromJson(Map.from(e)))
+        .map((e) => AuthenticationMethodReferenceEntry.fromJson(Map.from(e)))
         .toList();
     return AuthMFAGetAuthenticatorAssuranceLevelResponse(
       currentLevel: currentLevel,

--- a/packages/supabase_auth/lib/src/constants.dart
+++ b/packages/supabase_auth/lib/src/constants.dart
@@ -33,21 +33,20 @@ class Constants {
 }
 
 enum AuthChangeEvent {
-  initialSession('INITIAL_SESSION'),
-  passwordRecovery('PASSWORD_RECOVERY'),
-  signedIn('SIGNED_IN'),
-  signedOut('SIGNED_OUT'),
-  tokenRefreshed('TOKEN_REFRESHED'),
-  userUpdated('USER_UPDATED'),
-  mfaChallengeVerified('MFA_CHALLENGE_VERIFIED');
+  initialSession,
+  passwordRecovery,
+  signedIn,
+  signedOut,
+  tokenRefreshed,
+  userUpdated,
+  mfaChallengeVerified;
 
-  final String jsName;
-  const AuthChangeEvent(this.jsName);
+  String get value => snakeCase.toUpperCase();
 
   @internal
-  static AuthChangeEvent? fromString(String? value) {
+  static AuthChangeEvent? fromValue(String? value) {
     for (final event in AuthChangeEvent.values) {
-      if (event.name == value) {
+      if (event.value == value || event.name == value) {
         return event;
       }
     }
@@ -65,7 +64,7 @@ enum GenerateLinkType {
   unknown;
 
   @internal
-  static GenerateLinkType fromString(String? value) {
+  static GenerateLinkType fromValue(String? value) {
     for (final type in GenerateLinkType.values) {
       if (type.snakeCase == value) {
         return type;

--- a/packages/supabase_auth/lib/src/helper.dart
+++ b/packages/supabase_auth/lib/src/helper.dart
@@ -79,12 +79,12 @@ JwtPayload decodeJwtPayload(String token) {
 /// Validates the expiration time of a JWT
 ///
 /// Throws [AuthException] if the exp claim is missing or the JWT has expired.
-void validateExp(int? exp) {
-  if (exp == null) {
+void validateExpiration(int? expiresAt) {
+  if (expiresAt == null) {
     throw AuthException('Missing exp claim');
   }
   final timeNow = DateTime.now().millisecondsSinceEpoch / 1000;
-  if (exp <= timeNow) {
+  if (expiresAt <= timeNow) {
     throw AuthException('JWT has expired');
   }
 }

--- a/packages/supabase_auth/lib/src/types/auth_response.dart
+++ b/packages/supabase_auth/lib/src/types/auth_response.dart
@@ -129,7 +129,7 @@ class GenerateLinkProperties {
       emailOtp = json['email_otp'] ?? '',
       hashedToken = json['hashed_token'] ?? '',
       redirectTo = json['redirect_to'] ?? '',
-      verificationType = GenerateLinkType.fromString(
+      verificationType = GenerateLinkType.fromValue(
         json['verification_type'],
       );
 }

--- a/packages/supabase_auth/lib/src/types/custom_oauth_provider.dart
+++ b/packages/supabase_auth/lib/src/types/custom_oauth_provider.dart
@@ -9,7 +9,7 @@ enum CustomProviderType {
   oauth2,
   oidc;
 
-  static CustomProviderType fromString(String value) {
+  static CustomProviderType fromValue(String value) {
     return CustomProviderType.values.firstWhere((e) => e.name == value);
   }
 }
@@ -32,7 +32,7 @@ class OIDCDiscoveryDocument {
   final String jwksUri;
 
   /// URL of the userinfo endpoint
-  final String? userinfoEndpoint;
+  final String? userInfoEndpoint;
 
   /// URL of the revocation endpoint
   final String? revocationEndpoint;
@@ -47,19 +47,19 @@ class OIDCDiscoveryDocument {
   final List<String>? supportedSubjectTypes;
 
   /// List of supported ID token signing algorithms
-  final List<String>? supportedIdTokenSigningAlgs;
+  final List<String>? supportedIdTokenSigningAlgorithms;
 
   const OIDCDiscoveryDocument({
     required this.issuer,
     required this.authorizationEndpoint,
     required this.tokenEndpoint,
     required this.jwksUri,
-    this.userinfoEndpoint,
+    this.userInfoEndpoint,
     this.revocationEndpoint,
     this.supportedScopes,
     this.supportedResponseTypes,
     this.supportedSubjectTypes,
-    this.supportedIdTokenSigningAlgs,
+    this.supportedIdTokenSigningAlgorithms,
   });
 
   factory OIDCDiscoveryDocument.fromJson(Map<String, dynamic> json) {
@@ -68,13 +68,13 @@ class OIDCDiscoveryDocument {
       authorizationEndpoint: json['authorization_endpoint'] as String,
       tokenEndpoint: json['token_endpoint'] as String,
       jwksUri: json['jwks_uri'] as String,
-      userinfoEndpoint: json['userinfo_endpoint'] as String?,
+      userInfoEndpoint: json['userinfo_endpoint'] as String?,
       revocationEndpoint: json['revocation_endpoint'] as String?,
       supportedScopes: (json['supported_scopes'] as List?)?.cast(),
       supportedResponseTypes: (json['supported_response_types'] as List?)
           ?.cast(),
       supportedSubjectTypes: (json['supported_subject_types'] as List?)?.cast(),
-      supportedIdTokenSigningAlgs:
+      supportedIdTokenSigningAlgorithms:
           (json['supported_id_token_signing_algs'] as List?)?.cast(),
     );
   }
@@ -116,7 +116,7 @@ class CustomOAuthProvider {
   final Map<String, dynamic>? attributeMapping;
 
   /// Additional parameters sent with the authorization request
-  final Map<String, String>? authorizationParams;
+  final Map<String, String>? authorizationParameters;
 
   /// Whether the provider is enabled
   final bool? enabled;
@@ -140,7 +140,7 @@ class CustomOAuthProvider {
   final String? tokenUrl;
 
   /// OAuth2 userinfo URL
-  final String? userinfoUrl;
+  final String? userInfoUrl;
 
   /// JWKS URI for token verification
   final String? jwksUri;
@@ -165,7 +165,7 @@ class CustomOAuthProvider {
     this.customClaimsAllowlist,
     this.pkceEnabled,
     this.attributeMapping,
-    this.authorizationParams,
+    this.authorizationParameters,
     this.enabled,
     this.emailOptional,
     this.issuer,
@@ -173,7 +173,7 @@ class CustomOAuthProvider {
     this.skipNonceCheck,
     this.authorizationUrl,
     this.tokenUrl,
-    this.userinfoUrl,
+    this.userInfoUrl,
     this.jwksUri,
     this.discoveryDocument,
     required this.createdAt,
@@ -184,7 +184,7 @@ class CustomOAuthProvider {
     final discoveryDocument = json['discovery_document'];
     return CustomOAuthProvider(
       id: json['id'] as String,
-      providerType: CustomProviderType.fromString(
+      providerType: CustomProviderType.fromValue(
         json['provider_type'] as String,
       ),
       identifier: json['identifier'] as String,
@@ -195,7 +195,7 @@ class CustomOAuthProvider {
       customClaimsAllowlist: (json['custom_claims_allowlist'] as List?)?.cast(),
       pkceEnabled: json['pkce_enabled'] as bool?,
       attributeMapping: json['attribute_mapping'] as Map<String, dynamic>?,
-      authorizationParams: (json['authorization_params'] as Map?)?.cast(),
+      authorizationParameters: (json['authorization_params'] as Map?)?.cast(),
       enabled: json['enabled'] as bool?,
       emailOptional: json['email_optional'] as bool?,
       issuer: json['issuer'] as String?,
@@ -203,7 +203,7 @@ class CustomOAuthProvider {
       skipNonceCheck: json['skip_nonce_check'] as bool?,
       authorizationUrl: json['authorization_url'] as String?,
       tokenUrl: json['token_url'] as String?,
-      userinfoUrl: json['userinfo_url'] as String?,
+      userInfoUrl: json['userinfo_url'] as String?,
       jwksUri: json['jwks_uri'] as String?,
       discoveryDocument: discoveryDocument == null
           ? null
@@ -217,7 +217,7 @@ class CustomOAuthProvider {
 }
 
 /// Parameters for creating a new custom provider.
-class CreateCustomProviderParams {
+class CreateCustomProviderOptions {
   /// Provider type
   final CustomProviderType providerType;
 
@@ -252,7 +252,7 @@ class CreateCustomProviderParams {
   final Map<String, dynamic>? attributeMapping;
 
   /// Additional parameters sent with the authorization request
-  final Map<String, String>? authorizationParams;
+  final Map<String, String>? authorizationParameters;
 
   /// Whether the provider is enabled
   final bool? enabled;
@@ -276,12 +276,12 @@ class CreateCustomProviderParams {
   final String? tokenUrl;
 
   /// OAuth2 userinfo URL
-  final String? userinfoUrl;
+  final String? userInfoUrl;
 
   /// JWKS URI for token verification
   final String? jwksUri;
 
-  const CreateCustomProviderParams({
+  const CreateCustomProviderOptions({
     required this.providerType,
     required this.identifier,
     required this.name,
@@ -292,7 +292,7 @@ class CreateCustomProviderParams {
     this.customClaimsAllowlist,
     this.pkceEnabled,
     this.attributeMapping,
-    this.authorizationParams,
+    this.authorizationParameters,
     this.enabled,
     this.emailOptional,
     this.issuer,
@@ -300,7 +300,7 @@ class CreateCustomProviderParams {
     this.skipNonceCheck,
     this.authorizationUrl,
     this.tokenUrl,
-    this.userinfoUrl,
+    this.userInfoUrl,
     this.jwksUri,
   });
 
@@ -316,7 +316,7 @@ class CreateCustomProviderParams {
       'custom_claims_allowlist': ?customClaimsAllowlist,
       'pkce_enabled': ?pkceEnabled,
       'attribute_mapping': ?attributeMapping,
-      'authorization_params': ?authorizationParams,
+      'authorization_params': ?authorizationParameters,
       'enabled': ?enabled,
       'email_optional': ?emailOptional,
       'issuer': ?issuer,
@@ -324,7 +324,7 @@ class CreateCustomProviderParams {
       'skip_nonce_check': ?skipNonceCheck,
       'authorization_url': ?authorizationUrl,
       'token_url': ?tokenUrl,
-      'userinfo_url': ?userinfoUrl,
+      'userinfo_url': ?userInfoUrl,
       'jwks_uri': ?jwksUri,
     };
   }
@@ -334,7 +334,7 @@ class CreateCustomProviderParams {
 ///
 /// All fields are optional. Only provided fields will be updated.
 /// `providerType` and `identifier` are immutable and cannot be changed.
-class UpdateCustomProviderParams {
+class UpdateCustomProviderOptions {
   /// Human-readable name
   final String? name;
 
@@ -363,7 +363,7 @@ class UpdateCustomProviderParams {
   final Map<String, dynamic>? attributeMapping;
 
   /// Additional parameters sent with the authorization request
-  final Map<String, String>? authorizationParams;
+  final Map<String, String>? authorizationParameters;
 
   /// Whether the provider is enabled
   final bool? enabled;
@@ -387,12 +387,12 @@ class UpdateCustomProviderParams {
   final String? tokenUrl;
 
   /// OAuth2 userinfo URL
-  final String? userinfoUrl;
+  final String? userInfoUrl;
 
   /// JWKS URI for token verification
   final String? jwksUri;
 
-  const UpdateCustomProviderParams({
+  const UpdateCustomProviderOptions({
     this.name,
     this.clientId,
     this.clientSecret,
@@ -401,7 +401,7 @@ class UpdateCustomProviderParams {
     this.customClaimsAllowlist,
     this.pkceEnabled,
     this.attributeMapping,
-    this.authorizationParams,
+    this.authorizationParameters,
     this.enabled,
     this.emailOptional,
     this.issuer,
@@ -409,7 +409,7 @@ class UpdateCustomProviderParams {
     this.skipNonceCheck,
     this.authorizationUrl,
     this.tokenUrl,
-    this.userinfoUrl,
+    this.userInfoUrl,
     this.jwksUri,
   });
 
@@ -423,7 +423,7 @@ class UpdateCustomProviderParams {
       'custom_claims_allowlist': ?customClaimsAllowlist,
       'pkce_enabled': ?pkceEnabled,
       'attribute_mapping': ?attributeMapping,
-      'authorization_params': ?authorizationParams,
+      'authorization_params': ?authorizationParameters,
       'enabled': ?enabled,
       'email_optional': ?emailOptional,
       'issuer': ?issuer,
@@ -431,7 +431,7 @@ class UpdateCustomProviderParams {
       'skip_nonce_check': ?skipNonceCheck,
       'authorization_url': ?authorizationUrl,
       'token_url': ?tokenUrl,
-      'userinfo_url': ?userinfoUrl,
+      'userinfo_url': ?userInfoUrl,
       'jwks_uri': ?jwksUri,
     };
   }

--- a/packages/supabase_auth/lib/src/types/error_code.dart
+++ b/packages/supabase_auth/lib/src/types/error_code.dart
@@ -95,7 +95,7 @@ enum ErrorCode {
 
   static ErrorCode? fromCode(String code) {
     return ErrorCode.values.firstWhereOrNull(
-      (value) => value.code == code,
+      (errorCode) => errorCode.code == code,
     );
   }
 }

--- a/packages/supabase_auth/lib/src/types/jwt.dart
+++ b/packages/supabase_auth/lib/src/types/jwt.dart
@@ -6,33 +6,33 @@ import 'package:supabase_common/supabase_common.dart';
 /// JWT Header structure
 class JwtHeader {
   /// Algorithm used to sign the JWT (e.g., 'RS256', 'ES256', 'HS256')
-  final String alg;
+  final String algorithm;
 
   /// Key ID - identifies which key was used to sign the JWT
-  final String? kid;
+  final String? keyId;
 
   /// Token type - typically 'JWT'
-  final String? typ;
+  final String? type;
 
   const JwtHeader({
-    required this.alg,
-    this.kid,
-    this.typ,
+    required this.algorithm,
+    this.keyId,
+    this.type,
   });
 
   factory JwtHeader.fromJson(Map<String, dynamic> json) {
     return JwtHeader(
-      alg: json['alg'] as String,
-      kid: json['kid'] as String?,
-      typ: json['typ'] as String?,
+      algorithm: json['alg'] as String,
+      keyId: json['kid'] as String?,
+      type: json['typ'] as String?,
     );
   }
 
   Map<String, dynamic> toJson() {
     return {
-      'alg': alg,
-      'kid': ?kid,
-      'typ': ?typ,
+      'alg': algorithm,
+      'kid': ?keyId,
+      'typ': ?type,
     };
   }
 }
@@ -40,49 +40,49 @@ class JwtHeader {
 /// JWT Payload structure with standard claims
 class JwtPayload {
   /// Issuer - identifies principal that issued the JWT
-  final String? iss;
+  final String? issuer;
 
   /// Subject - identifies the subject of the JWT
-  final String? sub;
+  final String? subject;
 
   /// Audience - identifies recipients that the JWT is intended for
-  final dynamic aud;
+  final dynamic audience;
 
   /// Expiration time - timestamp after which the JWT must not be accepted
-  final int? exp;
+  final int? expiresAt;
 
   /// Not Before - timestamp before which the JWT must not be accepted
-  final int? nbf;
+  final int? notBefore;
 
   /// Issued At - timestamp when the JWT was issued
-  final int? iat;
+  final int? issuedAt;
 
   /// JWT ID - unique identifier for the JWT
-  final String? jti;
+  final String? jwtId;
 
   /// Additional claims stored in the payload
   final Map<String, dynamic> claims;
 
   JwtPayload({
-    this.iss,
-    this.sub,
-    this.aud,
-    this.exp,
-    this.nbf,
-    this.iat,
-    this.jti,
+    this.issuer,
+    this.subject,
+    this.audience,
+    this.expiresAt,
+    this.notBefore,
+    this.issuedAt,
+    this.jwtId,
     Map<String, dynamic>? claims,
   }) : claims = claims ?? {};
 
   factory JwtPayload.fromJson(Map<String, dynamic> json) {
     return JwtPayload(
-      iss: json['iss'] as String?,
-      sub: json['sub'] as String?,
-      aud: json['aud'],
-      exp: json['exp'] as int?,
-      nbf: json['nbf'] as int?,
-      iat: json['iat'] as int?,
-      jti: json['jti'] as String?,
+      issuer: json['iss'] as String?,
+      subject: json['sub'] as String?,
+      audience: json['aud'],
+      expiresAt: json['exp'] as int?,
+      notBefore: json['nbf'] as int?,
+      issuedAt: json['iat'] as int?,
+      jwtId: json['jti'] as String?,
       claims: Map<String, dynamic>.of(json),
     );
   }
@@ -189,39 +189,39 @@ class JWKSet {
 class JWK {
   /// The "kty" (key type) parameter identifies the cryptographic algorithm
   /// family used with the key, such as "RSA" or "EC".
-  final String kty;
+  final String keyType;
 
   /// The "key_ops" (key operations) parameter identifies the cryptographic
   /// operations for which the key is intended to be used.
-  final List<String> keyOps;
+  final List<String> keyOperations;
 
   /// The "alg" (algorithm) parameter identifies the algorithm intended for
   /// use with the key.
-  final String? alg;
+  final String? algorithm;
 
   /// The "kid" (key ID) parameter is used to match a specific key.
-  final String? kid;
+  final String? keyId;
 
   /// Additional arbitrary properties of the JWK.
   final Map<String, dynamic> _additionalProperties;
 
   /// {@macro jwk}
   JWK({
-    required this.kty,
-    required this.keyOps,
-    this.alg,
-    this.kid,
+    required this.keyType,
+    required this.keyOperations,
+    this.algorithm,
+    this.keyId,
     Map<String, dynamic>? additionalProperties,
   }) : _additionalProperties = additionalProperties ?? {};
 
   /// Creates a [JWK] from a JSON map.
   factory JWK.fromJson(Map<String, dynamic> json) {
-    final kty = json['kty'] as String;
-    final keyOps =
+    final keyType = json['kty'] as String;
+    final keyOperations =
         (json['key_ops'] as List<dynamic>?)?.map((e) => e as String).toList() ??
         [];
-    final alg = json['alg'] as String?;
-    final kid = json['kid'] as String?;
+    final algorithm = json['alg'] as String?;
+    final keyId = json['kid'] as String?;
 
     final Map<String, dynamic> additionalProperties = Map.of(json);
     additionalProperties.remove('kty');
@@ -230,30 +230,30 @@ class JWK {
     additionalProperties.remove('kid');
 
     return JWK(
-      kty: kty,
-      keyOps: keyOps,
-      alg: alg,
-      kid: kid,
+      keyType: keyType,
+      keyOperations: keyOperations,
+      algorithm: algorithm,
+      keyId: keyId,
       additionalProperties: additionalProperties,
     );
   }
 
   /// Allows accessing additional properties using operator[].
   dynamic operator [](String key) => switch (key) {
-    'kty' => kty,
-    'key_ops' => keyOps,
-    'alg' => alg,
-    'kid' => kid,
+    'kty' => keyType,
+    'key_ops' => keyOperations,
+    'alg' => algorithm,
+    'kid' => keyId,
     _ => _additionalProperties[key],
   };
 
   /// Converts this [JWK] to a JSON map.
   Map<String, dynamic> toJson() {
     return {
-      'kty': kty,
-      'key_ops': keyOps,
-      'alg': ?alg,
-      'kid': ?kid,
+      'kty': keyType,
+      'key_ops': keyOperations,
+      'alg': ?algorithm,
+      'kid': ?keyId,
       ..._additionalProperties,
     };
   }

--- a/packages/supabase_auth/lib/src/types/mfa.dart
+++ b/packages/supabase_auth/lib/src/types/mfa.dart
@@ -358,7 +358,7 @@ class AuthMFAGetAuthenticatorAssuranceLevelResponse {
   ///
   /// Use the information here to detect the last time a user verified a factor,
   /// for example if implementing a step-up scenario.
-  final List<AMREntry> currentAuthenticationMethods;
+  final List<AuthenticationMethodReferenceEntry> currentAuthenticationMethods;
 
   const AuthMFAGetAuthenticatorAssuranceLevelResponse({
     required this.currentLevel,
@@ -367,12 +367,12 @@ class AuthMFAGetAuthenticatorAssuranceLevelResponse {
   });
 }
 
-enum AMRMethod {
+enum AuthenticationMethodReference {
   password('password'),
   otp('otp'),
   oauth('oauth'),
   totp('totp'),
-  magiclink('magiclink'),
+  magicLink('magiclink'),
   recovery('recovery'),
   invite('invite'),
   ssoSaml('sso/saml'),
@@ -385,8 +385,8 @@ enum AMRMethod {
   passkey('passkey'),
   unknown('unknown');
 
-  final String code;
-  const AMRMethod(this.code);
+  final String value;
+  const AuthenticationMethodReference(this.value);
 }
 
 /// An authentication method reference (AMR) entry.
@@ -396,20 +396,25 @@ enum AMRMethod {
 ///
 /// see [AuthMFAApi.getAuthenticatorAssuranceLevel].
 ///
-class AMREntry {
+class AuthenticationMethodReferenceEntry {
   /// authentication method name
-  final AMRMethod method;
+  final AuthenticationMethodReference method;
 
   /// Timestamp when the method was successfully used.
   final DateTime timestamp;
 
-  const AMREntry({required this.method, required this.timestamp});
+  const AuthenticationMethodReferenceEntry({
+    required this.method,
+    required this.timestamp,
+  });
 
-  factory AMREntry.fromJson(Map<String, dynamic> json) {
-    return AMREntry(
-      method: AMRMethod.values.firstWhere(
-        (e) => e.code == json['method'],
-        orElse: () => AMRMethod.unknown,
+  factory AuthenticationMethodReferenceEntry.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    return AuthenticationMethodReferenceEntry(
+      method: AuthenticationMethodReference.values.firstWhere(
+        (e) => e.value == json['method'],
+        orElse: () => AuthenticationMethodReference.unknown,
       ),
       timestamp: parseUnixSeconds(json, 'timestamp'),
     );

--- a/packages/supabase_auth/lib/src/types/session.dart
+++ b/packages/supabase_auth/lib/src/types/session.dart
@@ -81,7 +81,7 @@ class Session {
 
   DateTime? get _expiresAt {
     try {
-      final expiresAtSeconds = decodeJwtPayload(accessToken).exp;
+      final expiresAtSeconds = decodeJwtPayload(accessToken).expiresAt;
       return expiresAtSeconds == null
           ? null
           : dateTimeFromUnixSeconds(expiresAtSeconds);

--- a/packages/supabase_auth/lib/src/types/types.dart
+++ b/packages/supabase_auth/lib/src/types/types.dart
@@ -110,7 +110,7 @@ enum OAuthClientType {
   public,
   confidential;
 
-  static OAuthClientType fromString(String value) {
+  static OAuthClientType fromValue(String value) {
     return OAuthClientType.values.firstWhere((e) => e.snakeCase == value);
   }
 }
@@ -121,7 +121,7 @@ enum OAuthClientRegistrationType {
   dynamic,
   manual;
 
-  static OAuthClientRegistrationType fromString(String value) {
+  static OAuthClientRegistrationType fromValue(String value) {
     return OAuthClientRegistrationType.values.firstWhere(
       (e) => e.snakeCase == value,
     );
@@ -144,7 +144,7 @@ class OAuthClient {
   final OAuthClientType clientType;
 
   /// Token endpoint authentication method
-  final String tokenEndpointAuthMethod;
+  final String tokenEndpointAuthenticationMethod;
 
   /// Registration type of the client
   final OAuthClientRegistrationType registrationType;
@@ -175,7 +175,7 @@ class OAuthClient {
     required this.clientName,
     this.clientSecret,
     required this.clientType,
-    required this.tokenEndpointAuthMethod,
+    required this.tokenEndpointAuthenticationMethod,
     required this.registrationType,
     this.clientUri,
     required this.redirectUris,
@@ -191,9 +191,10 @@ class OAuthClient {
       clientId: json['client_id'] as String,
       clientName: json['client_name'] as String,
       clientSecret: json['client_secret'] as String?,
-      clientType: OAuthClientType.fromString(json['client_type'] as String),
-      tokenEndpointAuthMethod: json['token_endpoint_auth_method'] as String,
-      registrationType: OAuthClientRegistrationType.fromString(
+      clientType: OAuthClientType.fromValue(json['client_type'] as String),
+      tokenEndpointAuthenticationMethod:
+          json['token_endpoint_auth_method'] as String,
+      registrationType: OAuthClientRegistrationType.fromValue(
         json['registration_type'] as String,
       ),
       clientUri: json['client_uri'] as String?,
@@ -221,7 +222,7 @@ class OAuthClient {
 
 /// Parameters for creating a new OAuth client.
 /// Only relevant when the OAuth 2.1 server is enabled in Supabase Auth.
-class CreateOAuthClientParams {
+class CreateOAuthClientOptions {
   /// Human-readable name of the OAuth client
   final String clientName;
 
@@ -241,7 +242,7 @@ class CreateOAuthClientParams {
   /// Scope of the OAuth client
   final String? scope;
 
-  const CreateOAuthClientParams({
+  const CreateOAuthClientOptions({
     required this.clientName,
     this.clientUri,
     required this.redirectUris,
@@ -264,7 +265,7 @@ class CreateOAuthClientParams {
 
 /// Parameters for updating an existing OAuth client.
 /// Only relevant when the OAuth 2.1 server is enabled in Supabase Auth.
-class UpdateOAuthClientParams {
+class UpdateOAuthClientOptions {
   /// Human-readable name of the OAuth client
   final String? clientName;
 
@@ -283,7 +284,7 @@ class UpdateOAuthClientParams {
   /// Scope of the OAuth client
   final String? scope;
 
-  const UpdateOAuthClientParams({
+  const UpdateOAuthClientOptions({
     this.clientName,
     this.clientUri,
     this.redirectUris,

--- a/packages/supabase_auth/lib/src/types/user.dart
+++ b/packages/supabase_auth/lib/src/types/user.dart
@@ -6,7 +6,7 @@ class User {
   final String id;
   final Map<String, dynamic> appMetadata;
   final Map<String, dynamic>? userMetadata;
-  final String aud;
+  final String audience;
   final DateTime? confirmationSentAt;
   final DateTime? recoverySentAt;
   final DateTime? emailChangeSentAt;
@@ -29,7 +29,7 @@ class User {
     required this.id,
     required this.appMetadata,
     required this.userMetadata,
-    required this.aud,
+    required this.audience,
     this.confirmationSentAt,
     this.recoverySentAt,
     this.emailChangeSentAt,
@@ -60,7 +60,7 @@ class User {
       id: json['id'] ?? '',
       appMetadata: json['app_metadata'] as Map<String, dynamic>? ?? {},
       userMetadata: json['user_metadata'] as Map<String, dynamic>?,
-      aud: json['aud'] ?? '',
+      audience: json['aud'] ?? '',
       confirmationSentAt: tryParseIso8601(json, 'confirmation_sent_at'),
       recoverySentAt: tryParseIso8601(json, 'recovery_sent_at'),
       emailChangeSentAt: tryParseIso8601(json, 'email_change_sent_at'),
@@ -92,7 +92,7 @@ class User {
       'id': id,
       'app_metadata': appMetadata,
       'user_metadata': userMetadata,
-      'aud': aud,
+      'aud': audience,
       'confirmation_sent_at': confirmationSentAt?.toIso8601String(),
       'recovery_sent_at': recoverySentAt?.toIso8601String(),
       'email_change_sent_at': emailChangeSentAt?.toIso8601String(),
@@ -116,7 +116,8 @@ class User {
   @override
   String toString() {
     return 'User(id: $id, appMetadata: $appMetadata, userMetadata: '
-        '$userMetadata, aud: $aud, confirmationSentAt: $confirmationSentAt, '
+        '$userMetadata, audience: $audience, confirmationSentAt: '
+        '$confirmationSentAt, '
         'recoverySentAt: $recoverySentAt, emailChangeSentAt: '
         '$emailChangeSentAt, newEmail: $newEmail, invitedAt: $invitedAt, '
         'actionLink: $actionLink, email: $email, phone: $phone, createdAt: '
@@ -135,7 +136,7 @@ class User {
         other.id == id &&
         collectionEquals(other.appMetadata, appMetadata) &&
         collectionEquals(other.userMetadata, userMetadata) &&
-        other.aud == aud &&
+        other.audience == audience &&
         other.confirmationSentAt == confirmationSentAt &&
         other.recoverySentAt == recoverySentAt &&
         other.emailChangeSentAt == emailChangeSentAt &&
@@ -162,7 +163,7 @@ class User {
     return id.hashCode ^
         collectionHash(appMetadata) ^
         collectionHash(userMetadata) ^
-        aud.hashCode ^
+        audience.hashCode ^
         confirmationSentAt.hashCode ^
         recoverySentAt.hashCode ^
         emailChangeSentAt.hashCode ^

--- a/packages/supabase_auth/lib/supabase_auth.dart
+++ b/packages/supabase_auth/lib/supabase_auth.dart
@@ -7,7 +7,7 @@ export 'package:supabase_common/supabase_common.dart'
 export 'src/constants.dart' hide Constants;
 export 'src/auth_admin_api.dart';
 export 'src/auth_client.dart';
-export 'src/helper.dart' show decodeJwt, validateExp;
+export 'src/helper.dart' show decodeJwt, validateExpiration;
 export 'src/types/auth_exception.dart';
 export 'src/types/auth_response.dart';
 export 'src/types/auth_state.dart';

--- a/packages/supabase_auth/test/client_test.dart
+++ b/packages/supabase_auth/test/client_test.dart
@@ -247,7 +247,10 @@ void main() {
       final payload = decodeJwt(data!.accessToken).payload;
       expect(
         data.expiresAt,
-        DateTime.fromMillisecondsSinceEpoch(payload.exp! * 1000, isUtc: true),
+        DateTime.fromMillisecondsSinceEpoch(
+          payload.expiresAt! * 1000,
+          isUtc: true,
+        ),
       );
     });
 
@@ -274,7 +277,10 @@ void main() {
       final payload = decodeJwt(data!.accessToken).payload;
       expect(
         data.expiresAt,
-        DateTime.fromMillisecondsSinceEpoch(payload.exp! * 1000, isUtc: true),
+        DateTime.fromMillisecondsSinceEpoch(
+          payload.expiresAt! * 1000,
+          isUtc: true,
+        ),
       );
     });
 

--- a/packages/supabase_auth/test/custom_providers_test.dart
+++ b/packages/supabase_auth/test/custom_providers_test.dart
@@ -2,9 +2,9 @@ import 'package:supabase_auth/supabase_auth.dart';
 import 'package:test/test.dart';
 
 void main() {
-  group('CreateCustomProviderParams serialization', () {
+  group('CreateCustomProviderOptions serialization', () {
     test('serializes required fields', () {
-      final parameters = CreateCustomProviderParams(
+      final parameters = CreateCustomProviderOptions(
         providerType: CustomProviderType.oauth2,
         identifier: 'custom:mycompany',
         name: 'My Company',
@@ -22,7 +22,7 @@ void main() {
     });
 
     test('omits custom_claims_allowlist when not provided', () {
-      final parameters = CreateCustomProviderParams(
+      final parameters = CreateCustomProviderOptions(
         providerType: CustomProviderType.oidc,
         identifier: 'custom:mycompany',
         name: 'My Company',
@@ -37,7 +37,7 @@ void main() {
     });
 
     test('serializes custom_claims_allowlist when provided', () {
-      final parameters = CreateCustomProviderParams(
+      final parameters = CreateCustomProviderOptions(
         providerType: CustomProviderType.oidc,
         identifier: 'custom:mycompany',
         name: 'My Company',
@@ -53,7 +53,7 @@ void main() {
     });
 
     test('serializes an empty custom_claims_allowlist', () {
-      final parameters = CreateCustomProviderParams(
+      final parameters = CreateCustomProviderOptions(
         providerType: CustomProviderType.oidc,
         identifier: 'custom:mycompany',
         name: 'My Company',
@@ -66,9 +66,9 @@ void main() {
     });
   });
 
-  group('UpdateCustomProviderParams serialization', () {
+  group('UpdateCustomProviderOptions serialization', () {
     test('omits custom_claims_allowlist when not provided', () {
-      const parameters = UpdateCustomProviderParams(name: 'New name');
+      const parameters = UpdateCustomProviderOptions(name: 'New name');
 
       final json = parameters.toJson();
       expect(json.containsKey('custom_claims_allowlist'), isFalse);
@@ -76,7 +76,7 @@ void main() {
     });
 
     test('serializes custom_claims_allowlist when provided', () {
-      const parameters = UpdateCustomProviderParams(
+      const parameters = UpdateCustomProviderOptions(
         customClaimsAllowlist: ['groups'],
       );
 

--- a/packages/supabase_auth/test/get_claims_test.dart
+++ b/packages/supabase_auth/test/get_claims_test.dart
@@ -60,12 +60,12 @@ void main() {
       final claimsResponse = await client.getClaims();
       final claims = claimsResponse.claims;
 
-      expect(claims.sub, isNotNull);
+      expect(claims.subject, isNotNull);
       expect(claims.claims['email'], newEmail);
       expect(claims.claims['role'], isNotNull);
-      expect(claimsResponse.claims.aud, isNotNull);
-      expect(claims.exp, isNotNull);
-      expect(claims.iat, isNotNull);
+      expect(claimsResponse.claims.audience, isNotNull);
+      expect(claims.expiresAt, isNotNull);
+      expect(claims.issuedAt, isNotNull);
     });
 
     test('getClaims() with explicit JWT parameter', () async {
@@ -82,7 +82,7 @@ void main() {
       final claimsResponse = await client.getClaims(accessToken);
       final claims = claimsResponse.claims;
 
-      expect(claims.sub, isNotNull);
+      expect(claims.subject, isNotNull);
       expect(claims.claims['email'], newEmail);
     });
 
@@ -187,10 +187,10 @@ void main() {
       final claims = claimsResponse.claims;
 
       // Check for standard JWT claims
-      expect(claims.sub, isNotNull); // Subject
-      expect(claims.aud, isNotNull); // Audience
-      expect(claims.exp, isNotNull); // Expiration
-      expect(claims.iat, isNotNull); // Issued at
+      expect(claims.subject, isNotNull); // Subject
+      expect(claims.audience, isNotNull); // Audience
+      expect(claims.expiresAt, isNotNull); // Expiration
+      expect(claims.issuedAt, isNotNull); // Issued at
       expect(claims.claims['role'], isNotNull); // Role
 
       // Check for Supabase-specific claims
@@ -284,14 +284,14 @@ void main() {
 
       final decoded = decodeJwt(jwt);
 
-      expect(decoded.header.alg, 'HS256');
-      expect(decoded.header.typ, 'JWT');
-      expect(decoded.header.kid, 'test-kid');
+      expect(decoded.header.algorithm, 'HS256');
+      expect(decoded.header.type, 'JWT');
+      expect(decoded.header.keyId, 'test-kid');
 
-      expect(decoded.payload.sub, '1234567890');
+      expect(decoded.payload.subject, '1234567890');
       expect(decoded.payload.claims['name'], 'John Doe');
-      expect(decoded.payload.iat, 1516239022);
-      expect(decoded.payload.exp, 9999999999);
+      expect(decoded.payload.issuedAt, 1516239022);
+      expect(decoded.payload.expiresAt, 9999999999);
     });
 
     test('decodeJwt() throws on invalid JWT structure', () {
@@ -329,10 +329,10 @@ void main() {
 
       final payload = decodeJwtPayload(jwt);
 
-      expect(payload.sub, '1234567890');
+      expect(payload.subject, '1234567890');
       expect(payload.claims['name'], 'John Doe');
-      expect(payload.iat, 1516239022);
-      expect(payload.exp, 9999999999);
+      expect(payload.issuedAt, 1516239022);
+      expect(payload.expiresAt, 9999999999);
     });
 
     test('decodeJwtPayload() decodes payload despite a non-JSON header', () {
@@ -343,8 +343,8 @@ void main() {
 
       final payload = decodeJwtPayload(jwt);
 
-      expect(payload.exp, 9999999999);
-      expect(payload.sub, '1234567890');
+      expect(payload.expiresAt, 9999999999);
+      expect(payload.subject, '1234567890');
     });
 
     test('decodeJwtPayload() throws on wrong number of parts', () {
@@ -354,26 +354,26 @@ void main() {
       );
     });
 
-    test('validateExp() throws on expired token', () {
+    test('validateExpiration() throws on expired token', () {
       final pastTime = DateTime.now().subtract(Duration(hours: 1));
       final expiresAt = pastTime.millisecondsSinceEpoch ~/ 1000;
 
       expect(
-        () => validateExp(expiresAt),
+        () => validateExpiration(expiresAt),
         throwsA(isA<AuthException>()),
       );
     });
 
-    test('validateExp() succeeds on valid token', () {
+    test('validateExpiration() succeeds on valid token', () {
       final futureTime = DateTime.now().add(Duration(hours: 1));
       final expiresAt = futureTime.millisecondsSinceEpoch ~/ 1000;
 
-      expect(() => validateExp(expiresAt), returnsNormally);
+      expect(() => validateExpiration(expiresAt), returnsNormally);
     });
 
-    test('validateExp() throws on null exp', () {
+    test('validateExpiration() throws on null exp', () {
       expect(
-        () => validateExp(null),
+        () => validateExpiration(null),
         throwsA(isA<AuthException>()),
       );
     });

--- a/packages/supabase_auth/test/src/auth_admin_custom_providers_api_test.dart
+++ b/packages/supabase_auth/test/src/auth_admin_custom_providers_api_test.dart
@@ -22,11 +22,11 @@ void main() {
     return 'custom:flutter-test-$timestamp';
   }
 
-  CreateCustomProviderParams oauth2Parameters(
+  CreateCustomProviderOptions oauth2Parameters(
     String identifier, {
     List<String>? customClaimsAllowlist,
   }) {
-    return CreateCustomProviderParams(
+    return CreateCustomProviderOptions(
       providerType: CustomProviderType.oauth2,
       identifier: identifier,
       name: 'Flutter Test Provider',
@@ -34,7 +34,7 @@ void main() {
       clientSecret: 'test-client-secret',
       authorizationUrl: 'https://example.com/authorize',
       tokenUrl: 'https://example.com/token',
-      userinfoUrl: 'https://example.com/userinfo',
+      userInfoUrl: 'https://example.com/userinfo',
       customClaimsAllowlist: customClaimsAllowlist,
     );
   }
@@ -163,7 +163,7 @@ void main() {
 
         final updated = await client.admin.customProviders.updateProvider(
           identifier,
-          const UpdateCustomProviderParams(
+          const UpdateCustomProviderOptions(
             name: 'Updated Provider Name',
             customClaimsAllowlist: ['groups'],
           ),

--- a/packages/supabase_auth/test/src/auth_admin_oauth_api_test.dart
+++ b/packages/supabase_auth/test/src/auth_admin_oauth_api_test.dart
@@ -38,7 +38,7 @@ void main() {
 
   group('OAuth client management', () {
     test('create OAuth client', () async {
-      final parameters = CreateOAuthClientParams(
+      final parameters = CreateOAuthClientOptions(
         clientName: 'Test OAuth Client',
         redirectUris: ['https://example.com/callback'],
         clientUri: 'https://example.com',
@@ -55,7 +55,7 @@ void main() {
 
     test('list OAuth clients', () async {
       // First create a client
-      final parameters = CreateOAuthClientParams(
+      final parameters = CreateOAuthClientOptions(
         clientName: 'Test OAuth Client for List',
         redirectUris: ['https://example.com/callback'],
       );
@@ -68,7 +68,7 @@ void main() {
 
     test('get OAuth client by ID', () async {
       // First create a client
-      final parameters = CreateOAuthClientParams(
+      final parameters = CreateOAuthClientOptions(
         clientName: 'Test OAuth Client for Get',
         redirectUris: ['https://example.com/callback'],
       );
@@ -83,7 +83,7 @@ void main() {
 
     test('update OAuth client', () async {
       // First create a client
-      final createParameters = CreateOAuthClientParams(
+      final createParameters = CreateOAuthClientOptions(
         clientName: 'Test OAuth Client for Update',
         redirectUris: ['https://example.com/callback'],
       );
@@ -93,7 +93,7 @@ void main() {
       final clientId = createResponse.client!.clientId;
 
       // Update the client
-      final updateParameters = UpdateOAuthClientParams(
+      final updateParameters = UpdateOAuthClientOptions(
         clientName: 'Updated OAuth Client Name',
       );
       final updateResponse = await client.admin.oauth.updateClient(
@@ -111,7 +111,7 @@ void main() {
 
     test('regenerate OAuth client secret', () async {
       // First create a client
-      final parameters = CreateOAuthClientParams(
+      final parameters = CreateOAuthClientOptions(
         clientName: 'Test OAuth Client for Regenerate',
         redirectUris: ['https://example.com/callback'],
       );
@@ -129,7 +129,7 @@ void main() {
 
     test('delete OAuth client', () async {
       // First create a client
-      final parameters = CreateOAuthClientParams(
+      final parameters = CreateOAuthClientOptions(
         clientName: 'Test OAuth Client for Delete',
         redirectUris: ['https://example.com/callback'],
       );
@@ -166,7 +166,7 @@ void main() {
     });
 
     test('updateClient() validates ids', () {
-      final parameters = UpdateOAuthClientParams(clientName: 'Updated Name');
+      final parameters = UpdateOAuthClientOptions(clientName: 'Updated Name');
       expect(
         () => client.admin.oauth.updateClient('invalid-id', parameters),
         throwsA(isA<ArgumentError>()),

--- a/packages/supabase_auth/test/src/auth_mfa_api_test.dart
+++ b/packages/supabase_auth/test/src/auth_mfa_api_test.dart
@@ -233,9 +233,12 @@ void main() {
       expect(response.currentLevel, AuthenticatorAssuranceLevel.aal2);
       expect(response.nextLevel, AuthenticatorAssuranceLevel.aal2);
       final passwordEntry = response.currentAuthenticationMethods
-          .firstWhereOrNull((element) => element.method == AMRMethod.password);
+          .firstWhereOrNull(
+            (element) =>
+                element.method == AuthenticationMethodReference.password,
+          );
       final totpEntry = response.currentAuthenticationMethods.firstWhereOrNull(
-        (element) => element.method == AMRMethod.totp,
+        (element) => element.method == AuthenticationMethodReference.totp,
       );
       expect(passwordEntry, isNotNull);
       expect(totpEntry, isNotNull);

--- a/packages/supabase_auth/test/src/auth_oauth_api_test.dart
+++ b/packages/supabase_auth/test/src/auth_oauth_api_test.dart
@@ -183,7 +183,7 @@ void main() {
   group('OAuth server', () {
     test('get authorization details', () async {
       final client = await fixture.build();
-      final clientParameters = CreateOAuthClientParams(
+      final clientParameters = CreateOAuthClientOptions(
         clientName: 'Test OAuth Client',
         redirectUris: ['http://127.0.0.1:3000/oauth/callback'],
         responseTypes: [OAuthClientResponseType.code],
@@ -210,7 +210,7 @@ void main() {
 
     test('approve authorization request', () async {
       final client = await fixture.build();
-      final clientParameters = CreateOAuthClientParams(
+      final clientParameters = CreateOAuthClientOptions(
         clientName: 'Test OAuth Client',
         redirectUris: ['http://127.0.0.1:3000/oauth/callback'],
       );
@@ -230,7 +230,7 @@ void main() {
 
     test('denies authorization request', () async {
       final client = await fixture.build();
-      final clientParameters = CreateOAuthClientParams(
+      final clientParameters = CreateOAuthClientOptions(
         clientName: 'Test OAuth Client',
         redirectUris: ['http://127.0.0.1:3000/oauth/callback'],
       );
@@ -254,7 +254,7 @@ void main() {
 
     test('approving authorization without getting details throws', () async {
       final client = await fixture.build();
-      final clientParameters = CreateOAuthClientParams(
+      final clientParameters = CreateOAuthClientOptions(
         clientName: 'Test OAuth Client',
         redirectUris: ['http://127.0.0.1:3000/oauth/callback'],
       );
@@ -275,7 +275,7 @@ void main() {
 
     test('lists grants after approving an authorization', () async {
       final client = await fixture.build();
-      final clientParameters = CreateOAuthClientParams(
+      final clientParameters = CreateOAuthClientOptions(
         clientName: 'Test OAuth Client',
         redirectUris: ['http://127.0.0.1:3000/oauth/callback'],
         responseTypes: [OAuthClientResponseType.code],
@@ -296,7 +296,7 @@ void main() {
 
     test('revokes a grant', () async {
       final client = await fixture.build();
-      final clientParameters = CreateOAuthClientParams(
+      final clientParameters = CreateOAuthClientOptions(
         clientName: 'Test OAuth Client',
         redirectUris: ['http://127.0.0.1:3000/oauth/callback'],
         responseTypes: [OAuthClientResponseType.code],
@@ -319,7 +319,7 @@ void main() {
       'approved does not throw',
       () async {
         final client = await fixture.build();
-        final clientParameters = CreateOAuthClientParams(
+        final clientParameters = CreateOAuthClientOptions(
           clientName: 'Test OAuth Client',
           redirectUris: ['http://127.0.0.1:3000/oauth/callback'],
           responseTypes: [OAuthClientResponseType.code],
@@ -376,7 +376,7 @@ class AuthOauthApiFixture {
   late final String _authUrl;
   late final String _serviceRoleToken;
 
-  Future<OAuthClient> createOAuthClient(CreateOAuthClientParams request) {
+  Future<OAuthClient> createOAuthClient(CreateOAuthClientOptions request) {
     return _client.admin.oauth
         .createClient(request)
         .then((response) => response.client!);

--- a/packages/supabase_auth/test/src/constants_test.dart
+++ b/packages/supabase_auth/test/src/constants_test.dart
@@ -63,72 +63,77 @@ void main() {
       );
     });
 
-    test('has correct JS names', () {
-      expect(AuthChangeEvent.initialSession.jsName, equals('INITIAL_SESSION'));
+    test('value is derived from the enum name', () {
       expect(
-        AuthChangeEvent.passwordRecovery.jsName,
+        AuthChangeEvent.initialSession.value,
+        equals('INITIAL_SESSION'),
+      );
+      expect(
+        AuthChangeEvent.passwordRecovery.value,
         equals('PASSWORD_RECOVERY'),
       );
-      expect(AuthChangeEvent.signedIn.jsName, equals('SIGNED_IN'));
-      expect(AuthChangeEvent.signedOut.jsName, equals('SIGNED_OUT'));
-      expect(AuthChangeEvent.tokenRefreshed.jsName, equals('TOKEN_REFRESHED'));
-      expect(AuthChangeEvent.userUpdated.jsName, equals('USER_UPDATED'));
+      expect(AuthChangeEvent.signedIn.value, equals('SIGNED_IN'));
+      expect(AuthChangeEvent.signedOut.value, equals('SIGNED_OUT'));
       expect(
-        AuthChangeEvent.mfaChallengeVerified.jsName,
+        AuthChangeEvent.tokenRefreshed.value,
+        equals('TOKEN_REFRESHED'),
+      );
+      expect(AuthChangeEvent.userUpdated.value, equals('USER_UPDATED'));
+      expect(
+        AuthChangeEvent.mfaChallengeVerified.value,
         equals('MFA_CHALLENGE_VERIFIED'),
       );
     });
 
     group('AuthChangeEvent', () {
-      test('fromString returns correct event for valid names', () {
+      test('fromValue returns correct event for valid names', () {
         expect(
-          AuthChangeEvent.fromString('initialSession'),
+          AuthChangeEvent.fromValue('initialSession'),
           equals(AuthChangeEvent.initialSession),
         );
         expect(
-          AuthChangeEvent.fromString('passwordRecovery'),
+          AuthChangeEvent.fromValue('passwordRecovery'),
           equals(AuthChangeEvent.passwordRecovery),
         );
         expect(
-          AuthChangeEvent.fromString('signedIn'),
+          AuthChangeEvent.fromValue('signedIn'),
           equals(AuthChangeEvent.signedIn),
         );
         expect(
-          AuthChangeEvent.fromString('signedOut'),
+          AuthChangeEvent.fromValue('signedOut'),
           equals(AuthChangeEvent.signedOut),
         );
         expect(
-          AuthChangeEvent.fromString('tokenRefreshed'),
+          AuthChangeEvent.fromValue('tokenRefreshed'),
           equals(AuthChangeEvent.tokenRefreshed),
         );
         expect(
-          AuthChangeEvent.fromString('userUpdated'),
+          AuthChangeEvent.fromValue('userUpdated'),
           equals(AuthChangeEvent.userUpdated),
         );
         expect(
-          AuthChangeEvent.fromString('mfaChallengeVerified'),
+          AuthChangeEvent.fromValue('mfaChallengeVerified'),
           equals(AuthChangeEvent.mfaChallengeVerified),
         );
       });
 
-      test('fromString returns null for invalid names', () {
-        expect(AuthChangeEvent.fromString('invalid'), isNull);
-        expect(AuthChangeEvent.fromString('userDeleted'), isNull);
-        expect(AuthChangeEvent.fromString('SIGNED_IN'), isNull);
-        expect(AuthChangeEvent.fromString('signed_in'), isNull);
-        expect(AuthChangeEvent.fromString(''), isNull);
+      test('fromValue returns null for invalid names', () {
+        expect(AuthChangeEvent.fromValue('invalid'), isNull);
+        expect(AuthChangeEvent.fromValue('userDeleted'), isNull);
+        expect(AuthChangeEvent.fromValue('USER_DELETED'), isNull);
+        expect(AuthChangeEvent.fromValue('signed_in'), isNull);
+        expect(AuthChangeEvent.fromValue(''), isNull);
       });
 
-      test('fromString returns null for null input', () {
-        expect(AuthChangeEvent.fromString(null), isNull);
+      test('fromValue returns null for null input', () {
+        expect(AuthChangeEvent.fromValue(null), isNull);
       });
 
-      test('fromString uses enum name, not jsName', () {
-        expect(AuthChangeEvent.fromString('SIGNED_IN'), isNull);
-        expect(
-          AuthChangeEvent.fromString('signedIn'),
-          equals(AuthChangeEvent.signedIn),
-        );
+      test('fromValue round trips every value through both forms', () {
+        for (final event in AuthChangeEvent.values) {
+          expect(AuthChangeEvent.fromValue(event.value), equals(event));
+          expect(AuthChangeEvent.fromValue(event.name), equals(event));
+        }
       });
     });
   });
@@ -152,55 +157,55 @@ void main() {
     });
 
     group('GenerateLinkType', () {
-      test('fromString returns correct type for valid snake_case names', () {
+      test('fromValue returns correct type for valid snake_case names', () {
         expect(
-          GenerateLinkType.fromString('signup'),
+          GenerateLinkType.fromValue('signup'),
           equals(GenerateLinkType.signup),
         );
         expect(
-          GenerateLinkType.fromString('invite'),
+          GenerateLinkType.fromValue('invite'),
           equals(GenerateLinkType.invite),
         );
         expect(
-          GenerateLinkType.fromString('magiclink'),
+          GenerateLinkType.fromValue('magiclink'),
           equals(GenerateLinkType.magiclink),
         );
         expect(
-          GenerateLinkType.fromString('recovery'),
+          GenerateLinkType.fromValue('recovery'),
           equals(GenerateLinkType.recovery),
         );
         expect(
-          GenerateLinkType.fromString('email_change_current'),
+          GenerateLinkType.fromValue('email_change_current'),
           equals(GenerateLinkType.emailChangeCurrent),
         );
         expect(
-          GenerateLinkType.fromString('email_change_new'),
+          GenerateLinkType.fromValue('email_change_new'),
           equals(GenerateLinkType.emailChangeNew),
         );
       });
 
-      test('fromString returns unknown for invalid names', () {
+      test('fromValue returns unknown for invalid names', () {
         expect(
-          GenerateLinkType.fromString('invalid'),
+          GenerateLinkType.fromValue('invalid'),
           equals(GenerateLinkType.unknown),
         );
         expect(
-          GenerateLinkType.fromString('emailChangeCurrent'),
+          GenerateLinkType.fromValue('emailChangeCurrent'),
           equals(GenerateLinkType.unknown),
         );
         expect(
-          GenerateLinkType.fromString('SIGNUP'),
+          GenerateLinkType.fromValue('SIGNUP'),
           equals(GenerateLinkType.unknown),
         );
         expect(
-          GenerateLinkType.fromString(''),
+          GenerateLinkType.fromValue(''),
           equals(GenerateLinkType.unknown),
         );
       });
 
-      test('fromString returns unknown for null input', () {
+      test('fromValue returns unknown for null input', () {
         expect(
-          GenerateLinkType.fromString(null),
+          GenerateLinkType.fromValue(null),
           equals(GenerateLinkType.unknown),
         );
       });
@@ -208,7 +213,7 @@ void main() {
       test('all enum values have corresponding snake_case representation', () {
         for (final type in GenerateLinkType.values) {
           if (type != GenerateLinkType.unknown) {
-            final result = GenerateLinkType.fromString(type.snakeCase);
+            final result = GenerateLinkType.fromValue(type.snakeCase);
             expect(result, equals(type), reason: 'Failed for ${type.name}');
           }
         }

--- a/packages/supabase_auth/test/src/helper_test.dart
+++ b/packages/supabase_auth/test/src/helper_test.dart
@@ -289,51 +289,75 @@ void main() {
     group('uuidRegex', () {
       test('matches valid UUIDs', () {
         expect(
-          uuidRegex.hasMatch('550e8400-e29b-41d4-a716-446655440000'),
+          uuidRegex.hasMatch(
+            '550e8400-e29b-41d4-a716-446655440000',
+          ),
           isTrue,
         );
         expect(
-          uuidRegex.hasMatch('6ba7b810-9dad-11d1-80b4-00c04fd430c8'),
+          uuidRegex.hasMatch(
+            '6ba7b810-9dad-11d1-80b4-00c04fd430c8',
+          ),
           isTrue,
         );
         expect(
-          uuidRegex.hasMatch('00000000-0000-0000-0000-000000000000'),
+          uuidRegex.hasMatch(
+            '00000000-0000-0000-0000-000000000000',
+          ),
           isTrue,
         );
       });
 
       test('does not match invalid UUIDs', () {
         expect(uuidRegex.hasMatch('invalid-uuid'), isFalse);
-        expect(uuidRegex.hasMatch('550e8400-e29b-41d4-a716'), isFalse);
-        expect(uuidRegex.hasMatch('550e8400e29b41d4a716446655440000'), isFalse);
         expect(
-          uuidRegex.hasMatch('550e8400-e29b-41d4-a716-44665544000g'),
+          uuidRegex.hasMatch('550e8400-e29b-41d4-a716'),
+          isFalse,
+        );
+        expect(
+          uuidRegex.hasMatch('550e8400e29b41d4a716446655440000'),
+          isFalse,
+        );
+        expect(
+          uuidRegex.hasMatch(
+            '550e8400-e29b-41d4-a716-44665544000g',
+          ),
           isFalse,
         );
       });
 
       test('matches hexadecimal characters regardless of case', () {
         expect(
-          uuidRegex.hasMatch('550E8400-E29B-41D4-A716-446655440000'),
+          uuidRegex.hasMatch(
+            '550E8400-E29B-41D4-A716-446655440000',
+          ),
           isTrue,
         );
         expect(
-          uuidRegex.hasMatch('550e8400-E29B-41d4-A716-446655440000'),
+          uuidRegex.hasMatch(
+            '550e8400-E29B-41d4-A716-446655440000',
+          ),
           isTrue,
         );
         expect(
-          uuidRegex.hasMatch('550e8400-e29b-41d4-a716-446655440000'),
+          uuidRegex.hasMatch(
+            '550e8400-e29b-41d4-a716-446655440000',
+          ),
           isTrue,
         );
       });
 
       test('matches exact pattern without partial matches', () {
         expect(
-          uuidRegex.hasMatch('prefix-550e8400-e29b-41d4-a716-446655440000'),
+          uuidRegex.hasMatch(
+            'prefix-550e8400-e29b-41d4-a716-446655440000',
+          ),
           isFalse,
         );
         expect(
-          uuidRegex.hasMatch('550e8400-e29b-41d4-a716-446655440000-suffix'),
+          uuidRegex.hasMatch(
+            '550e8400-e29b-41d4-a716-446655440000-suffix',
+          ),
           isFalse,
         );
       });

--- a/packages/supabase_auth/test/src/types/mfa_test.dart
+++ b/packages/supabase_auth/test/src/types/mfa_test.dart
@@ -28,14 +28,14 @@ void main() {
     });
   });
 
-  group('AMREntry', () {
+  group('AuthenticationMethodReferenceEntry', () {
     test('fromJson parses passkey method', () {
-      final entry = AMREntry.fromJson({
+      final entry = AuthenticationMethodReferenceEntry.fromJson({
         'method': 'passkey',
         'timestamp': 1735689600,
       });
 
-      expect(entry.method, AMRMethod.passkey);
+      expect(entry.method, AuthenticationMethodReference.passkey);
       expect(
         entry.timestamp,
         DateTime.fromMillisecondsSinceEpoch(1735689600 * 1000, isUtc: true),
@@ -43,21 +43,21 @@ void main() {
     });
 
     test('fromJson parses mfa/webauthn method', () {
-      final entry = AMREntry.fromJson({
+      final entry = AuthenticationMethodReferenceEntry.fromJson({
         'method': 'mfa/webauthn',
         'timestamp': 1735689600,
       });
 
-      expect(entry.method, AMRMethod.mfaWebauthn);
+      expect(entry.method, AuthenticationMethodReference.mfaWebauthn);
     });
 
     test('fromJson falls back to unknown for unrecognized methods', () {
-      final entry = AMREntry.fromJson({
+      final entry = AuthenticationMethodReferenceEntry.fromJson({
         'method': 'something-new',
         'timestamp': 1735689600,
       });
 
-      expect(entry.method, AMRMethod.unknown);
+      expect(entry.method, AuthenticationMethodReference.unknown);
     });
   });
 

--- a/packages/supabase_auth/test/src/types/session_test.dart
+++ b/packages/supabase_auth/test/src/types/session_test.dart
@@ -14,7 +14,7 @@ void main() {
         id: '123',
         appMetadata: {},
         userMetadata: <String, dynamic>{},
-        aud: 'authenticated',
+        audience: 'authenticated',
         createdAt: DateTime.utc(2023, 1, 1),
       );
     });
@@ -319,7 +319,7 @@ void main() {
           id: '456',
           appMetadata: {},
           userMetadata: <String, dynamic>{},
-          aud: 'authenticated',
+          audience: 'authenticated',
           createdAt: DateTime.utc(2023, 1, 2),
         );
 
@@ -344,7 +344,7 @@ void main() {
           id: '456',
           appMetadata: {},
           userMetadata: <String, dynamic>{},
-          aud: 'authenticated',
+          audience: 'authenticated',
           createdAt: DateTime.utc(2023, 1, 2),
         );
 
@@ -466,7 +466,7 @@ void main() {
           id: '123',
           appMetadata: {},
           userMetadata: {},
-          aud: 'authenticated',
+          audience: 'authenticated',
           createdAt: DateTime.utc(2023, 1, 1),
         );
 
@@ -474,7 +474,7 @@ void main() {
           id: '456',
           appMetadata: {},
           userMetadata: {},
-          aud: 'authenticated',
+          audience: 'authenticated',
           createdAt: DateTime.utc(2023, 1, 1),
         );
 

--- a/packages/supabase_auth/test/src/types/user_test.dart
+++ b/packages/supabase_auth/test/src/types/user_test.dart
@@ -46,7 +46,7 @@ void main() {
         expect(user!.id, equals('123'));
         expect(user.appMetadata, equals(<String, dynamic>{}));
         expect(user.userMetadata, equals(<String, dynamic>{}));
-        expect(user.aud, equals('authenticated'));
+        expect(user.audience, equals('authenticated'));
         expect(user.createdAt, equals(DateTime.utc(2023, 1, 1)));
         expect(user.isAnonymous, isFalse);
       });
@@ -86,7 +86,7 @@ void main() {
           user.userMetadata,
           equals(<String, dynamic>{'name': 'John Doe'}),
         );
-        expect(user.aud, equals('authenticated'));
+        expect(user.audience, equals('authenticated'));
         expect(user.confirmationSentAt, equals(DateTime.utc(2023, 1, 1)));
         expect(user.recoverySentAt, equals(DateTime.utc(2023, 1, 1, 1)));
         expect(user.emailChangeSentAt, equals(DateTime.utc(2023, 1, 1, 2)));
@@ -297,7 +297,7 @@ void main() {
           id: '123',
           appMetadata: {'provider': 'email'},
           userMetadata: <String, dynamic>{'name': 'John Doe'},
-          aud: 'authenticated',
+          audience: 'authenticated',
           confirmationSentAt: DateTime.utc(2023, 1, 1),
           recoverySentAt: DateTime.utc(2023, 1, 1, 1),
           emailChangeSentAt: DateTime.utc(2023, 1, 1, 2),
@@ -359,7 +359,7 @@ void main() {
           id: '123',
           appMetadata: {},
           userMetadata: <String, dynamic>{},
-          aud: 'authenticated',
+          audience: 'authenticated',
           createdAt: DateTime.utc(2023, 1, 1),
           identities: [identity],
         );
@@ -376,7 +376,7 @@ void main() {
           id: '123',
           appMetadata: {},
           userMetadata: <String, dynamic>{},
-          aud: 'authenticated',
+          audience: 'authenticated',
           createdAt: DateTime.utc(2023, 1, 1),
           identities: null,
           factors: null,
@@ -395,7 +395,7 @@ void main() {
           id: '123',
           appMetadata: {'provider': 'email'},
           userMetadata: <String, dynamic>{'name': 'John Doe'},
-          aud: 'authenticated',
+          audience: 'authenticated',
           email: 'test@example.com',
           createdAt: DateTime.utc(2023, 1, 1),
           isAnonymous: true,
@@ -416,7 +416,7 @@ void main() {
           id: '123',
           appMetadata: {'provider': 'email'},
           userMetadata: <String, dynamic>{'name': 'John Doe'},
-          aud: 'authenticated',
+          audience: 'authenticated',
           email: 'test@example.com',
           createdAt: DateTime.utc(2023, 1, 1),
           isAnonymous: false,
@@ -426,7 +426,7 @@ void main() {
           id: '123',
           appMetadata: {'provider': 'email'},
           userMetadata: <String, dynamic>{'name': 'John Doe'},
-          aud: 'authenticated',
+          audience: 'authenticated',
           email: 'test@example.com',
           createdAt: DateTime.utc(2023, 1, 1),
           isAnonymous: false,
@@ -441,7 +441,7 @@ void main() {
           id: '123',
           appMetadata: {},
           userMetadata: <String, dynamic>{},
-          aud: 'authenticated',
+          audience: 'authenticated',
           createdAt: DateTime.utc(2023, 1, 1),
         );
 
@@ -449,7 +449,7 @@ void main() {
           id: '456',
           appMetadata: {},
           userMetadata: <String, dynamic>{},
-          aud: 'authenticated',
+          audience: 'authenticated',
           createdAt: DateTime.utc(2023, 1, 1),
         );
 
@@ -461,7 +461,7 @@ void main() {
           id: '123',
           appMetadata: {'provider': 'email'},
           userMetadata: {},
-          aud: 'authenticated',
+          audience: 'authenticated',
           createdAt: DateTime.utc(2023, 1, 1),
         );
 
@@ -469,7 +469,7 @@ void main() {
           id: '123',
           appMetadata: {'provider': 'oauth'},
           userMetadata: {},
-          aud: 'authenticated',
+          audience: 'authenticated',
           createdAt: DateTime.utc(2023, 1, 1),
         );
 
@@ -485,7 +485,7 @@ void main() {
           userMetadata: <String, dynamic>{
             'list': [1, 2, 3],
           },
-          aud: 'authenticated',
+          audience: 'authenticated',
           createdAt: DateTime.utc(2023, 1, 1),
         );
 
@@ -497,7 +497,7 @@ void main() {
           userMetadata: <String, dynamic>{
             'list': [1, 2, 3],
           },
-          aud: 'authenticated',
+          audience: 'authenticated',
           createdAt: DateTime.utc(2023, 1, 1),
         );
 
@@ -511,7 +511,7 @@ void main() {
           id: '123',
           appMetadata: {'provider': 'email'},
           userMetadata: <String, dynamic>{'name': 'John Doe'},
-          aud: 'authenticated',
+          audience: 'authenticated',
           email: 'test@example.com',
           phone: '+1234567890',
           createdAt: DateTime.utc(2023, 1, 1),
@@ -536,7 +536,7 @@ void main() {
             'profile': <String, dynamic>{'name': 'John', 'age': 30},
             'preferences': ['dark_mode', 'notifications'],
           },
-          aud: 'authenticated',
+          audience: 'authenticated',
           createdAt: DateTime.utc(2023, 1, 1),
         );
 

--- a/packages/supabase_common/lib/src/timestamp.dart
+++ b/packages/supabase_common/lib/src/timestamp.dart
@@ -78,6 +78,50 @@ DateTime? tryParseUnixSeconds(Map<String, dynamic> json, String key) {
   return parseUnixSeconds(json, key);
 }
 
+/// Parses the Unix timestamp in milliseconds stored under [key] in [json] as a
+/// UTC [DateTime].
+///
+/// Throws a [FormatException] when the value is missing or is not a number.
+/// As in [parseIso8601], the exception does not carry [json] itself.
+DateTime parseUnixMilliseconds(Map<String, dynamic> json, String key) {
+  return DateTime.fromMillisecondsSinceEpoch(
+    _millisecondsUnder(json, key),
+    isUtc: true,
+  );
+}
+
+/// Same as [parseUnixMilliseconds], but returns `null` when the value under
+/// [key] is `null` or absent.
+DateTime? tryParseUnixMilliseconds(Map<String, dynamic> json, String key) {
+  if (json[key] == null) return null;
+  return parseUnixMilliseconds(json, key);
+}
+
+/// Parses the duration in milliseconds stored under [key] in [json].
+///
+/// Throws a [FormatException] when the value is missing or is not a number.
+/// As in [parseIso8601], the exception does not carry [json] itself.
+Duration parseMillisecondsDuration(Map<String, dynamic> json, String key) {
+  return Duration(milliseconds: _millisecondsUnder(json, key));
+}
+
+/// Same as [parseMillisecondsDuration], but returns `null` when the value under
+/// [key] is `null` or absent.
+Duration? tryParseMillisecondsDuration(Map<String, dynamic> json, String key) {
+  if (json[key] == null) return null;
+  return parseMillisecondsDuration(json, key);
+}
+
+int _millisecondsUnder(Map<String, dynamic> json, String key) {
+  final value = json[key];
+  if (value is! num) {
+    throw FormatException(
+      'Expected $key to be a number, got ${value.runtimeType}',
+    );
+  }
+  return value.round();
+}
+
 /// Converts a Unix timestamp in [seconds] to a UTC [DateTime].
 DateTime dateTimeFromUnixSeconds(num seconds) {
   return DateTime.fromMillisecondsSinceEpoch(

--- a/packages/supabase_common/test/timestamp_test.dart
+++ b/packages/supabase_common/test/timestamp_test.dart
@@ -206,6 +206,101 @@ void main() {
     });
   });
 
+  group('parseUnixMilliseconds', () {
+    test('parses whole milliseconds as UTC', () {
+      final parsed = parseUnixMilliseconds(
+        {'timestamp-ms': 1700000000000},
+        'timestamp-ms',
+      );
+
+      expect(parsed.isUtc, isTrue);
+      expect(
+        parsed,
+        DateTime.fromMillisecondsSinceEpoch(1700000000000, isUtc: true),
+      );
+    });
+
+    test('throws when the value is not a number', () {
+      expect(
+        () => parseUnixMilliseconds({'timestamp-ms': 'nope'}, 'timestamp-ms'),
+        throwsA(
+          isA<FormatException>().having(
+            (exception) => exception.message,
+            'message',
+            'Expected timestamp-ms to be a number, got String',
+          ),
+        ),
+      );
+    });
+
+    test('throws when the value is absent', () {
+      expect(
+        () => parseUnixMilliseconds({}, 'timestamp-ms'),
+        throwsA(isA<FormatException>()),
+      );
+    });
+  });
+
+  group('tryParseUnixMilliseconds', () {
+    test('returns null when the value is null or absent', () {
+      expect(
+        tryParseUnixMilliseconds({'last-updated-ms': null}, 'last-updated-ms'),
+        isNull,
+      );
+      expect(tryParseUnixMilliseconds({}, 'last-updated-ms'), isNull);
+    });
+
+    test('parses a present value', () {
+      expect(
+        tryParseUnixMilliseconds(
+          {'last-updated-ms': 1700000000000},
+          'last-updated-ms',
+        ),
+        DateTime.fromMillisecondsSinceEpoch(1700000000000, isUtc: true),
+      );
+    });
+  });
+
+  group('parseMillisecondsDuration', () {
+    test('parses milliseconds as a Duration', () {
+      expect(
+        parseMillisecondsDuration({
+          'max-ref-age-ms': 86400000,
+        }, 'max-ref-age-ms'),
+        const Duration(days: 1),
+      );
+    });
+
+    test('throws when the value is not a number', () {
+      expect(
+        () =>
+            parseMillisecondsDuration({'max-ref-age-ms': []}, 'max-ref-age-ms'),
+        throwsA(isA<FormatException>()),
+      );
+    });
+  });
+
+  group('tryParseMillisecondsDuration', () {
+    test('returns null when the value is null or absent', () {
+      expect(
+        tryParseMillisecondsDuration({
+          'max-ref-age-ms': null,
+        }, 'max-ref-age-ms'),
+        isNull,
+      );
+      expect(tryParseMillisecondsDuration({}, 'max-ref-age-ms'), isNull);
+    });
+
+    test('parses a present value', () {
+      expect(
+        tryParseMillisecondsDuration({
+          'max-ref-age-ms': 1500,
+        }, 'max-ref-age-ms'),
+        const Duration(milliseconds: 1500),
+      );
+    });
+  });
+
   group('dateTimeFromUnixSeconds and unixSecondsFromDateTime', () {
     test('round trip whole seconds', () {
       expect(

--- a/packages/supabase_flutter/lib/src/supabase_auth.dart
+++ b/packages/supabase_flutter/lib/src/supabase_auth.dart
@@ -356,13 +356,13 @@ extension AuthClientSignInProvider on AuthClient {
     String? redirectTo,
     String? scopes,
     LaunchMode authScreenLaunchMode = LaunchMode.platformDefault,
-    Map<String, String>? queryParams,
+    Map<String, String>? queryParameters,
   }) async {
     final response = await getOAuthSignInUrl(
       provider: provider,
       redirectTo: redirectTo,
       scopes: scopes,
-      queryParams: queryParams,
+      queryParameters: queryParameters,
     );
     return _launchAuthUrl(response.url, provider, authScreenLaunchMode);
   }
@@ -449,13 +449,13 @@ extension AuthClientSignInProvider on AuthClient {
     String? redirectTo,
     String? scopes,
     LaunchMode authScreenLaunchMode = LaunchMode.platformDefault,
-    Map<String, String>? queryParams,
+    Map<String, String>? queryParameters,
   }) async {
     final response = await getLinkIdentityUrl(
       provider,
       redirectTo: redirectTo,
       scopes: scopes,
-      queryParams: queryParams,
+      queryParameters: queryParameters,
     );
     return _launchAuthUrl(response.url, provider, authScreenLaunchMode);
   }

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -181,11 +181,11 @@ features:
       - JWK
       - JWK.JWK
       - JWK.[]
-      - JWK.alg
+      - JWK.algorithm
       - JWK.fromJson
-      - JWK.keyOps
-      - JWK.kid
-      - JWK.kty
+      - JWK.keyOperations
+      - JWK.keyId
+      - JWK.keyType
       - JWK.publicKey
       - JWK.toJson
       - JWKSet
@@ -195,22 +195,22 @@ features:
       - JWKSet.toJson
       - JwtHeader
       - JwtHeader.JwtHeader
-      - JwtHeader.alg
+      - JwtHeader.algorithm
       - JwtHeader.fromJson
-      - JwtHeader.kid
+      - JwtHeader.keyId
       - JwtHeader.toJson
-      - JwtHeader.typ
+      - JwtHeader.type
       - JwtPayload
       - JwtPayload.JwtPayload
-      - JwtPayload.aud
+      - JwtPayload.audience
       - JwtPayload.claims
-      - JwtPayload.exp
+      - JwtPayload.expiresAt
       - JwtPayload.fromJson
-      - JwtPayload.iat
-      - JwtPayload.iss
-      - JwtPayload.jti
-      - JwtPayload.nbf
-      - JwtPayload.sub
+      - JwtPayload.issuedAt
+      - JwtPayload.issuer
+      - JwtPayload.jwtId
+      - JwtPayload.notBefore
+      - JwtPayload.subject
       - JwtPayload.toJson
       - JwtRawParts
       - JwtRawParts.JwtRawParts
@@ -218,7 +218,7 @@ features:
       - JwtRawParts.payload
       - JwtRawParts.signature
       - decodeJwt
-      - validateExp
+      - validateExpiration
   auth.session.sign_out:
     status: implemented
     symbols:
@@ -238,8 +238,7 @@ features:
       - AuthClient.onAuthStateChange
     supporting_symbols:
       - AuthChangeEvent
-      - AuthChangeEvent.AuthChangeEvent
-      - AuthChangeEvent.jsName
+      - AuthChangeEvent.value
       - AuthState
       - AuthState.AuthState
       - AuthState.event
@@ -345,14 +344,14 @@ features:
       - AuthenticatorAssuranceLevel
       - AuthMFAApi.getAuthenticatorAssuranceLevel
     supporting_symbols:
-      - AMREntry
-      - AMREntry.AMREntry
-      - AMREntry.fromJson
-      - AMREntry.method
-      - AMREntry.timestamp
-      - AMRMethod
-      - AMRMethod.AMRMethod
-      - AMRMethod.code
+      - AuthenticationMethodReferenceEntry
+      - AuthenticationMethodReferenceEntry.AuthenticationMethodReferenceEntry
+      - AuthenticationMethodReferenceEntry.fromJson
+      - AuthenticationMethodReferenceEntry.method
+      - AuthenticationMethodReferenceEntry.timestamp
+      - AuthenticationMethodReference
+      - AuthenticationMethodReference.AuthenticationMethodReference
+      - AuthenticationMethodReference.value
       - AuthMFAGetAuthenticatorAssuranceLevelResponse
       - AuthMFAGetAuthenticatorAssuranceLevelResponse.AuthMFAGetAuthenticatorAssuranceLevelResponse
       - AuthMFAGetAuthenticatorAssuranceLevelResponse.currentAuthenticationMethods
@@ -529,35 +528,35 @@ features:
       - AuthAdminCustomProvidersApi.AuthAdminCustomProvidersApi
       - AuthAdminCustomProvidersApi.createProvider
       - CustomProviderType
-      - CustomProviderType.fromString
-      - CreateCustomProviderParams
-      - CreateCustomProviderParams.CreateCustomProviderParams
-      - CreateCustomProviderParams.acceptableClientIds
-      - CreateCustomProviderParams.attributeMapping
-      - CreateCustomProviderParams.authorizationParams
-      - CreateCustomProviderParams.authorizationUrl
-      - CreateCustomProviderParams.clientId
-      - CreateCustomProviderParams.clientSecret
-      - CreateCustomProviderParams.customClaimsAllowlist
-      - CreateCustomProviderParams.discoveryUrl
-      - CreateCustomProviderParams.emailOptional
-      - CreateCustomProviderParams.enabled
-      - CreateCustomProviderParams.identifier
-      - CreateCustomProviderParams.issuer
-      - CreateCustomProviderParams.jwksUri
-      - CreateCustomProviderParams.name
-      - CreateCustomProviderParams.pkceEnabled
-      - CreateCustomProviderParams.providerType
-      - CreateCustomProviderParams.scopes
-      - CreateCustomProviderParams.skipNonceCheck
-      - CreateCustomProviderParams.toJson
-      - CreateCustomProviderParams.tokenUrl
-      - CreateCustomProviderParams.userinfoUrl
+      - CustomProviderType.fromValue
+      - CreateCustomProviderOptions
+      - CreateCustomProviderOptions.CreateCustomProviderOptions
+      - CreateCustomProviderOptions.acceptableClientIds
+      - CreateCustomProviderOptions.attributeMapping
+      - CreateCustomProviderOptions.authorizationParameters
+      - CreateCustomProviderOptions.authorizationUrl
+      - CreateCustomProviderOptions.clientId
+      - CreateCustomProviderOptions.clientSecret
+      - CreateCustomProviderOptions.customClaimsAllowlist
+      - CreateCustomProviderOptions.discoveryUrl
+      - CreateCustomProviderOptions.emailOptional
+      - CreateCustomProviderOptions.enabled
+      - CreateCustomProviderOptions.identifier
+      - CreateCustomProviderOptions.issuer
+      - CreateCustomProviderOptions.jwksUri
+      - CreateCustomProviderOptions.name
+      - CreateCustomProviderOptions.pkceEnabled
+      - CreateCustomProviderOptions.providerType
+      - CreateCustomProviderOptions.scopes
+      - CreateCustomProviderOptions.skipNonceCheck
+      - CreateCustomProviderOptions.toJson
+      - CreateCustomProviderOptions.tokenUrl
+      - CreateCustomProviderOptions.userInfoUrl
       - CustomOAuthProvider
       - CustomOAuthProvider.CustomOAuthProvider
       - CustomOAuthProvider.acceptableClientIds
       - CustomOAuthProvider.attributeMapping
-      - CustomOAuthProvider.authorizationParams
+      - CustomOAuthProvider.authorizationParameters
       - CustomOAuthProvider.authorizationUrl
       - CustomOAuthProvider.clientId
       - CustomOAuthProvider.createdAt
@@ -578,7 +577,7 @@ features:
       - CustomOAuthProvider.skipNonceCheck
       - CustomOAuthProvider.tokenUrl
       - CustomOAuthProvider.updatedAt
-      - CustomOAuthProvider.userinfoUrl
+      - CustomOAuthProvider.userInfoUrl
       - OIDCDiscoveryDocument
       - OIDCDiscoveryDocument.OIDCDiscoveryDocument
       - OIDCDiscoveryDocument.authorizationEndpoint
@@ -586,12 +585,12 @@ features:
       - OIDCDiscoveryDocument.issuer
       - OIDCDiscoveryDocument.jwksUri
       - OIDCDiscoveryDocument.revocationEndpoint
-      - OIDCDiscoveryDocument.supportedIdTokenSigningAlgs
+      - OIDCDiscoveryDocument.supportedIdTokenSigningAlgorithms
       - OIDCDiscoveryDocument.supportedResponseTypes
       - OIDCDiscoveryDocument.supportedScopes
       - OIDCDiscoveryDocument.supportedSubjectTypes
       - OIDCDiscoveryDocument.tokenEndpoint
-      - OIDCDiscoveryDocument.userinfoEndpoint
+      - OIDCDiscoveryDocument.userInfoEndpoint
   auth.admin.get_provider:
     status: implemented
     symbols:
@@ -600,27 +599,27 @@ features:
     status: implemented
     symbols:
       - AuthAdminCustomProvidersApi.updateProvider
-      - UpdateCustomProviderParams
-      - UpdateCustomProviderParams.UpdateCustomProviderParams
-      - UpdateCustomProviderParams.acceptableClientIds
-      - UpdateCustomProviderParams.attributeMapping
-      - UpdateCustomProviderParams.authorizationParams
-      - UpdateCustomProviderParams.authorizationUrl
-      - UpdateCustomProviderParams.clientId
-      - UpdateCustomProviderParams.clientSecret
-      - UpdateCustomProviderParams.customClaimsAllowlist
-      - UpdateCustomProviderParams.discoveryUrl
-      - UpdateCustomProviderParams.emailOptional
-      - UpdateCustomProviderParams.enabled
-      - UpdateCustomProviderParams.issuer
-      - UpdateCustomProviderParams.jwksUri
-      - UpdateCustomProviderParams.name
-      - UpdateCustomProviderParams.pkceEnabled
-      - UpdateCustomProviderParams.scopes
-      - UpdateCustomProviderParams.skipNonceCheck
-      - UpdateCustomProviderParams.toJson
-      - UpdateCustomProviderParams.tokenUrl
-      - UpdateCustomProviderParams.userinfoUrl
+      - UpdateCustomProviderOptions
+      - UpdateCustomProviderOptions.UpdateCustomProviderOptions
+      - UpdateCustomProviderOptions.acceptableClientIds
+      - UpdateCustomProviderOptions.attributeMapping
+      - UpdateCustomProviderOptions.authorizationParameters
+      - UpdateCustomProviderOptions.authorizationUrl
+      - UpdateCustomProviderOptions.clientId
+      - UpdateCustomProviderOptions.clientSecret
+      - UpdateCustomProviderOptions.customClaimsAllowlist
+      - UpdateCustomProviderOptions.discoveryUrl
+      - UpdateCustomProviderOptions.emailOptional
+      - UpdateCustomProviderOptions.enabled
+      - UpdateCustomProviderOptions.issuer
+      - UpdateCustomProviderOptions.jwksUri
+      - UpdateCustomProviderOptions.name
+      - UpdateCustomProviderOptions.pkceEnabled
+      - UpdateCustomProviderOptions.scopes
+      - UpdateCustomProviderOptions.skipNonceCheck
+      - UpdateCustomProviderOptions.toJson
+      - UpdateCustomProviderOptions.tokenUrl
+      - UpdateCustomProviderOptions.userInfoUrl
   auth.admin.delete_provider:
     status: implemented
     symbols:
@@ -636,15 +635,15 @@ features:
     symbols:
       - AuthAdminOAuthApi.createClient
     supporting_symbols:
-      - CreateOAuthClientParams
-      - CreateOAuthClientParams.CreateOAuthClientParams
-      - CreateOAuthClientParams.clientName
-      - CreateOAuthClientParams.clientUri
-      - CreateOAuthClientParams.grantTypes
-      - CreateOAuthClientParams.redirectUris
-      - CreateOAuthClientParams.responseTypes
-      - CreateOAuthClientParams.scope
-      - CreateOAuthClientParams.toJson
+      - CreateOAuthClientOptions
+      - CreateOAuthClientOptions.CreateOAuthClientOptions
+      - CreateOAuthClientOptions.clientName
+      - CreateOAuthClientOptions.clientUri
+      - CreateOAuthClientOptions.grantTypes
+      - CreateOAuthClientOptions.redirectUris
+      - CreateOAuthClientOptions.responseTypes
+      - CreateOAuthClientOptions.scope
+      - CreateOAuthClientOptions.toJson
   auth.oauth_admin.get_client:
     status: implemented
     symbols:
@@ -654,15 +653,15 @@ features:
     symbols:
       - AuthAdminOAuthApi.updateClient
     supporting_symbols:
-      - UpdateOAuthClientParams
-      - UpdateOAuthClientParams.UpdateOAuthClientParams
-      - UpdateOAuthClientParams.clientName
-      - UpdateOAuthClientParams.clientUri
-      - UpdateOAuthClientParams.grantTypes
-      - UpdateOAuthClientParams.redirectUris
-      - UpdateOAuthClientParams.responseTypes
-      - UpdateOAuthClientParams.scope
-      - UpdateOAuthClientParams.toJson
+      - UpdateOAuthClientOptions
+      - UpdateOAuthClientOptions.UpdateOAuthClientOptions
+      - UpdateOAuthClientOptions.clientName
+      - UpdateOAuthClientOptions.clientUri
+      - UpdateOAuthClientOptions.grantTypes
+      - UpdateOAuthClientOptions.redirectUris
+      - UpdateOAuthClientOptions.responseTypes
+      - UpdateOAuthClientOptions.scope
+      - UpdateOAuthClientOptions.toJson
   auth.oauth_admin.delete_client:
     status: implemented
     symbols:
@@ -1172,7 +1171,7 @@ features:
   storage.file_buckets.file_info:
     status: implemented
     symbols:
-      - StorageFileApi.info
+      - StorageFileApi.getMetadata
     supporting_symbols:
       - FileObjectV2
       - FileObjectV2.FileObjectV2
@@ -1247,7 +1246,7 @@ features:
       - VectorBucketEncryption
       - VectorBucketEncryption.VectorBucketEncryption
       - VectorBucketEncryption.kmsKeyArn
-      - VectorBucketEncryption.sseType
+      - VectorBucketEncryption.serverSideEncryptionType
       - VectorBucketEncryption.fromJson
       - VectorBucketList
       - VectorBucketList.VectorBucketList
@@ -1407,7 +1406,7 @@ features:
       - CreateTableRequest.CreateTableRequest
       - CreateTableRequest.location
       - CreateTableRequest.name
-      - CreateTableRequest.partitionSpec
+      - CreateTableRequest.partitionSpecification
       - CreateTableRequest.properties
       - CreateTableRequest.schema
       - CreateTableRequest.stageCreate
@@ -1437,18 +1436,16 @@ features:
       - LoadTableOptions.ifNoneMatch
       - LoadTableOptions.snapshots
       - TableSnapshotScope
-      - TableSnapshotScope.TableSnapshotScope
-      - TableSnapshotScope.value
   storage.analytics.update_table:
     status: implemented
     note: Data definition table updates (schema, partition spec, sort order, properties, location) are modelled as typed TableUpdate subclasses; snapshot, statistics and encryption key updates are sent through the TableUpdate.raw escape hatch.
     symbols:
       - IcebergRestCatalog.updateTable
     supporting_symbols:
-      - AddPartitionSpecUpdate
-      - AddPartitionSpecUpdate.AddPartitionSpecUpdate
-      - AddPartitionSpecUpdate.spec
-      - AddPartitionSpecUpdate.toJson
+      - AddPartitionSpecificationUpdate
+      - AddPartitionSpecificationUpdate.AddPartitionSpecificationUpdate
+      - AddPartitionSpecificationUpdate.specification
+      - AddPartitionSpecificationUpdate.toJson
       - AddSchemaUpdate
       - AddSchemaUpdate.AddSchemaUpdate
       - AddSchemaUpdate.schema
@@ -1468,10 +1465,10 @@ features:
       - AssertDefaultSortOrderId.AssertDefaultSortOrderId
       - AssertDefaultSortOrderId.defaultSortOrderId
       - AssertDefaultSortOrderId.toJson
-      - AssertDefaultSpecId
-      - AssertDefaultSpecId.AssertDefaultSpecId
-      - AssertDefaultSpecId.defaultSpecId
-      - AssertDefaultSpecId.toJson
+      - AssertDefaultSpecificationId
+      - AssertDefaultSpecificationId.AssertDefaultSpecificationId
+      - AssertDefaultSpecificationId.defaultSpecificationId
+      - AssertDefaultSpecificationId.toJson
       - AssertLastAssignedFieldId
       - AssertLastAssignedFieldId.AssertLastAssignedFieldId
       - AssertLastAssignedFieldId.lastAssignedFieldId
@@ -1502,10 +1499,10 @@ features:
       - RawTableUpdate.action
       - RawTableUpdate.body
       - RawTableUpdate.toJson
-      - RemovePartitionSpecsUpdate
-      - RemovePartitionSpecsUpdate.RemovePartitionSpecsUpdate
-      - RemovePartitionSpecsUpdate.specIds
-      - RemovePartitionSpecsUpdate.toJson
+      - RemovePartitionSpecificationsUpdate
+      - RemovePartitionSpecificationsUpdate.RemovePartitionSpecificationsUpdate
+      - RemovePartitionSpecificationsUpdate.specificationIds
+      - RemovePartitionSpecificationsUpdate.toJson
       - RemovePropertiesUpdate
       - RemovePropertiesUpdate.RemovePropertiesUpdate
       - RemovePropertiesUpdate.removals
@@ -1530,10 +1527,10 @@ features:
       - SetDefaultSortOrderUpdate.SetDefaultSortOrderUpdate
       - SetDefaultSortOrderUpdate.sortOrderId
       - SetDefaultSortOrderUpdate.toJson
-      - SetDefaultSpecUpdate
-      - SetDefaultSpecUpdate.SetDefaultSpecUpdate
-      - SetDefaultSpecUpdate.specId
-      - SetDefaultSpecUpdate.toJson
+      - SetDefaultSpecificationUpdate
+      - SetDefaultSpecificationUpdate.SetDefaultSpecificationUpdate
+      - SetDefaultSpecificationUpdate.specificationId
+      - SetDefaultSpecificationUpdate.toJson
       - SetLocationUpdate
       - SetLocationUpdate.SetLocationUpdate
       - SetLocationUpdate.location
@@ -1659,7 +1656,7 @@ features:
       - RealtimeClient.disconnect
       - RealtimeClientOptions.connectionCloseTimeout
     supporting_symbols:
-      - Constants.wsCloseNormal
+      - Constants.webSocketCloseNormal
       - RealtimeClient.onClose
       - RealtimeCloseEvent
       - RealtimeCloseEvent.RealtimeCloseEvent
@@ -1698,7 +1695,7 @@ features:
   realtime.client.set_auth_token:
     status: implemented
     symbols:
-      - RealtimeClient.setAuth
+      - RealtimeClient.setAccessToken
     supporting_symbols:
       - RealtimeClient.accessToken
 
@@ -1771,9 +1768,9 @@ features:
       - PresenceEvents.state
       - PresenceOnJoinCallback
       - PresenceOnLeaveCallback
-      - PresenceOpts
-      - PresenceOpts.PresenceOpts
-      - PresenceOpts.events
+      - PresenceOptions
+      - PresenceOptions.PresenceOptions
+      - PresenceOptions.events
       - RealtimePresenceJoinPayload
       - RealtimePresenceJoinPayload.RealtimePresenceJoinPayload
       - RealtimePresenceJoinPayload.currentPresences
@@ -1839,7 +1836,7 @@ features:
       - Presence.deepClone
       - Presence.fromJson
       - Presence.payload
-      - Presence.presenceRef
+      - Presence.presenceReference
       - Presence.toString
       - RealtimeChannel.presence
       - RealtimePresence
@@ -1877,13 +1874,13 @@ features:
   realtime.configuration.reconnect_backoff:
     status: implemented
     symbols:
-      - RealtimeClient.reconnectAfterMs
+      - RealtimeClient.reconnectAfter
   realtime.configuration.heartbeat_interval:
     status: implemented
     symbols:
-      - RealtimeClient.heartbeatIntervalMs
+      - RealtimeClient.heartbeatInterval
     supporting_symbols:
-      - Constants.defaultHeartbeatIntervalMs
+      - Constants.defaultHeartbeatInterval
   realtime.configuration.access_token_callback:
     status: implemented
     note: "On connect the access token is resolved before the send buffer is flushed; buffered channel join payloads are patched with the token and re-sent so subscriptions authenticate correctly when the token resolves asynchronously (e.g. read from async storage)."
@@ -1907,7 +1904,7 @@ features:
       - RealtimeEncode
       - RealtimeProtocolVersion
       - RealtimeProtocolVersion.RealtimeProtocolVersion
-      - RealtimeProtocolVersion.vsn
+      - RealtimeProtocolVersion.wireVersion
   realtime.configuration.deferred_disconnect:
     status: implemented
     symbols:
@@ -1930,7 +1927,7 @@ features:
   functions.invocation.set_auth_token:
     status: implemented
     symbols:
-      - FunctionsClient.setAuth
+      - FunctionsClient.setAccessToken
   functions.invocation.method_override:
     status: implemented
     note: "The HttpMethod enum is shared with postgrest, so it also offers head, which supabase-js does not expose for function invocation."
@@ -1960,10 +1957,10 @@ features:
   client.authentication_integration.cross_client_token_sync:
     status: implemented
     symbols:
-      - PostgrestClient.setAuth
-      - RealtimeClient.setAuth
-      - SupabaseStorageClient.setAuth
-      - FunctionsClient.setAuth
+      - PostgrestClient.setAccessToken
+      - RealtimeClient.setAccessToken
+      - SupabaseStorageClient.setAccessToken
+      - FunctionsClient.setAccessToken
   client.authentication_integration.oauth_flow_type:
     status: implemented
     symbols:
@@ -2277,14 +2274,14 @@ supporting_symbols:
   - OAuthClient.registrationType
   - OAuthClient.responseTypes
   - OAuthClient.scope
-  - OAuthClient.tokenEndpointAuthMethod
+  - OAuthClient.tokenEndpointAuthenticationMethod
   - OAuthClient.updatedAt
   - OAuthClientGrantType
   - OAuthClientRegistrationType
-  - OAuthClientRegistrationType.fromString
+  - OAuthClientRegistrationType.fromValue
   - OAuthClientResponseType
   - OAuthClientType
-  - OAuthClientType.fromString
+  - OAuthClientType.fromValue
   - PartitionField
   - PartitionField.PartitionField
   - PartitionField.fieldId
@@ -2293,12 +2290,12 @@ supporting_symbols:
   - PartitionField.sourceId
   - PartitionField.toJson
   - PartitionField.transform
-  - PartitionSpec
-  - PartitionSpec.PartitionSpec
-  - PartitionSpec.fields
-  - PartitionSpec.fromJson
-  - PartitionSpec.specId
-  - PartitionSpec.toJson
+  - PartitionSpecification
+  - PartitionSpecification.PartitionSpecification
+  - PartitionSpecification.fields
+  - PartitionSpecification.fromJson
+  - PartitionSpecification.specificationId
+  - PartitionSpecification.toJson
   - Passkey
   - Passkey.==
   - Passkey.Passkey
@@ -2311,10 +2308,10 @@ supporting_symbols:
   - Passkey.toJson
   - PostgrestBuilder
   - PostgrestBuilder.PostgrestBuilder
-  - PostgrestBuilder.appendSearchParams
+  - PostgrestBuilder.appendSearchParameters
   - PostgrestBuilder.asStream
   - PostgrestBuilder.catchError
-  - PostgrestBuilder.overrideSearchParams
+  - PostgrestBuilder.overrideSearchParameters
   - PostgrestBuilder.then
   - PostgrestBuilder.whenComplete
   - PostgrestApiException
@@ -2368,9 +2365,9 @@ supporting_symbols:
   - RealtimeChannelConfig.toMap
   - RealtimeClient
   - RealtimeClient.RealtimeClient
-  - RealtimeClient.endPoint
-  - RealtimeClient.endPointURL
-  - RealtimeClient.params
+  - RealtimeClient.endpoint
+  - RealtimeClient.endpointUrl
+  - RealtimeClient.parameters
   - RealtimeClient.timeout
   - RealtimeClient.version
   - RealtimeClientOptions
@@ -2411,13 +2408,13 @@ supporting_symbols:
   - Snapshot.sequenceNumber
   - Snapshot.snapshotId
   - Snapshot.summary
-  - Snapshot.timestampMs
+  - Snapshot.timestamp
   - Snapshot.toJson
   - SnapshotReference
   - SnapshotReference.SnapshotReference
   - SnapshotReference.fromJson
-  - SnapshotReference.maxReferenceAgeMs
-  - SnapshotReference.maxSnapshotAgeMs
+  - SnapshotReference.maxReferenceAge
+  - SnapshotReference.maxSnapshotAge
   - SnapshotReference.minSnapshotsToKeep
   - SnapshotReference.snapshotId
   - SnapshotReference.toJson
@@ -2500,7 +2497,7 @@ supporting_symbols:
   - SupabaseStreamFilterBuilder.SupabaseStreamFilterBuilder
   - TableField
   - TableField.TableField
-  - TableField.doc
+  - TableField.documentation
   - TableField.fromJson
   - TableField.id
   - TableField.initialDefault
@@ -2521,16 +2518,16 @@ supporting_symbols:
   - TableMetadata.currentSchemaId
   - TableMetadata.currentSnapshotId
   - TableMetadata.defaultSortOrderId
-  - TableMetadata.defaultSpecId
+  - TableMetadata.defaultSpecificationId
   - TableMetadata.formatVersion
   - TableMetadata.fromJson
   - TableMetadata.lastColumnId
-  - TableMetadata.lastUpdatedMs
+  - TableMetadata.lastUpdated
   - TableMetadata.location
   - TableMetadata.metadataLocation
-  - TableMetadata.partitionSpecs
+  - TableMetadata.partitionSpecifications
   - TableMetadata.properties
-  - TableMetadata.refs
+  - TableMetadata.references
   - TableMetadata.schemas
   - TableMetadata.snapshots
   - TableMetadata.sortOrders
@@ -2547,7 +2544,7 @@ supporting_symbols:
   - User.User
   - User.actionLink
   - User.appMetadata
-  - User.aud
+  - User.audience
   - User.confirmationSentAt
   - User.createdAt
   - User.email


### PR DESCRIPTION
## What kind of change does this PR introduce?

Breaking change, refactor. Closes SDK-1479.

## What is the current behavior?

A repository-wide sweep found public identifiers that still use abbreviations: `setAuth`, `queryParams`, `opts`, `vsn`, `heartbeatIntervalMs`, the Iceberg `spec` cluster, and more.

## What is the new behavior?

They are spelled out, continuing the precedent set by `conn` to `connection`.

**The wire format is untouched.** Wherever a JSON key, query parameter or URL path matched the abbreviation, only the Dart identifier is renamed and the literal key stays: `vsn`, `presence_ref`, `iss`/`sub`/`aud`/`exp`/`nbf`/`iat`/`jti`, `kty`/`key_ops`/`alg`/`kid`, `authorization_params`, `token_endpoint_auth_method`, `sseType`, `spec-id`, `spec-ids`, `default-spec-id`, `partition-specs`, `refs`, `doc`, `timestamp-ms`, `max-ref-age-ms`, `max-snapshot-age-ms`, `last-updated-ms`, and the `/object/info/` path.

### Highlights

Across every package: `setAuth()` → `setAccessToken()`, `queryParams:` → `queryParameters:`, `opts:` → `options:`, `PresenceOpts` → `PresenceOptions`, and `appendSearchParams`/`overrideSearchParams`/`toQueryParams` → `…Parameters`.

`realtime_client`: `params` → `parameters`, `endPoint`/`endPointURL` → `endpoint`/`endpointUrl`, `wsCloseNormal` → `webSocketCloseNormal`, `RealtimeProtocolVersion.vsn` → `wireVersion`, `Presence.presenceRef` → `presenceReference`, and the `RealtimeChannel` constructor takes `config:` instead of `params:` (it always took a `RealtimeChannelConfig`).

`supabase_auth`: the JWT claim and header fields spell out their names, `User.aud` → `audience`, the four `…Params` option classes become `…Options`, `validateExp` → `validateExpiration`, `AMRMethod`/`AMREntry` → `AuthenticationMethodReference`/`AuthenticationMethodReferenceEntry`.

`storage_client`: `StorageFileApi.info()` → `getMetadata()`, `sseType` → `serverSideEncryptionType`, the Iceberg `spec` cluster becomes `…Specification…`, `TableField.doc` → `documentation`, `TableMetadata.refs` → `references`.

### Enums use the built-in `name`

`AuthChangeEvent.jsName` is gone rather than renamed: the enum declares `name` itself, so `AuthChangeEvent.signedIn.name` is `'SIGNED_IN'`, the value it always sent. The internal `fromString` therefore matches on the wire value; writer and reader both use `.name`, so nothing round-trips differently.

`TableSnapshotScope` drops its redundant `value` field, since `all` and `refs` already match what the catalog expects, and `.name` returns the same string.

### Type changes

`RealtimeClient.heartbeatInterval` and the function returned by `reconnectAfter` use `Duration` instead of millisecond counts, and the Iceberg fields that carried an `Ms` suffix drop it for `Duration` (`maxReferenceAge`, `maxSnapshotAge`) or `DateTime` (`Snapshot.timestamp`, `TableMetadata.lastUpdated`).

### Deliberately not renamed

`JWK`/`JWKSet` (more common than spelling them out), `PlatformInfo`, `uuidRegex`, `YAJsonIsolate` (matches its package), `RealtimeLogLevel.warn` (the wire value), and the `signup`/`magiclink` enum values on `GenerateLinkType`/`OtpType` (their `snakeCase` already produces the wire value). Also `rpc(String fn, {params})`, the PostgREST operator family and `PostgresChangeFilterType`, for cross-SDK parity.

## Additional context

`MIGRATION.md` gains a section listing every rename, and `sdk-compliance.yaml` is reconciled. The three supabase/sdk checks (`check-api-symbols`, `check-drift`, `validate-compliance`) pass locally, as do `dart analyze`, `dart format`, `dcm analyze` and every package's test suite against a local Supabase stack.

Internal identifiers, tests and examples landed separately in #1709 (SDK-1480), which this branch is rebased on top of.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added utilities for converting millisecond values into UTC timestamps and `Duration` values.
  - Added migration guidance for updated public API names and types.

- **Breaking Changes**
  - Replaced abbreviated public identifiers with descriptive names across authentication, realtime, storage, PostgREST, functions, and shared models.
  - Authentication token setters now use `setAccessToken`.
  - Realtime timing options use `Duration`, and timestamp fields use `DateTime`.
  - JSON, URL, query, and wire-format names remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->