### PR TITLE
refactor!: remove the dead setAccessToken mutators

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1339,16 +1339,19 @@ try {
 `PostgrestClient.setAccessToken()`, `SupabaseStorageClient.setAccessToken()` and
 `FunctionsClient.setAccessToken()` are removed. `RealtimeClient.setAccessToken()` stays.
 
-`SupabaseClient` never called any of the three. It wraps the HTTP client the rest, storage and
-functions clients use, and resolves the current session token on every request, so a token pushed in
-by hand was overwritten by the live one anyway. Nothing changes for you if you go through
-`SupabaseClient`, and the token you set with `SupabaseClient.accessToken` or by signing in still
-reaches all three.
+Despite the name, these three pinned a token rather than kept one in sync. `SupabaseClient` gives
+the rest, storage and functions clients an HTTP client that attaches the current session token to
+every request, but only when the request does not already carry an `Authorization` header. A token
+set through `setAccessToken` did carry one, so it won, and nothing ever cleared it: it kept
+overriding the session token across refreshes and sign-outs for the rest of the client's life.
 
-Realtime keeps its setter because it holds a live socket and has to push a new token over it rather
-than attach one per request.
+If you never called them, nothing changes. If you did, the replacement depends on what you were
+after.
 
-If you construct one of these clients yourself, pass the header to the constructor instead:
+To authenticate as the signed-in user, do nothing. `SupabaseClient` already resolves that token on
+every request.
+
+To pin a token on a client you construct yourself, pass it as a constructor header:
 
 ```dart
 // Before
@@ -1362,19 +1365,24 @@ final functions = FunctionsClient(functionsUrl, {
 });
 ```
 
-To use a different token per call, pass it to that call rather than to the client. This already
-worked in v2:
+To use a different token for a single call, pass it to that call:
 
 ```dart
 await functions.invoke('hello', headers: {'Authorization': 'Bearer $jwt'});
 await postgrest.from('countries').select().setHeader('Authorization', 'Bearer $jwt');
 ```
 
-If you have to swap the token on a long-lived client you built yourself, the header maps are still
-mutable. `SupabaseStorageClient.setHeader()` is unaffected, and `PostgrestClient.headers` and
-`FunctionsClient.headers` can be written to directly:
+To pin a token on a client you got from `SupabaseClient`, set the header yourself. The header maps
+are still mutable:
 
 ```dart
-storage.setHeader('Authorization', 'Bearer $jwt');
-postgrest.headers['Authorization'] = 'Bearer $jwt';
+supabase.storage.setHeader('Authorization', 'Bearer $jwt');
+supabase.rest.headers['Authorization'] = 'Bearer $jwt';
+supabase.functions.headers['Authorization'] = 'Bearer $jwt';
 ```
+
+That shadows the session token exactly as the old setter did, so remove the header again once the
+pinned token should no longer apply.
+
+Realtime keeps its setter because it holds a live socket and has to push a new token over it rather
+than attach one per request.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -668,7 +668,7 @@ already inert: unused types, options the client ignored, or values the server ne
 | `OAuthProvider.snakeCase` | `OAuthProvider.name` | `supabase_auth` |
 | `User.confirmedAt` | `User.emailConfirmedAt` | `supabase_auth` |
 | `ReturningOption` | none, it was unused | `postgrest` |
-| `PostgrestClient.auth()` | `PostgrestClient.setAuth()` | `postgrest` |
+| `PostgrestClient.auth()` | none, pass an `Authorization` header instead | `postgrest` |
 | `RealtimeClient.longpollerTimeout` | none, there is no longpoll transport | `supabase_realtime` |
 | `ChannelResponse.rateLimited` | none, it was never returned | `supabase_realtime` |
 | `FileObject.lastAccessedAt`, `FileObjectV2.lastAccessedAt` | none, the server does not populate it | `supabase_storage` |

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1167,7 +1167,7 @@ Across every package:
 
 | Before | After |
 | --- | --- |
-| `setAuth()` | `setAccessToken()` |
+| `RealtimeClient.setAuth()` | `RealtimeClient.setAccessToken()` |
 | `queryParams:` | `queryParameters:` |
 | `opts:` | `options:` |
 | `PresenceOpts` | `PresenceOptions` |
@@ -1332,4 +1332,49 @@ try {
     // Retry it yourself, or surface it.
   }
 }
+```
+
+### `setAccessToken()` is gone from the rest, storage and functions clients
+
+`PostgrestClient.setAccessToken()`, `SupabaseStorageClient.setAccessToken()` and
+`FunctionsClient.setAccessToken()` are removed. `RealtimeClient.setAccessToken()` stays.
+
+`SupabaseClient` never called any of the three. It wraps the HTTP client the rest, storage and
+functions clients use, and resolves the current session token on every request, so a token pushed in
+by hand was overwritten by the live one anyway. Nothing changes for you if you go through
+`SupabaseClient`, and the token you set with `SupabaseClient.accessToken` or by signing in still
+reaches all three.
+
+Realtime keeps its setter because it holds a live socket and has to push a new token over it rather
+than attach one per request.
+
+If you construct one of these clients yourself, pass the header to the constructor instead:
+
+```dart
+// Before
+final functions = FunctionsClient(functionsUrl, {'apikey': anonKey});
+functions.setAccessToken(jwt);
+
+// After
+final functions = FunctionsClient(functionsUrl, {
+  'apikey': anonKey,
+  'Authorization': 'Bearer $jwt',
+});
+```
+
+To use a different token per call, pass it to that call rather than to the client. This already
+worked in v2:
+
+```dart
+await functions.invoke('hello', headers: {'Authorization': 'Bearer $jwt'});
+await postgrest.from('countries').select().setHeader('Authorization', 'Bearer $jwt');
+```
+
+If you have to swap the token on a long-lived client you built yourself, the header maps are still
+mutable. `SupabaseStorageClient.setHeader()` is unaffected, and `PostgrestClient.headers` and
+`FunctionsClient.headers` can be written to directly:
+
+```dart
+storage.setHeader('Authorization', 'Bearer $jwt');
+postgrest.headers['Authorization'] = 'Bearer $jwt';
 ```

--- a/packages/postgrest/lib/src/postgrest.dart
+++ b/packages/postgrest/lib/src/postgrest.dart
@@ -68,19 +68,6 @@ class PostgrestClient {
     _log.finest('Initialize with headers: $headers');
   }
 
-  /// Authenticates the request with JWT.
-  ///
-  /// Passing `null` clears the `Authorization` header.
-  PostgrestClient setAccessToken(String? token) {
-    _log.finest("setAccessToken with: $token");
-    if (token != null) {
-      headers['Authorization'] = 'Bearer $token';
-    } else {
-      headers.remove('Authorization');
-    }
-    return this;
-  }
-
   /// Perform a table operation.
   PostgrestQueryBuilder<void> from(String table) {
     final requestUrl = '$url/$table';

--- a/packages/postgrest/test/basic_test.dart
+++ b/packages/postgrest/test/basic_test.dart
@@ -111,17 +111,6 @@ void main() {
       );
     });
 
-    test('auth', () async {
-      postgrest = PostgrestClient(
-        localStackRestUrl,
-        headers: {'Authorization': 'Bearer foo'},
-      );
-      expect(
-        postgrest.headers['Authorization'],
-        'Bearer foo',
-      );
-    });
-
     test('set header on rpc', () async {
       final httpClient = CustomHttpClient();
       final client = PostgrestClient(localStackRestUrl, httpClient: httpClient);

--- a/packages/postgrest/test/basic_test.dart
+++ b/packages/postgrest/test/basic_test.dart
@@ -112,7 +112,10 @@ void main() {
     });
 
     test('auth', () async {
-      postgrest = PostgrestClient(localStackRestUrl).setAccessToken('foo');
+      postgrest = PostgrestClient(
+        localStackRestUrl,
+        headers: {'Authorization': 'Bearer foo'},
+      );
       expect(
         postgrest.headers['Authorization'],
         'Bearer foo',

--- a/packages/supabase/test/client_test.dart
+++ b/packages/supabase/test/client_test.dart
@@ -250,6 +250,47 @@ void main() {
       await mockServer.close();
     });
 
+    test(
+      'a per-request Authorization header wins over the session token',
+      () async {
+        final (:sessionString, accessToken: _) = getSessionData(
+          DateTime.now().add(Duration(hours: 1)),
+        );
+
+        final mockServer = await HttpServer.bind('localhost', 0);
+        final supabase = SupabaseClient(
+          'http://${mockServer.address.host}:${mockServer.port}',
+          "supabaseKey",
+          authOptions: AuthClientOptions(autoRefreshToken: false),
+        );
+        await supabase.auth.recoverSession(sessionString);
+
+        unawaited(
+          supabase.functions
+              .invoke("test", headers: {'Authorization': 'Bearer pinned'})
+              .then((value) => null),
+        );
+        unawaited(
+          supabase
+              .from("test")
+              .select()
+              .setHeader('Authorization', 'Bearer pinned')
+              .then((value) => null),
+        );
+
+        var count = 0;
+        await for (final request in mockServer) {
+          expect(request.headers.value('Authorization'), 'Bearer pinned');
+          count++;
+          if (count == 2) {
+            break;
+          }
+        }
+
+        await mockServer.close();
+      },
+    );
+
     test('call recoverSession', () async {
       final expiresAt = DateTime.now().add(Duration(seconds: 31));
 

--- a/packages/supabase/test/client_test.dart
+++ b/packages/supabase/test/client_test.dart
@@ -265,28 +265,34 @@ void main() {
         );
         await supabase.auth.recoverSession(sessionString);
 
-        unawaited(
-          supabase.functions
-              .invoke("test", headers: {'Authorization': 'Bearer pinned'})
-              .then((value) => null),
-        );
-        unawaited(
+        final pending = <Future<Object?>>[
+          supabase.functions.invoke(
+            "test",
+            headers: {'Authorization': 'Bearer pinned'},
+          ),
+          // then() subscribes, which is what starts a Postgrest builder.
           supabase
               .from("test")
               .select()
               .setHeader('Authorization', 'Bearer pinned')
-              .then((value) => null),
-        );
+              .then((value) => value),
+        ];
 
         var count = 0;
         await for (final request in mockServer) {
           expect(request.headers.value('Authorization'), 'Bearer pinned');
+          request.response
+            ..headers.contentType = ContentType.json
+            ..write('[]');
+          await request.response.close();
           count++;
-          if (count == 2) {
+          if (count == pending.length) {
             break;
           }
         }
 
+        await Future.wait(pending);
+        await supabase.dispose();
         await mockServer.close();
       },
     );

--- a/packages/supabase/test/client_test.dart
+++ b/packages/supabase/test/client_test.dart
@@ -258,14 +258,16 @@ void main() {
         );
 
         final mockServer = await HttpServer.bind('localhost', 0);
+        addTearDown(() => mockServer.close(force: true));
         final supabase = SupabaseClient(
           'http://${mockServer.address.host}:${mockServer.port}',
           "supabaseKey",
           authOptions: AuthClientOptions(autoRefreshToken: false),
         );
+        addTearDown(supabase.dispose);
         await supabase.auth.recoverSession(sessionString);
 
-        final pending = <Future<Object?>>[
+        final pending = [
           supabase.functions.invoke(
             "test",
             headers: {'Authorization': 'Bearer pinned'},
@@ -292,8 +294,6 @@ void main() {
         }
 
         await Future.wait(pending);
-        await supabase.dispose();
-        await mockServer.close();
       },
     );
 

--- a/packages/supabase_functions/lib/src/functions_client.dart
+++ b/packages/supabase_functions/lib/src/functions_client.dart
@@ -45,13 +45,6 @@ class FunctionsClient {
     return _headers;
   }
 
-  /// Updates the authorization header
-  ///
-  /// [token] - the new jwt token sent in the authorization header
-  void setAccessToken(String token) {
-    _headers['Authorization'] = 'Bearer $token';
-  }
-
   /// Invokes a function
   ///
   /// [functionName] is the name of the function to invoke

--- a/packages/supabase_functions/test/functions_dart_test.dart
+++ b/packages/supabase_functions/test/functions_dart_test.dart
@@ -438,10 +438,12 @@ void main() {
     });
 
     group('Headers', () {
-      test('headers getter returns the client headers', () {
-        final headers = functionsCustomHttpClient.headers;
+      test('headers getter returns the constructor headers merged with the '
+          'defaults', () {
+        final client = FunctionsClient("", {'apikey': 'foo'});
 
-        expect(headers, contains('X-Client-Info'));
+        expect(client.headers['apikey'], 'foo');
+        expect(client.headers, contains('X-Client-Info'));
       });
 
       test('custom headers override defaults', () async {

--- a/packages/supabase_functions/test/functions_dart_test.dart
+++ b/packages/supabase_functions/test/functions_dart_test.dart
@@ -438,20 +438,9 @@ void main() {
     });
 
     group('Headers', () {
-      test('setAccessToken updates authorization header', () async {
-        functionsCustomHttpClient.setAccessToken('new-token');
-
-        await functionsCustomHttpClient.invoke('function');
-
-        final request = customHttpClient.receivedRequests.last;
-        expect(request.headers['Authorization'], 'Bearer new-token');
-      });
-
-      test('headers getter returns current headers', () {
-        functionsCustomHttpClient.setAccessToken('test-token');
-
+      test('headers getter returns the client headers', () {
         final headers = functionsCustomHttpClient.headers;
-        expect(headers['Authorization'], 'Bearer test-token');
+
         expect(headers, contains('X-Client-Info'));
       });
 

--- a/packages/supabase_storage/lib/src/storage_client.dart
+++ b/packages/supabase_storage/lib/src/storage_client.dart
@@ -140,10 +140,6 @@ class SupabaseStorageClient extends StorageBucketApi {
     storageFetch,
   );
 
-  void setAccessToken(String jwt) {
-    headers['Authorization'] = 'Bearer $jwt';
-  }
-
   /// Sets an HTTP header for subsequent requests.
   ///
   /// Mutates the headers map used by this client in place. Instances of

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -1971,8 +1971,10 @@ features:
       - FunctionResponse.FunctionResponse
   functions.invocation.set_auth_token:
     status: implemented
+    note: "There is no dedicated setter. The token is passed as an Authorization header, either to the constructor for every invocation or to invoke for a single one. Through SupabaseClient the live session token is resolved and applied per request, so no manual call is needed."
     symbols:
-      - FunctionsClient.setAccessToken
+      - FunctionsClient.FunctionsClient
+      - FunctionsClient.invoke
   functions.invocation.method_override:
     status: implemented
     note: "The HttpMethod enum is shared with postgrest, so it also offers head, which supabase-js does not expose for function invocation."
@@ -2001,11 +2003,10 @@ features:
       - SupabaseClient.accessToken
   client.authentication_integration.cross_client_token_sync:
     status: implemented
+    note: "The rest, storage and functions clients share an HTTP client that resolves the current access token on every request, so there is nothing to synchronize and they expose no setter. Realtime keeps one because it pushes the token over a live socket rather than per request."
     symbols:
-      - PostgrestClient.setAccessToken
       - RealtimeClient.setAccessToken
-      - SupabaseStorageClient.setAccessToken
-      - FunctionsClient.setAccessToken
+      - SupabaseClient.accessToken
   client.authentication_integration.oauth_flow_type:
     status: implemented
     symbols:

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -1971,7 +1971,7 @@ features:
       - FunctionResponse.FunctionResponse
   functions.invocation.set_auth_token:
     status: implemented
-    note: "There is no dedicated setter. The token is passed as an Authorization header, either to the constructor for every invocation or to invoke for a single one. Through SupabaseClient the live session token is resolved and applied per request, so no manual call is needed."
+    note: "There is no dedicated setter. Through SupabaseClient the current session token is resolved on every invocation, so it stays up to date without one. A standalone FunctionsClient takes the Authorization header in its constructor, or per call through invoke."
     symbols:
       - FunctionsClient.FunctionsClient
       - FunctionsClient.invoke


### PR DESCRIPTION
## Summary

Removes `PostgrestClient.setAccessToken()`, `SupabaseStorageClient.setAccessToken()` and `FunctionsClient.setAccessToken()`. `RealtimeClient.setAccessToken()` stays.

Nothing in the repository called the three that are gone, but they were not inert either. Despite the name they pinned a token rather than kept one in sync: `AuthHttpClient` applies the current session token with `putIfAbsent`, so an `Authorization` header set through one of these setters took precedence over it, and nothing ever cleared it. The pinned token kept shadowing the session across refreshes and sign-outs for the rest of the client's life. A method named `setAccessToken` on a client that is otherwise authenticated per request is a poor way to spell that.

The capability survives without them. The header maps are still mutable, so a token can be pinned with `supabase.rest.headers['Authorization'] = ...` or `storage.setHeader(...)`, passed to a constructor, or scoped to a single call with `invoke(headers: ...)` / `.setHeader(...)`. What goes away is four inconsistent signatures for the same idea, one of which reads like auth synchronization.

Realtime is the real case for a setter: it holds a live socket and has to push a new token over it rather than attach one per request, so `SupabaseClient` genuinely calls its setter on auth state changes.

## Why

Mirrors https://github.com/supabase/supabase-swift/pull/1233, which removed the equivalent `FunctionsClient.setAuth(token:)` from supabase-swift in favour of a per-request access token closure. Flutter already resolves the token per request through `AuthHttpClient`, so only the cleanup half applies here.

The header-clobbering bug that PR also fixed does not exist in this SDK: `putIfAbsent` means an `Authorization` passed to a single `invoke` or query survives the live token. `client_test.dart` now covers that end to end, since it is the replacement this migration points callers at.

## Notes

The three header maps stay mutable. `SupabaseClient.headers` still rewrites them in place on assignment, and `SupabaseStorageClient.setHeader()` still mutates its own. Making them unmodifiable is a separate change that has to deal with that setter first.

`sdk-compliance.yaml` is updated for both affected capabilities:

- `functions.invocation.set_auth_token` now points at the constructor and `invoke`, which are the two ways to supply the header, with a note on the deviation from the reference implementation.
- `client.authentication_integration.cross_client_token_sync` now lists `RealtimeClient.setAccessToken` and `SupabaseClient.accessToken`, with a note explaining why the other three clients need no setter.

`MIGRATION.md` also drops a step that had gone stale independently of this change: the v2 deprecation table told readers to replace `PostgrestClient.auth()` with `PostgrestClient.setAuth()`, which was renamed earlier in v3 and is now removed outright.

## Test plan

- `dart test` in `postgrest` (202), `supabase_functions` (50) and `supabase` (143), all passing
- New test in `client_test.dart`: a per-request `Authorization` beats the live session token for both functions and rest. Verified it fails if `AuthHttpClient` is changed to overwrite instead of `putIfAbsent`
- `dart analyze` clean and `dart format -l 80` clean on the four affected packages
- Capability matrix validated against supabase/sdk: compliance file valid, symbol check reports all new public symbols covered
- `supabase_storage` has 21 failures locally from a dirty local stack, identical on clean `origin/main`; CI runs against a fresh stack

Closes SDK-1521


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Removed `setAccessToken()` from PostgREST, Storage, and Functions clients.
  * Renamed Realtime’s `setAuth()` method to `setAccessToken()`.
  * PostgREST authentication now requires an `Authorization` header.

* **New Features**
  * Added chainable `setHeader()` support for updating Storage client headers.

* **Documentation**
  * Added migration guidance for constructor and per-request authorization headers.
  * Clarified authorization requirements for standalone Functions clients and session-based invocations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->