### PR TITLE
perf(yet_another_json_isolate): process small payloads inline and large ones on short-lived isolates

### DIFF
--- a/packages/postgrest/lib/src/postgrest_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_builder.dart
@@ -414,7 +414,7 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
             if (isolate != null) {
               body = await isolate.decodeBytes(response.bodyBytes);
             } else {
-              body = jsonDecode(response.body);
+              body = jsonDecode(utf8.decode(response.bodyBytes));
             }
           } on FormatException catch (_) {
             // A 2xx status does not guarantee a JSON body. A proxy or gateway

--- a/packages/postgrest/lib/src/postgrest_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_builder.dart
@@ -411,8 +411,8 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
         } else {
           try {
             final isolate = _isolate;
-            if ((response.contentLength ?? 0) > 10000 && isolate != null) {
-              body = await isolate.decode(response.body);
+            if (isolate != null) {
+              body = await isolate.decodeBytes(response.bodyBytes);
             } else {
               body = jsonDecode(response.body);
             }

--- a/packages/supabase/lib/src/supabase_client.dart
+++ b/packages/supabase/lib/src/supabase_client.dart
@@ -40,8 +40,9 @@ import 'trace_http_client.dart';
 /// if this is not supported by the client libraries. When set, the `auth`
 /// namespace of the Supabase client cannot be used.
 ///
-/// Pass an instance of `YAJsonIsolate` to [isolate] to use your own persisted
-/// isolate instance. A new instance will be created if [isolate] is omitted.
+/// Pass an instance of `YAJsonIsolate` to [isolate] to share one instance
+/// for JSON encoding and decoding across clients. A new instance will be
+/// created if [isolate] is omitted.
 ///
 /// The pkce flow is used by default and keeps its code verifiers in the
 /// `AuthAsyncStorage` passed to the `pkceAsyncStorage` field of [authOptions].

--- a/packages/supabase_functions/lib/src/functions_client.dart
+++ b/packages/supabase_functions/lib/src/functions_client.dart
@@ -220,17 +220,16 @@ class FunctionsClient {
       if (bodyBytes.isEmpty) {
         data = "";
       } else {
-        final bodyText = utf8.decode(bodyBytes);
         dynamic decoded;
         try {
-          decoded = await _isolate.decode(bodyText);
+          decoded = await _isolate.decodeBytes(bodyBytes);
         } on FormatException {
           // A body labeled JSON that doesn't parse is only tolerated on an
           // error status, where the raw text still needs to reach the caller
           // as the exception `details`. On a success status it's a real
           // anomaly, so keep surfacing it instead of handing back a String.
           if (isSuccessStatus) rethrow;
-          decoded = bodyText;
+          decoded = utf8.decode(bodyBytes);
         }
         data = decoded;
       }

--- a/packages/yet_another_json_isolate/README.md
+++ b/packages/yet_another_json_isolate/README.md
@@ -7,7 +7,7 @@
   <h1 align="center">yet_another_json_isolate</h1>
 
   <p align="center">
-    Simplify and improve JSON parsing in isolates by keeping one isolate running per instance.
+    JSON parsing that never blocks the main isolate for long: small payloads are processed inline, large payloads on short lived isolates that hand their result back without copying.
   </p>
 </p>
 
@@ -21,14 +21,17 @@
 ## Usage
 
 ```dart
-// initialize an `YAJsonIsolate` instance
-final isolate = YAJsonIsolate()..initialize();
+final isolate = YAJsonIsolate();
 
-// serialize a JSON using an isolate
+// serialize to a JSON string
 final requestBody = await isolate.encode(requestObject);
 
-// deserialize a JSON string using an isolate
+// deserialize a JSON string
 final json = await isolate.decode(responseBody);
+
+// deserialize UTF-8 encoded JSON bytes, such as an HTTP response body,
+// without materializing the intermediate string on the calling isolate
+final data = await isolate.decodeBytes(response.bodyBytes);
 
 // dispose when no longer needed
 isolate.dispose();

--- a/packages/yet_another_json_isolate/benchmark/yet_another_json_isolate_benchmark.dart
+++ b/packages/yet_another_json_isolate/benchmark/yet_another_json_isolate_benchmark.dart
@@ -1,0 +1,306 @@
+/// Benchmarks [YAJsonIsolate] with payload shapes similar to Supabase API
+/// responses: lists of row objects at various sizes, plus concurrent load.
+///
+/// Reports per-operation latency and the longest main-isolate event-loop
+/// stall observed during each scenario, so that improvements in throughput
+/// that come at the cost of blocking the main isolate are visible.
+///
+/// Run with: dart run benchmark/yet_another_json_isolate_benchmark.dart
+library;
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:yet_another_json_isolate/yet_another_json_isolate.dart';
+
+Future<void> main() async {
+  stdout.writeln('Dart ${Platform.version}');
+  stdout.writeln('');
+
+  final singleRow = jsonEncode(_buildRow(0));
+  final kilobytes2 = _buildJsonListOfApproximateSize(2 * 1024);
+  final kilobytes50 = _buildJsonListOfApproximateSize(50 * 1024);
+  final megabytes1 = _buildJsonListOfApproximateSize(1024 * 1024);
+  final megabytes5 = _buildJsonListOfApproximateSize(5 * 1024 * 1024);
+
+  final results = <_ScenarioResult>[];
+
+  for (final scenario in [
+    _decodeScenario(
+      'decode single row (${_formatSize(singleRow.length)})',
+      singleRow,
+      400,
+    ),
+    _decodeScenario(
+      'decode ${_formatSize(kilobytes2.length)}',
+      kilobytes2,
+      400,
+    ),
+    _decodeScenario(
+      'decode ${_formatSize(kilobytes50.length)}',
+      kilobytes50,
+      200,
+    ),
+    _decodeScenario('decode ${_formatSize(megabytes1.length)}', megabytes1, 40),
+    _decodeScenario('decode ${_formatSize(megabytes5.length)}', megabytes5, 10),
+    _encodeScenario(
+      'encode single row (${_formatSize(singleRow.length)})',
+      singleRow,
+      400,
+    ),
+    _encodeScenario(
+      'encode ${_formatSize(kilobytes2.length)}',
+      kilobytes2,
+      400,
+    ),
+    _encodeScenario(
+      'encode ${_formatSize(kilobytes50.length)}',
+      kilobytes50,
+      200,
+    ),
+    _encodeScenario('encode ${_formatSize(megabytes1.length)}', megabytes1, 40),
+    _decodeBytesScenario(
+      'decodeBytes ${_formatSize(kilobytes50.length)}',
+      kilobytes50,
+      200,
+    ),
+    _decodeBytesScenario(
+      'decodeBytes ${_formatSize(megabytes1.length)}',
+      megabytes1,
+      40,
+    ),
+    _decodeBytesScenario(
+      'decodeBytes ${_formatSize(megabytes5.length)}',
+      megabytes5,
+      10,
+    ),
+    _concurrentDecodeScenario(
+      'decode ${_formatSize(kilobytes50.length)} x8 concurrent',
+      kilobytes50,
+      8,
+      50,
+    ),
+    _concurrentDecodeScenario(
+      'decode ${_formatSize(megabytes1.length)} x4 concurrent',
+      megabytes1,
+      4,
+      15,
+    ),
+  ]) {
+    results.add(await _runScenario(scenario));
+  }
+
+  _printTable(results);
+}
+
+class _Scenario {
+  _Scenario({
+    required this.name,
+    required this.iterations,
+    required this.body,
+  });
+
+  final String name;
+  final int iterations;
+  final Future<void> Function(YAJsonIsolate isolate) body;
+}
+
+class _ScenarioResult {
+  _ScenarioResult({
+    required this.name,
+    required this.latenciesMicroseconds,
+    required this.maxStallMicroseconds,
+  });
+
+  final String name;
+  final List<int> latenciesMicroseconds;
+  final int maxStallMicroseconds;
+
+  int get median => _percentile(0.5);
+  int get percentile90 => _percentile(0.9);
+  int get maximum => latenciesMicroseconds.last;
+
+  int _percentile(double fraction) {
+    final index = ((latenciesMicroseconds.length - 1) * fraction).round();
+    return latenciesMicroseconds[index];
+  }
+}
+
+_Scenario _decodeScenario(String name, String json, int iterations) {
+  return _Scenario(
+    name: name,
+    iterations: iterations,
+    body: (isolate) => isolate.decode(json),
+  );
+}
+
+_Scenario _decodeBytesScenario(String name, String json, int iterations) {
+  final bytes = utf8.encode(json);
+  return _Scenario(
+    name: name,
+    iterations: iterations,
+    body: (isolate) => isolate.decodeBytes(bytes),
+  );
+}
+
+_Scenario _encodeScenario(String name, String json, int iterations) {
+  final value = jsonDecode(json);
+  return _Scenario(
+    name: name,
+    iterations: iterations,
+    body: (isolate) => isolate.encode(value),
+  );
+}
+
+_Scenario _concurrentDecodeScenario(
+  String name,
+  String json,
+  int concurrency,
+  int iterations,
+) {
+  return _Scenario(
+    name: name,
+    iterations: iterations,
+    body: (isolate) => Future.wait(
+      [for (var i = 0; i < concurrency; i++) isolate.decode(json)],
+    ),
+  );
+}
+
+Future<_ScenarioResult> _runScenario(_Scenario scenario) async {
+  final isolate = YAJsonIsolate(debugName: 'benchmark');
+  await isolate.initialize();
+
+  final warmupIterations = (scenario.iterations ~/ 10).clamp(2, 20);
+  for (var i = 0; i < warmupIterations; i++) {
+    await scenario.body(isolate);
+  }
+
+  final latencies = <int>[];
+  final stallMonitor = _EventLoopStallMonitor()..start();
+  final stopwatch = Stopwatch();
+  for (var i = 0; i < scenario.iterations; i++) {
+    stopwatch
+      ..reset()
+      ..start();
+    await scenario.body(isolate);
+    stopwatch.stop();
+    latencies.add(stopwatch.elapsedMicroseconds);
+    // Yields to the event queue so the stall monitor's timer gets a chance
+    // to fire between operations; awaiting only the operation would starve
+    // it and hide stalls caused by synchronous work.
+    await Future<void>.delayed(Duration.zero);
+  }
+  final maxStall = stallMonitor.stop();
+  await isolate.dispose();
+
+  latencies.sort();
+  stdout.writeln('finished: ${scenario.name}');
+  return _ScenarioResult(
+    name: scenario.name,
+    latenciesMicroseconds: latencies,
+    maxStallMicroseconds: maxStall,
+  );
+}
+
+/// Measures gaps between 1ms periodic timer ticks on the main isolate.
+///
+/// A gap far above 1ms means the main isolate was blocked and would have
+/// dropped frames in a Flutter application.
+class _EventLoopStallMonitor {
+  final Stopwatch _stopwatch = Stopwatch();
+  Timer? _timer;
+  int _previousTickMicroseconds = 0;
+  int _maxGapMicroseconds = 0;
+
+  void start() {
+    _stopwatch
+      ..reset()
+      ..start();
+    _previousTickMicroseconds = 0;
+    _maxGapMicroseconds = 0;
+    _timer = Timer.periodic(const Duration(milliseconds: 1), (_) {
+      final now = _stopwatch.elapsedMicroseconds;
+      final gap = now - _previousTickMicroseconds;
+      if (gap > _maxGapMicroseconds) {
+        _maxGapMicroseconds = gap;
+      }
+      _previousTickMicroseconds = now;
+    });
+  }
+
+  /// Stops the monitor and returns the longest stall in microseconds, with
+  /// the expected 1ms tick interval subtracted.
+  int stop() {
+    _timer?.cancel();
+    _stopwatch.stop();
+    final stall = _maxGapMicroseconds - 1000;
+    return stall < 0 ? 0 : stall;
+  }
+}
+
+Map<String, dynamic> _buildRow(int index) {
+  return {
+    'id': index,
+    'uuid': '00000000-0000-4000-8000-${index.toString().padLeft(12, '0')}',
+    'created_at': '2026-08-20T09:00:00.000Z',
+    'name': 'user_$index',
+    'email': 'user_$index@example.com',
+    'is_active': index.isEven,
+    'score': index * 1.5,
+    'tags': ['alpha', 'beta', 'gamma'],
+    'metadata': {
+      'source': 'benchmark',
+      'index': index,
+      'nested': {'depth': 2, 'flag': true},
+    },
+    'description':
+        'Row $index with a description long enough to resemble real user '
+        'generated content stored in a text column of a Supabase table.',
+  };
+}
+
+String _buildJsonListOfApproximateSize(int targetBytes) {
+  final rows = <Map<String, dynamic>>[];
+  var encodedLength = 2;
+  var index = 0;
+  while (encodedLength < targetBytes) {
+    final row = _buildRow(index++);
+    encodedLength += jsonEncode(row).length + 1;
+    rows.add(row);
+  }
+  return jsonEncode(rows);
+}
+
+String _formatSize(int bytes) {
+  if (bytes >= 1024 * 1024) {
+    return '${(bytes / (1024 * 1024)).toStringAsFixed(1)} MB';
+  }
+  if (bytes >= 1024) {
+    return '${(bytes / 1024).toStringAsFixed(1)} KB';
+  }
+  return '$bytes B';
+}
+
+void _printTable(List<_ScenarioResult> results) {
+  const nameWidth = 34;
+  const columnWidth = 12;
+  stdout.writeln('');
+  stdout.writeln(
+    '${'scenario'.padRight(nameWidth)}'
+    '${'p50 µs'.padLeft(columnWidth)}'
+    '${'p90 µs'.padLeft(columnWidth)}'
+    '${'max µs'.padLeft(columnWidth)}'
+    '${'stall µs'.padLeft(columnWidth)}',
+  );
+  for (final result in results) {
+    stdout.writeln(
+      '${result.name.padRight(nameWidth)}'
+      '${result.median.toString().padLeft(columnWidth)}'
+      '${result.percentile90.toString().padLeft(columnWidth)}'
+      '${result.maximum.toString().padLeft(columnWidth)}'
+      '${result.maxStallMicroseconds.toString().padLeft(columnWidth)}',
+    );
+  }
+}

--- a/packages/yet_another_json_isolate/benchmark/yet_another_json_isolate_benchmark.dart
+++ b/packages/yet_another_json_isolate/benchmark/yet_another_json_isolate_benchmark.dart
@@ -95,7 +95,7 @@ Future<void> main() async {
 }
 
 class _Scenario {
-  _Scenario({
+  const _Scenario({
     required this.name,
     required this.iterations,
     required this.body,
@@ -107,7 +107,7 @@ class _Scenario {
 }
 
 class _ScenarioResult {
-  _ScenarioResult({
+  const _ScenarioResult({
     required this.name,
     required this.latenciesMicroseconds,
     required this.maxStallMicroseconds,

--- a/packages/yet_another_json_isolate/lib/src/_isolates_io.dart
+++ b/packages/yet_another_json_isolate/lib/src/_isolates_io.dart
@@ -51,13 +51,14 @@ class YAJsonIsolate {
   /// initialize: large payloads are processed on short lived isolates spawned
   /// per call.
   Future<void> initialize() {
-    _throwIfDisposed();
-    assert(
-      _hasStartedInitialize == false,
-      'initialize() can only be called once per isolate.',
-    );
-    _hasStartedInitialize = true;
-    return Future.value();
+    return Future.sync(() {
+      _throwIfDisposed();
+      assert(
+        _hasStartedInitialize == false,
+        'initialize() can only be called once per isolate.',
+      );
+      _hasStartedInitialize = true;
+    });
   }
 
   /// Dispose the instance.
@@ -82,9 +83,10 @@ class YAJsonIsolate {
   /// Decodes UTF-8 encoded JSON in [encodedJson] into Dart values.
   ///
   /// Preferred over [decode] when the payload is available as bytes, such as
-  /// an HTTP response body: the bytes are moved to the decoding isolate
-  /// without copying and the UTF-8 and JSON decoding steps are fused, so the
-  /// calling isolate never pays for materializing the intermediate string.
+  /// an HTTP response body: the bytes are copied once into a buffer that is
+  /// handed to the decoding isolate in constant time, and the UTF-8 and JSON
+  /// decoding steps are fused, so the calling isolate never pays for
+  /// materializing the intermediate string.
   Future<dynamic> decodeBytes(Uint8List encodedJson) async {
     _throwIfDisposed();
     if (encodedJson.length < _isolateThresholdBytes) {
@@ -101,14 +103,20 @@ class YAJsonIsolate {
   /// Encodes [json] into a JSON string, like [jsonEncode].
   ///
   /// Payloads estimated to be small are encoded inline, the rest on a short
-  /// lived isolate.
+  /// lived isolate. A value that cannot be sent to an isolate, for example an
+  /// object whose `toJson()` result is encodable while the object itself
+  /// holds a `ReceivePort`, is encoded inline instead.
   Future<String> encode(Object? json) async {
     _throwIfDisposed();
     if (_remainingBudget(json, _isolateThresholdBytes, 0) >= 0) {
       await null;
       return jsonEncode(json);
     }
-    return Isolate.run(() => jsonEncode(json), debugName: debugName);
+    try {
+      return await Isolate.run(() => jsonEncode(json), debugName: debugName);
+    } on ArgumentError {
+      return jsonEncode(json);
+    }
   }
 }
 

--- a/packages/yet_another_json_isolate/lib/src/_isolates_io.dart
+++ b/packages/yet_another_json_isolate/lib/src/_isolates_io.dart
@@ -88,6 +88,8 @@ class YAJsonIsolate {
   /// Decodes [json] into Dart values, like [jsonDecode].
   ///
   /// Small payloads are decoded inline, large ones on a short lived isolate.
+  /// The threshold compares the length in UTF-16 code units, which is what
+  /// the cost of parsing a string scales with.
   Future<dynamic> decode(String json) async {
     _throwIfDisposed();
     if (json.length < _isolateThresholdBytes) {
@@ -104,14 +106,16 @@ class YAJsonIsolate {
   /// handed to the decoding isolate in constant time, and the UTF-8 and JSON
   /// decoding steps are fused, so the calling isolate never pays for
   /// materializing the intermediate string.
+  ///
+  /// The bytes are read before control returns to the caller, so the buffer
+  /// can be reused as soon as the call returns.
   Future<dynamic> decodeBytes(Uint8List encodedJson) async {
     _throwIfDisposed();
     if (encodedJson.length < _isolateThresholdBytes) {
-      await null;
       return _utf8JsonDecoder.convert(encodedJson);
     }
     final transferable = TransferableTypedData.fromList([encodedJson]);
-    return _runTracked(
+    return await _runTracked(
       () => _utf8JsonDecoder.convert(transferable.materialize().asUint8List()),
     );
   }
@@ -122,10 +126,12 @@ class YAJsonIsolate {
   /// lived isolate. A value that cannot be sent to an isolate, for example an
   /// object whose `toJson()` result is encodable while the object itself
   /// holds a `ReceivePort`, is encoded inline instead.
+  ///
+  /// The value is consumed before control returns to the caller, so it can
+  /// be mutated as soon as the call returns.
   Future<String> encode(Object? json) async {
     _throwIfDisposed();
     if (_remainingBudget(json, _isolateThresholdBytes, 0) >= 0) {
-      await null;
       return jsonEncode(json);
     }
     try {

--- a/packages/yet_another_json_isolate/lib/src/_isolates_io.dart
+++ b/packages/yet_another_json_isolate/lib/src/_isolates_io.dart
@@ -1,24 +1,39 @@
-//Modified from https://github.com/dart-lang/samples/blob/master/isolates/bin/long_running_isolate.dart
-
 import 'dart:async';
 import 'dart:convert';
 import 'dart:isolate';
+import 'dart:typed_data';
 
-import 'package:async/async.dart';
+/// Payloads estimated to be smaller than this are processed directly on the
+/// calling isolate.
+///
+/// Below this size the JSON work takes well under a millisecond even on slow
+/// devices, while handing it to another isolate costs more than that in
+/// messaging overhead.
+const _isolateThresholdBytes = 64 * 1024;
 
-// One instance manages one isolate
+/// Depth guard for [_remainingBudget], so that a cyclic or extremely deep
+/// structure is handed to the isolate path instead of overflowing the stack
+/// during estimation.
+const _maxEstimationDepth = 512;
+
+final Converter<List<int>, Object?> _utf8JsonDecoder = const Utf8Decoder().fuse(
+  const JsonDecoder(),
+);
+
+/// Encodes and decodes JSON without blocking the calling isolate.
+///
+/// Small payloads are processed inline, because parsing them costs less than
+/// an isolate round trip. Large payloads are processed on a short lived
+/// isolate spawned per call: its result is handed back through `Isolate.exit`
+/// without copying, and independent calls run in parallel.
 class YAJsonIsolate {
   YAJsonIsolate({
     this.debugName,
   });
 
-  /// The debug name used for the isolate spawned by this instance.
+  /// The debug name used for the isolates spawned by this instance.
   final String? debugName;
 
-  final _receivePort = ReceivePort();
-  late final SendPort _sendPort;
-  final _createdIsolate = Completer<void>();
-  late final _events = StreamQueue(_receivePort);
   bool _hasStartedInitialize = false;
   Future<void>? _disposal;
 
@@ -30,11 +45,11 @@ class YAJsonIsolate {
     }
   }
 
-  /// Initialize the isolate
+  /// Kept for backwards compatibility.
   ///
-  /// This method is called automatically when the first method is called.
-  /// Manually initializing before the first JSON decode or encode can improve
-  /// performance.
+  /// There is no persistent isolate anymore, so there is nothing to
+  /// initialize: large payloads are processed on short lived isolates spawned
+  /// per call.
   Future<void> initialize() async {
     _throwIfDisposed();
     assert(
@@ -42,134 +57,102 @@ class YAJsonIsolate {
       'initialize() can only be called once per isolate.',
     );
     _hasStartedInitialize = true;
-    await Isolate.spawn(
-      _compute,
-      _receivePort.sendPort,
-      onExit: _receivePort.sendPort,
-      onError: _receivePort.sendPort,
-      debugName: debugName,
-    );
-    _sendPort = await _events.next;
-    _createdIsolate.complete();
   }
 
-  /// Dispose the isolate
+  /// Dispose the instance.
   ///
-  /// This exits the isolate. Safe to call more than once, and safe to call on
-  /// an instance that was never used. Concurrent calls all await the same
-  /// shutdown, so awaiting any of them means the isolate is gone. Using the
+  /// Safe to call more than once, and safe to call on an instance that was
+  /// never used. Concurrent calls all await the same disposal. Using the
   /// instance afterwards throws a [StateError].
-  Future<void> dispose() => _disposal ??= _dispose();
+  Future<void> dispose() => _disposal ??= Future.value();
 
-  Future<void> _dispose() async {
-    if (!_hasStartedInitialize) {
-      _receivePort.close();
-      return;
-    }
-
-    await _createdIsolate.future;
-    _sendPort.send(null);
-    _receivePort.close();
-    await _events.cancel();
-  }
-
+  /// Decodes [json] into Dart values, like [jsonDecode].
+  ///
+  /// Small payloads are decoded inline, large ones on a short lived isolate.
   Future<dynamic> decode(String json) async {
     _throwIfDisposed();
-    if (!_createdIsolate.isCompleted) {
-      if (!_hasStartedInitialize) await initialize();
-      await _createdIsolate.future;
+    if (json.length < _isolateThresholdBytes) {
+      await null;
+      return jsonDecode(json);
     }
-    _sendPort.send([json, false]);
-    return _handleResponse(await _events.next);
+    return Isolate.run(() => jsonDecode(json), debugName: debugName);
   }
 
+  /// Decodes UTF-8 encoded JSON in [encodedJson] into Dart values.
+  ///
+  /// Preferred over [decode] when the payload is available as bytes, such as
+  /// an HTTP response body: the bytes are moved to the decoding isolate
+  /// without copying and the UTF-8 and JSON decoding steps are fused, so the
+  /// calling isolate never pays for materializing the intermediate string.
+  Future<dynamic> decodeBytes(Uint8List encodedJson) async {
+    _throwIfDisposed();
+    if (encodedJson.length < _isolateThresholdBytes) {
+      await null;
+      return _utf8JsonDecoder.convert(encodedJson);
+    }
+    final transferable = TransferableTypedData.fromList([encodedJson]);
+    return Isolate.run(
+      () => _utf8JsonDecoder.convert(transferable.materialize().asUint8List()),
+      debugName: debugName,
+    );
+  }
+
+  /// Encodes [json] into a JSON string, like [jsonEncode].
+  ///
+  /// Payloads estimated to be small are encoded inline, the rest on a short
+  /// lived isolate.
   Future<String> encode(Object? json) async {
     _throwIfDisposed();
-    if (!_createdIsolate.isCompleted) {
-      if (!_hasStartedInitialize) await initialize();
-      await _createdIsolate.future;
+    if (_remainingBudget(json, _isolateThresholdBytes, 0) >= 0) {
+      await null;
+      return jsonEncode(json);
     }
-    _sendPort.send([json, true]);
-    return _handleResponse(await _events.next);
-  }
-
-  Future<R> _handleResponse<R>(List<dynamic> response) async {
-    final int type = response.length;
-    assert(1 <= type && type <= 3);
-
-    switch (type) {
-      // success; see _buildSuccessResponse
-      case 1:
-        return response[0] as R;
-
-      // native error; see Isolate.addErrorListener
-      case 2:
-        await Future<Never>.error(
-          RemoteError(
-            response[0] as String,
-            response[1] as String,
-          ),
-        );
-
-      // caught error; see _buildErrorResponse
-      case 3:
-      default:
-        assert(type == 3 && response[2] == null);
-
-        await Future<Never>.error(
-          response[0] as Object,
-          response[1] as StackTrace,
-        );
-    }
+    return Isolate.run(() => jsonEncode(json), debugName: debugName);
   }
 }
 
-List<dynamic> _computeResponse(dynamic input, {required bool isEncoding}) {
-  try {
-    return _buildSuccessResponse(
-      isEncoding ? jsonEncode(input) : jsonDecode(input),
-    );
-  } catch (error, stackTrace) {
-    return _buildErrorResponse(error, stackTrace);
-  }
-}
-
-void _compute(SendPort sendPort) async {
-  final commandPort = ReceivePort();
-  sendPort.send(commandPort.sendPort);
-
-  await for (final event in commandPort) {
-    // [event] is a list of [input, isEncoding]
-    if (event is List) {
-      final input = event.first;
-
-      /// `true` for encoding and `false` for decoding
-      final bool isEncoding = event.last;
-
-      sendPort.send(_computeResponse(input, isEncoding: isEncoding));
-    } else if (event == null) {
-      break;
-    }
-  }
-  Isolate.exit();
-}
-
-/// Wrap in [List] to ensure our expectations in the main [Isolate] are met.
+/// Returns what is left of [budget] after subtracting an estimate of the
+/// encoded size of [value], or a negative number as soon as the estimate
+/// exceeds the budget.
 ///
-/// We need to wrap a success result in a [List] because the user provided type
-/// [R] could also be a [List]. Meaning, a check `result is R` could return true
-/// for what was an error event.
-List<R> _buildSuccessResponse<R>(R result) {
-  return List.filled(1, result);
-}
-
-/// Wrap in [List] to ensure our expectations in the main isolate are met.
-///
-/// We wrap a caught error in a 3 element [List]. Where the last element is
-/// always null. We do this so we have a way to know if an error was one we
-/// caught or one thrown by the library code.
-List<dynamic> _buildErrorResponse(Object error, StackTrace stackTrace) {
-  return List<dynamic>.filled(3, null)
-    ..[0] = error
-    ..[1] = stackTrace;
+/// The estimate is deliberately rough: it only has to decide whether encoding
+/// inline could block the calling isolate for too long, and it must cost far
+/// less than the encoding itself. Values of unrecognized types, and structures
+/// nested deeper than [_maxEstimationDepth], exhaust the budget immediately so
+/// they are encoded on an isolate.
+int _remainingBudget(Object? value, int budget, int depth) {
+  if (budget < 0 || depth > _maxEstimationDepth) {
+    return -1;
+  }
+  switch (value) {
+    case null:
+      return budget - 4;
+    case bool _:
+      return budget - 5;
+    case num _:
+      return budget - 8;
+    case String string:
+      return budget - string.length - 2;
+    case List<dynamic> list:
+      budget -= 2;
+      for (final element in list) {
+        budget = _remainingBudget(element, budget, depth + 1) - 1;
+        if (budget < 0) {
+          return -1;
+        }
+      }
+      return budget;
+    case Map<dynamic, dynamic> map:
+      budget -= 2;
+      for (final entry in map.entries) {
+        budget = _remainingBudget(entry.key, budget, depth + 1);
+        budget = _remainingBudget(entry.value, budget, depth + 1) - 2;
+        if (budget < 0) {
+          return -1;
+        }
+      }
+      return budget;
+    default:
+      return -1;
+  }
 }

--- a/packages/yet_another_json_isolate/lib/src/_isolates_io.dart
+++ b/packages/yet_another_json_isolate/lib/src/_isolates_io.dart
@@ -36,6 +36,7 @@ class YAJsonIsolate {
 
   bool _hasStartedInitialize = false;
   Future<void>? _disposal;
+  final Set<Future<void>> _activeWork = {};
 
   bool get _isDisposed => _disposal != null;
 
@@ -63,10 +64,26 @@ class YAJsonIsolate {
 
   /// Dispose the instance.
   ///
-  /// Safe to call more than once, and safe to call on an instance that was
-  /// never used. Concurrent calls all await the same disposal. Using the
-  /// instance afterwards throws a [StateError].
-  Future<void> dispose() => _disposal ??= Future.value();
+  /// Rejects new work immediately and completes once the isolate work that
+  /// was still in flight has finished. Safe to call more than once, and safe
+  /// to call on an instance that was never used. Concurrent calls all await
+  /// the same disposal. Using the instance afterwards throws a [StateError].
+  Future<void> dispose() => _disposal ??= _activeWork.isEmpty
+      ? Future.value()
+      : Future.wait(_activeWork.toList()).then((_) {});
+
+  /// Runs [computation] on a short lived isolate, keeping the call tracked
+  /// so [dispose] can await it.
+  Future<T> _runTracked<T>(T Function() computation) async {
+    final completer = Completer<void>();
+    _activeWork.add(completer.future);
+    try {
+      return await Isolate.run(computation, debugName: debugName);
+    } finally {
+      _activeWork.remove(completer.future);
+      completer.complete();
+    }
+  }
 
   /// Decodes [json] into Dart values, like [jsonDecode].
   ///
@@ -77,7 +94,7 @@ class YAJsonIsolate {
       await null;
       return jsonDecode(json);
     }
-    return Isolate.run(() => jsonDecode(json), debugName: debugName);
+    return _runTracked(() => jsonDecode(json));
   }
 
   /// Decodes UTF-8 encoded JSON in [encodedJson] into Dart values.
@@ -94,9 +111,8 @@ class YAJsonIsolate {
       return _utf8JsonDecoder.convert(encodedJson);
     }
     final transferable = TransferableTypedData.fromList([encodedJson]);
-    return Isolate.run(
+    return _runTracked(
       () => _utf8JsonDecoder.convert(transferable.materialize().asUint8List()),
-      debugName: debugName,
     );
   }
 
@@ -113,7 +129,7 @@ class YAJsonIsolate {
       return jsonEncode(json);
     }
     try {
-      return await Isolate.run(() => jsonEncode(json), debugName: debugName);
+      return await _runTracked(() => jsonEncode(json));
     } on ArgumentError {
       return jsonEncode(json);
     }
@@ -129,6 +145,13 @@ class YAJsonIsolate {
 /// less than the encoding itself. Values of unrecognized types, and structures
 /// nested deeper than [_maxEstimationDepth], exhaust the budget immediately so
 /// they are encoded on an isolate.
+///
+/// Numbers are charged at their maximum textual width. Strings are charged
+/// one character each, without inspecting them for characters that JSON
+/// escaping expands, because such a scan would cost nearly as much as the
+/// encoding itself. A string dense in escaped characters can therefore be
+/// undercounted by up to a factor of six, which at worst lets a payload a few
+/// times [_isolateThresholdBytes] be encoded inline.
 int _remainingBudget(Object? value, int budget, int depth) {
   if (budget < 0 || depth > _maxEstimationDepth) {
     return -1;
@@ -139,7 +162,7 @@ int _remainingBudget(Object? value, int budget, int depth) {
     case bool _:
       return budget - 5;
     case num _:
-      return budget - 8;
+      return budget - 20;
     case String string:
       return budget - string.length - 2;
     case List<dynamic> list:

--- a/packages/yet_another_json_isolate/lib/src/_isolates_io.dart
+++ b/packages/yet_another_json_isolate/lib/src/_isolates_io.dart
@@ -50,13 +50,14 @@ class YAJsonIsolate {
   /// There is no persistent isolate anymore, so there is nothing to
   /// initialize: large payloads are processed on short lived isolates spawned
   /// per call.
-  Future<void> initialize() async {
+  Future<void> initialize() {
     _throwIfDisposed();
     assert(
       _hasStartedInitialize == false,
       'initialize() can only be called once per isolate.',
     );
     _hasStartedInitialize = true;
+    return Future.value();
   }
 
   /// Dispose the instance.

--- a/packages/yet_another_json_isolate/lib/src/_isolates_web.dart
+++ b/packages/yet_another_json_isolate/lib/src/_isolates_web.dart
@@ -24,9 +24,8 @@ class YAJsonIsolate {
     return jsonDecode(json);
   }
 
-  Future<dynamic> decodeBytes(Uint8List encodedJson) async {
-    await null;
-    return _utf8JsonDecoder.convert(encodedJson);
+  Future<dynamic> decodeBytes(Uint8List encodedJson) {
+    return Future.sync(() => _utf8JsonDecoder.convert(encodedJson));
   }
 
   Future<String> encode(Object? json) async {

--- a/packages/yet_another_json_isolate/lib/src/_isolates_web.dart
+++ b/packages/yet_another_json_isolate/lib/src/_isolates_web.dart
@@ -1,5 +1,15 @@
 import 'dart:convert';
+import 'dart:typed_data';
 
+final Converter<List<int>, Object?> _utf8JsonDecoder = const Utf8Decoder().fuse(
+  const JsonDecoder(),
+);
+
+/// Web variant of [YAJsonIsolate].
+///
+/// The web platform has no isolates, so all work happens inline. Decoding
+/// from bytes still fuses the UTF-8 and JSON decoding steps, which avoids
+/// materializing the intermediate string.
 class YAJsonIsolate {
   const YAJsonIsolate({
     String? debugName,
@@ -12,6 +22,11 @@ class YAJsonIsolate {
   Future<dynamic> decode(String json) async {
     await null;
     return jsonDecode(json);
+  }
+
+  Future<dynamic> decodeBytes(Uint8List encodedJson) async {
+    await null;
+    return _utf8JsonDecoder.convert(encodedJson);
   }
 
   Future<String> encode(Object? json) async {

--- a/packages/yet_another_json_isolate/lib/yet_another_json_isolate.dart
+++ b/packages/yet_another_json_isolate/lib/yet_another_json_isolate.dart
@@ -1,5 +1,6 @@
-/// Simplifies JSON parsing in isolates by keeping one isolate running per
-/// instance.
+/// JSON encoding and decoding that never blocks the calling isolate for
+/// long: small payloads are processed inline, large payloads on short lived
+/// isolates that hand their result back without copying.
 library;
 
 export 'src/_isolates_io.dart'

--- a/packages/yet_another_json_isolate/pubspec.yaml
+++ b/packages/yet_another_json_isolate/pubspec.yaml
@@ -1,5 +1,5 @@
 name: yet_another_json_isolate
-description: Package to simplify and improve JSON parsing in isolates by keeping one isolate running per instance.
+description: Package for JSON parsing off the main isolate, processing small payloads inline and large payloads on short lived isolates without copying results.
 version: 2.1.1
 homepage: 'https://supabase.com'
 repository: 'https://github.com/supabase/supabase-flutter/tree/main/packages/yet_another_json_isolate'
@@ -14,9 +14,6 @@ environment:
   sdk: '>=3.9.0 <4.0.0'
 
 resolution: workspace
-
-dependencies:
-  async: ^2.12.0
 
 dev_dependencies:
   supabase_lints: ^0.1.1

--- a/packages/yet_another_json_isolate/test/yet_another_json_isolate_io_test.dart
+++ b/packages/yet_another_json_isolate/test/yet_another_json_isolate_io_test.dart
@@ -120,7 +120,11 @@ void main() {
         ];
 
         final encoded = await isolate.encode(large);
-        expect(encoded, endsWith('{"type":"unsendable"}]'));
+        final decoded = jsonDecode(encoded) as List<dynamic>;
+        expect(decoded, hasLength(5001));
+        expect(decoded.first, {'id': 0, 'name': 'user_0'});
+        expect(decoded[4999], {'id': 4999, 'name': 'user_4999'});
+        expect(decoded.last, {'type': 'unsendable'});
       },
     );
   });

--- a/packages/yet_another_json_isolate/test/yet_another_json_isolate_io_test.dart
+++ b/packages/yet_another_json_isolate/test/yet_another_json_isolate_io_test.dart
@@ -1,6 +1,8 @@
 @TestOn('vm')
 library;
 
+import 'dart:async';
+import 'dart:convert';
 import 'dart:isolate';
 
 import 'package:test/test.dart';
@@ -74,6 +76,26 @@ void main() {
       await dispose(isolate);
 
       expect(isolate.decode('{}'), throwsStateError);
+    });
+
+    test('dispose waits for in-flight isolate work', () async {
+      final isolate = YAJsonIsolate();
+      final largeJson = jsonEncode([
+        for (var i = 0; i < 5000; i++) {'id': i, 'name': 'user_$i'},
+      ]);
+
+      var decodeCompleted = false;
+      final pending = isolate.decode(largeJson).then((_) {
+        decodeCompleted = true;
+      });
+
+      await dispose(isolate);
+      // One event loop turn lets the completion listeners of the awaited
+      // work run; the isolate round trip itself takes far longer, so this
+      // fails when disposal stops awaiting in-flight work.
+      await Future<void>.delayed(Duration.zero);
+      expect(decodeCompleted, isTrue);
+      await pending;
     });
 
     test('encodes an unsendable value inline', () async {

--- a/packages/yet_another_json_isolate/test/yet_another_json_isolate_io_test.dart
+++ b/packages/yet_another_json_isolate/test/yet_another_json_isolate_io_test.dart
@@ -15,7 +15,7 @@ void main() {
       final isolate = YAJsonIsolate();
       await isolate.initialize();
       addTearDown(() => dispose(isolate));
-      expect(isolate.initialize(), throwsA(isA<AssertionError>()));
+      expect(() => isolate.initialize(), throwsA(isA<AssertionError>()));
     });
 
     test('exposes the provided debug name', () {
@@ -56,7 +56,7 @@ void main() {
 
       expect(isolate.decode('{}'), throwsStateError);
       expect(isolate.encode({}), throwsStateError);
-      expect(isolate.initialize(), throwsStateError);
+      expect(() => isolate.initialize(), throwsStateError);
     });
 
     test('a never used isolate also rejects work after dispose', () async {

--- a/packages/yet_another_json_isolate/test/yet_another_json_isolate_io_test.dart
+++ b/packages/yet_another_json_isolate/test/yet_another_json_isolate_io_test.dart
@@ -1,8 +1,18 @@
 @TestOn('vm')
 library;
 
+import 'dart:isolate';
+
 import 'package:test/test.dart';
 import 'package:yet_another_json_isolate/yet_another_json_isolate.dart';
+
+/// JSON encodable through [toJson], but not sendable to another isolate
+/// because it holds a [ReceivePort].
+class _UnsendableButEncodable {
+  final ReceivePort port = ReceivePort();
+
+  Map<String, dynamic> toJson() => {'type': 'unsendable'};
+}
 
 /// Every disposal in this group is bounded, so a regression that makes
 /// `dispose()` wait forever fails the test instead of hanging the suite.
@@ -15,7 +25,7 @@ void main() {
       final isolate = YAJsonIsolate();
       await isolate.initialize();
       addTearDown(() => dispose(isolate));
-      expect(() => isolate.initialize(), throwsA(isA<AssertionError>()));
+      expect(isolate.initialize(), throwsA(isA<AssertionError>()));
     });
 
     test('exposes the provided debug name', () {
@@ -56,7 +66,7 @@ void main() {
 
       expect(isolate.decode('{}'), throwsStateError);
       expect(isolate.encode({}), throwsStateError);
-      expect(() => isolate.initialize(), throwsStateError);
+      expect(isolate.initialize(), throwsStateError);
     });
 
     test('a never used isolate also rejects work after dispose', () async {
@@ -65,5 +75,31 @@ void main() {
 
       expect(isolate.decode('{}'), throwsStateError);
     });
+
+    test('encodes an unsendable value inline', () async {
+      final isolate = YAJsonIsolate();
+      addTearDown(() => dispose(isolate));
+      final value = _UnsendableButEncodable();
+      addTearDown(value.port.close);
+
+      expect(await isolate.encode(value), '{"type":"unsendable"}');
+    });
+
+    test(
+      'encodes a large structure holding an unsendable value inline',
+      () async {
+        final isolate = YAJsonIsolate();
+        addTearDown(() => dispose(isolate));
+        final value = _UnsendableButEncodable();
+        addTearDown(value.port.close);
+        final large = [
+          for (var i = 0; i < 5000; i++) {'id': i, 'name': 'user_$i'},
+          value,
+        ];
+
+        final encoded = await isolate.encode(large);
+        expect(encoded, endsWith('{"type":"unsendable"}]'));
+      },
+    );
   });
 }

--- a/packages/yet_another_json_isolate/test/yet_another_json_isolate_test.dart
+++ b/packages/yet_another_json_isolate/test/yet_another_json_isolate_test.dart
@@ -152,6 +152,13 @@ void main() {
         throwsFormatException,
       );
     });
+
+    test('reads the buffer before the caller can mutate it', () async {
+      final bytes = Uint8List.fromList(utf8.encode(_jsonString));
+      final pending = isolate.decodeBytes(bytes);
+      bytes.fillRange(0, bytes.length, 0x20);
+      expect(await pending, _jsonMap);
+    });
   });
 
   group('large payloads', () {

--- a/packages/yet_another_json_isolate/test/yet_another_json_isolate_test.dart
+++ b/packages/yet_another_json_isolate/test/yet_another_json_isolate_test.dart
@@ -1,10 +1,22 @@
 import 'dart:convert';
+import 'dart:typed_data';
 
 import 'package:test/test.dart';
 import 'package:yet_another_json_isolate/yet_another_json_isolate.dart';
 
 const _jsonString = '{"a":1,"b":2}';
 const _jsonMap = {'a': 1, 'b': 2};
+
+/// Large enough to encode to well over 64 KiB, so that operations on it are
+/// processed on an isolate rather than inline.
+final _largeValue = List.generate(
+  2000,
+  (index) => {
+    'id': index,
+    'name': 'user_$index',
+    'description': 'A description for row $index. ${'x' * 40}',
+  },
+);
 
 void main() {
   late YAJsonIsolate isolate;
@@ -103,6 +115,93 @@ void main() {
     test('round trips an encoded value back to the original', () async {
       final encoded = await isolate.encode(_jsonMap);
       expect(await isolate.decode(encoded), _jsonMap);
+    });
+  });
+
+  group('decodeBytes', () {
+    setUp(() {
+      isolate = YAJsonIsolate();
+    });
+
+    tearDown(() async {
+      await isolate.dispose();
+    });
+
+    test('decodes UTF-8 encoded JSON bytes', () async {
+      expect(await isolate.decodeBytes(utf8.encode(_jsonString)), _jsonMap);
+    });
+
+    test('preserves unicode characters', () async {
+      const value = {'emoji': '🚀', 'text': 'Grüße'};
+      expect(
+        await isolate.decodeBytes(utf8.encode(jsonEncode(value))),
+        value,
+      );
+    });
+
+    test('throws FormatException for invalid JSON bytes', () async {
+      await expectLater(
+        isolate.decodeBytes(utf8.encode('{not valid json')),
+        throwsFormatException,
+      );
+    });
+
+    test('throws FormatException for invalid UTF-8 bytes', () async {
+      await expectLater(
+        isolate.decodeBytes(Uint8List.fromList([0x22, 0xFF, 0xFE, 0x22])),
+        throwsFormatException,
+      );
+    });
+  });
+
+  group('large payloads', () {
+    setUp(() {
+      isolate = YAJsonIsolate();
+    });
+
+    tearDown(() async {
+      await isolate.dispose();
+    });
+
+    test('round trips a large structure', () async {
+      final encoded = await isolate.encode(_largeValue);
+      expect(encoded.length, greaterThan(64 * 1024));
+      expect(await isolate.decode(encoded), _largeValue);
+    });
+
+    test('decodes large UTF-8 encoded JSON bytes', () async {
+      final encoded = utf8.encode(jsonEncode(_largeValue));
+      expect(await isolate.decodeBytes(encoded), _largeValue);
+    });
+
+    test('throws FormatException for large invalid JSON', () async {
+      final truncated = jsonEncode(
+        _largeValue,
+      ).substring(0, 70 * 1024);
+      await expectLater(isolate.decode(truncated), throwsFormatException);
+      await expectLater(
+        isolate.decodeBytes(utf8.encode(truncated)),
+        throwsFormatException,
+      );
+    });
+
+    test('throws for a large structure with a non encodable value', () async {
+      final value = [..._largeValue, DateTime.now()];
+      await expectLater(
+        isolate.encode(value),
+        throwsA(isA<JsonUnsupportedObjectError>()),
+      );
+    });
+
+    test('resolves concurrent large decodes to the correct results', () async {
+      final first = jsonEncode(_largeValue);
+      final second = jsonEncode(_largeValue.reversed.toList());
+      final results = await Future.wait([
+        isolate.decode(first),
+        isolate.decode(second),
+      ]);
+      expect(results[0], _largeValue);
+      expect(results[1], _largeValue.reversed.toList());
     });
   });
 

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -2617,6 +2617,7 @@ supporting_symbols:
   - YAJsonIsolate.YAJsonIsolate
   - YAJsonIsolate.debugName
   - YAJsonIsolate.decode
+  - YAJsonIsolate.decodeBytes
   - YAJsonIsolate.dispose
   - YAJsonIsolate.encode
   - YAJsonIsolate.initialize


### PR DESCRIPTION
## What kind of change does this PR introduce?

Performance improvement for `yet_another_json_isolate`, plus a benchmark to keep it honest. Resolves the copying and serialization overhead of the long-lived isolate design.

## What is the current behavior?

`YAJsonIsolate` keeps one long-lived isolate per instance and routes every `decode`/`encode` through it. This has three hidden costs:

- Small payloads pay an isolate messaging round trip that costs more than parsing them inline.
- Large decoded object graphs are deep-copied back to the calling isolate, which roughly doubles the work and stalls the main isolate for up to ~10ms on 5MB payloads.
- Concurrent calls are processed one at a time through a single event queue.

On top of that, both postgrest and the functions client decode the HTTP body bytes to a `String` on the main isolate before handing it over.

## What is the new behavior?

The long-lived isolate is gone. The public API is unchanged (`initialize`/`dispose` are kept as compatibility no-ops with the same contracts), and internally:

- Payloads estimated below 64KB are processed inline, where the parse takes well under a millisecond even on slow devices.
- Larger payloads run on a short-lived isolate per call via `Isolate.run`, whose result is handed back through `Isolate.exit` without copying. Concurrent calls run in parallel.
- A new `decodeBytes(Uint8List)` API takes HTTP `bodyBytes` directly: the bytes move to the isolate via `TransferableTypedData` without copying, and the UTF-8 and JSON decoding steps are fused so the intermediate string never materializes on the calling isolate. The postgrest and functions clients now use it.
- `encode` picks its path with a cheap bounded size estimate (depth-capped, so cyclic input still reaches `jsonEncode`'s own cycle error on the isolate).

## Benchmarks

A benchmark now lives in `packages/yet_another_json_isolate/benchmark/` (`dart run benchmark/yet_another_json_isolate_benchmark.dart`). It measures Supabase-shaped payloads (lists of row objects, 0.4KB to 5MB) and reports both per-operation latency and the longest main-isolate event-loop stall, so a change that improves throughput by blocking the main isolate is visible.

Headline numbers on an M-series Mac (p50, old vs new):

| Scenario | Old | New |
|---|---|---|
| decode 0.4KB | 16µs | 2µs |
| decode 2KB | 17µs | 6µs |
| decode 50KB | 180µs | 120µs |
| decode 5MB | ~30ms | ~25ms |
| decode 5MB from `bodyBytes` (SDK path) | 36.6ms | 26.4ms |
| decode 50KB x8 concurrent | 1.28ms | ~0.6-1.0ms |
| encode 0.4KB | 10µs | 4µs |
| main-isolate stall during 5MB decode | 7-10.7ms | ~6ms |

<details>
<summary>Full benchmark output, old implementation (long-lived isolate)</summary>

Measured with the same harness semantics (stall monitor with event loop yields between iterations). The `bodyBytes` rows are `utf8.decode` on the main isolate followed by `isolate.decode`, which was the SDK's decode path.

```
scenario                    p50 µs    p90 µs  stall µs
decode 0.4KB                    16        27       448
decode 2KB                      17        23       716
decode 10KB                     41        52       304
decode 50KB                    180       508      1259
decode 200KB                  1848      2225      2271
decode 1MB                    6152     10896      3051
decode 5MB                   29647     40863      7184
encode 0.4KB                    10        14       310
encode 2KB                      16        22       138
encode 10KB                     52        66       406
encode 50KB                    223       337       731
encode 200KB                   794       828      1281
encode 1MB                    4195      5716      1284
bodyBytes 50KB                 190       197       171
bodyBytes 1MB                 4236      6230      1431
bodyBytes 5MB                36618     44473      9725
decode 50KB x8 concurrent     1284      1400      2108
decode 1MB x4 concurrent     24890     38756      7032
```

</details>

<details>
<summary>Full benchmark output, new implementation</summary>

The `decodeBytes` rows replace the `bodyBytes` rows above: no main-isolate UTF-8 decode, bytes transferred without copying.

```
scenario                                p50 µs      p90 µs      max µs    stall µs
decode single row (415 B)                    2           3          31         801
decode 2.0 KB                                6           8        1044         414
decode 50.0 KB                             120         127        1024         849
decode 1.0 MB                             3421        9345       12680        5540
decode 5.0 MB                            25703       26995       34054        6230
encode single row (415 B)                    4           6          67          29
encode 2.0 KB                                8           9          14         350
encode 50.0 KB                             193         204         264         763
encode 1.0 MB                             4174        5726        6049        1737
decodeBytes 50.0 KB                        105         115         200         501
decodeBytes 1.0 MB                        3379        8698       11150        5818
decodeBytes 5.0 MB                       26441       27797       28027        7646
decode 50.0 KB x8 concurrent              1040        1270        4176        4264
decode 1.0 MB x4 concurrent              21436       23872       27843       11160
```

</details>

The 1MB rows are noisy run-to-run (GC pressure from holding the payload), but consistently equal or better. During design, inline-everything was also measured and rejected: it is the fastest in wall time but stalls the main isolate for 18-22ms on 5MB payloads, which is exactly the jank this package exists to prevent.

Behavior notes:

- postgrest previously decoded bodies under 10KB inline and used the isolate above that; the threshold now lives in the package at 64KB, so 10-64KB responses decode inline as well (strictly faster, still sub-millisecond).
- The `async` dependency is no longer needed and was removed.
- `YAJsonIsolate.decodeBytes` is registered in `sdk-compliance.yaml`; the local symbol check passes.

## Additional context

The web variant gains the same `decodeBytes` API with fused decoding and compiles under `dart compile js`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for decoding JSON directly from UTF-8 bytes through `decodeBytes`.
  * Improved JSON processing across supported platforms for small and large payloads.
* **Performance**
  * Large payloads are processed asynchronously to help reduce event-loop blocking.
  * Encoding and decoding now adapt processing based on payload size.
* **Documentation**
  * Updated usage guidance for short-lived processing and shared isolate configurations.
* **Tests**
  * Added coverage for Unicode, invalid input, large payloads, and concurrent decoding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->