### PR TITLE
feat(supabase_flutter): forward the isolate parameter through Supabase.initialize

### DIFF
--- a/packages/supabase/lib/src/supabase_client.dart
+++ b/packages/supabase/lib/src/supabase_client.dart
@@ -5,7 +5,6 @@ import 'package:supabase/src/logger.dart';
 import 'package:supabase/src/supabase_constants.dart';
 import 'package:supabase/src/version.dart';
 import 'package:supabase/supabase.dart';
-import 'package:yet_another_json_isolate/yet_another_json_isolate.dart';
 
 import 'api_key.dart';
 import 'auth_http_client.dart';

--- a/packages/supabase/lib/src/supabase_query_schema.dart
+++ b/packages/supabase/lib/src/supabase_query_schema.dart
@@ -1,6 +1,5 @@
 import 'package:http/http.dart';
 import 'package:supabase/supabase.dart';
-import 'package:yet_another_json_isolate/yet_another_json_isolate.dart';
 
 import 'counter.dart';
 

--- a/packages/supabase/lib/supabase.dart
+++ b/packages/supabase/lib/supabase.dart
@@ -8,6 +8,8 @@ export 'package:supabase_auth/supabase_auth.dart';
 export 'package:postgrest/postgrest.dart';
 export 'package:supabase_realtime/supabase_realtime.dart';
 export 'package:supabase_storage/supabase_storage.dart';
+export 'package:yet_another_json_isolate/yet_another_json_isolate.dart'
+    show YAJsonIsolate;
 
 export 'src/realtime_client_options.dart';
 export 'src/supabase_client.dart';

--- a/packages/supabase/test/client_test.dart
+++ b/packages/supabase/test/client_test.dart
@@ -5,7 +5,6 @@ import 'package:supabase/src/supabase_client.dart' as real;
 import 'package:supabase/supabase.dart' hide SupabaseClient;
 import 'package:supabase_common/supabase_common.dart';
 import 'package:test/test.dart';
-import 'package:yet_another_json_isolate/yet_another_json_isolate.dart';
 
 import 'utils.dart';
 

--- a/packages/supabase_flutter/lib/src/supabase.dart
+++ b/packages/supabase_flutter/lib/src/supabase.dart
@@ -61,6 +61,12 @@ class Supabase {
   ///
   /// Custom http client can be used by passing [httpClient] parameter.
   ///
+  /// Pass [isolate] to supply the [YAJsonIsolate] used for JSON encoding and
+  /// decoding, for example to share a single instance with code outside of
+  /// Supabase. An instance supplied here is owned by the caller and is not
+  /// disposed together with the client. One is created internally when this
+  /// is omitted.
+  ///
   /// [realtimeClientOptions], [postgrestOptions], and [storageOptions]
   /// configure their respective underlying clients, for example
   /// `storageOptions.retryOptions` configures how an upload to Supabase
@@ -95,6 +101,7 @@ class Supabase {
     TracePropagationOptions tracePropagationOptions =
         const TracePropagationOptions(),
     Future<String?> Function()? accessToken,
+    YAJsonIsolate? isolate,
   }) async {
     if (_instance._isInitialized) {
       flutterLogger.info(
@@ -130,6 +137,7 @@ class Supabase {
       storageOptions: storageOptions,
       tracePropagationOptions: tracePropagationOptions,
       accessToken: accessToken,
+      isolate: isolate,
     );
 
     if (accessToken == null) {
@@ -260,6 +268,7 @@ class Supabase {
     required AuthClientOptions authOptions,
     required TracePropagationOptions tracePropagationOptions,
     required Future<String?> Function()? accessToken,
+    required YAJsonIsolate? isolate,
   }) {
     final headers = {
       ...SupabaseFlutterConstants.defaultHeaders,
@@ -276,6 +285,7 @@ class Supabase {
       authOptions: authOptions,
       tracePropagationOptions: tracePropagationOptions,
       accessToken: accessToken,
+      isolate: isolate,
     );
 
     // Close any previous realtime client that may still be connected due to

--- a/packages/supabase_flutter/test/initialization_test.dart
+++ b/packages/supabase_flutter/test/initialization_test.dart
@@ -41,6 +41,36 @@ void main() {
       });
     });
 
+    group('Custom isolate initialization', () {
+      test('initializes with a caller supplied isolate', () async {
+        final isolate = YAJsonIsolate(debugName: 'custom');
+        addTearDown(isolate.dispose);
+
+        await Supabase.initialize(
+          url: supabaseUrl,
+          publishableKey: supabaseKey,
+          isolate: isolate,
+        );
+
+        expect(Supabase.instance.isInitialized, isTrue);
+      });
+
+      test('leaves a caller supplied isolate usable after dispose', () async {
+        final isolate = YAJsonIsolate(debugName: 'custom');
+        addTearDown(isolate.dispose);
+
+        await Supabase.initialize(
+          url: supabaseUrl,
+          publishableKey: supabaseKey,
+          isolate: isolate,
+        );
+        await Supabase.instance.dispose();
+
+        // The caller owns it, so the client must not have disposed it.
+        expect(await isolate.decode('{"a":1}'), {'a': 1});
+      });
+    });
+
     group('Custom storage initialization', () {
       test('initialize successfully with custom localStorage', () {
         const localStorage = MockLocalStorage();


### PR DESCRIPTION
Closes the remaining item from #1749.

`SupabaseClient` already takes an `isolate:` parameter and already tracks
ownership — `_hasCustomIsolate` keeps `dispose()` from disposing an instance it
did not create. `Supabase.initialize` just never forwarded it, so a
`supabase_flutter` app cannot reach the parameter at all.

`YAJsonIsolate` was also not exported by `supabase` or `supabase_flutter`, which
made the existing `SupabaseClient` parameter unusable without adding a direct
dependency on `yet_another_json_isolate`. This exports the type (`show
YAJsonIsolate`) so the public API is callable, and drops three now-redundant
imports the analyzer flagged as a result.

### Changes

- `supabase`: export `YAJsonIsolate`.
- `supabase_flutter`: `isolate:` on `Supabase.initialize`, threaded to
  `SupabaseClient` through `_init`, with dartdoc noting that a supplied instance
  is owned by the caller.
- Two tests: initialization with a caller supplied isolate, and that such an
  isolate is still usable after `Supabase.instance.dispose()`.

### Why

Sharing one instance with code outside Supabase, and — for anyone still on the
released `yet_another_json_isolate` 2.1.1, where a single persistent worker
backs every `functions.invoke` and every large postgrest decode — being able to
hold and supervise that instance. #1746 makes the second reason far less
pressing once it ships; the first stands on its own.

### Verification

`flutter analyze` clean on both packages. `packages/supabase` and
`packages/supabase_flutter` test suites pass. `stream_integration_test.dart`
fails identically before and after this change (it needs a local stack).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for supplying a custom JSON-processing isolate during Supabase initialization.
  * Exposed the JSON isolate type for use by applications.
  * Caller-provided isolates remain under caller ownership and are not disposed automatically.

* **Tests**
  * Added coverage confirming custom isolate initialization succeeds and lifecycle ownership is preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->