### PR TITLE
refactor: share the auth callback parameters and secure random helpers

### DIFF
--- a/packages/iceberg/lib/src/iceberg_rest_catalog.dart
+++ b/packages/iceberg/lib/src/iceberg_rest_catalog.dart
@@ -1,5 +1,4 @@
 import 'dart:convert';
-import 'dart:math';
 
 import 'package:http/http.dart' as http;
 import 'package:iceberg/src/iceberg_error.dart';
@@ -31,7 +30,6 @@ class IcebergRestCatalog {
   final http.Client? _httpClient;
   final String? _warehouse;
   final String? _accessDelegation;
-  final _random = Random.secure();
 
   Future<String>? _prefixFuture;
 
@@ -69,9 +67,7 @@ class IcebergRestCatalog {
     bytes[3] = (milliseconds >> 16) & 0xff;
     bytes[4] = (milliseconds >> 8) & 0xff;
     bytes[5] = milliseconds & 0xff;
-    for (var index = 6; index < 16; index++) {
-      bytes[index] = _random.nextInt(256);
-    }
+    bytes.setRange(6, 16, randomBytes(10));
     bytes[6] = (bytes[6] & 0x0f) | 0x70;
     bytes[8] = (bytes[8] & 0x3f) | 0x80;
     final hex = bytes
@@ -161,7 +157,7 @@ class IcebergRestCatalog {
         ? json.decode(response.body)
         : response.body;
 
-    if (response.statusCode < 200 || response.statusCode >= 300) {
+    if (!isSuccessStatusCode(response.statusCode)) {
       throw IcebergApiException.fromResponse(response.statusCode, decoded);
     }
 

--- a/packages/postgrest/lib/src/postgrest_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_builder.dart
@@ -328,10 +328,8 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
         case HttpMethod.get || HttpMethod.head || HttpMethod.delete:
           break;
       }
-      final client = _httpClient ?? http.Client();
-
       try {
-        final streamResponse = await client.send(request);
+        final streamResponse = await request.sendWith(_httpClient);
         return await http.Response.fromStream(streamResponse);
       } on RequestAbortedException {
         if (timedOut) {
@@ -340,9 +338,6 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
         rethrow;
       } finally {
         timeoutTimer?.cancel();
-        if (_httpClient == null) {
-          client.close();
-        }
       }
     }
 

--- a/packages/supabase_auth/lib/src/auth_client.dart
+++ b/packages/supabase_auth/lib/src/auth_client.dart
@@ -1171,7 +1171,7 @@ class AuthClient {
     if (authCode != null) {
       return await exchangeCodeForSession(
         authCode,
-        flowId: url.queryParameters[AuthConstants.pkceFlowIdParam],
+        flowId: url.queryParameters[pkceFlowIdParam],
       );
     }
 

--- a/packages/supabase_auth/lib/src/auth_constants.dart
+++ b/packages/supabase_auth/lib/src/auth_constants.dart
@@ -12,14 +12,6 @@ class AuthConstants {
   /// storage key prefix to store code verifiers
   static const String defaultStorageKey = 'supabase.auth.token';
 
-  /// Reserved query parameter appended to `redirectTo` URLs of PKCE flows when
-  /// `appendPkceFlowIdToRedirects` is enabled.
-  ///
-  /// It round-trips through the auth server untouched and identifies the
-  /// verifier slot the callback belongs to. The verifier itself never
-  /// appears in a URL.
-  static const String pkceFlowIdParam = 'sb_flow_id';
-
   /// Maximum number of PKCE code verifiers kept in storage at once. Starting
   /// another flow beyond this evicts the oldest pending verifier.
   static const int pkceMaxConcurrentFlows = 5;

--- a/packages/supabase_auth/lib/src/helper.dart
+++ b/packages/supabase_auth/lib/src/helper.dart
@@ -1,6 +1,5 @@
 import 'dart:convert';
 
-import 'package:supabase_auth/src/auth_constants.dart';
 import 'package:supabase_auth/src/types/auth_exception.dart';
 import 'package:supabase_auth/src/types/jwt.dart';
 import 'package:meta/meta.dart';
@@ -108,7 +107,7 @@ String appendPKCEFlowIdToRedirect(String redirectTo, String flowId) {
   }
 
   final separator = base.contains('?') ? '&' : '?';
-  return '$base$separator${AuthConstants.pkceFlowIdParam}='
+  return '$base$separator$pkceFlowIdParam='
       '${Uri.encodeQueryComponent(flowId)}$fragment';
 }
 
@@ -121,8 +120,8 @@ String _withoutFlowId(String pairs) => pairs
     .where(
       (pair) =>
           pair.isNotEmpty &&
-          pair != AuthConstants.pkceFlowIdParam &&
-          !pair.startsWith('${AuthConstants.pkceFlowIdParam}='),
+          pair != pkceFlowIdParam &&
+          !pair.startsWith('$pkceFlowIdParam='),
     )
     .join('&');
 

--- a/packages/supabase_auth/lib/src/pkce_verifier_store.dart
+++ b/packages/supabase_auth/lib/src/pkce_verifier_store.dart
@@ -1,9 +1,9 @@
 import 'dart:convert';
-import 'dart:math';
 
 import 'package:supabase_auth/src/auth_constants.dart';
 import 'package:supabase_auth/src/types/auth_async_storage.dart';
 import 'package:meta/meta.dart';
+import 'package:supabase_common/supabase_common.dart';
 
 /// Stores PKCE code verifiers in a separate slot per flow, so several flows can
 /// be pending at the same time.
@@ -67,13 +67,7 @@ class PKCEVerifierStore {
   ///
   /// The id only selects a verifier held in storage and is never secret, but it
   /// is generated from a secure source so that concurrent flows cannot collide.
-  static String generateFlowId() {
-    final random = Random.secure();
-    return List.generate(
-      16,
-      (_) => random.nextInt(256).toRadixString(16).padLeft(2, '0'),
-    ).join();
-  }
+  static String generateFlowId() => randomHex(16);
 
   /// Stores [verifier] in [flowId]'s own slot, evicting the oldest pending slot
   /// when that would exceed [AuthConstants.pkceMaxConcurrentFlows].

--- a/packages/supabase_auth/test/pkce_flow_test.dart
+++ b/packages/supabase_auth/test/pkce_flow_test.dart
@@ -5,6 +5,7 @@ import 'package:supabase_auth/src/auth_constants.dart';
 import 'package:supabase_auth/src/helper.dart';
 import 'package:supabase_auth/src/pkce_verifier_store.dart';
 import 'package:http/http.dart';
+import 'package:supabase_common/supabase_common.dart';
 import 'package:test/test.dart';
 
 import 'utils.dart';
@@ -655,7 +656,7 @@ void main() {
       final redirectTo = Uri.parse(mockClient.lastRedirectTo!);
       expect(
         PKCEVerifierStore.validateFlowId(
-          redirectTo.queryParameters[AuthConstants.pkceFlowIdParam],
+          redirectTo.queryParameters[pkceFlowIdParam],
         ),
         isNotNull,
       );
@@ -668,7 +669,7 @@ void main() {
 
       expect(
         mockClient.lastRedirectTo,
-        contains('${AuthConstants.pkceFlowIdParam}='),
+        contains('$pkceFlowIdParam='),
       );
     });
 
@@ -685,7 +686,7 @@ void main() {
         response.url.queryParameters['redirect_to']!,
       );
       expect(
-        redirectTo.queryParameters[AuthConstants.pkceFlowIdParam],
+        redirectTo.queryParameters[pkceFlowIdParam],
         response.flowId,
       );
     });

--- a/packages/supabase_common/lib/src/auth_callback.dart
+++ b/packages/supabase_common/lib/src/auth_callback.dart
@@ -1,0 +1,28 @@
+/// The reserved query parameter appended to `redirectTo` URLs of PKCE flows
+/// when `appendPkceFlowIdToRedirects` is enabled.
+///
+/// It round-trips through the auth server untouched and identifies the
+/// verifier slot the callback belongs to. The verifier itself never appears
+/// in a URL.
+const String pkceFlowIdParam = 'sb_flow_id';
+
+/// Every URL parameter an auth callback (magic link, OAuth redirect, error
+/// redirect) can carry, in the query or the fragment.
+///
+/// Defined once so the packages that read the parameters and the packages
+/// that strip them from a callback URL cannot drift apart.
+const Set<String> authCallbackParameters = {
+  'code',
+  'access_token',
+  'expires_in',
+  'expires_at',
+  'refresh_token',
+  'token_type',
+  'provider_token',
+  'provider_refresh_token',
+  'error',
+  'error_code',
+  'error_description',
+  'type',
+  pkceFlowIdParam,
+};

--- a/packages/supabase_common/lib/src/pkce.dart
+++ b/packages/supabase_common/lib/src/pkce.dart
@@ -1,15 +1,12 @@
 import 'dart:convert';
-import 'dart:math';
 
 import 'package:crypto/crypto.dart';
+import 'package:supabase_common/src/random.dart';
 
 /// Generates a random PKCE code verifier.
 String generatePKCEVerifier() {
   const verifierLength = 56;
-  final random = Random.secure();
-  return base64UrlEncode(
-    List.generate(verifierLength, (_) => random.nextInt(256)),
-  ).split('=')[0];
+  return base64UrlEncode(randomBytes(verifierLength)).split('=')[0];
 }
 
 /// Generates the PKCE code challenge for the given [verifier].

--- a/packages/supabase_common/lib/src/random.dart
+++ b/packages/supabase_common/lib/src/random.dart
@@ -1,0 +1,15 @@
+import 'dart:math';
+import 'dart:typed_data';
+
+final Random _secureRandom = Random.secure();
+
+/// [length] bytes from a cryptographically secure random source.
+Uint8List randomBytes(int length) => Uint8List.fromList(
+  List.generate(length, (_) => _secureRandom.nextInt(256)),
+);
+
+/// A lowercase hex string of [length] bytes from a cryptographically secure
+/// random source, so twice as many characters as [length].
+String randomHex(int length) => randomBytes(
+  length,
+).map((byte) => byte.toRadixString(16).padLeft(2, '0')).join();

--- a/packages/supabase_common/lib/supabase_common.dart
+++ b/packages/supabase_common/lib/supabase_common.dart
@@ -6,6 +6,7 @@
 library;
 
 export 'src/access_token_client.dart';
+export 'src/auth_callback.dart';
 export 'src/backoff.dart';
 export 'src/base64url.dart';
 export 'src/client_info.dart';
@@ -16,6 +17,7 @@ export 'src/http_status.dart';
 export 'src/persist_session_key.dart';
 export 'src/pkce.dart';
 export 'src/platform/platform_info.dart';
+export 'src/random.dart';
 export 'src/redaction.dart';
 export 'src/replay_subject.dart';
 export 'src/retry.dart';

--- a/packages/supabase_flutter/lib/src/clear_auth_url_parameters.dart
+++ b/packages/supabase_flutter/lib/src/clear_auth_url_parameters.dart
@@ -1,20 +1,5 @@
 import 'package:meta/meta.dart';
-
-const _authParameters = {
-  'code',
-  'access_token',
-  'expires_in',
-  'expires_at',
-  'refresh_token',
-  'token_type',
-  'provider_token',
-  'provider_refresh_token',
-  'error',
-  'error_code',
-  'error_description',
-  'type',
-  'sb_flow_id',
-};
+import 'package:supabase_common/supabase_common.dart';
 
 /// Returns [url] with all authentication parameters removed from both the
 /// query and the fragment, preserving any unrelated parameters.
@@ -27,7 +12,7 @@ String removeAuthParametersFromUrl(String url) {
   final currentUri = Uri.parse(url);
 
   final query = Map<String, List<String>>.of(currentUri.queryParametersAll)
-    ..removeWhere((key, value) => _authParameters.contains(key));
+    ..removeWhere((key, value) => authCallbackParameters.contains(key));
 
   final cleanedUri = Uri(
     scheme: currentUri.scheme,
@@ -49,7 +34,7 @@ String? _removeAuthParametersFromFragment(String fragment) {
   final fragmentParameters = Uri(query: fragment).queryParametersAll;
   final cleaned = {
     for (final entry in fragmentParameters.entries)
-      if (!_authParameters.contains(entry.key)) entry.key: entry.value,
+      if (!authCallbackParameters.contains(entry.key)) entry.key: entry.value,
   };
   if (cleaned.length == fragmentParameters.length) {
     return fragment;

--- a/packages/supabase_flutter/lib/src/supabase_auth.dart
+++ b/packages/supabase_flutter/lib/src/supabase_auth.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:convert';
-import 'dart:math';
 
 import 'package:app_links/app_links.dart';
 import 'package:flutter/foundation.dart'
@@ -437,10 +436,7 @@ extension AuthClientSignInProvider on AuthClient {
     );
   }
 
-  String generateRawNonce() {
-    final random = Random.secure();
-    return base64Url.encode(List.generate(16, (_) => random.nextInt(256)));
-  }
+  String generateRawNonce() => base64Url.encode(randomBytes(16));
 
   /// Links an oauth identity to an existing user.
   /// This method supports the PKCE flow.


### PR DESCRIPTION
Follow-up to #1572 (SDK-1281): a duplication sweep after the extraction tiers landed surfaced a few remaining production-code items.

## Changes

- **Shared auth callback parameter vocabulary.** The `sb_flow_id` literal was hardcoded in `supabase_flutter` because `AuthConstants` is internal to `supabase_auth`, and the set of auth callback URL parameters was listed independently in `supabase_auth` and `supabase_flutter`. Both now come from `supabase_common` (`pkceFlowIdParam`, `authCallbackParameters`), so the package that reads the parameters and the package that strips them from a callback URL cannot drift apart.
- **Shared secure random helpers.** `randomBytes` and `randomHex` in `supabase_common` replace four hand-rolled "generate N secure random bytes and encode them" sites: the PKCE verifier generation, the PKCE flow id generation, `generateRawNonce` in `supabase_flutter` (public API unchanged, only the body moved), and the UUIDv7 idempotency key in `iceberg`.
- **`iceberg` uses the shared `isSuccessStatusCode`** instead of an inlined status range check, the last local status check in the repo.
- **`postgrest` uses the shared `sendWith`** transport helper instead of hand-rolling the "create a one-off client when none is injected and close it afterwards" dance that storage, functions, and iceberg already get from `supabase_common`.

No public API changes; `AuthConstants.pkceFlowIdParam` was `@internal`.

## Testing

- `dart analyze` clean on all touched packages
- Full test suites of `supabase_common`, `iceberg`, `postgrest`, `supabase_auth`, `supabase`, and `supabase_flutter` pass against the local CLI stack
- Compliance symbol and drift checks pass locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added shared secure random-generation utilities for authentication flows.
  - Standardized authentication callback parameter handling across packages.
  - Improved PKCE redirect flow tracking and verifier identification.

- **Bug Fixes**
  - Improved HTTP success-status detection and request cancellation handling.
  - Strengthened entropy generation for idempotency keys, PKCE verifiers, and nonces.
  - Reduced the risk of authentication callback parameters becoming inconsistent across components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->