### PR TITLE
fix(auth): fail with an AuthException when a redirect response has no url

### DIFF
--- a/packages/supabase_auth/lib/src/auth_client.dart
+++ b/packages/supabase_auth/lib/src/auth_client.dart
@@ -803,7 +803,7 @@ class AuthClient {
       ),
     );
 
-    return Uri.parse(response['url'] as String);
+    return Uri.parse(_urlFromResponse(response));
   }
 
   /// Returns a new session, regardless of expiry status. Takes in an optional
@@ -1274,7 +1274,7 @@ class AuthClient {
         jwt: _currentSession?.accessToken,
       ),
     );
-    return OAuthResponse(provider: provider, url: response['url']);
+    return OAuthResponse(provider: provider, url: _urlFromResponse(response));
   }
 
   /// Unlinks an identity from a user by deleting it.
@@ -1509,6 +1509,20 @@ class AuthClient {
     };
     final oauthUrl = '$url?${Uri(queryParameters: urlParameters).query}';
     return OAuthResponse(provider: provider, url: oauthUrl);
+  }
+
+  /// Reads the `url` field out of a response that is expected to carry one.
+  ///
+  /// The decoded body is untyped, so without this check a server that omits
+  /// `url` or sends the wrong type for it surfaces as a [TypeError] from
+  /// whichever line happens to consume the value first. Fail at the response
+  /// boundary instead, with an exception from this package's own hierarchy.
+  String _urlFromResponse(dynamic response) {
+    final url = response is Map ? response['url'] : null;
+    if (url is! String) {
+      throw AuthException('No url detected.');
+    }
+    return url;
   }
 
   /// set currentSession and currentUser

--- a/packages/supabase_auth/test/mocks/json_response_mock_client.dart
+++ b/packages/supabase_auth/test/mocks/json_response_mock_client.dart
@@ -1,0 +1,27 @@
+import 'dart:convert';
+
+import 'package:http/http.dart';
+
+/// A mock HTTP client that answers every request with the same JSON body.
+class JsonResponseMockClient extends BaseClient {
+  JsonResponseMockClient({required this.body, this.statusCode = 200});
+
+  /// The body the mocked server encodes and returns for every request.
+  final Object? body;
+
+  final int statusCode;
+
+  Uri? lastUri;
+
+  @override
+  Future<StreamedResponse> send(BaseRequest request) async {
+    lastUri = request.url;
+
+    return StreamedResponse(
+      Stream.value(utf8.encode(jsonEncode(body))),
+      statusCode,
+      request: request,
+      headers: {'content-type': 'application/json'},
+    );
+  }
+}

--- a/packages/supabase_auth/test/redirect_url_mock_test.dart
+++ b/packages/supabase_auth/test/redirect_url_mock_test.dart
@@ -1,0 +1,76 @@
+import 'package:supabase_auth/supabase_auth.dart';
+import 'package:test/test.dart';
+
+import 'mocks/json_response_mock_client.dart';
+import 'utils.dart';
+
+void main() {
+  final missingUrl = throwsA(
+    isA<AuthException>().having(
+      (exception) => exception.message,
+      'message',
+      'No url detected.',
+    ),
+  );
+
+  group('a response that carries no usable url', () {
+    AuthClient createClient(Object? body) {
+      final client = AuthClient(
+        url: 'http://localhost:9999',
+        httpClient: JsonResponseMockClient(body: body),
+        autoRefreshToken: false,
+        asyncStorage: TestAsyncStorage(),
+      );
+      addTearDown(client.dispose);
+      return client;
+    }
+
+    test('fails getSSOSignInUrl when the field is absent', () async {
+      await expectLater(
+        createClient({'id': 'not-a-url'}).getSSOSignInUrl(domain: 'a.com'),
+        missingUrl,
+      );
+    });
+
+    test('fails getSSOSignInUrl when the field is not a string', () async {
+      await expectLater(
+        createClient({'url': 42}).getSSOSignInUrl(domain: 'a.com'),
+        missingUrl,
+      );
+    });
+
+    test('fails getSSOSignInUrl when the body is not an object', () async {
+      await expectLater(
+        createClient(['https://idp.example.com']).getSSOSignInUrl(
+          domain: 'a.com',
+        ),
+        missingUrl,
+      );
+    });
+
+    test('fails getLinkIdentityUrl when the field is absent', () async {
+      await expectLater(
+        createClient({'id': 'not-a-url'}).getLinkIdentityUrl(
+          OAuthProvider.google,
+        ),
+        missingUrl,
+      );
+    });
+
+    test('fails getLinkIdentityUrl when the field is not a string', () async {
+      await expectLater(
+        createClient({'url': 42}).getLinkIdentityUrl(OAuthProvider.google),
+        missingUrl,
+      );
+    });
+
+    test('fails getLinkIdentityUrl when the body is not an object', () async {
+      await expectLater(
+        createClient(['https://idp.example.com']).getLinkIdentityUrl(
+          OAuthProvider.google,
+        ),
+        missingUrl,
+      );
+    });
+  });
+}

--- a/packages/supabase_auth/test/redirect_url_mock_test.dart
+++ b/packages/supabase_auth/test/redirect_url_mock_test.dart
@@ -48,6 +48,13 @@ void main() {
       );
     });
 
+    test('fails getSSOSignInUrl when the body is null', () async {
+      await expectLater(
+        createClient(null).getSSOSignInUrl(domain: 'a.com'),
+        missingUrl,
+      );
+    });
+
     test('fails getLinkIdentityUrl when the field is absent', () async {
       await expectLater(
         createClient({'id': 'not-a-url'}).getLinkIdentityUrl(
@@ -69,6 +76,13 @@ void main() {
         createClient(['https://idp.example.com']).getLinkIdentityUrl(
           OAuthProvider.google,
         ),
+        missingUrl,
+      );
+    });
+
+    test('fails getLinkIdentityUrl when the body is null', () async {
+      await expectLater(
+        createClient(null).getLinkIdentityUrl(OAuthProvider.google),
         missingUrl,
       );
     });


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix. Closes SDK-1497.

## What is the current behavior?

Two methods read a `url` out of an untyped response body without checking it.

`getLinkIdentityUrl` handed the value straight to `OAuthResponse`:

```dart
return OAuthResponse(provider: provider, url: response['url']);
```

`getSSOSignInUrl` cast it:

```dart
return Uri.parse(response['url'] as String);
```

`strict-casts` is not enabled, so the first line compiles as an implicit
downcast. Both forms behave the same at runtime: if the server omits `url`, or
sends a number or a list for it, the caller gets a bare `TypeError` from
whichever line consumes the value first, with nothing pointing at the response
that caused it. A `TypeError` is also outside this package's exception
hierarchy, so callers that catch `AuthException` do not see it.

Worth being explicit about: adding an `as String` to the first line would have
changed nothing at runtime. The implicit downcast already throws the same
`TypeError` in the same place. Only a real check changes the behaviour.

## What is the new behavior?

Both call sites read the field through one helper that validates it and throws
an `AuthException` at the response boundary:

```dart
String _urlFromResponse(dynamic response) {
  final url = response is Map ? response['url'] : null;
  if (url is! String) {
    throw AuthException('No url detected.');
  }
  return url;
}
```

The message follows the convention the client already uses for missing response
fields (`No access_token detected.`, `No refresh_token detected.`, and so on).
The `response is Map` guard means a body that is not an object at all, a JSON
list for instance, reports the same error rather than a `NoSuchMethodError`.

## Tests

`packages/supabase_auth/test/redirect_url_mock_test.dart` covers both methods
against three malformed bodies each: field absent, field present with the wrong
type, and a body that is not an object. All six fail with a `TypeError` on the
old code and pass on the new code, so they pin down the behaviour rather than
just the happy path.

The mock is a small reusable `JsonResponseMockClient` in `test/mocks/`, since
every existing mocked test in this package hand-rolls its own client.

No backend needed: `dart test test/redirect_url_mock_test.dart` runs standalone.

## Notes

Not a breaking change, so this does not need to wait for v3.

SDK-1496 changes `OAuthResponse.url` to a `Uri` and touches the same
`getLinkIdentityUrl` line. That PR is stacked on this branch, so merge this one
first.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of SSO and identity-link responses.
  * Clear authentication errors are now shown when a valid URL is missing, malformed, null, or returned in an unexpected format.
  * Prevented invalid authentication redirect data from being used.

* **Tests**
  * Added coverage for missing URLs, invalid URL values, null responses, and unexpected response formats.
  * Added reusable HTTP response mocking for authentication scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->