### PR TITLE
test(supabase): give postgrest_options_test a PKCE async storage

### DIFF
--- a/packages/supabase/test/postgrest_options_test.dart
+++ b/packages/supabase/test/postgrest_options_test.dart
@@ -69,7 +69,9 @@ void main() {
       'http://localhost:9999',
       supabaseKey,
       httpClient: client,
-      authOptions: AuthClientOptions(pkceAsyncStorage: MemoryAuthAsyncStorage()),
+      authOptions: AuthClientOptions(
+        pkceAsyncStorage: MemoryAuthAsyncStorage(),
+      ),
       postgrestOptions: PostgrestClientOptions(
         retryOptions: retryOptions,
         requestTimeout: requestTimeout,

--- a/packages/supabase/test/postgrest_options_test.dart
+++ b/packages/supabase/test/postgrest_options_test.dart
@@ -69,6 +69,7 @@ void main() {
       'http://localhost:9999',
       supabaseKey,
       httpClient: client,
+      authOptions: AuthClientOptions(pkceAsyncStorage: MemoryAuthAsyncStorage()),
       postgrestOptions: PostgrestClientOptions(
         retryOptions: retryOptions,
         requestTimeout: requestTimeout,


### PR DESCRIPTION
`main` is red: all six tests in `packages/supabase/test/postgrest_options_test.dart` fail.

`SupabaseClient` defaults to `AuthFlowType.pkce`, and 30729cc9 made `AuthClient` assert that `asyncStorage` is provided for that flow. The `initializeWith` helper in this file builds a client without one, so every test using it throws the assertion during setup and then fails again on the uninitialized `supabase` local.

Passes a `MemoryAuthAsyncStorage`, which is what the assertion message suggests and what `client_test.dart` already does. These tests never touch auth, so no other behaviour changes.

## Test plan

`dart test packages/supabase/test/postgrest_options_test.dart` goes from 6 failures to 6 passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication setup when initializing the Supabase client.
  * Enabled reliable in-memory PKCE state handling during PostgREST option tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->