### PR TITLE
chore: use caret constraints for internal package dependencies

### DIFF
--- a/packages/functions_client/pubspec.yaml
+++ b/packages/functions_client/pubspec.yaml
@@ -21,8 +21,8 @@ dependencies:
   http: ^1.6.0
   logging: ^1.3.0
   meta: ^1.16.0
-  supabase_common: 0.1.2
-  yet_another_json_isolate: 2.1.1
+  supabase_common: ^0.1.2
+  yet_another_json_isolate: ^2.1.1
 
 dev_dependencies:
   supabase_lints: ^0.1.1

--- a/packages/postgrest/pubspec.yaml
+++ b/packages/postgrest/pubspec.yaml
@@ -19,10 +19,10 @@ resolution: workspace
 
 dependencies:
   http: ^1.6.0
-  yet_another_json_isolate: 2.1.1
+  yet_another_json_isolate: ^2.1.1
   meta: ^1.16.0
   logging: ^1.3.0
-  supabase_common: 0.1.2
+  supabase_common: ^0.1.2
 
 dev_dependencies:
   collection: ^1.19.0

--- a/packages/realtime_client/pubspec.yaml
+++ b/packages/realtime_client/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
   http: ^1.6.0
   logging: ^1.3.0
   meta: ^1.16.0
-  supabase_common: 0.1.2
+  supabase_common: ^0.1.2
   web_socket_channel: ^3.0.3
 
 dev_dependencies:

--- a/packages/storage_client/pubspec.yaml
+++ b/packages/storage_client/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
   mime: '>=2.0.0 <3.0.0'
   meta: ^1.16.0
   logging: ^1.3.0
-  supabase_common: 0.1.2
+  supabase_common: ^0.1.2
 
 dev_dependencies:
   test: ^1.25.0

--- a/packages/supabase/pubspec.yaml
+++ b/packages/supabase/pubspec.yaml
@@ -18,15 +18,15 @@ environment:
 resolution: workspace
 
 dependencies:
-  functions_client: 2.7.1
+  functions_client: ^2.7.1
   http: ^1.6.0
   meta: ^1.7.0
-  postgrest: 2.9.1
-  realtime_client: 2.13.0
-  storage_client: 2.8.0
-  supabase_auth: 3.0.0-dev.1
-  supabase_common: 0.1.2
-  yet_another_json_isolate: 2.1.1
+  postgrest: ^2.9.1
+  realtime_client: ^2.13.0
+  storage_client: ^2.8.0
+  supabase_auth: ^3.0.0-dev.1
+  supabase_common: ^0.1.2
+  yet_another_json_isolate: ^2.1.1
   logging: ^1.3.0
 
 dev_dependencies:

--- a/packages/supabase_auth/pubspec.yaml
+++ b/packages/supabase_auth/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
   http: ^1.6.0
   meta: ^1.16.0
   logging: ^1.3.0
-  supabase_common: 0.1.2
+  supabase_common: ^0.1.2
   web: ">=1.0.0 <2.0.0"
   dart_jsonwebtoken: ">=3.0.0 <4.0.0"
 

--- a/packages/supabase_flutter/pubspec.yaml
+++ b/packages/supabase_flutter/pubspec.yaml
@@ -26,8 +26,8 @@ dependencies:
   http: ^1.6.0
   meta: ^1.16.0
   passkeys_platform_interface: ^2.8.0
-  supabase: 2.16.0
-  supabase_common: 0.1.2
+  supabase: ^2.16.0
+  supabase_common: ^0.1.2
   url_launcher: ^6.3.2
   shared_preferences: ^2.5.5
   logging: ^1.3.0


### PR DESCRIPTION
## What

Every internal package dependency in this repo now uses a caret constraint instead of an exact pin.

| Package | Dependencies changed |
| --- | --- |
| `supabase` | `functions_client`, `postgrest`, `realtime_client`, `storage_client`, `supabase_auth`, `supabase_common`, `yet_another_json_isolate` |
| `supabase_flutter` | `supabase`, `supabase_common` |
| `functions_client` | `supabase_common`, `yet_another_json_isolate` |
| `postgrest` | `yet_another_json_isolate`, `supabase_common` |
| `supabase_auth` | `supabase_common` |
| `storage_client` | `supabase_common` |
| `realtime_client` | `supabase_common` |

## Why

Exact pins meant a patch release of any leaf package required republishing every package above it in the tree just to let users pick the fix up. With carets, a patch or minor release of an internal package flows through to consumers without a coordinated bump across the workspace.

## Notes

- `supabase_common: ^0.1.2` resolves to `>=0.1.2 <0.2.0` under pub's pre-1.0 caret rules, so a `0.2.0` release still requires bumping dependents. That is the standard convention for a pre-1.0 package.
- `supabase_auth: ^3.0.0-dev.1` resolves to `>=3.0.0-dev.1 <4.0.0`, which admits later dev prereleases and the eventual stable `3.0.0`.
- `supabase_lints` dev dependencies and the example apps already used carets, so they are untouched.

## Testing

`dart pub get` resolves the workspace cleanly.