### PR TITLE
ci: group codeql-action dependabot updates and run them weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,4 +3,11 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "sunday"
+    groups:
+      # CodeQL fails unless init and analyze run the exact same version, so
+      # they have to be bumped together in a single pull request.
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"


### PR DESCRIPTION
## What

Two changes to `.github/dependabot.yml`:

1. Group `github/codeql-action*` updates into a single pull request.
2. Change the `github-actions` update interval from daily to weekly on Sundays.

## Why

CodeQL requires `init` and `analyze` to run the exact same version. Dependabot treats them as two separate dependencies, so it opened one pull request per action, and each failed in isolation:

```
analyze post-action step failed: Loaded a configuration file for
version '4.37.6', but running version '4.37.7'
```

This happened with #1724 (`analyze`) and #1725 (`init`), and would recur on every codeql-action release. Grouping them means both pins move together in one pull request, which is the only combination CodeQL accepts.

The interval change to weekly on Sundays reduces the dependency bump noise.

## Notes

Grouping applies to version updates only, which is Dependabot's default for `groups`. A *security* update for codeql-action would still be split into separate pull requests. That is unlikely enough that I left it out rather than adding a second `applies-to: security-updates` group, but it is a one-line addition if you want it covered.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * GitHub Actions dependency update checks now run weekly on Sundays.
  * CodeQL Action updates are grouped into a single pull request.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->