### PR TITLE
feat(storage)!: return the file id from upload and update methods

### DIFF
--- a/examples/storage_transforms/lib/storage_repository.dart
+++ b/examples/storage_transforms/lib/storage_repository.dart
@@ -25,12 +25,13 @@ class StorageRepository {
   Future<String> uploadImage({
     required String name,
     required Uint8List bytes,
-  }) {
-    return _files.uploadBinary(
+  }) async {
+    final response = await _files.uploadBinary(
       name,
       bytes,
       fileOptions: const FileOptions(contentType: 'image/png', upsert: true),
     );
+    return response.path;
   }
 
   /// Lists the images in the bucket, newest first.

--- a/packages/supabase_storage/lib/src/fetch.dart
+++ b/packages/supabase_storage/lib/src/fetch.dart
@@ -69,7 +69,7 @@ class Fetch {
 
     _log.finest('Request: ${method.value} $url ${request.headers.redacted}');
     final streamedResponse = await request.sendWith(httpClient);
-    return _handleResponse<T>(streamedResponse, options);
+    return _handleResponse(streamedResponse, options);
   }
 
   Future<Map<String, dynamic>> _handleFileRequest(
@@ -177,7 +177,7 @@ class Fetch {
           (error is ClientException || error is TimeoutException),
     );
 
-    return _handleResponse<Map<String, dynamic>>(streamedResponse, options);
+    return _handleResponse(streamedResponse, options);
   }
 
   /// Reads the response body and returns it as a [T]: [Uint8List] when
@@ -222,7 +222,7 @@ class Fetch {
   }
 
   Future<T> get<T>(String url, {FetchOptions? options}) {
-    return _handleRequest<T>(HttpMethod.get, url, null, options);
+    return _handleRequest(HttpMethod.get, url, null, options);
   }
 
   /// Performs a GET request and yields the response body as a byte stream
@@ -262,7 +262,7 @@ class Fetch {
     Map<String, dynamic>? body, {
     FetchOptions? options,
   }) {
-    return _handleRequest<T>(HttpMethod.post, url, body, options);
+    return _handleRequest(HttpMethod.post, url, body, options);
   }
 
   Future<T> put<T>(
@@ -270,7 +270,7 @@ class Fetch {
     Map<String, dynamic>? body, {
     FetchOptions? options,
   }) {
-    return _handleRequest<T>(HttpMethod.put, url, body, options);
+    return _handleRequest(HttpMethod.put, url, body, options);
   }
 
   Future<T> delete<T>(
@@ -278,7 +278,7 @@ class Fetch {
     Map<String, dynamic>? body, {
     FetchOptions? options,
   }) {
-    return _handleRequest<T>(HttpMethod.delete, url, body, options);
+    return _handleRequest(HttpMethod.delete, url, body, options);
   }
 
   Future<Map<String, dynamic>> postFile(

--- a/packages/supabase_storage/lib/src/fetch.dart
+++ b/packages/supabase_storage/lib/src/fetch.dart
@@ -52,7 +52,7 @@ class Fetch {
     return exception;
   }
 
-  Future<dynamic> _handleRequest(
+  Future<T> _handleRequest<T>(
     HttpMethod method,
     String url,
     Map<String, dynamic>? body,
@@ -69,10 +69,10 @@ class Fetch {
 
     _log.finest('Request: ${method.value} $url ${request.headers.redacted}');
     final streamedResponse = await request.sendWith(httpClient);
-    return _handleResponse(streamedResponse, options);
+    return _handleResponse<T>(streamedResponse, options);
   }
 
-  Future<dynamic> _handleFileRequest(
+  Future<Map<String, dynamic>> _handleFileRequest(
     HttpMethod method,
     String url,
     File file,
@@ -101,7 +101,7 @@ class Fetch {
     );
   }
 
-  Future<dynamic> _handleBinaryFileRequest(
+  Future<Map<String, dynamic>> _handleBinaryFileRequest(
     HttpMethod method,
     String url,
     Uint8List data,
@@ -130,7 +130,7 @@ class Fetch {
     );
   }
 
-  Future<dynamic> _handleMultipartRequest(
+  Future<Map<String, dynamic>> _handleMultipartRequest(
     HttpMethod method,
     String url,
     MultipartFile Function() createMultipartFile,
@@ -177,23 +177,32 @@ class Fetch {
           (error is ClientException || error is TimeoutException),
     );
 
-    return _handleResponse(streamedResponse, options);
+    return _handleResponse<Map<String, dynamic>>(streamedResponse, options);
   }
 
-  Future<dynamic> _handleResponse(
+  /// Reads the response body and returns it as a [T]: [Uint8List] when
+  /// `noResolveJson` is set, `null` for an empty body, and decoded JSON
+  /// otherwise. Throws a [StorageException] when the body is not a [T].
+  Future<T> _handleResponse<T>(
     http.StreamedResponse streamedResponse,
     FetchOptions? options,
   ) async {
     final response = await http.Response.fromStream(streamedResponse);
     if (isSuccessStatusCode(response.statusCode)) {
+      final dynamic body;
       if (options?.noResolveJson == true) {
-        return response.bodyBytes;
+        body = response.bodyBytes;
+      } else if (response.body.isEmpty) {
+        body = null;
+      } else {
+        body = json.decode(response.body);
       }
-      if (response.body.isEmpty) {
-        return null;
+      if (body is! T) {
+        throw StorageException(
+          'Expected a $T response, but got a ${body.runtimeType}',
+        );
       }
-      final jsonBody = json.decode(response.body);
-      return jsonBody;
+      return body;
     }
     throw _handleError(
       response,
@@ -203,8 +212,8 @@ class Fetch {
     );
   }
 
-  Future<dynamic> head(String url, {FetchOptions? options}) {
-    return _handleRequest(
+  Future<void> head(String url, {FetchOptions? options}) {
+    return _handleRequest<dynamic>(
       HttpMethod.head,
       url,
       null,
@@ -212,8 +221,8 @@ class Fetch {
     );
   }
 
-  Future<dynamic> get(String url, {FetchOptions? options}) {
-    return _handleRequest(HttpMethod.get, url, null, options);
+  Future<T> get<T>(String url, {FetchOptions? options}) {
+    return _handleRequest<T>(HttpMethod.get, url, null, options);
   }
 
   /// Performs a GET request and yields the response body as a byte stream
@@ -248,31 +257,31 @@ class Fetch {
     );
   }
 
-  Future<dynamic> post(
+  Future<T> post<T>(
     String url,
     Map<String, dynamic>? body, {
     FetchOptions? options,
   }) {
-    return _handleRequest(HttpMethod.post, url, body, options);
+    return _handleRequest<T>(HttpMethod.post, url, body, options);
   }
 
-  Future<dynamic> put(
+  Future<T> put<T>(
     String url,
     Map<String, dynamic>? body, {
     FetchOptions? options,
   }) {
-    return _handleRequest(HttpMethod.put, url, body, options);
+    return _handleRequest<T>(HttpMethod.put, url, body, options);
   }
 
-  Future<dynamic> delete(
+  Future<T> delete<T>(
     String url,
     Map<String, dynamic>? body, {
     FetchOptions? options,
   }) {
-    return _handleRequest(HttpMethod.delete, url, body, options);
+    return _handleRequest<T>(HttpMethod.delete, url, body, options);
   }
 
-  Future<dynamic> postFile(
+  Future<Map<String, dynamic>> postFile(
     String url,
     File file,
     FileOptions fileOptions, {
@@ -291,7 +300,7 @@ class Fetch {
     );
   }
 
-  Future<dynamic> putFile(
+  Future<Map<String, dynamic>> putFile(
     String url,
     File file,
     FileOptions fileOptions, {
@@ -310,7 +319,7 @@ class Fetch {
     );
   }
 
-  Future<dynamic> postBinaryFile(
+  Future<Map<String, dynamic>> postBinaryFile(
     String url,
     Uint8List data,
     FileOptions fileOptions, {
@@ -329,7 +338,7 @@ class Fetch {
     );
   }
 
-  Future<dynamic> putBinaryFile(
+  Future<Map<String, dynamic>> putBinaryFile(
     String url,
     Uint8List data,
     FileOptions fileOptions, {

--- a/packages/supabase_storage/lib/src/storage_file_api.dart
+++ b/packages/supabase_storage/lib/src/storage_file_api.dart
@@ -54,6 +54,15 @@ class StorageFileApi {
 
   FetchOptions get _fetchOptions => FetchOptions(headers);
 
+  UploadResponse _uploadResponse(String cleanPath, dynamic response) {
+    final data = response as Map;
+    return UploadResponse(
+      id: data['Id'] as String?,
+      path: cleanPath,
+      fullPath: data['Key'] as String,
+    );
+  }
+
   void _assertValidRetryAttempts(int? retryAttempts) {
     assert(
       retryAttempts == null || retryAttempts >= 0,
@@ -76,7 +85,10 @@ class StorageFileApi {
   ///
   /// You can pass a [retryController] and call `cancel()` to cancel the retry
   /// attempts.
-  Future<String> upload(
+  ///
+  /// Returns an [UploadResponse] with the id, path and full path of the
+  /// stored object.
+  Future<UploadResponse> upload(
     String path,
     File file, {
     FileOptions fileOptions = const FileOptions(),
@@ -84,7 +96,8 @@ class StorageFileApi {
     StorageRetryController? retryController,
   }) async {
     _assertValidRetryAttempts(retryAttempts);
-    final finalPath = _getFinalPath(path);
+    final cleanPath = _removeEmptyFolders(path);
+    final finalPath = _getFinalPath(cleanPath);
     final response = await _storageFetch.postFile(
       '$url/object/$finalPath',
       file,
@@ -94,7 +107,7 @@ class StorageFileApi {
       retryController: retryController,
     );
 
-    return (response as Map)['Key'] as String;
+    return _uploadResponse(cleanPath, response);
   }
 
   /// Uploads a binary file to an existing bucket. Can be used on the web.
@@ -112,7 +125,10 @@ class StorageFileApi {
   ///
   /// You can pass a [retryController] and call `cancel()` to cancel the retry
   /// attempts.
-  Future<String> uploadBinary(
+  ///
+  /// Returns an [UploadResponse] with the id, path and full path of the
+  /// stored object.
+  Future<UploadResponse> uploadBinary(
     String path,
     Uint8List data, {
     FileOptions fileOptions = const FileOptions(),
@@ -120,7 +136,8 @@ class StorageFileApi {
     StorageRetryController? retryController,
   }) async {
     _assertValidRetryAttempts(retryAttempts);
-    final finalPath = _getFinalPath(path);
+    final cleanPath = _removeEmptyFolders(path);
+    final finalPath = _getFinalPath(cleanPath);
     final response = await _storageFetch.postBinaryFile(
       '$url/object/$finalPath',
       data,
@@ -130,7 +147,7 @@ class StorageFileApi {
       retryController: retryController,
     );
 
-    return (response as Map)['Key'] as String;
+    return _uploadResponse(cleanPath, response);
   }
 
   /// Upload a file with a token generated from `createUploadSignedUrl`.
@@ -142,7 +159,11 @@ class StorageFileApi {
   /// [token] The token generated from `createUploadSignedUrl`
   ///
   /// [file] The body of the file to be stored in the bucket.
-  Future<String> uploadToSignedUrl(
+  ///
+  /// Returns an [UploadResponse] with the path and full path of the stored
+  /// object. [UploadResponse.id] is `null`, because the server does not
+  /// report it for uploads through a signed URL.
+  Future<UploadResponse> uploadToSignedUrl(
     String path,
     String token,
     File file, [
@@ -157,7 +178,7 @@ class StorageFileApi {
     var requestUrl = Uri.parse('$url/object/upload/sign/$finalPath');
     requestUrl = requestUrl.replace(queryParameters: {'token': token});
 
-    await _storageFetch.putFile(
+    final response = await _storageFetch.putFile(
       requestUrl.toString(),
       file,
       fileOptions,
@@ -165,7 +186,7 @@ class StorageFileApi {
       retryController: retryController,
     );
 
-    return cleanPath;
+    return _uploadResponse(cleanPath, response);
   }
 
   /// Upload a binary file with a token generated from `createUploadSignedUrl`.
@@ -177,7 +198,11 @@ class StorageFileApi {
   /// [token] The token generated from `createUploadSignedUrl`
   ///
   /// [data] The body of the binary file to be stored in the bucket.
-  Future<String> uploadBinaryToSignedUrl(
+  ///
+  /// Returns an [UploadResponse] with the path and full path of the stored
+  /// object. [UploadResponse.id] is `null`, because the server does not
+  /// report it for uploads through a signed URL.
+  Future<UploadResponse> uploadBinaryToSignedUrl(
     String path,
     String token,
     Uint8List data, [
@@ -188,11 +213,11 @@ class StorageFileApi {
     _assertValidRetryAttempts(retryAttempts);
 
     final cleanPath = _removeEmptyFolders(path);
-    final path0 = _getFinalPath(cleanPath);
-    var requestUrl = Uri.parse('$url/object/upload/sign/$path0');
+    final finalPath = _getFinalPath(cleanPath);
+    var requestUrl = Uri.parse('$url/object/upload/sign/$finalPath');
     requestUrl = requestUrl.replace(queryParameters: {'token': token});
 
-    await _storageFetch.putBinaryFile(
+    final response = await _storageFetch.putBinaryFile(
       requestUrl.toString(),
       data,
       fileOptions,
@@ -200,7 +225,7 @@ class StorageFileApi {
       retryController: retryController,
     );
 
-    return cleanPath;
+    return _uploadResponse(cleanPath, response);
   }
 
   /// Creates a signed upload URL.
@@ -257,7 +282,10 @@ class StorageFileApi {
   ///
   /// You can pass a [retryController] and call `cancel()` to cancel the retry
   /// attempts.
-  Future<String> update(
+  ///
+  /// Returns an [UploadResponse] with the id, path and full path of the
+  /// stored object.
+  Future<UploadResponse> update(
     String path,
     File file, {
     FileOptions fileOptions = const FileOptions(),
@@ -265,7 +293,8 @@ class StorageFileApi {
     StorageRetryController? retryController,
   }) async {
     _assertValidRetryAttempts(retryAttempts);
-    final finalPath = _getFinalPath(path);
+    final cleanPath = _removeEmptyFolders(path);
+    final finalPath = _getFinalPath(cleanPath);
     final response = await _storageFetch.putFile(
       '$url/object/$finalPath',
       file,
@@ -275,7 +304,7 @@ class StorageFileApi {
       retryController: retryController,
     );
 
-    return (response as Map<String, dynamic>)['Key'] as String;
+    return _uploadResponse(cleanPath, response);
   }
 
   /// Replaces an existing file at the specified path with a new one. Can be
@@ -294,7 +323,10 @@ class StorageFileApi {
   ///
   /// You can pass a [retryController] and call `cancel()` to cancel the retry
   /// attempts.
-  Future<String> updateBinary(
+  ///
+  /// Returns an [UploadResponse] with the id, path and full path of the
+  /// stored object.
+  Future<UploadResponse> updateBinary(
     String path,
     Uint8List data, {
     FileOptions fileOptions = const FileOptions(),
@@ -302,7 +334,8 @@ class StorageFileApi {
     StorageRetryController? retryController,
   }) async {
     _assertValidRetryAttempts(retryAttempts);
-    final finalPath = _getFinalPath(path);
+    final cleanPath = _removeEmptyFolders(path);
+    final finalPath = _getFinalPath(cleanPath);
     final response = await _storageFetch.putBinaryFile(
       '$url/object/$finalPath',
       data,
@@ -312,7 +345,7 @@ class StorageFileApi {
       retryController: retryController,
     );
 
-    return (response as Map)['Key'] as String;
+    return _uploadResponse(cleanPath, response);
   }
 
   /// Moves an existing file.

--- a/packages/supabase_storage/lib/src/storage_file_api.dart
+++ b/packages/supabase_storage/lib/src/storage_file_api.dart
@@ -524,7 +524,7 @@ class StorageFileApi {
     TransformOptions? transform,
     Map<String, String>? queryParameters,
     String? cacheNonce,
-  }) async {
+  }) {
     final fetchUrl = _downloadUri(
       path,
       transform: transform,
@@ -532,7 +532,7 @@ class StorageFileApi {
       cacheNonce: cacheNonce,
     );
 
-    return _storageFetch.get<Uint8List>(
+    return _storageFetch.get(
       fetchUrl.toString(),
       options: FetchOptions(headers, noResolveJson: true),
     );

--- a/packages/supabase_storage/lib/src/storage_file_api.dart
+++ b/packages/supabase_storage/lib/src/storage_file_api.dart
@@ -54,8 +54,7 @@ class StorageFileApi {
 
   FetchOptions get _fetchOptions => FetchOptions(headers);
 
-  UploadResponse _uploadResponse(String cleanPath, dynamic response) {
-    final data = response as Map;
+  UploadResponse _uploadResponse(String cleanPath, Map<String, dynamic> data) {
     return UploadResponse(
       id: data['Id'] as String?,
       path: cleanPath,
@@ -244,7 +243,7 @@ class StorageFileApi {
   }) async {
     final finalPath = _getFinalPath(path);
 
-    final data = await _storageFetch.post(
+    final data = await _storageFetch.post<Map<String, dynamic>>(
       '$url/object/upload/sign/$finalPath',
       {},
       options: FetchOptions({
@@ -363,7 +362,7 @@ class StorageFileApi {
     String? destinationBucket,
   }) async {
     final options = _fetchOptions;
-    final response = await _storageFetch.post(
+    final response = await _storageFetch.post<Map<String, dynamic>>(
       '$url/object/move',
       {
         'bucketId': bucketId,
@@ -373,7 +372,7 @@ class StorageFileApi {
       },
       options: options,
     );
-    return (response as Map<String, dynamic>)['message'] as String;
+    return response['message'] as String;
   }
 
   /// Copies an existing file.
@@ -392,7 +391,7 @@ class StorageFileApi {
     String? destinationBucket,
   }) async {
     final options = _fetchOptions;
-    final response = await _storageFetch.post(
+    final response = await _storageFetch.post<Map<String, dynamic>>(
       '$url/object/copy',
       {
         'bucketId': bucketId,
@@ -402,7 +401,7 @@ class StorageFileApi {
       },
       options: options,
     );
-    return (response as Map<String, dynamic>)['Key'] as String;
+    return response['Key'] as String;
   }
 
   /// Create signed URL to download file without requiring permissions. This URL
@@ -432,7 +431,7 @@ class StorageFileApi {
   }) async {
     final finalPath = _getFinalPath(path);
     final options = _fetchOptions;
-    final response = await _storageFetch.post(
+    final response = await _storageFetch.post<Map<String, dynamic>>(
       '$url/object/sign/$finalPath',
       {
         'expiresIn': expiresIn,
@@ -440,8 +439,7 @@ class StorageFileApi {
       },
       options: options,
     );
-    final signedUrlPath =
-        (response as Map<String, dynamic>)['signedURL'] as String?;
+    final signedUrlPath = response['signedURL'] as String?;
     if (signedUrlPath == null) {
       throw StorageException('No signed URL returned by API');
     }
@@ -481,7 +479,7 @@ class StorageFileApi {
     String? cacheNonce,
   }) async {
     final options = _fetchOptions;
-    final response = await _storageFetch.post(
+    final response = await _storageFetch.post<List<dynamic>>(
       '$url/object/sign/$bucketId',
       {
         'expiresIn': expiresIn,
@@ -489,7 +487,7 @@ class StorageFileApi {
       },
       options: options,
     );
-    return (response as List).map<SignedUrlResult>((e) {
+    return response.map<SignedUrlResult>((e) {
       final signedUrlPath = e['signedURL'] as String?;
       final path = e['path'] as String? ?? '';
       if (signedUrlPath != null) {
@@ -534,11 +532,10 @@ class StorageFileApi {
       cacheNonce: cacheNonce,
     );
 
-    final response = await _storageFetch.get(
+    return _storageFetch.get<Uint8List>(
       fetchUrl.toString(),
       options: FetchOptions(headers, noResolveJson: true),
     );
-    return response as Uint8List;
   }
 
   /// Builds the download URL shared by [download] and [downloadStream],
@@ -608,7 +605,7 @@ class StorageFileApi {
   Future<FileObjectV2> getMetadata(String path) async {
     final finalPath = _getFinalPath(path);
     final options = _fetchOptions;
-    final response = await _storageFetch.get(
+    final response = await _storageFetch.get<Map<String, dynamic>>(
       '$url/object/info/$finalPath',
       options: options,
     );
@@ -702,13 +699,13 @@ class StorageFileApi {
   /// name. For example: `remove(['folder/image.png'])`.
   Future<List<FileObject>> remove(List<String> paths) async {
     final options = _fetchOptions;
-    final response = await _storageFetch.delete(
+    final response = await _storageFetch.delete<List<dynamic>>(
       '$url/object/$bucketId',
       {'prefixes': paths},
       options: options,
     );
     final fileObjects = List<FileObject>.from(
-      (response as List).map(
+      response.map(
         (item) => FileObject.fromJson(item),
       ),
     );
@@ -738,12 +735,12 @@ class StorageFileApi {
         queryParameters: {'transformations': 'true'},
       );
     }
-    final response = await _storageFetch.delete(
+    final response = await _storageFetch.delete<Map<String, dynamic>>(
       requestUrl.toString(),
       {},
       options: _fetchOptions,
     );
-    return (response as Map<String, dynamic>)['message'] as String;
+    return response['message'] as String;
   }
 
   /// Lists all the files within a bucket.
@@ -760,13 +757,13 @@ class StorageFileApi {
       ...searchOptions.toMap(),
     };
     final options = _fetchOptions;
-    final response = await _storageFetch.post(
+    final response = await _storageFetch.post<List<dynamic>>(
       '$url/object/list/$bucketId',
       body,
       options: options,
     );
     final fileObjects = List<FileObject>.from(
-      (response as List).map(
+      response.map(
         (item) => FileObject.fromJson(item),
       ),
     );
@@ -785,11 +782,11 @@ class StorageFileApi {
   Future<PaginatedListResult> listPaginated({
     PaginatedSearchOptions options = const PaginatedSearchOptions(),
   }) async {
-    final response = await _storageFetch.post(
+    final response = await _storageFetch.post<Map<String, dynamic>>(
       '$url/object/list-v2/$bucketId',
       options.toMap(),
       options: _fetchOptions,
     );
-    return PaginatedListResult.fromJson(response as Map<String, dynamic>);
+    return PaginatedListResult.fromJson(response);
   }
 }

--- a/packages/supabase_storage/lib/src/types.dart
+++ b/packages/supabase_storage/lib/src/types.dart
@@ -574,6 +574,32 @@ final class SignedUrlFailure extends SignedUrlResult {
   String toString() => 'SignedUrlFailure(path: $path, error: $error)';
 }
 
+/// Response of an upload or update operation, describing where the object was
+/// stored.
+class UploadResponse {
+  /// The identifier of the stored object.
+  ///
+  /// `null` when the server does not report one, which is the case for uploads
+  /// through a signed URL.
+  final String? id;
+
+  /// The path of the object within the bucket, without the bucket id.
+  final String path;
+
+  /// The path of the object prefixed with the bucket id.
+  final String fullPath;
+
+  const UploadResponse({
+    this.id,
+    required this.path,
+    required this.fullPath,
+  });
+
+  @override
+  String toString() =>
+      'UploadResponse(id: $id, path: $path, fullPath: $fullPath)';
+}
+
 class SignedUploadURLResponse extends SignedUrl {
   /// Token to be used when uploading files with the `uploadToSignedUrl` method.
   final String token;

--- a/packages/supabase_storage/test/basic_test.dart
+++ b/packages/supabase_storage/test/basic_test.dart
@@ -251,22 +251,30 @@ void main() {
       final file = File('a.txt');
       file.writeAsStringSync('File content');
 
-      customHttpClient.response = {'Key': 'public/a.txt'};
+      customHttpClient.response = {
+        'Id': 'e668cf46-2f9b-4a89-8889-9d95f2653c78',
+        'Key': 'public/a.txt',
+      };
 
       final response = await client.from('public').upload('a.txt', file);
-      expect(response, isA<String>());
-      expect(response, endsWith('/a.txt'));
+      expect(response.id, 'e668cf46-2f9b-4a89-8889-9d95f2653c78');
+      expect(response.path, 'a.txt');
+      expect(response.fullPath, 'public/a.txt');
     });
 
     test('should update file', () async {
       final file = File('a.txt');
       file.writeAsStringSync('Updated content');
 
-      customHttpClient.response = {'Key': 'public/a.txt'};
+      customHttpClient.response = {
+        'Id': 'e668cf46-2f9b-4a89-8889-9d95f2653c78',
+        'Key': 'public/a.txt',
+      };
 
       final response = await client.from('public').update('a.txt', file);
-      expect(response, isA<String>());
-      expect(response, endsWith('/a.txt'));
+      expect(response.id, 'e668cf46-2f9b-4a89-8889-9d95f2653c78');
+      expect(response.path, 'a.txt');
+      expect(response.fullPath, 'public/a.txt');
     });
 
     test('should move file', () async {
@@ -809,8 +817,9 @@ void main() {
       file.writeAsStringSync('File content');
 
       final response = await client.from('public').upload('a.txt', file);
-      expect(response, isA<String>());
-      expect(response, endsWith('/a.txt'));
+      expect(response.id, isNull);
+      expect(response.path, 'a.txt');
+      expect(response.fullPath, 'public/a.txt');
     });
 
     test('aborting upload should throw', () async {
@@ -840,8 +849,8 @@ void main() {
       final response = await client
           .from('public')
           .uploadBinary('a.txt', file.readAsBytesSync());
-      expect(response, isA<String>());
-      expect(response, endsWith('/a.txt'));
+      expect(response.path, 'a.txt');
+      expect(response.fullPath, 'public/a.txt');
     });
 
     test('should update file with few network failures', () async {
@@ -849,8 +858,8 @@ void main() {
       file.writeAsStringSync('File content');
 
       final response = await client.from('public').update('a.txt', file);
-      expect(response, isA<String>());
-      expect(response, endsWith('/a.txt'));
+      expect(response.path, 'a.txt');
+      expect(response.fullPath, 'public/a.txt');
     });
     test('should update binary with few network failures', () async {
       final file = File('a.txt');
@@ -859,8 +868,8 @@ void main() {
       final response = await client
           .from('public')
           .updateBinary('a.txt', file.readAsBytesSync());
-      expect(response, isA<String>());
-      expect(response, endsWith('/a.txt'));
+      expect(response.path, 'a.txt');
+      expect(response.fullPath, 'public/a.txt');
     });
   });
 

--- a/packages/supabase_storage/test/client_test.dart
+++ b/packages/supabase_storage/test/client_test.dart
@@ -189,11 +189,12 @@ void main() {
           .from(newBucketName)
           .createSignedUploadUrl(uploadPath);
 
-      final uploadedPath = await storage
+      final uploadResponse = await storage
           .from(newBucketName)
           .uploadToSignedUrl(response.path, response.token, file);
 
-      expect(uploadedPath, uploadPath);
+      expect(uploadResponse.path, uploadPath);
+      expect(uploadResponse.fullPath, '$newBucketName/$uploadPath');
     });
 
     test('can upload a binary file with a signed url', () async {
@@ -201,7 +202,7 @@ void main() {
           .from(newBucketName)
           .createSignedUploadUrl(uploadPath);
 
-      final uploadedPath = await storage
+      final uploadResponse = await storage
           .from(newBucketName)
           .uploadBinaryToSignedUrl(
             response.path,
@@ -209,7 +210,7 @@ void main() {
             file.readAsBytesSync(),
           );
 
-      expect(uploadedPath, uploadPath);
+      expect(uploadResponse.path, uploadPath);
     });
 
     test('cannot upload to a signed url twice', () async {
@@ -217,11 +218,11 @@ void main() {
           .from(newBucketName)
           .createSignedUploadUrl(uploadPath);
 
-      final uploadedPath = await storage
+      final uploadResponse = await storage
           .from(newBucketName)
           .uploadToSignedUrl(response.path, response.token, file);
 
-      expect(uploadedPath, uploadPath);
+      expect(uploadResponse.path, uploadPath);
       await expectLater(
         storage
             .from(newBucketName)
@@ -246,11 +247,11 @@ void main() {
           .from(newBucketName)
           .createSignedUploadUrl(uploadPath, upsert: true);
 
-      final uploadedPath = await storage
+      final uploadResponse = await storage
           .from(newBucketName)
           .uploadToSignedUrl(response.path, response.token, file);
 
-      expect(uploadedPath, uploadPath);
+      expect(uploadResponse.path, uploadPath);
     });
   });
 
@@ -484,7 +485,9 @@ void main() {
       );
 
       final response = await storage.from(bucketName).upload(uploadPath, file);
-      expect(response, isA<String>());
+      expect(response.id, isNotNull);
+      expect(response.path, uploadPath);
+      expect(response.fullPath, '$bucketName/$uploadPath');
     });
 
     test('cannot upload a file that exceed the file size limit', () async {
@@ -520,7 +523,7 @@ void main() {
               contentType: 'image/png',
             ),
           );
-      expect(response, isA<String>());
+      expect(response.path, uploadPath);
     });
 
     test('cannot upload a file an invalid mime type', () async {

--- a/packages/supabase_storage/test/fetch_test.dart
+++ b/packages/supabase_storage/test/fetch_test.dart
@@ -65,7 +65,7 @@ void main() {
             .from('bucket')
             .uploadBinary('folder/file.png', Uint8List.fromList([1, 2, 3]));
 
-        expect(result, 'public/a.txt');
+        expect(result.fullPath, 'public/a.txt');
         expect(retryClient.attempts, 2);
       },
     );
@@ -74,7 +74,7 @@ void main() {
       'detects content type from the path of a binary signed url upload',
       () async {
         final mockClient = CustomHttpClient();
-        mockClient.response = <String, dynamic>{};
+        mockClient.response = {'Key': 'bucket/folder/image.png'};
         mockClient.statusCode = 200;
         final client = SupabaseStorageClient(
           storageUrl,
@@ -101,7 +101,7 @@ void main() {
       'removes leading, trailing and duplicate slashes from the path',
       () async {
         final mockClient = CustomHttpClient();
-        mockClient.response = <String, dynamic>{};
+        mockClient.response = {'Key': 'bucket/folder/image.png'};
         mockClient.statusCode = 200;
         final client = SupabaseStorageClient(
           storageUrl,
@@ -109,7 +109,7 @@ void main() {
           httpClient: mockClient,
         );
 
-        final cleanPath = await client
+        final response = await client
             .from('bucket')
             .uploadBinaryToSignedUrl(
               '/folder//image.png/',
@@ -117,7 +117,8 @@ void main() {
               Uint8List.fromList([1]),
             );
 
-        expect(cleanPath, 'folder/image.png');
+        expect(response.path, 'folder/image.png');
+        expect(response.fullPath, 'bucket/folder/image.png');
 
         final requestPath = mockClient.receivedRequests.single.url.path;
         expect(requestPath, endsWith('/bucket/folder/image.png'));

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -987,6 +987,12 @@ features:
       - FileOptions.contentType
       - FileOptions.headers
       - FileOptions.upsert
+      - UploadResponse
+      - UploadResponse.UploadResponse
+      - UploadResponse.id
+      - UploadResponse.path
+      - UploadResponse.fullPath
+      - UploadResponse.toString
   storage.file_buckets.upload_with_metadata:
     status: implemented
     symbols:


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature (breaking change, part of v3, #1278).

Closes #1274

## What is the current behavior?

`upload`, `uploadBinary`, `update`, `updateBinary`, `uploadToSignedUrl` and `uploadBinaryToSignedUrl` return a plain `String` key, so the id of the created object is discarded even though the storage server has been returning it since [supabase/storage#332](https://github.com/supabase/storage/pull/332).

## What is the new behavior?

All six methods return an `UploadResponse` with:

- `id`: the identifier of the stored object (`null` for signed URL uploads, where the server does not report it)
- `path`: the path of the object within the bucket
- `fullPath`: the path prefixed with the bucket id

This matches the `{ id, path, fullPath }` shape supabase-js returns from its upload methods.

## Additional context

- The upload and update methods now normalize the object path the same way the signed URL uploads already did (leading, trailing and duplicate slashes are removed), matching supabase-js.
- The new `UploadResponse` symbols are registered in `sdk-compliance.yaml`; the symbol, drift and schema checks pass locally.
- Unit tests and the storage integration suite pass against the local stack, including a new assertion that the real server returns the id.