### PR TITLE
refactor(postgrest)!: fix the retried status codes to 503 and 520

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1237,22 +1237,52 @@ The individual retry parameters are replaced by one `PostgrestRetryOptions` valu
 
 | Before | After |
 | --- | --- |
-| `PostgrestClient(retryEnabled: …, retryCount: …, retryableStatusCodes: …)` | `PostgrestClient(retryOptions: …)` |
-| `PostgrestClientOptions(retryEnabled: …, retryCount: …, retryableStatusCodes: …)` | `PostgrestClientOptions(retryOptions: …)` |
-| `PostgrestBuilder`, `PostgrestQueryBuilder` and `PostgrestRpcBuilder` constructors, same three parameters | `retryOptions: …` |
-| `PostgrestClient.defaultRetryableStatusCodes` | `PostgrestRetryOptions.defaultStatusCodes` |
+| `PostgrestClient(retryEnabled: …, retryCount: …)` | `PostgrestClient(retryOptions: …)` |
+| `PostgrestClientOptions(retryEnabled: …, retryCount: …)` | `PostgrestClientOptions(retryOptions: …)` |
+| `PostgrestBuilder`, `PostgrestQueryBuilder` and `PostgrestRpcBuilder` constructors, same parameters | `retryOptions: …` |
 
 ```dart
 // Before
 postgrestOptions: const PostgrestClientOptions(
   retryCount: 5,
-  retryableStatusCodes: {503},
 ),
 
 // After
 postgrestOptions: const PostgrestClientOptions(
-  retryOptions: PostgrestRetryOptions(count: 5, statusCodes: {503}),
+  retryOptions: PostgrestRetryOptions(count: 5),
 ),
 ```
 
 The per-request `.retry()` override is unchanged.
+
+### The retried status codes are no longer configurable
+
+`503 Service Unavailable` and `520 Unknown Error` are the only responses worth
+repeating, so the set of retried status codes is fixed. Retrying anything else,
+a `500` from a failing query for example, only multiplies the load without a
+chance of a different answer.
+
+| Before | After |
+| --- | --- |
+| `PostgrestClient(retryableStatusCodes: …)` | removed |
+| `PostgrestClientOptions(retryableStatusCodes: …)` | removed |
+| `PostgrestClient.defaultRetryableStatusCodes` | `PostgrestRetryOptions.statusCodes` |
+
+If you retried a status code outside that set, catch the exception and decide
+what to do with it yourself:
+
+```dart
+// Before
+postgrestOptions: const PostgrestClientOptions(
+  retryableStatusCodes: {500, 503, 520},
+),
+
+// After
+try {
+  await supabase.from('todos').select();
+} on PostgrestApiException catch (error) {
+  if (error.statusCode == 500) {
+    // Retry it yourself, or surface it.
+  }
+}
+```

--- a/packages/postgrest/lib/src/postgrest.dart
+++ b/packages/postgrest/lib/src/postgrest.dart
@@ -50,14 +50,9 @@ class PostgrestClient {
     String? schema,
     this.httpClient,
     YAJsonIsolate? isolate,
-    PostgrestRetryOptions retryOptions = const PostgrestRetryOptions(),
+    this.retryOptions = const PostgrestRetryOptions(),
     this.requestTimeout,
-  }) : // Snapshot the status codes so that mutating the set the caller passed
-       // does not change the retry behavior of an existing client.
-       retryOptions = retryOptions.copyWith(
-         statusCodes: Set.unmodifiable(retryOptions.statusCodes),
-       ),
-       _schema = schema,
+  }) : _schema = schema,
        headers = {...defaultHeaders, ...?headers},
        _isolate = isolate ?? (YAJsonIsolate()..initialize()),
        _hasCustomIsolate = isolate != null {

--- a/packages/postgrest/lib/src/postgrest_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_builder.dart
@@ -140,11 +140,7 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
          isolate: isolate,
          count: count,
          maybeSingle: maybeSingle,
-         // Snapshot the status codes so that mutating the set the caller
-         // passed does not change the retry behavior of this request.
-         retry: retryOptions.copyWith(
-           statusCodes: Set.unmodifiable(retryOptions.statusCodes),
-         ),
+         retry: retryOptions,
          requestTimeout: requestTimeout,
          abortSignal: abortSignal,
        );
@@ -361,7 +357,6 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
     Map<String, String> execHeaders,
   ) async {
     final maxRetries = _retry.count;
-    final retryableStatusCodes = _retry.statusCodes;
 
     final isRetryableMethod =
         method == HttpMethod.get || method == HttpMethod.head;
@@ -379,7 +374,7 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
 
       try {
         final response = await send();
-        if (!retryableStatusCodes.contains(response.statusCode) ||
+        if (!PostgrestRetryOptions.statusCodes.contains(response.statusCode) ||
             attempt == maxRetries) {
           return response;
         }

--- a/packages/postgrest/lib/src/postgrest_retry_options.dart
+++ b/packages/postgrest/lib/src/postgrest_retry_options.dart
@@ -6,12 +6,12 @@ import 'package:supabase_common/supabase_common.dart';
 ///
 /// Only GET and HEAD requests are retried, since they are the only methods
 /// that are safe to repeat. A request is retried when it fails with a network
-/// error or answers with one of [statusCodes].
+/// error or answers with one of the [statusCodes].
 ///
 /// ```dart
 /// PostgrestClient(
 ///   restUrl,
-///   retryOptions: PostgrestRetryOptions(count: 5, statusCodes: {503}),
+///   retryOptions: PostgrestRetryOptions(count: 5),
 /// );
 /// ```
 ///
@@ -19,8 +19,13 @@ import 'package:supabase_common/supabase_common.dart';
 /// request.
 @immutable
 class PostgrestRetryOptions {
-  /// The HTTP status codes that trigger a retry by default.
-  static const Set<int> defaultStatusCodes = {503, 520};
+  /// The HTTP status codes that trigger a retry.
+  ///
+  /// `503 Service Unavailable` and `520 Unknown Error` are the only responses
+  /// a Supabase project answers with that are worth repeating, so the set is
+  /// fixed. Retrying anything else, a `500` from a failing query for example,
+  /// only multiplies the load without a chance of a different answer.
+  static const Set<int> statusCodes = {503, 520};
 
   /// Whether automatic retries are performed.
   final bool enabled;
@@ -29,9 +34,6 @@ class PostgrestRetryOptions {
   ///
   /// Set it to `0` to send every request exactly once.
   final int count;
-
-  /// The HTTP status codes that trigger a retry.
-  final Set<int> statusCodes;
 
   /// How long to wait before the first retry, doubled for every attempt after
   /// that until [maxDelay] is reached.
@@ -48,7 +50,6 @@ class PostgrestRetryOptions {
   const PostgrestRetryOptions({
     this.enabled = true,
     this.count = 3,
-    this.statusCodes = defaultStatusCodes,
     this.initialDelay = const Duration(seconds: 1),
     this.maxDelay = const Duration(seconds: 30),
     this.randomizationFactor = 0,
@@ -66,7 +67,6 @@ class PostgrestRetryOptions {
   PostgrestRetryOptions copyWith({
     bool? enabled,
     int? count,
-    Set<int>? statusCodes,
     Duration? initialDelay,
     Duration? maxDelay,
     double? randomizationFactor,
@@ -74,7 +74,6 @@ class PostgrestRetryOptions {
     return PostgrestRetryOptions(
       enabled: enabled ?? this.enabled,
       count: count ?? this.count,
-      statusCodes: statusCodes ?? this.statusCodes,
       initialDelay: initialDelay ?? this.initialDelay,
       maxDelay: maxDelay ?? this.maxDelay,
       randomizationFactor: randomizationFactor ?? this.randomizationFactor,
@@ -84,6 +83,6 @@ class PostgrestRetryOptions {
   @override
   String toString() =>
       'PostgrestRetryOptions(enabled: $enabled, count: $count, '
-      'statusCodes: $statusCodes, initialDelay: $initialDelay, '
-      'maxDelay: $maxDelay, randomizationFactor: $randomizationFactor)';
+      'initialDelay: $initialDelay, maxDelay: $maxDelay, '
+      'randomizationFactor: $randomizationFactor)';
 }

--- a/packages/postgrest/test/retry_test.dart
+++ b/packages/postgrest/test/retry_test.dart
@@ -87,7 +87,6 @@ PostgrestClient _buildClient(
   _MockRetryClient mock, {
   bool enabled = true,
   int count = 3,
-  Set<int> statusCodes = const {503, 520},
 }) {
   return PostgrestClient(
     'http://localhost:3000',
@@ -95,7 +94,6 @@ PostgrestClient _buildClient(
     retryOptions: PostgrestRetryOptions(
       enabled: enabled,
       count: count,
-      statusCodes: statusCodes,
       initialDelay: Duration.zero,
     ),
   );
@@ -168,6 +166,17 @@ void main() {
 
     test('GET does not retry on non-520 error (e.g., 400)', () async {
       final mock = _MockRetryClient([_status(400)]);
+      final client = _buildClient(mock);
+
+      await expectLater(
+        () => client.from('users').select(),
+        throwsA(isA<PostgrestApiException>()),
+      );
+      expect(mock.callCount, 1);
+    });
+
+    test('GET does not retry on 500', () async {
+      final mock = _MockRetryClient([_status(500)]);
       final client = _buildClient(mock);
 
       await expectLater(
@@ -344,67 +353,11 @@ void main() {
     });
   });
 
-  group('configurable retryable status codes', () {
-    test('retries on a custom status code', () async {
-      final mock = _MockRetryClient([_status(500), _ok()]);
-      final client = _buildClient(mock, statusCodes: {500});
-
-      final result = await client.from('users').select();
-
-      expect(result, isEmpty);
-      expect(mock.callCount, 2);
-    });
-
-    test('does not retry on a status code outside the custom set', () async {
-      final mock = _MockRetryClient([_status(520)]);
-      final client = _buildClient(mock, statusCodes: {500});
-
-      await expectLater(
-        () => client.from('users').select(),
-        throwsA(isA<PostgrestApiException>()),
-      );
-      expect(mock.callCount, 1);
-    });
-
-    test('a directly built builder snapshots the provided set', () async {
-      final mock = _MockRetryClient([_status(500), _ok()]);
-      final statusCodes = {500};
-      final builder = PostgrestQueryBuilder<dynamic>(
-        url: Uri.parse('http://localhost:3000/users'),
-        httpClient: mock,
-        retryOptions: PostgrestRetryOptions(
-          statusCodes: statusCodes,
-          initialDelay: Duration.zero,
-        ),
-      );
-
-      statusCodes.clear();
-
-      await builder.select();
-
-      expect(mock.callCount, 2);
-    });
-
-    test('mutating the provided set does not affect retry behavior', () async {
-      final mock = _MockRetryClient([_status(500), _ok()]);
-      final statusCodes = {500};
-      final client = _buildClient(mock, statusCodes: statusCodes);
-
-      statusCodes.clear();
-
-      final result = await client.from('users').select();
-
-      expect(result, isEmpty);
-      expect(mock.callCount, 2);
-    });
-  });
-
   group('PostgrestRetryOptions', () {
     test('copyWith keeps the fields that are not overridden', () {
       const options = PostgrestRetryOptions(
         enabled: false,
         count: 7,
-        statusCodes: {500},
         initialDelay: Duration(milliseconds: 5),
         maxDelay: Duration(milliseconds: 50),
         randomizationFactor: 0.5,
@@ -414,7 +367,6 @@ void main() {
 
       expect(copy.enabled, isTrue);
       expect(copy.count, 7);
-      expect(copy.statusCodes, {500});
       expect(copy.initialDelay, const Duration(milliseconds: 5));
       expect(copy.maxDelay, const Duration(milliseconds: 50));
       expect(copy.randomizationFactor, 0.5);
@@ -455,45 +407,45 @@ void main() {
     });
 
     test('the client keeps the retry options it was given', () {
-      final options = PostgrestRetryOptions(count: 1, statusCodes: {500});
+      const options = PostgrestRetryOptions(count: 1);
       final client = PostgrestClient(
         'http://localhost:3000',
         retryOptions: options,
       );
 
-      expect(client.retryOptions.count, 1);
-      expect(client.retryOptions.statusCodes, {500});
+      expect(client.retryOptions, same(options));
+    });
+
+    test('the retried status codes are 503 and 520', () {
+      expect(PostgrestRetryOptions.statusCodes, {503, 520});
     });
   });
 
   group('retry config propagation through builder chain', () {
-    test(
-      'count() preserves a custom retry count and status codes',
-      () async {
-        _ResponseFactory okWithCount() =>
-            (req) => Future.value(
-              StreamedResponse(
-                Stream.value(Uint8List.fromList('[]'.codeUnits)),
-                200,
-                request: req,
-                headers: {
-                  'content-type': 'application/json',
-                  'content-range': '0-0/0',
-                },
-              ),
-            );
-        final mock = _MockRetryClient([
-          _status(500),
-          _status(500),
-          okWithCount(),
-        ]);
-        final client = _buildClient(mock, count: 5, statusCodes: {500});
+    test('count() preserves a custom retry count', () async {
+      _ResponseFactory okWithCount() =>
+          (req) => Future.value(
+            StreamedResponse(
+              Stream.value(Uint8List.fromList('[]'.codeUnits)),
+              200,
+              request: req,
+              headers: {
+                'content-type': 'application/json',
+                'content-range': '0-0/0',
+              },
+            ),
+          );
+      final mock = _MockRetryClient([
+        _status(520),
+        _status(520),
+        okWithCount(),
+      ]);
+      final client = _buildClient(mock, count: 5);
 
-        await client.from('users').select().count(CountOption.exact);
+      await client.from('users').select().count(CountOption.exact);
 
-        expect(mock.callCount, 3);
-      },
-    );
+      expect(mock.callCount, 3);
+    });
   });
 
   group('request timeout', () {

--- a/packages/supabase/test/postgrest_options_test.dart
+++ b/packages/supabase/test/postgrest_options_test.dart
@@ -69,6 +69,9 @@ void main() {
       'http://localhost:9999',
       supabaseKey,
       httpClient: client,
+      authOptions: AuthClientOptions(
+        pkceAsyncStorage: MemoryAuthAsyncStorage(),
+      ),
       postgrestOptions: PostgrestClientOptions(
         retryOptions: retryOptions,
         requestTimeout: requestTimeout,
@@ -90,12 +93,13 @@ void main() {
     requestTimeout: const Duration(milliseconds: 50),
   );
 
-  /// 500 is not retried by default, so a request that recovers from it proves
-  /// that the configured options were used and not the default ones.
-  void initializeWithCustomStatusCode() => initialize(
-    statuses: [500, 500, 200],
-    retryOptions: PostgrestRetryOptions(
-      statusCodes: {500},
+  /// The default of three retries gives up before the fifth response, so a
+  /// request that recovers on it proves that the configured options were used
+  /// and not the default ones.
+  void initializeWithCustomRetryCount() => initialize(
+    statuses: [503, 503, 503, 503, 200],
+    retryOptions: const PostgrestRetryOptions(
+      count: 5,
       initialDelay: Duration.zero,
     ),
   );
@@ -105,11 +109,11 @@ void main() {
   });
 
   test('from() retries with the configured retry options', () async {
-    initializeWithCustomStatusCode();
+    initializeWithCustomRetryCount();
 
     await supabase.from('todos').select();
 
-    expect(httpClient.callCount, 3);
+    expect(httpClient.callCount, 5);
   });
 
   test('from() honors disabled retries', () async {
@@ -127,19 +131,19 @@ void main() {
   });
 
   test('schema().from() retries with the configured retry options', () async {
-    initializeWithCustomStatusCode();
+    initializeWithCustomRetryCount();
 
     await supabase.schema('personal').from('todos').select();
 
-    expect(httpClient.callCount, 3);
+    expect(httpClient.callCount, 5);
   });
 
   test('rpc() retries with the configured retry options', () async {
-    initializeWithCustomStatusCode();
+    initializeWithCustomRetryCount();
 
     await supabase.rpc('get_todos', params: {}, get: true);
 
-    expect(httpClient.callCount, 3);
+    expect(httpClient.callCount, 5);
   });
 
   test('from() times out with the configured request timeout', () async {

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -968,7 +968,6 @@ features:
       - PostgrestRetryOptions.enabled
       - PostgrestRetryOptions.count
       - PostgrestRetryOptions.statusCodes
-      - PostgrestRetryOptions.defaultStatusCodes
       - PostgrestRetryOptions.initialDelay
       - PostgrestRetryOptions.maxDelay
       - PostgrestRetryOptions.randomizationFactor


### PR DESCRIPTION
## What

`PostgrestRetryOptions.statusCodes` is a static constant now instead of a configurable field, so `503 Service Unavailable` and `520 Unknown Error` are the only responses that ever trigger a retry.

Letting callers pass their own set invites retrying responses that cannot change on a second attempt, a `500` from a failing query for example, which only multiplies the load on the project without a chance of a different answer.

```dart
// Before
retryOptions: PostgrestRetryOptions(count: 5, statusCodes: {500, 503, 520}),

// After
retryOptions: PostgrestRetryOptions(count: 5),
```

Everything else about the retry configuration is unchanged: `enabled`, `count`, the backoff knobs and the per-request `.retry()` override all stay.

Since the set is a `const` now, the two places that snapshotted it with `Set.unmodifiable` so a caller could not mutate a live client's behavior are gone as well.

### Breaking changes

| Before | After |
| --- | --- |
| `PostgrestRetryOptions(statusCodes: …)` | removed |
| `PostgrestRetryOptions.copyWith(statusCodes: …)` | removed |
| `PostgrestRetryOptions.statusCodes` (instance field) | `PostgrestRetryOptions.statusCodes` (static constant) |
| `PostgrestRetryOptions.defaultStatusCodes` | `PostgrestRetryOptions.statusCodes` |

The v2 `PostgrestClient(retryableStatusCodes:)` and `PostgrestClientOptions(retryableStatusCodes:)` were already replaced by `retryOptions` in #1731, and now have no replacement at all. `MIGRATION.md` gets a section for that and the existing v3 retry section drops its `statusCodes` references.

## Tests

- `packages/postgrest/test/retry_test.dart` loses the "configurable retryable status codes" group, gains an explicit "GET does not retry on 500" case and an assertion that the fixed set is `{503, 520}`.
- `packages/supabase/test/postgrest_options_test.dart` proved that the configured options were threaded through `from()`, `schema().from()` and `rpc()` by retrying a custom status code. It now uses a retry count above the default of three instead, so the request only recovers on the fifth response.
- That file also fails on `main` since #1489 landed, because `SupabaseClient` asserts on a PKCE flow without `asyncStorage`. It passes a `MemoryAuthAsyncStorage` now, which is unrelated to the retry change but needed for the file to run at all.
- `sdk-compliance.yaml` drops `PostgrestRetryOptions.defaultStatusCodes`; symbol, drift and schema checks run clean locally.

Closes #1736


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Retry configuration now uses a single `PostgrestRetryOptions` value across clients and request builders.
  * Automatic retries are limited to HTTP 503 and 520 responses.
  * Custom retry status codes are no longer supported; handle other statuses by catching API exceptions.
  * Per-request retry count overrides remain available.
* **Tests**
  * Updated coverage confirms retry counts and status-code behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->