### PR TITLE
refactor(auth)!: return a Uri from OAuthResponse.url instead of a String

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -90,6 +90,30 @@ final Uri ssoUrl = await supabase.auth.getSSOSignInUrl(domain: 'company.com');
 
 If you need the URL string, use `ssoUrl.toString()`.
 
+### `OAuthResponse.url` is a `Uri`
+
+`OAuthResponse.url` is a `Uri` rather than a `String`, so `getOAuthSignInUrl()` and
+`getLinkIdentityUrl()` now hand back the same type `getSSOSignInUrl()` does.
+
+```dart
+// Before
+final response = await supabase.auth.getOAuthSignInUrl(
+  provider: OAuthProvider.google,
+);
+final String url = response.url;
+
+// After
+final response = await supabase.auth.getOAuthSignInUrl(
+  provider: OAuthProvider.google,
+);
+final Uri url = response.url;
+```
+
+If you need the URL string, use `response.url.toString()`. Callers that were parsing it
+themselves can drop the `Uri.parse()`.
+
+The URL the server receives is unchanged, only the Dart type differs.
+
 ### `RealtimeClient.connectionState` is now typed
 
 `RealtimeClient` used to expose the socket state twice: a typed `connState` field and a stringly

--- a/packages/supabase_auth/lib/src/auth_client.dart
+++ b/packages/supabase_auth/lib/src/auth_client.dart
@@ -417,14 +417,15 @@ class AuthClient {
     String? redirectTo,
     String? scopes,
     Map<String, String>? queryParameters,
-  }) {
-    return _getUrlForProvider(
+  }) async {
+    final url = await _getUrlForProvider(
       provider,
       url: '$_url/authorize',
       redirectTo: redirectTo,
       scopes: scopes,
       queryParameters: queryParameters,
     );
+    return OAuthResponse(provider: provider, url: url);
   }
 
   /// Verifies the PKCE code verifier and retrieves a session.
@@ -1258,7 +1259,7 @@ class AuthClient {
     String? scopes,
     Map<String, String>? queryParameters,
   }) async {
-    final urlResponse = await _getUrlForProvider(
+    final authorizeUrl = await _getUrlForProvider(
       provider,
       url: '$_url/user/identities/authorize',
       redirectTo: redirectTo,
@@ -1267,14 +1268,17 @@ class AuthClient {
       skipBrowserRedirect: true,
     );
     final response = await _fetch.request(
-      urlResponse.url,
+      authorizeUrl.toString(),
       HttpMethod.get,
       options: AuthRequestOptions(
         headers: _headers,
         jwt: _currentSession?.accessToken,
       ),
     );
-    return OAuthResponse(provider: provider, url: _urlFromResponse(response));
+    return OAuthResponse(
+      provider: provider,
+      url: Uri.parse(_urlFromResponse(response)),
+    );
   }
 
   /// Unlinks an identity from a user by deleting it.
@@ -1486,7 +1490,7 @@ class AuthClient {
   }
 
   /// Returns the OAuth sign in URL constructed from the [url] parameter.
-  Future<OAuthResponse> _getUrlForProvider(
+  Future<Uri> _getUrlForProvider(
     OAuthProvider provider, {
     required String url,
     required String? scopes,
@@ -1507,8 +1511,7 @@ class AuthClient {
       },
       if (skipBrowserRedirect) 'skip_http_redirect': 'true',
     };
-    final oauthUrl = '$url?${Uri(queryParameters: urlParameters).query}';
-    return OAuthResponse(provider: provider, url: oauthUrl);
+    return Uri.parse('$url?${Uri(queryParameters: urlParameters).query}');
   }
 
   /// Reads the `url` field out of a response that is expected to carry one.

--- a/packages/supabase_auth/lib/src/types/auth_response.dart
+++ b/packages/supabase_auth/lib/src/types/auth_response.dart
@@ -19,7 +19,9 @@ class AuthResponse {
 /// Response of OAuth signin
 class OAuthResponse {
   final OAuthProvider provider;
-  final String url;
+
+  /// The provider's authorization URL to send the user to.
+  final Uri url;
 
   /// Instantiates an `OAuthResponse` object from json response.
   const OAuthResponse({

--- a/packages/supabase_auth/test/client_test.dart
+++ b/packages/supabase_auth/test/client_test.dart
@@ -508,7 +508,7 @@ void main() {
         final response = await client.getOAuthSignInUrl(
           provider: OAuthProvider.google,
         );
-        expect(response.url, isA<String>());
+        expect(response.url, isA<Uri>());
         expect(response.provider, OAuthProvider.google);
       });
 
@@ -518,7 +518,7 @@ void main() {
           redirectTo: 'https://supabase.com',
         );
         expect(
-          response.url,
+          response.url.toString(),
           '$authUrl/authorize?provider=google'
           '&redirect_to=https%3A%2F%2Fsupabase.com',
         );
@@ -530,7 +530,10 @@ void main() {
           provider: OAuthProvider.google,
           redirectTo: 'https://localhost:9000/welcome',
         );
-        expect(response.url, isA<String>());
+        expect(
+          response.url.queryParameters['redirect_to'],
+          'https://localhost:9000/welcome',
+        );
         expect(response.provider, OAuthProvider.google);
       });
 
@@ -539,7 +542,7 @@ void main() {
           provider: OAuthProvider.google,
           scopes: 'repo',
         );
-        expect(response.url, isA<String>());
+        expect(response.url.queryParameters['scopes'], 'repo');
         expect(response.provider, OAuthProvider.google);
       });
 
@@ -549,7 +552,14 @@ void main() {
           redirectTo: 'https://localhost:9000/welcome',
           scopes: 'repo',
         );
-        expect(response.url, isA<String>());
+        expect(
+          response.url.queryParameters,
+          containsPair('scopes', 'repo'),
+        );
+        expect(
+          response.url.queryParameters,
+          containsPair('redirect_to', 'https://localhost:9000/welcome'),
+        );
         expect(response.provider, OAuthProvider.google);
       });
     });
@@ -646,8 +656,8 @@ void main() {
     test('Call getLinkIdentityUrl', () async {
       await client.signInWithPassword(email: email1, password: password);
       final response = await client.getLinkIdentityUrl(OAuthProvider.google);
-      expect(response.url, isA<String>());
-      final uri = Uri.parse(response.url);
+      expect(response.url, isA<Uri>());
+      final uri = response.url;
       expect(uri.host, 'accounts.google.com');
     });
   });
@@ -739,8 +749,7 @@ void main() {
         final response = await client.getOAuthSignInUrl(
           provider: OAuthProvider.google,
         );
-        final url = Uri.parse(response.url);
-        final queryParameters = url.queryParameters;
+        final queryParameters = response.url.queryParameters;
         expect(queryParameters['provider'], 'google');
         expect(queryParameters['flow_type'], 'pkce');
         expect(queryParameters['code_challenge_method'], 's256');

--- a/packages/supabase_auth/test/custom_oauth_provider_test.dart
+++ b/packages/supabase_auth/test/custom_oauth_provider_test.dart
@@ -33,9 +33,9 @@ void main() {
         final response = await client.getOAuthSignInUrl(provider: provider);
 
         expect(response.provider, provider);
-        expect(response.url, startsWith('$authUrl/authorize?'));
+        expect(response.url.toString(), startsWith('$authUrl/authorize?'));
 
-        final uri = Uri.parse(response.url);
+        final uri = response.url;
         expect(uri.queryParameters['provider'], 'custom:my-provider');
       },
     );

--- a/packages/supabase_auth/test/provider_test.dart
+++ b/packages/supabase_auth/test/provider_test.dart
@@ -33,7 +33,7 @@ void main() {
       );
       final url = response.url;
       final provider = response.provider;
-      expect(url, startsWith('$authUrl/authorize?provider=google'));
+      expect(url.toString(), startsWith('$authUrl/authorize?provider=google'));
       expect(provider, OAuthProvider.google);
     });
 
@@ -46,7 +46,7 @@ void main() {
       final url = response.url;
       final provider = response.provider;
       expect(
-        url,
+        url.toString(),
         startsWith(
           '$authUrl/authorize?provider=github&scopes=repo&redirect_to=redirectToURL',
         ),
@@ -59,7 +59,7 @@ void main() {
         provider: OAuthProvider('custom:my-oidc-provider'),
       );
       expect(
-        response.url,
+        response.url.toString(),
         startsWith(
           '$authUrl/authorize?provider=custom%3Amy-oidc-provider',
         ),
@@ -74,9 +74,10 @@ void main() {
         redirectTo: 'https://localhost:9000/callback',
         scopes: 'openid profile email',
       );
-      expect(response.url, contains('provider=custom%3Amy-oidc-provider'));
-      expect(response.url, contains('redirect_to='));
-      expect(response.url, contains('scopes='));
+      final url = response.url.toString();
+      expect(url, contains('provider=custom%3Amy-oidc-provider'));
+      expect(url, contains('redirect_to='));
+      expect(url, contains('scopes='));
       expect(response.provider.name, 'custom:my-oidc-provider');
     });
   });

--- a/packages/supabase_flutter/lib/src/supabase_auth.dart
+++ b/packages/supabase_flutter/lib/src/supabase_auth.dart
@@ -370,12 +370,10 @@ extension AuthClientSignInProvider on AuthClient {
   /// Launches the [url] for an OAuth or identity-linking flow, forcing an
   /// external browser for Google on Android.
   Future<bool> _launchAuthUrl(
-    String url,
+    Uri url,
     OAuthProvider provider,
     LaunchMode authScreenLaunchMode,
   ) {
-    final uri = Uri.parse(url);
-
     LaunchMode launchMode = authScreenLaunchMode;
 
     // `defaultTargetPlatform` reports the host OS even on web, so guard with
@@ -389,7 +387,7 @@ extension AuthClientSignInProvider on AuthClient {
     }
 
     return launchUrl(
-      uri,
+      url,
       mode: launchMode,
       webOnlyWindowName: '_self',
     );

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -38,6 +38,7 @@ features:
       - OtpChannel
   auth.sign_in.sign_in_with_oauth:
     status: implemented
+    note: "getOAuthSignInUrl returns an OAuthResponse whose url is a Uri rather than the string JS returns, and supabase_flutter's signInWithOAuth launches that URL in the browser and returns Future<bool>."
     symbols:
       - AuthClient.getOAuthSignInUrl
       - AuthClientSignInProvider.signInWithOAuth
@@ -254,7 +255,7 @@ features:
   # auth — identities
   auth.identities.link_identity:
     status: implemented
-    note: "Split into getLinkIdentityUrl (OAuth) and linkIdentityWithIdToken (ID token) rather than a single overloaded method."
+    note: "Split into getLinkIdentityUrl (OAuth) and linkIdentityWithIdToken (ID token) rather than a single overloaded method. getLinkIdentityUrl's OAuthResponse carries a Uri rather than the string url JS returns."
     symbols:
       - AuthClient.getLinkIdentityUrl
       - AuthClient.linkIdentityWithIdToken


### PR DESCRIPTION
## What kind of change does this PR introduce?

Breaking change, refactor. Closes SDK-1496.

> [!NOTE]
> This was originally stacked on #1728. That has landed, so this branch is
> rebased directly onto `main` and stands on its own.

## What is the current behavior?

#1722 changed `getSSOSignInUrl` to return a `Future<Uri>`, which left the two
sibling URL getters disagreeing with it:

| Method | Returns |
| --- | --- |
| `AuthClient.getSSOSignInUrl` | `Future<Uri>` |
| `AuthClient.getOAuthSignInUrl` | `Future<OAuthResponse>` with `String url` |
| `AuthClient.getLinkIdentityUrl` | `Future<OAuthResponse>` with `String url` |

Shipping v3 that way means three URL-returning auth methods with two different
types for the same concept, and callers still writing `Uri.parse` for two of
them.

## What is the new behavior?

`OAuthResponse.url` is a `Uri`. Both getters share that type, so this covers
them in one change and makes all three consistent.

Two internal tidy-ups fall out of it:

- `_getUrlForProvider` returns the `Uri` it builds rather than a whole
  `OAuthResponse`. `getLinkIdentityUrl` only ever wanted the URL to send a
  request to, and the response type belongs at the public boundary, so it is now
  constructed there by both public methods.
- `supabase_flutter`'s `_launchAuthUrl` takes a `Uri` and drops its internal
  `Uri.parse`. It hands the value straight to `launchUrl`.

## The wire format is unchanged

This is the part worth scrutinising, since the URL is built by string
interpolation and is now parsed before it leaves the client.

The query is still built with `Uri(queryParameters: ...)` exactly as before, and
`Uri.parse` round-trips the result byte for byte. Verified against the shapes
this code actually produces:

```
SAME  ...?provider=google&redirect_to=https%3A%2F%2Fsupabase.com
SAME  ...?provider=github&scopes=repo&redirect_to=redirectToURL
SAME  ...?provider=custom%3Amy-oidc-provider&scopes=openid+profile+email
SAME  ...?provider=google&redirect_to=my-app%3A%2F%2Fcallback%3Fa%3Db%26c%3Dd
SAME  ...?provider=google&code_challenge=abc-_~.123&flow_type=pkce
```

Percent-encoded redirect targets, nested query strings inside `redirect_to`,
plus-encoded spaces in `scopes` and the PKCE challenge characters all survive
unchanged. `client_test.dart` also still asserts one full URL by exact string
equality, including `%3A%2F%2F`, and passes against a real GoTrue.

## Tests

Existing coverage was updated rather than replaced. Three tests in
`client_test.dart` named "can append a redirectUrl", "can append scopes" and
"can append options" only asserted `isA<String>()` and never checked the thing
their names promise. Now that `url` is a `Uri` they read the parameters directly:

```dart
expect(response.url.queryParameters['scopes'], 'repo');
```

The remaining `isA<String>()` assertions became `isA<Uri>()`. Those were
tautological before this PR and still are, so they are left alone rather than
rewritten here.

Verified with the local Supabase stack running:

- `packages/supabase_auth`: `dart test -j 1`, 472 passing, which includes
  `getLinkIdentityUrl` against real GoTrue returning a real Google URL
- `packages/supabase_flutter`: `flutter test`, 76 passing
- `dart analyze packages`: no issues
- `dart format`: no changes

## Migration

`MIGRATION.md` gets an `OAuthResponse.url` section next to the
`getSSOSignInUrl` one, and the affected `sdk-compliance.yaml` notes are updated.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * OAuth sign-in and identity-linking URLs are now returned as `Uri` values.
  * URL query parameters can be inspected directly without manual parsing.
  * Flutter launches OAuth URLs directly and preserves the provided URI.

* **Documentation**
  * Added migration guidance for upgrading from v2 to v3, including converting URIs to text with `toString()` when needed.
  * Documented Dart and Flutter OAuth URL and return-type differences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->