### PR TITLE
fix(auth): parse expires_in as num in Session.fromJson

### DIFF
--- a/packages/supabase_auth/lib/src/auth_admin_oauth_api.dart
+++ b/packages/supabase_auth/lib/src/auth_admin_oauth_api.dart
@@ -44,9 +44,9 @@ class OAuthClientListResponse {
           .map((e) => OAuthClient.fromJson(e as Map<String, dynamic>))
           .toList(),
       audience: json['aud'] as String?,
-      nextPage: json['nextPage'] as int?,
-      lastPage: json['lastPage'] as int?,
-      total: json['total'] as int? ?? 0,
+      nextPage: (json['nextPage'] as num?)?.toInt(),
+      lastPage: (json['lastPage'] as num?)?.toInt(),
+      total: (json['total'] as num?)?.toInt() ?? 0,
     );
   }
 }

--- a/packages/supabase_auth/lib/src/types/jwt.dart
+++ b/packages/supabase_auth/lib/src/types/jwt.dart
@@ -79,9 +79,9 @@ class JwtPayload {
       issuer: json['iss'] as String?,
       subject: json['sub'] as String?,
       audience: json['aud'],
-      expiresAt: json['exp'] as int?,
-      notBefore: json['nbf'] as int?,
-      issuedAt: json['iat'] as int?,
+      expiresAt: (json['exp'] as num?)?.toInt(),
+      notBefore: (json['nbf'] as num?)?.toInt(),
+      issuedAt: (json['iat'] as num?)?.toInt(),
       jwtId: json['jti'] as String?,
       claims: Map<String, dynamic>.of(json),
     );

--- a/packages/supabase_auth/lib/src/types/session.dart
+++ b/packages/supabase_auth/lib/src/types/session.dart
@@ -47,7 +47,7 @@ class Session {
     }
     return Session(
       accessToken: json['access_token'] as String,
-      expiresIn: json['expires_in'] as int?,
+      expiresIn: (json['expires_in'] as num?)?.toInt(),
       refreshToken: json['refresh_token'] as String?,
       tokenType: json['token_type'] as String,
       providerToken: json['provider_token'] as String?,

--- a/packages/supabase_auth/test/src/helper_test.dart
+++ b/packages/supabase_auth/test/src/helper_test.dart
@@ -1,4 +1,5 @@
 import 'package:supabase_auth/src/helper.dart';
+import 'package:supabase_auth/src/types/jwt.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -361,6 +362,21 @@ void main() {
           isFalse,
         );
       });
+    });
+  });
+
+  group('JwtPayload', () {
+    test('fromJson accepts double exp, nbf, and iat', () {
+      final payload = JwtPayload.fromJson({
+        'sub': '1234567890',
+        'exp': 1700000000.0,
+        'nbf': 1600000000.0,
+        'iat': 1650000000.0,
+      });
+
+      expect(payload.expiresAt, equals(1700000000));
+      expect(payload.notBefore, equals(1600000000));
+      expect(payload.issuedAt, equals(1650000000));
     });
   });
 }

--- a/packages/supabase_auth/test/src/types/session_test.dart
+++ b/packages/supabase_auth/test/src/types/session_test.dart
@@ -109,6 +109,26 @@ void main() {
         );
         expect(session.user.id, equals('123'));
       });
+
+      test('accepts a double expires_in, as sent by a BroadcastChannel', () {
+        final json = {
+          'access_token': 'test-access-token',
+          'expires_in': 3600.0,
+          'token_type': 'bearer',
+          'user': {
+            'id': '123',
+            'app_metadata': <String, dynamic>{},
+            'user_metadata': <String, dynamic>{},
+            'aud': 'authenticated',
+            'created_at': '2023-01-01T00:00:00Z',
+          },
+        };
+
+        final session = Session.fromJson(json);
+
+        expect(session, isNotNull);
+        expect(session!.expiresIn, equals(3600));
+      });
     });
 
     group('toJson', () {


### PR DESCRIPTION
## What

Fixes an issue where `Session.fromJson` threw a runtime `TypeError` on Web when compiled with WebAssembly (`flutter build web --wasm`) during cross-tab authentication synchronization.

Resolves #1687

---

## Root Cause Analysis

In `packages/supabase_auth/lib/src/types/session.dart`, `Session.fromJson` previously cast `json['expires_in']` directly to `int?`:

```dart
expiresIn: json['expires_in'] as int?,
```

While JSON parsed by Dart's native `dart:convert` `jsonDecode` deserializes integer literals as `int`, `Session.fromJson` is also invoked directly with map payloads from JavaScript interop in `AuthClient._mayStartBroadcastChannel` (via `broadcast_web.dart`):

```dart
if (messageEvent['session'] != null) {
  session = Session.fromJson(messageEvent['session']);
}
```

In Dart JS-interop (`dartify()`), all JavaScript numbers cross the boundary as `double` values (e.g. `3600.0`).

- **Under `dart2js`:** Dart integers and doubles share an underlying JavaScript `Number` representation at runtime, so `3600.0 as int?` succeeded without throwing.
- **Under `dart2wasm` & Dart VM:** `int` and `double` are distinct runtime types. Attempting to cast `3600.0 as int?` results in a runtime error:
  ```
  TypeError: type 'double' is not a subtype of type 'int?' in type cast
  ```

Because this exception occurred inside the `BroadcastChannel` `onMessage` event listener (outside the initial channel setup `try/catch` guard), all remaining operations in the listener were aborted:
- `_saveSession(session)` / `_removeSession()` was skipped.
- `notifyAllSubscribers(event, session: session, broadcast: false)` was skipped.

Consequently, receiving browser tabs silently failed to synchronize session state (login, logout, token refresh), causing unexpected sign-outs or stale tokens when switching between tabs.

---

## Changes

### 1. `Session.fromJson`
In [`packages/supabase_auth/lib/src/types/session.dart`](https://github.com/supabase/supabase-flutter/blob/main/packages/supabase_auth/lib/src/types/session.dart):
- Updated `expiresIn` parsing to `(json['expires_in'] as num?)?.toInt()`. This safely accommodates `int`, `double`, and `null` without throwing a type cast error.

### 2. Sibling Model Defensive Updates
For consistency and resilience against numbers crossing JS boundaries:
- In [`packages/supabase_auth/lib/src/types/jwt.dart`](https://github.com/supabase/supabase-flutter/blob/main/packages/supabase_auth/lib/src/types/jwt.dart): Updated `JwtPayload.fromJson` to parse `exp`, `nbf`, and `iat` claims using `(json['...'] as num?)?.toInt()`.
- In [`packages/supabase_auth/lib/src/auth_admin_oauth_api.dart`](https://github.com/supabase/supabase-flutter/blob/main/packages/supabase_auth/lib/src/auth_admin_oauth_api.dart): Updated `OAuthClientListResponse.fromJson` to parse `nextPage`, `lastPage`, and `total` using `(json['...'] as num?)?.toInt()`.

### 3. Unit Tests
- Added unit test in [`packages/supabase_auth/test/src/types/session_test.dart`](https://github.com/supabase/supabase-flutter/blob/main/packages/supabase_auth/test/src/types/session_test.dart) verifying that `Session.fromJson` parses a `double` `expires_in` (e.g. `3600.0`) to `int` `3600`.
- Added unit test in [`packages/supabase_auth/test/src/helper_test.dart`](https://github.com/supabase/supabase-flutter/blob/main/packages/supabase_auth/test/src/helper_test.dart) verifying that `JwtPayload.fromJson` correctly parses `double` timestamps for `exp`, `nbf`, and `iat`.

---

## Testing & Verification

- **Unit Tests**: Ran `dart test test/src/types/session_test.dart test/src/helper_test.dart` in `packages/supabase_auth` (all 59 tests passing).
- **Workspace Static Analysis**: Ran `dart run melos analyze` across all 12 packages and 8 example projects with zero errors or warnings (`SUCCESS`).
- **Code Formatting**: Formatted adhering to 80-character line length limit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication data handling when numeric values are received in different JSON formats.
  * OAuth client lists now correctly interpret pagination and total counts while preserving missing values and default totals.
  * JWT timestamps and session expiration values are consistently converted to integers.
* **Tests**
  * Added coverage for decimal-formatted timestamp and expiration values to ensure reliable parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->