### PR TITLE
fix(gotrue): parse expires_in as num in Session.fromJson

### DIFF
--- a/.github/workflows/validate-capabilities.yml
+++ b/.github/workflows/validate-capabilities.yml
@@ -3,6 +3,8 @@ name: SDK Compliance
 on:
   workflow_dispatch:
   pull_request:
+    branches:
+      - main
 
 permissions:
   contents: read

--- a/packages/gotrue/lib/src/gotrue_admin_oauth_api.dart
+++ b/packages/gotrue/lib/src/gotrue_admin_oauth_api.dart
@@ -40,9 +40,9 @@ class OAuthClientListResponse {
           .map((e) => OAuthClient.fromJson(e as Map<String, dynamic>))
           .toList(),
       aud: json['aud'] as String?,
-      nextPage: json['nextPage'] as int?,
-      lastPage: json['lastPage'] as int?,
-      total: json['total'] as int? ?? 0,
+      nextPage: (json['nextPage'] as num?)?.toInt(),
+      lastPage: (json['lastPage'] as num?)?.toInt(),
+      total: (json['total'] as num?)?.toInt() ?? 0,
     );
   }
 }

--- a/packages/gotrue/lib/src/types/jwt.dart
+++ b/packages/gotrue/lib/src/types/jwt.dart
@@ -79,9 +79,9 @@ class JwtPayload {
       iss: json['iss'] as String?,
       sub: json['sub'] as String?,
       aud: json['aud'],
-      exp: json['exp'] as int?,
-      nbf: json['nbf'] as int?,
-      iat: json['iat'] as int?,
+      exp: (json['exp'] as num?)?.toInt(),
+      nbf: (json['nbf'] as num?)?.toInt(),
+      iat: (json['iat'] as num?)?.toInt(),
       jti: json['jti'] as String?,
       claims: Map<String, dynamic>.of(json),
     );

--- a/packages/gotrue/lib/src/types/session.dart
+++ b/packages/gotrue/lib/src/types/session.dart
@@ -46,7 +46,7 @@ class Session {
     }
     return Session(
       accessToken: json['access_token'] as String,
-      expiresIn: json['expires_in'] as int?,
+      expiresIn: (json['expires_in'] as num?)?.toInt(),
       refreshToken: json['refresh_token'] as String?,
       tokenType: json['token_type'] as String,
       providerToken: json['provider_token'] as String?,

--- a/packages/gotrue/test/src/helper_test.dart
+++ b/packages/gotrue/test/src/helper_test.dart
@@ -1,4 +1,5 @@
 import 'package:gotrue/src/helper.dart';
+import 'package:gotrue/src/types/jwt.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -328,6 +329,21 @@ void main() {
           isFalse,
         );
       });
+    });
+  });
+
+  group('JwtPayload', () {
+    test('fromJson accepts double exp, nbf, and iat', () {
+      final payload = JwtPayload.fromJson({
+        'sub': '1234567890',
+        'exp': 1700000000.0,
+        'nbf': 1600000000.0,
+        'iat': 1650000000.0,
+      });
+
+      expect(payload.exp, equals(1700000000));
+      expect(payload.nbf, equals(1600000000));
+      expect(payload.iat, equals(1650000000));
     });
   });
 }

--- a/packages/gotrue/test/src/types/session_test.dart
+++ b/packages/gotrue/test/src/types/session_test.dart
@@ -109,6 +109,26 @@ void main() {
         );
         expect(session.user.id, equals('123'));
       });
+
+      test('accepts a double expires_in, as sent by a BroadcastChannel', () {
+        final json = {
+          'access_token': 'test-access-token',
+          'expires_in': 3600.0,
+          'token_type': 'bearer',
+          'user': {
+            'id': '123',
+            'app_metadata': <String, dynamic>{},
+            'user_metadata': <String, dynamic>{},
+            'aud': 'authenticated',
+            'created_at': '2023-01-01T00:00:00Z',
+          },
+        };
+
+        final session = Session.fromJson(json);
+
+        expect(session, isNotNull);
+        expect(session!.expiresIn, equals(3600));
+      });
     });
 
     group('toJson', () {

--- a/packages/storage_client/lib/src/storage_client.dart
+++ b/packages/storage_client/lib/src/storage_client.dart
@@ -42,6 +42,7 @@ class SupabaseStorageClient extends StorageBucketApi {
   /// only if your project has the dedicated storage host enabled; otherwise
   /// every storage request will fail with an `Invalid Storage request` error.
   /// Defaults to `false` (opt-in).
+  // ignore: use_super_parameters
   SupabaseStorageClient(
     String url,
     Map<String, String> headers, {

--- a/packages/supabase_flutter/example/android/app/build.gradle
+++ b/packages/supabase_flutter/example/android/app/build.gradle
@@ -11,12 +11,8 @@ android {
     ndkVersion = flutter.ndkVersion
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
-    }
-
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
     defaultConfig {
@@ -36,6 +32,12 @@ android {
             // Signing with the debug keys for now, so `flutter run --release` works.
             signingConfig = signingConfigs.debug
         }
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
     }
 }
 

--- a/packages/supabase_flutter/example/android/gradle.properties
+++ b/packages/supabase_flutter/example/android/gradle.properties
@@ -1,4 +1,7 @@
-org.gradle.jvmargs=-Xmx4G -XX:MaxMetaspaceSize=2G -XX:+HeapDumpOnOutOfMemoryError
+org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
-android.enableJetifier=true
-kotlin.version=2.1.20
+# This newDsl flag was added by the Flutter template
+android.newDsl=false
+# This builtInKotlin flag was added by the Flutter template
+android.builtInKotlin=false
+kotlin.version=2.4.0

--- a/packages/supabase_flutter/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/supabase_flutter/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-all.zip

--- a/packages/supabase_flutter/example/android/settings.gradle
+++ b/packages/supabase_flutter/example/android/settings.gradle
@@ -18,8 +18,8 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version '8.13.1' apply false
-    id "org.jetbrains.kotlin.android" version "2.1.20" apply false
+    id "com.android.application" version "9.1.0" apply false
+    id "org.jetbrains.kotlin.android" version "2.4.0" apply false
 }
 
 include ":app"


### PR DESCRIPTION
## What

Hotfix for the `gotrue` 2.27.x line, backporting the Wasm `Session.fromJson` crash fix from #1716.

The base is `release/gotrue-2.27.x`, a maintenance branch cut at the `gotrue-v2.27.1` tag. It cannot target `main`, because `main` has since renamed the package to `supabase_auth` (#1697) and renamed the public API (#1712), so a PR against `main` would read as reverting everything merged since the tag.

Resolves #1687 for the 2.x line.

## The bug

`Session.fromJson` cast `json['expires_in']` straight to `int?`. That map does not always come from `jsonDecode`. `GoTrueClient._mayStartBroadcastChannel` also feeds it payloads that crossed the JavaScript interop boundary through `dartify()` in `broadcast_web.dart`, where every JavaScript number arrives as a `double`.

Under `dart2js` this was invisible, because Dart `int` and `double` share a JavaScript `Number` at runtime, so `3600.0 as int?` succeeded. Under `dart2wasm` they are distinct runtime types and the cast throws:

```
TypeError: type 'double' is not a subtype of type 'int?' in type cast
```

The `json.decode(json.encode(dataMap))` round trip in `broadcast_web.dart` does not rescue this: `3600.0` encodes to `"3600.0"` and decodes back to a `double`.

Because the throw happened inside the `BroadcastChannel` message listener, outside the setup `try`/`catch`, the rest of the listener was skipped. No `_saveSession` or `_removeSession` ran, and `notifyAllSubscribers` never fired, so receiving tabs silently failed to synchronize login, logout, and token refresh.

## The fix

`expires_in` is now parsed as `(json['expires_in'] as num?)?.toInt()`, which accepts `int`, `double`, and `null`. `JwtPayload.fromJson` (`exp`, `nbf`, `iat`) and `OAuthClientListResponse.fromJson` (`nextPage`, `lastPage`, `total`) get the same treatment for their numeric fields.

I traced the rest of the reachable surface. `dartify()` is called in exactly one place in the repository, and the only types built from that data are `Session`, `User`, `UserIdentity`, and `Factor`. `User.fromJson` has no numeric fields, its timestamps are ISO 8601 strings, so after this change nothing reachable from the interop boundary casts to `int`. Everything else in the workspace decodes from a string through `dart:convert`, where integer literals stay `int` on every backend.

## Pipeline fixes

The tag this branch is frozen at no longer builds against the current toolchain, so the second commit carries three unrelated fixes needed to get a green run. All three were verified to be pre-existing drift rather than fallout from this change, by comparing against #1717, an equivalent change on `main` whose run passed minutes apart.

- Flutter stable now ships AGP 9, which rejects the example app's old Gradle DSL. The example's Gradle configuration is ported from `main` (AGP 8.13.1 to 9.1.0, Gradle 8.13 to 9.3.1, Kotlin 2.1.20 to 2.4.0). The example is `publish_to: none`, so nothing published changes.
- `dart analyze --fatal-infos` now reports `use_super_parameters` on `SupabaseStorageClient`. `main` resolved this as part of the fetch layer refactor in #1647, which gave `StorageBucketApi` a stored client field. At this tag the superclass stores nothing, so the local field is still needed and the lint is suppressed instead of backporting that refactor.
- The compliance workflow validates against `supabase/sdk@main`, whose canonical capability identifiers keep moving, so a branch frozen at an old release can never satisfy them. Its `pull_request` trigger is now scoped to pull requests that target `main`.

## Release notes

`melos version` on this branch proposes `gotrue` 2.27.2, plus `supabase` 2.16.1 and `supabase_flutter` 2.17.2 as dependency cascades. Those cascades are required, not incidental: the published `supabase` 2.16.0 pins `gotrue: 2.27.1` exactly and `supabase_flutter` 2.17.1 pins `supabase: 2.16.0` exactly, so publishing `gotrue` alone would reach nobody using the higher level packages.

Note that `release-tag.yml` only triggers on pushes to `main`, so merging the version pull request into this maintenance branch will not create the tags. They need to be pushed manually, or that workflow needs a `workflow_dispatch` trigger, before `release-publish.yml` can run against `gotrue-v2.27.2`.

## Testing

- `dart pub get` resolves the workspace cleanly.
- `dart analyze lib test` in `packages/gotrue`: no issues.
- `dart analyze --fatal-infos packages/storage_client`: no issues.
- `dart test test/src/types/session_test.dart test/src/helper_test.dart`: 57 passing, including two new tests covering a `double` `expires_in` and `double` `exp`, `nbf`, and `iat`.
- `dart format`: clean.
- The Android build is verified by CI only, it was not built locally.
