### PR TITLE
test(supabase_flutter): deflake the expired session stream expectation

### DIFF
--- a/packages/supabase_flutter/test/supabase_flutter_test.dart
+++ b/packages/supabase_flutter/test/supabase_flutter_test.dart
@@ -78,12 +78,12 @@ void main() {
     });
 
     test('emits exception when no auto refresh', () async {
-      // Give it a delay to wait for recoverSession to throw
-      await Future.delayed(const Duration(milliseconds: 100));
-
+      // The session recovery emits a `signedOut` event before the failure
+      // reaches the stream, and the subject replays only the latest event,
+      // so skip past any data events until the error arrives.
       await expectLater(
         Supabase.instance.client.auth.onAuthStateChange,
-        emitsError(isA<AuthException>()),
+        emitsThrough(emitsError(isA<AuthException>())),
       );
     });
   });


### PR DESCRIPTION
## What kind of change does this PR introduce?

Test fix for a flaky WASM CI failure on main.

## What is the current behavior?

`Expired session emits exception when no auto refresh` waits a fixed 100ms and then asserts that the next event on `onAuthStateChange` is an error:

```dart
await Future.delayed(const Duration(milliseconds: 100));
await expectLater(
  Supabase.instance.client.auth.onAuthStateChange,
  emitsError(isA<AuthException>()),
);
```

The session recovery flow emits `initialSession`, then `signedOut` (with `signOutReason: sessionExpired`), and only after the logout HTTP call fails does the `AuthException` reach the stream. Since `ReplaySubject` replays only the latest event, the test passes only when the whole flow, including the HTTP roundtrip, completes within the 100ms budget. On a slow runner the subscription lands between `signedOut` and the error, the replayed event is a data event, and `emitsError` fails:

```
Which: emitted • AuthState(event: signedOut, session: null, fromBroadcast: false, signOutReason: sessionExpired)
```

This is exactly the failure seen on the main WASM runs starting with the run for #1716. The race is unrelated to that commit: reducing the delay reproduces the identical failure on 29286f43, the commit before it, and both failing CI runs executed concurrently on loaded runners while all passing runs did not.

## What is the new behavior?

The test drops the fixed delay and skips past data events until the error arrives, which is deterministic for every interleaving:

```dart
await expectLater(
  Supabase.instance.client.auth.onAuthStateChange,
  emitsThrough(emitsError(isA<AuthException>())),
);
```

Verified locally on the VM and with `flutter test --platform chrome --wasm`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated expired-session authentication coverage to account for intermediate sign-out events and event replay.
  * Improved validation of eventual authentication errors without relying on fixed timing delays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->