### PR TITLE
feat: resolve an access token per request on the standalone clients

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1351,7 +1351,9 @@ after.
 To authenticate as the signed-in user, do nothing. `SupabaseClient` already resolves that token on
 every request.
 
-To pin a token on a client you construct yourself, pass it as a constructor header:
+On a client you construct yourself, pass an `accessToken` callback. It is resolved before every
+request, so a token that rotates is picked up without you pushing the new value anywhere. This is
+the closest replacement for the old setter, and unlike it, it does not go stale:
 
 ```dart
 // Before
@@ -1359,11 +1361,25 @@ final functions = FunctionsClient(functionsUrl, {'apikey': anonKey});
 functions.setAccessToken(jwt);
 
 // After
+final functions = FunctionsClient(
+  functionsUrl,
+  {'apikey': anonKey},
+  accessToken: () async => currentJwt,
+);
+```
+
+`PostgrestClient` and `SupabaseStorageClient` take the same callback. If the token never changes,
+a constructor header is still enough:
+
+```dart
 final functions = FunctionsClient(functionsUrl, {
   'apikey': anonKey,
   'Authorization': 'Bearer $jwt',
 });
 ```
+
+Passing both an `Authorization` header and `accessToken` asserts, because the header would win on
+every request and the callback would never be used.
 
 To use a different token for a single call, pass it to that call:
 
@@ -1372,8 +1388,9 @@ await functions.invoke('hello', headers: {'Authorization': 'Bearer $jwt'});
 await postgrest.from('countries').select().setHeader('Authorization', 'Bearer $jwt');
 ```
 
-To pin a token on a client you got from `SupabaseClient`, set the header yourself. The header maps
-are still mutable:
+To pin a token on a client you got from `SupabaseClient`, set the header yourself. `SupabaseClient`
+builds its sub-clients, so there is no `accessToken` callback to pass, but the header maps are
+still mutable:
 
 ```dart
 supabase.storage.setHeader('Authorization', 'Bearer $jwt');

--- a/packages/postgrest/lib/src/postgrest.dart
+++ b/packages/postgrest/lib/src/postgrest.dart
@@ -52,15 +52,34 @@ class PostgrestClient {
   /// thrown once the retries are exhausted. When `null` (the default) no
   /// timeout is applied. Use [PostgrestBuilder.abortSignal] to cancel a request
   /// outright, which stops retrying immediately.
+  ///
+  /// [accessToken] is resolved before every request and sent as
+  /// `Authorization: Bearer <token>`. Use it when the token rotates, for
+  /// example a session token that is refreshed. Returning `null` sends no
+  /// bearer token, and it is resolved again for every retry. A header set with
+  /// [PostgrestBuilder.setHeader] still wins over it, so a single request can
+  /// be made with a different token.
   PostgrestClient(
     this.url, {
     Map<String, String>? headers,
     String? schema,
-    this.httpClient,
+    Client? httpClient,
     YAJsonIsolate? isolate,
     this.retryOptions = const SupabaseRetryOptions(),
     this.requestTimeout,
-  }) : _schema = schema,
+    Future<String?> Function()? accessToken,
+  }) : assert(
+         accessToken == null || headers?.header('Authorization') == null,
+         'Pass either an Authorization header or accessToken, not both: the '
+         'header would win over the resolved token on every request.',
+       ),
+       // The transport belongs to the caller, so the client never closes it,
+       // the same way it leaves a caller-provided isolate alone.
+       // ignore: dispose-class-fields
+       httpClient = accessToken == null
+           ? httpClient
+           : AccessTokenClient(accessToken, httpClient),
+       _schema = schema,
        headers = {...defaultHeaders, ...?headers},
        _isolate = isolate ?? (YAJsonIsolate()..initialize()),
        _hasCustomIsolate = isolate != null {

--- a/packages/postgrest/test/basic_test.dart
+++ b/packages/postgrest/test/basic_test.dart
@@ -111,6 +111,54 @@ void main() {
       );
     });
 
+    test('accessToken is resolved before every request', () async {
+      var calls = 0;
+      final httpClient = CustomHttpClient();
+      final client = PostgrestClient(
+        localStackRestUrl,
+        httpClient: httpClient,
+        accessToken: () async => 'token-${calls++}',
+      );
+
+      await client.from('empty-succ').select().head();
+      final first = httpClient.lastRequest!.headers['Authorization'];
+      await client.from('empty-succ').select().head();
+      final second = httpClient.lastRequest!.headers['Authorization'];
+
+      expect([first, second], ['Bearer token-0', 'Bearer token-1']);
+    });
+
+    test('setHeader wins over accessToken', () async {
+      final httpClient = CustomHttpClient();
+      final client = PostgrestClient(
+        localStackRestUrl,
+        httpClient: httpClient,
+        accessToken: () async => 'resolved',
+      );
+
+      await client
+          .from('empty-succ')
+          .select()
+          .setHeader('Authorization', 'Bearer per-request')
+          .head();
+
+      expect(
+        httpClient.lastRequest!.headers['Authorization'],
+        'Bearer per-request',
+      );
+    });
+
+    test('accessToken together with an Authorization header asserts', () {
+      expect(
+        () => PostgrestClient(
+          localStackRestUrl,
+          headers: {'Authorization': 'Bearer static'},
+          accessToken: () async => 'resolved',
+        ),
+        throwsA(isA<AssertionError>()),
+      );
+    });
+
     test('set header on rpc', () async {
       final httpClient = CustomHttpClient();
       final client = PostgrestClient(localStackRestUrl, httpClient: httpClient);

--- a/packages/supabase_common/lib/src/access_token_client.dart
+++ b/packages/supabase_common/lib/src/access_token_client.dart
@@ -1,0 +1,33 @@
+import 'package:http/http.dart';
+import 'package:supabase_common/src/http.dart';
+
+/// An HTTP client that resolves an access token per request and sends it as a
+/// bearer token.
+///
+/// The token is resolved fresh for every request, including every retry, so a
+/// token that rotates between attempts is picked up without the caller having
+/// to push the new value anywhere.
+///
+/// A request that already carries an `Authorization` header keeps it, which is
+/// how a per-request override wins over the resolved token.
+class AccessTokenClient extends BaseClient {
+  AccessTokenClient(this._accessToken, this._inner);
+
+  final Future<String?> Function() _accessToken;
+
+  /// The transport to send over, or `null` to use a one-off client per
+  /// request, matching what every Supabase client does with a null transport.
+  final Client? _inner;
+
+  @override
+  Future<StreamedResponse> send(BaseRequest request) async {
+    final accessToken = await _accessToken();
+    if (accessToken != null) {
+      request.headers.putIfAbsent('Authorization', () => 'Bearer $accessToken');
+    }
+    return request.sendWith(_inner);
+  }
+
+  @override
+  void close() => _inner?.close();
+}

--- a/packages/supabase_common/lib/supabase_common.dart
+++ b/packages/supabase_common/lib/supabase_common.dart
@@ -5,6 +5,7 @@
 /// notice.
 library;
 
+export 'src/access_token_client.dart';
 export 'src/backoff.dart';
 export 'src/base64url.dart';
 export 'src/client_info.dart';

--- a/packages/supabase_common/test/access_token_client_test.dart
+++ b/packages/supabase_common/test/access_token_client_test.dart
@@ -1,0 +1,69 @@
+import 'dart:convert';
+
+import 'package:http/http.dart';
+import 'package:supabase_common/supabase_common.dart';
+import 'package:test/test.dart';
+
+class _Capture extends BaseClient {
+  final List<BaseRequest> requests = [];
+
+  @override
+  Future<StreamedResponse> send(BaseRequest request) async {
+    requests.add(request);
+    return StreamedResponse(Stream.value(utf8.encode('{}')), 200);
+  }
+}
+
+void main() {
+  late _Capture inner;
+
+  setUp(() => inner = _Capture());
+
+  Future<void> sendThrough(AccessTokenClient client) =>
+      client.send(Request('GET', Uri.parse('http://localhost/x')));
+
+  test('sends the resolved token as a bearer token', () async {
+    await sendThrough(AccessTokenClient(() async => 'token', inner));
+
+    expect(inner.requests.single.headers['Authorization'], 'Bearer token');
+  });
+
+  test('resolves the token again for every request', () async {
+    var calls = 0;
+    final client = AccessTokenClient(() async => 'token-${calls++}', inner);
+
+    await sendThrough(client);
+    await sendThrough(client);
+
+    expect(
+      inner.requests.map((request) => request.headers['Authorization']),
+      ['Bearer token-0', 'Bearer token-1'],
+    );
+  });
+
+  test('sends no bearer token when the token is null', () async {
+    await sendThrough(AccessTokenClient(() async => null, inner));
+
+    expect(inner.requests.single.headers, isNot(contains('Authorization')));
+  });
+
+  test('keeps an Authorization header the request already carries', () async {
+    final client = AccessTokenClient(() async => 'token', inner);
+    final request = Request('GET', Uri.parse('http://localhost/x'))
+      ..headers['Authorization'] = 'Bearer per-request';
+
+    await client.send(request);
+
+    expect(
+      inner.requests.single.headers['Authorization'],
+      'Bearer per-request',
+    );
+  });
+
+  test('propagates an error from the token callback', () async {
+    final client = AccessTokenClient(() async => throw StateError('no'), inner);
+
+    await expectLater(sendThrough(client), throwsStateError);
+    expect(inner.requests, isEmpty);
+  });
+}

--- a/packages/supabase_functions/lib/src/functions_client.dart
+++ b/packages/supabase_functions/lib/src/functions_client.dart
@@ -20,17 +20,34 @@ class FunctionsClient {
 
   /// In case you don't provide your own isolate, call [dispose] when you're
   /// done
+  ///
+  /// [accessToken] is resolved before every invocation and sent as
+  /// `Authorization: Bearer <token>`. Use it when the token rotates, for
+  /// example a session token that is refreshed. Returning `null` sends no
+  /// bearer token. A header passed to [invoke] still wins over it, so a single
+  /// call can be made with a different token.
   FunctionsClient(
     String url,
     Map<String, String> headers, {
     http.Client? httpClient,
     YAJsonIsolate? isolate,
     String? region,
-  }) : _url = url,
+    Future<String?> Function()? accessToken,
+  }) : assert(
+         accessToken == null || headers.header('Authorization') == null,
+         'Pass either an Authorization header or accessToken, not both: the '
+         'header would win over the resolved token on every invocation.',
+       ),
+       _url = url,
        _headers = {...FunctionsConstants.defaultHeaders, ...headers},
        _isolate = isolate ?? (YAJsonIsolate()..initialize()),
        _hasCustomIsolate = isolate != null,
-       _httpClient = httpClient,
+       // The transport belongs to the caller, so the client never closes it,
+       // the same way it leaves a caller-provided isolate alone.
+       // ignore: dispose-class-fields
+       _httpClient = accessToken == null
+           ? httpClient
+           : AccessTokenClient(accessToken, httpClient),
        _region = region {
     functionsLogger.config(
       "Initialize FunctionsClient v$version with url "

--- a/packages/supabase_functions/test/functions_dart_test.dart
+++ b/packages/supabase_functions/test/functions_dart_test.dart
@@ -446,6 +446,72 @@ void main() {
         expect(client.headers, contains('X-Client-Info'));
       });
 
+      test('accessToken is resolved before every invocation', () async {
+        var calls = 0;
+        final client = FunctionsClient(
+          "",
+          {},
+          httpClient: customHttpClient,
+          accessToken: () async => 'token-${calls++}',
+        );
+
+        await client.invoke('function');
+        await client.invoke('function');
+
+        expect(
+          customHttpClient.receivedRequests
+              .map((request) => request.headers['Authorization'])
+              .toList(),
+          ['Bearer token-0', 'Bearer token-1'],
+        );
+      });
+
+      test('a header passed to invoke wins over accessToken', () async {
+        final client = FunctionsClient(
+          "",
+          {},
+          httpClient: customHttpClient,
+          accessToken: () async => 'resolved',
+        );
+
+        await client.invoke(
+          'function',
+          headers: {'Authorization': 'Bearer per-call'},
+        );
+
+        expect(
+          customHttpClient.receivedRequests.last.headers['Authorization'],
+          'Bearer per-call',
+        );
+      });
+
+      test('accessToken sends nothing when it resolves to null', () async {
+        final client = FunctionsClient(
+          "",
+          {},
+          httpClient: customHttpClient,
+          accessToken: () async => null,
+        );
+
+        await client.invoke('function');
+
+        expect(
+          customHttpClient.receivedRequests.last.headers,
+          isNot(contains('Authorization')),
+        );
+      });
+
+      test('accessToken together with an Authorization header asserts', () {
+        expect(
+          () => FunctionsClient(
+            "",
+            {'Authorization': 'Bearer static'},
+            accessToken: () async => 'resolved',
+          ),
+          throwsA(isA<AssertionError>()),
+        );
+      });
+
       test('custom headers override defaults', () async {
         await functionsCustomHttpClient.invoke(
           'function',

--- a/packages/supabase_storage/lib/src/storage_client.dart
+++ b/packages/supabase_storage/lib/src/storage_client.dart
@@ -1,3 +1,4 @@
+import 'package:http/http.dart';
 import 'package:iceberg/iceberg.dart';
 import 'package:supabase_storage/src/logger.dart';
 import 'package:meta/meta.dart';
@@ -30,6 +31,12 @@ class SupabaseStorageClient extends StorageBucketApi {
   /// Override it for a single upload with the `retryOptions` parameter of
   /// [StorageFileApi.upload] and its siblings.
   ///
+  /// [accessToken] is resolved before every request and sent as
+  /// `Authorization: Bearer <token>`. Use it when the token rotates, for
+  /// example a session token that is refreshed. Returning `null` sends no
+  /// bearer token, and it is resolved again for every upload retry. A header
+  /// set with [setHeader] still wins over it.
+  ///
   /// [useNewHostname] controls whether legacy storage URLs are rewritten to use
   /// the dedicated storage host (`<ref>.storage.supabase.co`). Set to `true`
   /// only if your project has the dedicated storage host enabled; otherwise
@@ -38,12 +45,21 @@ class SupabaseStorageClient extends StorageBucketApi {
   SupabaseStorageClient(
     String url,
     Map<String, String> headers, {
-    super.httpClient,
+    Client? httpClient,
     this.retryOptions = const SupabaseRetryOptions(count: 0),
     bool useNewHostname = false,
-  }) : super(
+    Future<String?> Function()? accessToken,
+  }) : assert(
+         accessToken == null || headers.header('Authorization') == null,
+         'Pass either an Authorization header or accessToken, not both: the '
+         'header would win over the resolved token on every request.',
+       ),
+       super(
          useNewHostname ? _transformStorageUrl(url) : url,
          {...StorageConstants.defaultHeaders, ...headers},
+         httpClient: accessToken == null
+             ? httpClient
+             : AccessTokenClient(accessToken, httpClient),
        ) {
     storageLogger.config(
       'Initialize SupabaseStorageClient v$version with url: '

--- a/packages/supabase_storage/test/basic_test.dart
+++ b/packages/supabase_storage/test/basic_test.dart
@@ -924,6 +924,60 @@ void main() {
     });
   });
 
+  group('accessToken', () {
+    setUp(() {
+      customHttpClient.response = [testBucketJson];
+    });
+
+    test('is resolved before every request', () async {
+      var calls = 0;
+      final storage = SupabaseStorageClient(
+        '$supabaseUrl/storage/v1',
+        {},
+        httpClient: customHttpClient,
+        accessToken: () async => 'token-${calls++}',
+      );
+
+      await storage.listBuckets();
+      await storage.listBuckets();
+
+      expect(
+        customHttpClient.receivedRequests
+            .map((request) => request.headers['Authorization'])
+            .toList(),
+        ['Bearer token-0', 'Bearer token-1'],
+      );
+    });
+
+    test('setHeader wins over the resolved token', () async {
+      final storage = SupabaseStorageClient(
+        '$supabaseUrl/storage/v1',
+        {},
+        httpClient: customHttpClient,
+        accessToken: () async => 'resolved',
+      );
+
+      storage.setHeader('Authorization', 'Bearer pinned');
+      await storage.listBuckets();
+
+      expect(
+        customHttpClient.receivedRequests.last.headers['Authorization'],
+        'Bearer pinned',
+      );
+    });
+
+    test('together with an Authorization header asserts', () {
+      expect(
+        () => SupabaseStorageClient(
+          '$supabaseUrl/storage/v1',
+          {'Authorization': 'Bearer static'},
+          accessToken: () async => 'resolved',
+        ),
+        throwsA(isA<AssertionError>()),
+      );
+    });
+  });
+
   group('URL Construction', () {
     group('default behavior (useNewHostname: false)', () {
       test('should NOT transform legacy prod host by default', () {

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -1969,7 +1969,7 @@ features:
       - FunctionResponse.FunctionResponse
   functions.invocation.set_auth_token:
     status: implemented
-    note: "There is no dedicated setter. Through SupabaseClient the current session token is resolved on every invocation, so it stays up to date without one. A standalone FunctionsClient takes the Authorization header in its constructor, or per call through invoke."
+    note: "There is no setter. The token is supplied as an accessToken callback that is resolved before every invocation, so a rotating token is picked up without a call to update it. Through SupabaseClient it is wired up automatically. A single invocation can override it with an Authorization header."
     symbols:
       - FunctionsClient.FunctionsClient
       - FunctionsClient.invoke


### PR DESCRIPTION
> [!NOTE]
> Stacked on #1739. Review that one first; the diff here is only the last commit.

## Summary

Gives `PostgrestClient`, `SupabaseStorageClient` and `FunctionsClient` an optional `accessToken` callback, resolved before every request and sent as `Authorization: Bearer <token>`.

```dart
final functions = FunctionsClient(
  functionsUrl,
  {'apikey': anonKey},
  accessToken: () async => currentJwt,
);
```

## Why

#1739 removes `setAccessToken` from these three clients. Through `SupabaseClient` nothing is lost, because `AuthHttpClient` already resolves the session token per request. @Vinzent03 pointed out on that PR that standalone users of these packages have no such wrapper, and are left with a static constructor header or mutating the header map by hand.

That is the gap the setters were filling, and filling badly: they pinned a value that went stale, which is exactly why they became a footgun once `AuthHttpClient` landed. A callback resolved per request covers the same need without that failure mode.

This is the same shape supabase/supabase-swift#1233 gives the Swift `FunctionsClient`.

## Behaviour

- Resolved before every request, and again for **every retry**, so a token that rotates between attempts is picked up. Postgrest's retry loop and storage's upload retry both go through it.
- Returning `null` sends no bearer token.
- A request that already carries an `Authorization` header keeps it, so `invoke(headers: ...)`, `PostgrestBuilder.setHeader` and `SupabaseStorageClient.setHeader` all still win over the callback.
- Passing both a constructor `Authorization` header and `accessToken` asserts, since the header would win on every request and the callback would never run.

Purely additive: the parameter is optional, and the assert can only fire on a combination that was not expressible before this PR.

## Implementation

One `AccessTokenClient` in `supabase_common`, wrapping the caller's transport. All three clients already funnel every request through a single nullable `Client?`, so wrapping at construction covers every path including multipart uploads and retries. A null transport still falls back to a one-off client per request, unchanged.

`SupabaseClient` deliberately does not use this. It wires its sub-clients through `AuthHttpClient`, which also handles the `apikey` header and the new-format key rules. Consolidating the two is worth doing separately (SDK-1523 notes it).

## Test plan

- New `access_token_client_test.dart`: per-request resolution, null token, per-request header precedence, error propagation
- Per-client tests for all three: resolution on every request, per-request override winning, and the assert
- `dart test`: `supabase_common` (109), `postgrest` (200), `supabase_functions` (54), `supabase` (143), all passing
- `dart analyze` clean across `packages/`, `dart format -l 80` clean
- Capability matrix: compliance file valid, symbol check clean (no new public symbols; `supabase_common` is in `.sdk-parse-ignore` and a parameter is not a symbol)
- `supabase_storage` shows 21 failures locally from a dirty local stack, identical on clean `main`; CI runs a fresh stack

Closes SDK-1523


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added dynamic access-token support for Functions, PostgREST, and Storage clients.
  - Tokens are refreshed before each request, including retries.
  - Per-request `Authorization` headers can override resolved tokens.
  - Requests without a token no longer include an authorization header.

- **Bug Fixes**
  - Prevented conflicting static authorization headers and access-token callbacks.

- **Documentation**
  - Updated migration guidance and SDK capability documentation for token rotation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->