### PR TITLE
fix(realtime): parse whole-number doubles in toInt transformer

### DIFF
--- a/packages/realtime_client/lib/src/transformers.dart
+++ b/packages/realtime_client/lib/src/transformers.dart
@@ -230,11 +230,14 @@ double? toDouble(dynamic value) {
 
 @internal
 int? toInt(dynamic value) {
-  if (value is int) {
-    return value;
-  }
+  // On the web an integral number satisfies both `is int` and `is double`,
+  // so check `double` first to keep the whole-number and range validation
+  // in effect on every platform.
   if (value is double) {
     return _wholeDoubleToInt(value);
+  }
+  if (value is int) {
+    return value;
   }
   if (value == null) {
     return null;

--- a/packages/realtime_client/lib/src/transformers.dart
+++ b/packages/realtime_client/lib/src/transformers.dart
@@ -244,15 +244,28 @@ int? toInt(dynamic value) {
   if (parsedInt != null) {
     return parsedInt;
   }
-  final parsedDouble = double.tryParse(stringValue);
-  if (parsedDouble == null) {
+  final match = _integerWithZeroFraction.firstMatch(stringValue);
+  if (match == null) {
     return null;
   }
-  return _wholeDoubleToInt(parsedDouble);
+  return int.tryParse(match.group(1)!);
 }
+
+/// Matches an integer with a decimal fraction of only zeros, such as `10.0`
+/// or `-3.000`. Parsing the integer part directly keeps values above 2^53
+/// exact, which a round trip through [double] would not.
+final _integerWithZeroFraction = RegExp(r'^([+-]?\d+)\.0+$');
+
+/// The lowest and highest [double] values enclosing the native 64-bit
+/// integer range, -2^63 and 2^63. Both are exactly representable as doubles.
+const _minIntAsDouble = -9223372036854775808.0;
+const _maxIntExclusiveAsDouble = 9223372036854775808.0;
 
 int? _wholeDoubleToInt(double value) {
   if (!value.isFinite || value.truncateToDouble() != value) {
+    return null;
+  }
+  if (value < _minIntAsDouble || value >= _maxIntExclusiveAsDouble) {
     return null;
   }
   return value.toInt();

--- a/packages/realtime_client/lib/src/transformers.dart
+++ b/packages/realtime_client/lib/src/transformers.dart
@@ -233,10 +233,29 @@ int? toInt(dynamic value) {
   if (value is int) {
     return value;
   }
+  if (value is double) {
+    return _wholeDoubleToInt(value);
+  }
   if (value == null) {
     return null;
   }
-  return int.tryParse(value.toString());
+  final stringValue = value.toString();
+  final parsedInt = int.tryParse(stringValue);
+  if (parsedInt != null) {
+    return parsedInt;
+  }
+  final parsedDouble = double.tryParse(stringValue);
+  if (parsedDouble == null) {
+    return null;
+  }
+  return _wholeDoubleToInt(parsedDouble);
+}
+
+int? _wholeDoubleToInt(double value) {
+  if (!value.isFinite || value.truncateToDouble() != value) {
+    return null;
+  }
+  return value.toInt();
 }
 
 @internal

--- a/packages/realtime_client/test/transformers_test.dart
+++ b/packages/realtime_client/test/transformers_test.dart
@@ -23,6 +23,14 @@ void main() {
   test('transformers toInt', () {
     expect(toInt(10), equals(10));
     expect(toInt('10'), equals(10));
+    expect(toInt(10.0), equals(10));
+    expect(toInt('10.0'), equals(10));
+    expect(toInt('1e3'), equals(1000));
+    expect(toInt(10.5), isNull);
+    expect(toInt('10.5'), isNull);
+    expect(toInt(double.nan), isNull);
+    expect(toInt(double.infinity), isNull);
+    expect(toInt('NaN'), isNull);
     expect(toInt(null), isNull);
     expect(toInt(''), isNull);
     expect(toInt('not a number'), isNull);

--- a/packages/realtime_client/test/transformers_test.dart
+++ b/packages/realtime_client/test/transformers_test.dart
@@ -25,11 +25,19 @@ void main() {
     expect(toInt('10'), equals(10));
     expect(toInt(10.0), equals(10));
     expect(toInt('10.0'), equals(10));
-    expect(toInt('1e3'), equals(1000));
+    expect(toInt('-3.000'), equals(-3));
+    // Above 2^53, where a round trip through double would lose precision.
+    expect(toInt('9007199254740993.0'), equals(9007199254740993));
+    // Outside the 64-bit integer range.
+    expect(toInt('9223372036854775808.0'), isNull);
+    expect(toInt(1e19), isNull);
+    expect(toInt(-1e19), isNull);
+    expect(toInt('1e3'), isNull);
     expect(toInt(10.5), isNull);
     expect(toInt('10.5'), isNull);
     expect(toInt(double.nan), isNull);
     expect(toInt(double.infinity), isNull);
+    expect(toInt(double.negativeInfinity), isNull);
     expect(toInt('NaN'), isNull);
     expect(toInt(null), isNull);
     expect(toInt(''), isNull);


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix / hardening.

## What is the current behavior?

The `toInt` transformer in `packages/realtime_client/lib/src/transformers.dart` falls back to `int.tryParse(value.toString())`, which returns null for whole-number doubles such as `1.0` or the string `'1.0'`. In practice Postgres does not send `1.0` for `int4`/`int8` columns, so this has not caused issues, but the transformer silently dropped such values instead of converting them.

## What is the new behavior?

- `double` inputs that are whole numbers (for example `1.0`) now convert to `int`. Non-finite values and values outside the 64-bit integer range return null instead of clamping.
- String inputs still try `int.tryParse` first, then accept an integer with an all-zero decimal fraction (for example `'10.0'` or `'-3.000'`). The integer part is parsed directly, so values above 2^53 keep exact precision instead of being rounded through `double`.
- Non-integral values (`10.5`, `'10.5'`), scientific notation (`'1e3'`), `NaN`, and infinities return null rather than silently truncating or rounding.

Test cases were added for all of the above, including regression coverage above 2^53 and outside the 64-bit integer range.

## Additional context

No public API changes, `toInt` is `@internal`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved numeric conversion for whole-number decimal values, decimal strings, and scientific notation.
  * Invalid, fractional, infinite, out-of-range, and non-numeric values are now safely rejected.

* **Tests**
  * Expanded coverage for valid and invalid numeric formats, including large values, fractional values, scientific notation, and non-finite numbers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->