### PR TITLE
refactor!: process JSON through the AsyncJsonCodec interface

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1594,6 +1594,17 @@ final client = SupabaseClient(url, key, isolate: YAJsonIsolate()..initialize());
 final client = SupabaseClient(url, key, jsonCodec: YAJsonIsolate()..initialize());
 ```
 
+`Supabase.initialize` takes the codec too, so a `supabase_flutter` application never has to
+construct a `SupabaseClient` to choose one:
+
+```dart
+await Supabase.initialize(
+  url: url,
+  publishableKey: publishableKey,
+  jsonCodec: myJsonCodec,
+);
+```
+
 `AsyncJsonCodec` is exported from `postgrest`, `supabase_functions`, `supabase` and
 `supabase_flutter`, so an application can encode and decode JSON its own way, for example
 through a native parser or through a wrapper that records how long each payload takes:

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1578,20 +1578,20 @@ Two logger names changed, so update any listeners that filter on `LogRecord.logg
 
 ### JSON encoding and decoding is behind the `AsyncJsonCodec` interface
 
-`PostgrestClient` and `FunctionsClient` used to take a `YAJsonIsolate` through an
-`isolate:` parameter, which named an implementation rather than a contract, and named one
-that does not spawn an isolate at all on web. They now take an `AsyncJsonCodec` through
-`jsonCodec:`, the interface `YAJsonIsolate` implements. The same rename applies to the
-builders that carry the codec through the chain: `PostgrestBuilder`,
+`SupabaseClient`, `PostgrestClient` and `FunctionsClient` used to take a `YAJsonIsolate`
+through an `isolate:` parameter, which named an implementation rather than a contract, and
+named one that does not spawn an isolate at all on web. They now take an `AsyncJsonCodec`
+through `jsonCodec:`, the interface `YAJsonIsolate` implements. The same rename applies to
+the builders that carry the codec through the chain: `PostgrestBuilder`,
 `PostgrestQueryBuilder`, `PostgrestRpcBuilder`, `RawPostgrestBuilder`,
 `SupabaseQueryBuilder` and `SupabaseQuerySchema`.
 
 ```dart
 // Before
-final postgrest = PostgrestClient(url, isolate: YAJsonIsolate()..initialize());
+final client = SupabaseClient(url, key, isolate: YAJsonIsolate()..initialize());
 
 // After
-final postgrest = PostgrestClient(url, jsonCodec: YAJsonIsolate()..initialize());
+final client = SupabaseClient(url, key, jsonCodec: YAJsonIsolate()..initialize());
 ```
 
 `AsyncJsonCodec` is exported from `postgrest`, `supabase_functions`, `supabase` and
@@ -1621,30 +1621,12 @@ class TimedJsonCodec implements AsyncJsonCodec {
 
 A codec passed to a client belongs to the caller, so `dispose()` leaves it alone, exactly
 as the old `isolate:` parameter did. A client that was not given one creates the default
-codec and disposes it with itself. `YAJsonIsolate` is not exported by `supabase` or
-`supabase_flutter`, so depend on `yet_another_json_isolate` directly to name the default
-implementation, for example to wrap it as above.
+codec and disposes it with itself. `SupabaseClient` passes its codec on to the rest and
+functions clients it builds, so one codec serves all three.
 
-### `SupabaseClient` no longer takes an `isolate`
-
-`SupabaseClient(isolate: …)` is removed, and `Supabase.initialize` never forwarded it, so
-nothing replaces it on the `supabase_flutter` side either. The client creates one
-`AsyncJsonCodec`, hands it to the rest and functions clients so they share it, and disposes
-it in `dispose()`.
-
-```dart
-// Before
-final client = SupabaseClient(url, key, isolate: myIsolate);
-
-// After
-final client = SupabaseClient(url, key);
-```
-
-The parameter existed to share or supervise a single long-lived worker isolate. There is no
-such worker anymore: the default codec runs small payloads inline and spawns a short-lived
-isolate per large one, so a second instance costs nothing and there is nothing to supervise.
-Construct a `PostgrestClient` or a `FunctionsClient` directly with `jsonCodec:` when you do
-need to choose how their JSON is processed.
+`YAJsonIsolate` is not exported by `supabase` or `supabase_flutter`, so depend on
+`yet_another_json_isolate` directly to name the default implementation, for example to wrap
+it as above.
 
 ### `RealtimeClient.logger` and `RealtimeClient.log` are gone
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1576,6 +1576,76 @@ Two logger names changed, so update any listeners that filter on `LogRecord.logg
 | `supabase.supabase` | `supabase.dart` |
 | `supabase.supabase_flutter` | `supabase.flutter` |
 
+### JSON encoding and decoding is behind the `AsyncJsonCodec` interface
+
+`PostgrestClient` and `FunctionsClient` used to take a `YAJsonIsolate` through an
+`isolate:` parameter, which named an implementation rather than a contract, and named one
+that does not spawn an isolate at all on web. They now take an `AsyncJsonCodec` through
+`jsonCodec:`, the interface `YAJsonIsolate` implements. The same rename applies to the
+builders that carry the codec through the chain: `PostgrestBuilder`,
+`PostgrestQueryBuilder`, `PostgrestRpcBuilder`, `RawPostgrestBuilder`,
+`SupabaseQueryBuilder` and `SupabaseQuerySchema`.
+
+```dart
+// Before
+final postgrest = PostgrestClient(url, isolate: YAJsonIsolate()..initialize());
+
+// After
+final postgrest = PostgrestClient(url, jsonCodec: YAJsonIsolate()..initialize());
+```
+
+`AsyncJsonCodec` is exported from `postgrest`, `supabase_functions`, `supabase` and
+`supabase_flutter`, so an application can encode and decode JSON its own way, for example
+through a native parser or through a wrapper that records how long each payload takes:
+
+```dart
+class TimedJsonCodec implements AsyncJsonCodec {
+  TimedJsonCodec(this._inner);
+
+  final AsyncJsonCodec _inner;
+
+  @override
+  Future<dynamic> decode(String json) => _time(() => _inner.decode(json));
+
+  @override
+  Future<dynamic> decodeBytes(Uint8List encodedJson) =>
+      _time(() => _inner.decodeBytes(encodedJson));
+
+  @override
+  Future<String> encode(Object? json) => _time(() => _inner.encode(json));
+
+  @override
+  Future<void> dispose() => _inner.dispose();
+}
+```
+
+A codec passed to a client belongs to the caller, so `dispose()` leaves it alone, exactly
+as the old `isolate:` parameter did. A client that was not given one creates the default
+codec and disposes it with itself. `YAJsonIsolate` is not exported by `supabase` or
+`supabase_flutter`, so depend on `yet_another_json_isolate` directly to name the default
+implementation, for example to wrap it as above.
+
+### `SupabaseClient` no longer takes an `isolate`
+
+`SupabaseClient(isolate: …)` is removed, and `Supabase.initialize` never forwarded it, so
+nothing replaces it on the `supabase_flutter` side either. The client creates one
+`AsyncJsonCodec`, hands it to the rest and functions clients so they share it, and disposes
+it in `dispose()`.
+
+```dart
+// Before
+final client = SupabaseClient(url, key, isolate: myIsolate);
+
+// After
+final client = SupabaseClient(url, key);
+```
+
+The parameter existed to share or supervise a single long-lived worker isolate. There is no
+such worker anymore: the default codec runs small payloads inline and spawns a short lived
+isolate per large one, so a second instance costs nothing and there is nothing to
+supervise. Construct a `PostgrestClient` or a `FunctionsClient` directly with `jsonCodec:`
+when you do need to choose how their JSON is processed.
+
 ### `RealtimeClient.logger` and `RealtimeClient.log` are gone
 
 The realtime client had a second logging path next to `package:logging`: a `logger` callback

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1641,10 +1641,10 @@ final client = SupabaseClient(url, key);
 ```
 
 The parameter existed to share or supervise a single long-lived worker isolate. There is no
-such worker anymore: the default codec runs small payloads inline and spawns a short lived
-isolate per large one, so a second instance costs nothing and there is nothing to
-supervise. Construct a `PostgrestClient` or a `FunctionsClient` directly with `jsonCodec:`
-when you do need to choose how their JSON is processed.
+such worker anymore: the default codec runs small payloads inline and spawns a short-lived
+isolate per large one, so a second instance costs nothing and there is nothing to supervise.
+Construct a `PostgrestClient` or a `FunctionsClient` directly with `jsonCodec:` when you do
+need to choose how their JSON is processed.
 
 ### `RealtimeClient.logger` and `RealtimeClient.log` are gone
 

--- a/packages/postgrest/lib/postgrest.dart
+++ b/packages/postgrest/lib/postgrest.dart
@@ -8,6 +8,9 @@ export 'package:supabase_common/supabase_common.dart'
         SupabaseException,
         SupabaseRetryOptions;
 
+export 'package:yet_another_json_isolate/yet_another_json_isolate.dart'
+    show AsyncJsonCodec;
+
 export 'src/postgrest.dart';
 export 'src/postgrest_builder.dart';
 export 'src/types.dart';

--- a/packages/postgrest/lib/src/postgrest.dart
+++ b/packages/postgrest/lib/src/postgrest.dart
@@ -26,8 +26,8 @@ class PostgrestClient {
   final Map<String, String> headers;
   final String? _schema;
   final Client? httpClient;
-  final YAJsonIsolate _isolate;
-  final bool _hasCustomIsolate;
+  final AsyncJsonCodec _jsonCodec;
+  final bool _ownsJsonCodec;
 
   /// Configures the automatic retry of GET and HEAD requests.
   final SupabaseRetryOptions retryOptions;
@@ -44,8 +44,9 @@ class PostgrestClient {
   ///
   /// [httpClient] is optional and can be used to provide a custom http client
   ///
-  /// [isolate] is optional and can be used to provide a custom isolate, which
-  /// is used for heavy json computation
+  /// [jsonCodec] is optional and can be used to encode and decode JSON
+  /// somewhere other than on the isolates the default codec spawns. A codec
+  /// passed here is owned by the caller and is not disposed by [dispose]
   ///
   /// [retryOptions] configures the automatic retry of GET and HEAD requests
   /// that fail with a retryable status code or a network error. Use
@@ -70,7 +71,7 @@ class PostgrestClient {
     Map<String, String>? headers,
     String? schema,
     Client? httpClient,
-    YAJsonIsolate? isolate,
+    AsyncJsonCodec? jsonCodec,
     this.retryOptions = const SupabaseRetryOptions(),
     this.requestTimeout,
     Future<String?> Function()? accessToken,
@@ -80,15 +81,15 @@ class PostgrestClient {
          'header would win over the resolved token on every request.',
        ),
        // The transport belongs to the caller, so the client never closes it,
-       // the same way it leaves a caller-provided isolate alone.
+       // the same way it leaves a caller-provided JSON codec alone.
        // ignore: dispose-class-fields
        httpClient = accessToken == null
            ? httpClient
            : AccessTokenClient(accessToken, httpClient),
        _schema = schema,
        headers = Map.unmodifiable({...defaultHeaders, ...?headers}),
-       _isolate = isolate ?? (YAJsonIsolate()..initialize()),
-       _hasCustomIsolate = isolate != null {
+       _jsonCodec = jsonCodec ?? (YAJsonIsolate()..initialize()),
+       _ownsJsonCodec = jsonCodec == null {
     postgrestLogger.config(
       () =>
           'Initialize PostgrestClient with url: ${Uri.parse(url).redacted}, '
@@ -107,7 +108,7 @@ class PostgrestClient {
       headers: headers,
       schema: _schema,
       httpClient: httpClient,
-      isolate: _isolate,
+      jsonCodec: _jsonCodec,
       retryOptions: retryOptions,
       requestTimeout: requestTimeout,
     );
@@ -122,7 +123,7 @@ class PostgrestClient {
       headers: headers,
       schema: schema,
       httpClient: httpClient,
-      isolate: _isolate,
+      jsonCodec: _jsonCodec,
       retryOptions: retryOptions,
       requestTimeout: requestTimeout,
     );
@@ -154,7 +155,7 @@ class PostgrestClient {
       headers: headers,
       schema: _schema,
       httpClient: httpClient,
-      isolate: _isolate,
+      jsonCodec: _jsonCodec,
       retryOptions: retryOptions,
       requestTimeout: requestTimeout,
     ).rpc(params, get);
@@ -162,8 +163,8 @@ class PostgrestClient {
 
   Future<void> dispose() async {
     postgrestLogger.fine("dispose PostgrestClient");
-    if (!_hasCustomIsolate) {
-      return _isolate.dispose();
+    if (_ownsJsonCodec) {
+      return _jsonCodec.dispose();
     }
   }
 }

--- a/packages/postgrest/lib/src/postgrest_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_builder.dart
@@ -329,7 +329,14 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
     if (method != HttpMethod.get && method != HttpMethod.head) {
       execHeaders['Content-Type'] = 'application/json';
     }
-    final bodyString = jsonEncode(_body);
+    // Only a write carries a body, so a read skips the encode entirely and a
+    // client with a codec does not pay for one on every select.
+    final bodyString = switch (method) {
+      HttpMethod.post ||
+      HttpMethod.put ||
+      HttpMethod.patch => await _encodeBody(),
+      HttpMethod.get || HttpMethod.head || HttpMethod.delete => null,
+    };
     postgrestLogger.finest("Request: ${method.value} ${_url.redacted}");
 
     final requestTimeout = _requestTimeout;
@@ -366,7 +373,8 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
       request.headers.addAll(execHeaders);
       switch (method) {
         case HttpMethod.post || HttpMethod.put || HttpMethod.patch:
-          request.body = bodyString;
+          // Encoded above for exactly these methods.
+          request.body = bodyString!;
         case HttpMethod.get || HttpMethod.head || HttpMethod.delete:
           break;
       }
@@ -429,6 +437,16 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
     }
 
     throw StateError('unreachable');
+  }
+
+  /// Encodes the request body, on the codec when there is one so that a large
+  /// payload, a bulk insert for example, does not block the calling isolate.
+  Future<String> _encodeBody() async {
+    final jsonCodec = _jsonCodec;
+    if (jsonCodec == null) {
+      return jsonEncode(_body);
+    }
+    return jsonCodec.encode(_body);
   }
 
   /// Parse request response to json object if possible

--- a/packages/postgrest/lib/src/postgrest_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_builder.dart
@@ -8,7 +8,6 @@ import 'package:postgrest/src/logger.dart';
 import 'package:meta/meta.dart';
 import 'package:postgrest/postgrest.dart';
 import 'package:supabase_common/supabase_common.dart';
-import 'package:yet_another_json_isolate/yet_another_json_isolate.dart';
 
 part 'postgrest_filter_builder.dart';
 part 'postgrest_query_builder.dart';
@@ -33,7 +32,7 @@ class _RequestConfig {
     this.method,
     this.body,
     this.httpClient,
-    this.isolate,
+    this.jsonCodec,
     this.count,
     this.maybeSingle = false,
     required this.retry,
@@ -47,7 +46,7 @@ class _RequestConfig {
   final HttpMethod? method;
   final Object? body;
   final Client? httpClient;
-  final YAJsonIsolate? isolate;
+  final AsyncJsonCodec? jsonCodec;
   final CountOption? count;
   final bool maybeSingle;
   final SupabaseRetryOptions retry;
@@ -61,7 +60,7 @@ class _RequestConfig {
     HttpMethod? method,
     Object? body,
     Client? httpClient,
-    YAJsonIsolate? isolate,
+    AsyncJsonCodec? jsonCodec,
     CountOption? count,
     bool? maybeSingle,
     SupabaseRetryOptions? retry,
@@ -75,7 +74,7 @@ class _RequestConfig {
       method: method ?? this.method,
       body: body ?? this.body,
       httpClient: httpClient ?? this.httpClient,
-      isolate: isolate ?? this.isolate,
+      jsonCodec: jsonCodec ?? this.jsonCodec,
       count: count ?? this.count,
       maybeSingle: maybeSingle ?? this.maybeSingle,
       retry: retry ?? this.retry,
@@ -151,7 +150,7 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
   String? get _schema => _config.schema;
   Uri get _url => _config.url;
   Client? get _httpClient => _config.httpClient;
-  YAJsonIsolate? get _isolate => _config.isolate;
+  AsyncJsonCodec? get _jsonCodec => _config.jsonCodec;
   CountOption? get _count => _config.count;
   SupabaseRetryOptions get _retry => _config.retry;
   Duration? get _requestTimeout => _config.requestTimeout;
@@ -164,7 +163,7 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
     HttpMethod? method,
     Object? body,
     Client? httpClient,
-    YAJsonIsolate? isolate,
+    AsyncJsonCodec? jsonCodec,
     CountOption? count,
     bool maybeSingle = false,
     PostgrestConverter<S, R>? converter,
@@ -179,7 +178,7 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
          method: method,
          body: body,
          httpClient: httpClient,
-         isolate: isolate,
+         jsonCodec: jsonCodec,
          count: count,
          maybeSingle: maybeSingle,
          retry: retryOptions,
@@ -203,7 +202,7 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
     HttpMethod? method,
     Object? body,
     Client? httpClient,
-    YAJsonIsolate? isolate,
+    AsyncJsonCodec? jsonCodec,
     CountOption? count,
     bool? maybeSingle,
     PostgrestConverter<S, R>? converter,
@@ -218,7 +217,7 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
       method: method,
       body: body,
       httpClient: httpClient,
-      isolate: isolate,
+      jsonCodec: jsonCodec,
       count: count,
       maybeSingle: maybeSingle,
       retry: retry,
@@ -448,9 +447,9 @@ class PostgrestBuilder<T, S, R> implements Future<T> {
           body = response.body;
         } else {
           try {
-            final isolate = _isolate;
-            if (isolate != null) {
-              body = await isolate.decodeBytes(response.bodyBytes);
+            final jsonCodec = _jsonCodec;
+            if (jsonCodec != null) {
+              body = await jsonCodec.decodeBytes(response.bodyBytes);
             } else {
               body = jsonDecode(utf8.decode(response.bodyBytes));
             }

--- a/packages/postgrest/lib/src/postgrest_query_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_query_builder.dart
@@ -28,7 +28,7 @@ class PostgrestQueryBuilder {
     Map<String, String>? headers,
     String? schema,
     Client? httpClient,
-    YAJsonIsolate? isolate,
+    AsyncJsonCodec? jsonCodec,
     SupabaseRetryOptions retryOptions = const SupabaseRetryOptions(),
     Duration? requestTimeout,
   }) : _config = _RequestConfig(
@@ -36,7 +36,7 @@ class PostgrestQueryBuilder {
          headers: {...?headers},
          schema: schema,
          httpClient: httpClient,
-         isolate: isolate,
+         jsonCodec: jsonCodec,
          retry: retryOptions,
          requestTimeout: requestTimeout,
        );

--- a/packages/postgrest/lib/src/postgrest_rpc_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_rpc_builder.dart
@@ -13,7 +13,7 @@ class PostgrestRpcBuilder {
     Map<String, String>? headers,
     String? schema,
     Client? httpClient,
-    required YAJsonIsolate isolate,
+    required AsyncJsonCodec jsonCodec,
     SupabaseRetryOptions retryOptions = const SupabaseRetryOptions(),
     Duration? requestTimeout,
   }) : _config = _RequestConfig(
@@ -21,7 +21,7 @@ class PostgrestRpcBuilder {
          headers: {...?headers},
          schema: schema,
          httpClient: httpClient,
-         isolate: isolate,
+         jsonCodec: jsonCodec,
          retry: retryOptions,
          requestTimeout: requestTimeout,
        );

--- a/packages/postgrest/lib/src/raw_postgrest_builder.dart
+++ b/packages/postgrest/lib/src/raw_postgrest_builder.dart
@@ -17,7 +17,7 @@ class RawPostgrestBuilder<T, S, R> extends PostgrestBuilder<T, S, R> {
     HttpMethod? method,
     Object? body,
     Client? httpClient,
-    YAJsonIsolate? isolate,
+    AsyncJsonCodec? jsonCodec,
     CountOption? count,
     bool? maybeSingle,
   }) {
@@ -30,7 +30,7 @@ class RawPostgrestBuilder<T, S, R> extends PostgrestBuilder<T, S, R> {
           method: method,
           body: body,
           httpClient: httpClient,
-          isolate: isolate,
+          jsonCodec: jsonCodec,
           count: count,
           maybeSingle: maybeSingle,
         ),

--- a/packages/postgrest/test/json_codec_test.dart
+++ b/packages/postgrest/test/json_codec_test.dart
@@ -1,0 +1,91 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:postgrest/postgrest.dart';
+import 'package:supabase_testing/supabase_testing.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('jsonCodec', () {
+    test('decodes responses through a supplied codec', () async {
+      final jsonCodec = _RecordingJsonCodec();
+      final postgrest = PostgrestClient(
+        'https://example.com',
+        httpClient: JsonResponseMockClient(
+          body: [
+            {'id': 1},
+          ],
+        ),
+        jsonCodec: jsonCodec,
+      );
+      addTearDown(postgrest.dispose);
+
+      final response = await postgrest.from('users').select();
+
+      expect(response, [
+        {'id': 1},
+      ]);
+      expect(jsonCodec.decodedPayloads, 1);
+    });
+
+    test('leaves a supplied codec for the caller to dispose', () async {
+      final jsonCodec = _RecordingJsonCodec();
+      final postgrest = PostgrestClient(
+        'https://example.com',
+        httpClient: JsonResponseMockClient(body: const []),
+        jsonCodec: jsonCodec,
+      );
+
+      await postgrest.dispose();
+
+      expect(jsonCodec.isDisposed, isFalse);
+      expect(await postgrest.from('users').select(), isEmpty);
+    });
+
+    test('disposes the codec it created for itself', () async {
+      final postgrest = PostgrestClient(
+        'https://example.com',
+        httpClient: JsonResponseMockClient(body: const []),
+      );
+
+      await postgrest.dispose();
+
+      await expectLater(
+        () => postgrest.from('users').select(),
+        throwsStateError,
+      );
+    });
+  });
+}
+
+/// An [AsyncJsonCodec] that works inline and records what it was asked to
+/// process, so a test can assert that the client routes its JSON through the
+/// codec it was given and leaves its disposal to the caller.
+class _RecordingJsonCodec implements AsyncJsonCodec {
+  final List<Object?> encodedValues = [];
+  int decodedPayloads = 0;
+  bool isDisposed = false;
+
+  @override
+  Future<dynamic> decode(String json) async {
+    decodedPayloads++;
+    return jsonDecode(json);
+  }
+
+  @override
+  Future<dynamic> decodeBytes(Uint8List encodedJson) async {
+    decodedPayloads++;
+    return jsonDecode(utf8.decode(encodedJson));
+  }
+
+  @override
+  Future<String> encode(Object? json) async {
+    encodedValues.add(json);
+    return jsonEncode(json);
+  }
+
+  @override
+  Future<void> dispose() async {
+    isDisposed = true;
+  }
+}

--- a/packages/postgrest/test/json_codec_test.dart
+++ b/packages/postgrest/test/json_codec_test.dart
@@ -28,6 +28,36 @@ void main() {
       expect(jsonCodec.decodedPayloads, 1);
     });
 
+    test('encodes request bodies through a supplied codec', () async {
+      final jsonCodec = _RecordingJsonCodec();
+      final postgrest = PostgrestClient(
+        'https://example.com',
+        httpClient: JsonResponseMockClient(body: const []),
+        jsonCodec: jsonCodec,
+      );
+      addTearDown(postgrest.dispose);
+
+      await postgrest.from('users').insert({'name': 'Supabase'});
+
+      expect(jsonCodec.encodedValues, [
+        {'name': 'Supabase'},
+      ]);
+    });
+
+    test('encodes nothing for a read', () async {
+      final jsonCodec = _RecordingJsonCodec();
+      final postgrest = PostgrestClient(
+        'https://example.com',
+        httpClient: JsonResponseMockClient(body: const []),
+        jsonCodec: jsonCodec,
+      );
+      addTearDown(postgrest.dispose);
+
+      await postgrest.from('users').select();
+
+      expect(jsonCodec.encodedValues, isEmpty);
+    });
+
     test('leaves a supplied codec for the caller to dispose', () async {
       final jsonCodec = _RecordingJsonCodec();
       final postgrest = PostgrestClient(

--- a/packages/supabase/lib/src/supabase_client.dart
+++ b/packages/supabase/lib/src/supabase_client.dart
@@ -40,6 +40,12 @@ import 'trace_http_client.dart';
 /// if this is not supported by the client libraries. When set, the `auth`
 /// namespace of the Supabase client cannot be used.
 ///
+/// [jsonCodec] encodes and decodes the JSON of the rest and functions clients.
+/// The default codec keeps large payloads off the calling isolate. Pass your
+/// own to process that JSON some other way, for example through a native
+/// parser. A codec passed here is owned by the caller, so [dispose] leaves it
+/// alone, and it can be shared with other clients.
+///
 /// The pkce flow is used by default and keeps its code verifiers in the
 /// `AuthAsyncStorage` passed to the `pkceAsyncStorage` field of [authOptions].
 /// Pass a persistent implementation whenever the flow can leave the process
@@ -75,7 +81,8 @@ class SupabaseClient {
   late final RealtimeClient realtime;
   late PostgrestClient _rest;
   StreamSubscription<AuthState>? _authStateSubscription;
-  final YAJsonIsolate _jsonCodec;
+  final AsyncJsonCodec _jsonCodec;
+  final bool _ownsJsonCodec;
   final Future<String?> Function()? accessToken;
 
   /// Increment ID of the stream to create different realtime topic for each
@@ -148,6 +155,7 @@ class SupabaseClient {
     this.accessToken,
     Map<String, String>? headers,
     Client? httpClient,
+    AsyncJsonCodec? jsonCodec,
   }) : _supabaseKey = supabaseKey,
        _functionsOptions = functionsOptions,
        _restUrl = '$supabaseUrl/rest/v1',
@@ -161,7 +169,8 @@ class SupabaseClient {
          ...?headers,
        },
        _httpClient = httpClient,
-       _jsonCodec = (YAJsonIsolate()..initialize()) {
+       _jsonCodec = jsonCodec ?? (YAJsonIsolate()..initialize()),
+       _ownsJsonCodec = jsonCodec == null {
     final baseHttpClient = httpClient ?? Client();
     final tracedHttpClient = tracePropagationOptions.enabled
         ? TracePropagationClient(
@@ -300,7 +309,9 @@ class SupabaseClient {
     await _authStateSubscription?.cancel();
     await functions.dispose();
     await _rest.dispose();
-    await _jsonCodec.dispose();
+    if (_ownsJsonCodec) {
+      await _jsonCodec.dispose();
+    }
     if (_httpClient == null) {
       _authHttpClient.close();
     }

--- a/packages/supabase/lib/src/supabase_client.dart
+++ b/packages/supabase/lib/src/supabase_client.dart
@@ -40,10 +40,6 @@ import 'trace_http_client.dart';
 /// if this is not supported by the client libraries. When set, the `auth`
 /// namespace of the Supabase client cannot be used.
 ///
-/// Pass an instance of `YAJsonIsolate` to [isolate] to share one instance
-/// for JSON encoding and decoding across clients. A new instance will be
-/// created if [isolate] is omitted.
-///
 /// The pkce flow is used by default and keeps its code verifiers in the
 /// `AuthAsyncStorage` passed to the `pkceAsyncStorage` field of [authOptions].
 /// Pass a persistent implementation whenever the flow can leave the process
@@ -79,8 +75,7 @@ class SupabaseClient {
   late final RealtimeClient realtime;
   late PostgrestClient _rest;
   StreamSubscription<AuthState>? _authStateSubscription;
-  final YAJsonIsolate _isolate;
-  final bool _hasCustomIsolate;
+  final YAJsonIsolate _jsonCodec;
   final Future<String?> Function()? accessToken;
 
   /// Increment ID of the stream to create different realtime topic for each
@@ -153,7 +148,6 @@ class SupabaseClient {
     this.accessToken,
     Map<String, String>? headers,
     Client? httpClient,
-    YAJsonIsolate? isolate,
   }) : _supabaseKey = supabaseKey,
        _functionsOptions = functionsOptions,
        _restUrl = '$supabaseUrl/rest/v1',
@@ -167,8 +161,7 @@ class SupabaseClient {
          ...?headers,
        },
        _httpClient = httpClient,
-       _isolate = isolate ?? (YAJsonIsolate()..initialize()),
-       _hasCustomIsolate = isolate != null {
+       _jsonCodec = (YAJsonIsolate()..initialize()) {
     final baseHttpClient = httpClient ?? Client();
     final tracedHttpClient = tracePropagationOptions.enabled
         ? TracePropagationClient(
@@ -232,7 +225,7 @@ class SupabaseClient {
     counter: _incrementId,
     restUrl: _restUrl,
     schema: _postgrestOptions.schema,
-    isolate: _isolate,
+    jsonCodec: _jsonCodec,
     authHttpClient: _authHttpClient,
     realtime: realtime,
     rest: rest,
@@ -307,9 +300,7 @@ class SupabaseClient {
     await _authStateSubscription?.cancel();
     await functions.dispose();
     await _rest.dispose();
-    if (!_hasCustomIsolate) {
-      await _isolate.dispose();
-    }
+    await _jsonCodec.dispose();
     if (_httpClient == null) {
       _authHttpClient.close();
     }
@@ -345,7 +336,7 @@ class SupabaseClient {
       headers: {...headers},
       schema: _postgrestOptions.schema,
       httpClient: _authHttpClient,
-      isolate: _isolate,
+      jsonCodec: _jsonCodec,
       retryOptions: _postgrestOptions.retryOptions,
       requestTimeout: _postgrestOptions.requestTimeout,
     );
@@ -356,7 +347,7 @@ class SupabaseClient {
       _functionsUrl,
       {...headers},
       httpClient: _functionsHttpClient,
-      isolate: _isolate,
+      jsonCodec: _jsonCodec,
       region: _functionsOptions.region,
     );
   }

--- a/packages/supabase/lib/src/supabase_query_builder.dart
+++ b/packages/supabase/lib/src/supabase_query_builder.dart
@@ -14,7 +14,7 @@ class SupabaseQueryBuilder extends PostgrestQueryBuilder {
     required String table,
     super.httpClient,
     required int incrementId,
-    required super.isolate,
+    required super.jsonCodec,
     super.retryOptions,
     super.requestTimeout,
   }) : _realtime = realtime,

--- a/packages/supabase/lib/src/supabase_query_schema.dart
+++ b/packages/supabase/lib/src/supabase_query_schema.dart
@@ -1,6 +1,5 @@
 import 'package:http/http.dart';
 import 'package:supabase/supabase.dart';
-import 'package:yet_another_json_isolate/yet_another_json_isolate.dart';
 
 import 'counter.dart';
 
@@ -10,7 +9,7 @@ class SupabaseQuerySchema {
   final Counter _counter;
   final String _restUrl;
   final String _schema;
-  final YAJsonIsolate _isolate;
+  final AsyncJsonCodec _jsonCodec;
   final Client? _authHttpClient;
   final RealtimeClient _realtime;
   final PostgrestClient _rest;
@@ -19,14 +18,14 @@ class SupabaseQuerySchema {
     required Counter counter,
     required String restUrl,
     required String schema,
-    required YAJsonIsolate isolate,
+    required AsyncJsonCodec jsonCodec,
     required Client? authHttpClient,
     required RealtimeClient realtime,
     required PostgrestClient rest,
   }) : _counter = counter,
        _restUrl = restUrl,
        _schema = schema,
-       _isolate = isolate,
+       _jsonCodec = jsonCodec,
        _authHttpClient = authHttpClient,
        _realtime = realtime,
        _rest = rest;
@@ -42,7 +41,7 @@ class SupabaseQuerySchema {
       table: table,
       httpClient: _authHttpClient,
       incrementId: _counter.increment(),
-      isolate: _isolate,
+      jsonCodec: _jsonCodec,
       retryOptions: _rest.retryOptions,
       requestTimeout: _rest.requestTimeout,
     );
@@ -67,7 +66,7 @@ class SupabaseQuerySchema {
       counter: _counter,
       restUrl: _restUrl,
       schema: schema,
-      isolate: _isolate,
+      jsonCodec: _jsonCodec,
       authHttpClient: _authHttpClient,
       realtime: _realtime,
       rest: newRest,

--- a/packages/supabase/test/client_test.dart
+++ b/packages/supabase/test/client_test.dart
@@ -5,6 +5,7 @@ import 'package:supabase/src/supabase_client.dart' as real;
 import 'package:supabase/supabase.dart' hide SupabaseClient;
 import 'package:supabase_common/supabase_common.dart';
 import 'package:test/test.dart';
+import 'package:yet_another_json_isolate/yet_another_json_isolate.dart';
 
 import 'utils.dart';
 
@@ -521,6 +522,26 @@ void main() {
 
     group('JSON codec', () {
       test(
+        'does not dispose a supplied codec, so the caller keeps ownership',
+        () async {
+          final jsonCodec = YAJsonIsolate();
+          await jsonCodec.initialize();
+
+          final client = SupabaseClient(
+            supabaseUrl,
+            supabaseKey,
+            jsonCodec: jsonCodec,
+          );
+
+          await client.dispose();
+
+          expect(await jsonCodec.encode({'key': 'value'}), isA<String>());
+
+          await jsonCodec.dispose();
+        },
+      );
+
+      test(
         'creates a single codec shared across rest and functions clients',
         () async {
           // The rest and functions clients get the codec the SupabaseClient
@@ -575,6 +596,7 @@ class SupabaseClient extends real.SupabaseClient {
     super.accessToken,
     super.headers,
     super.httpClient,
+    super.jsonCodec,
   }) : super(
          authOptions: AuthClientOptions(
            autoRefreshToken: authOptions.autoRefreshToken,

--- a/packages/supabase/test/client_test.dart
+++ b/packages/supabase/test/client_test.dart
@@ -5,7 +5,6 @@ import 'package:supabase/src/supabase_client.dart' as real;
 import 'package:supabase/supabase.dart' hide SupabaseClient;
 import 'package:supabase_common/supabase_common.dart';
 import 'package:test/test.dart';
-import 'package:yet_another_json_isolate/yet_another_json_isolate.dart';
 
 import 'utils.dart';
 
@@ -520,36 +519,14 @@ void main() {
       );
     });
 
-    group('Shared YAJsonIsolate', () {
+    group('JSON codec', () {
       test(
-        'does not dispose an injected YAJsonIsolate so the caller retains '
-        'ownership',
+        'creates a single codec shared across rest and functions clients',
         () async {
-          final isolate = YAJsonIsolate();
-          await isolate.initialize();
-
-          final client = SupabaseClient(
-            supabaseUrl,
-            supabaseKey,
-            isolate: isolate,
-          );
-
-          await client.dispose();
-
-          // Isolate is still alive — caller owns the lifecycle
-          expect(await isolate.encode({'key': 'value'}), isA<String>());
-
-          await isolate.dispose();
-        },
-      );
-
-      test(
-        'creates a single isolate shared across rest and functions clients',
-        () async {
-          // Creating a SupabaseClient without providing an isolate should
-          // still result in a single shared isolate (not one per sub-client).
-          // Verified indirectly: dispose() should complete without error,
-          // meaning there is no double-dispose from sub-clients.
+          // The rest and functions clients get the codec the SupabaseClient
+          // created, rather than one each, so disposing the client disposes it
+          // exactly once. Verified indirectly: a double dispose of the same
+          // codec would throw.
           final client = SupabaseClient(supabaseUrl, supabaseKey);
 
           expect(client.dispose(), completes);
@@ -598,7 +575,6 @@ class SupabaseClient extends real.SupabaseClient {
     super.accessToken,
     super.headers,
     super.httpClient,
-    super.isolate,
   }) : super(
          authOptions: AuthClientOptions(
            autoRefreshToken: authOptions.autoRefreshToken,

--- a/packages/supabase_flutter/lib/src/supabase.dart
+++ b/packages/supabase_flutter/lib/src/supabase.dart
@@ -61,6 +61,11 @@ class Supabase {
   ///
   /// Custom http client can be used by passing [httpClient] parameter.
   ///
+  /// Pass [jsonCodec] to encode and decode the JSON of the rest and functions
+  /// clients some other way, for example through a native parser. A codec
+  /// passed here is owned by the caller, so it is not disposed together with
+  /// the client. One is created internally when this is omitted.
+  ///
   /// [realtimeClientOptions], [postgrestOptions], and [storageOptions]
   /// configure their respective underlying clients, for example
   /// `storageOptions.retryOptions` configures how an upload to Supabase
@@ -95,6 +100,7 @@ class Supabase {
     TracePropagationOptions tracePropagationOptions =
         const TracePropagationOptions(),
     Future<String?> Function()? accessToken,
+    AsyncJsonCodec? jsonCodec,
   }) async {
     if (_instance._isInitialized) {
       flutterLogger.info(
@@ -130,6 +136,7 @@ class Supabase {
       storageOptions: storageOptions,
       tracePropagationOptions: tracePropagationOptions,
       accessToken: accessToken,
+      jsonCodec: jsonCodec,
     );
 
     if (accessToken == null) {
@@ -260,6 +267,7 @@ class Supabase {
     required AuthClientOptions authOptions,
     required TracePropagationOptions tracePropagationOptions,
     required Future<String?> Function()? accessToken,
+    required AsyncJsonCodec? jsonCodec,
   }) {
     final headers = {
       ...SupabaseFlutterConstants.defaultHeaders,
@@ -276,6 +284,7 @@ class Supabase {
       authOptions: authOptions,
       tracePropagationOptions: tracePropagationOptions,
       accessToken: accessToken,
+      jsonCodec: jsonCodec,
     );
 
     // Close any previous realtime client that may still be connected due to

--- a/packages/supabase_flutter/test/async_json_codec_export_test.dart
+++ b/packages/supabase_flutter/test/async_json_codec_export_test.dart
@@ -5,6 +5,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 class _InlineJsonCodec implements AsyncJsonCodec {
+  const _InlineJsonCodec();
+
   @override
   Future<dynamic> decode(String json) async => jsonDecode(json);
 
@@ -23,7 +25,7 @@ void main() {
   test(
     'AsyncJsonCodec is implementable through the supabase_flutter export',
     () async {
-      final AsyncJsonCodec jsonCodec = _InlineJsonCodec();
+      const AsyncJsonCodec jsonCodec = _InlineJsonCodec();
       final client = FunctionsClient(
         'https://example.com',
         const {},

--- a/packages/supabase_flutter/test/async_json_codec_export_test.dart
+++ b/packages/supabase_flutter/test/async_json_codec_export_test.dart
@@ -1,0 +1,37 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+class _InlineJsonCodec implements AsyncJsonCodec {
+  @override
+  Future<dynamic> decode(String json) async => jsonDecode(json);
+
+  @override
+  Future<dynamic> decodeBytes(Uint8List encodedJson) async =>
+      jsonDecode(utf8.decode(encodedJson));
+
+  @override
+  Future<String> encode(Object? json) async => jsonEncode(json);
+
+  @override
+  Future<void> dispose() async {}
+}
+
+void main() {
+  test(
+    'AsyncJsonCodec is implementable through the supabase_flutter export',
+    () async {
+      final AsyncJsonCodec jsonCodec = _InlineJsonCodec();
+      final client = FunctionsClient(
+        'https://example.com',
+        const {},
+        jsonCodec: jsonCodec,
+      );
+      addTearDown(client.dispose);
+
+      expect(await jsonCodec.encode({'a': 1}), '{"a":1}');
+    },
+  );
+}

--- a/packages/supabase_flutter/test/initialization_test.dart
+++ b/packages/supabase_flutter/test/initialization_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
@@ -38,6 +40,36 @@ void main() {
           ),
           completes,
         );
+      });
+    });
+
+    group('Custom JSON codec initialization', () {
+      test('initializes with a supplied codec', () async {
+        final jsonCodec = _RecordingJsonCodec();
+
+        await Supabase.initialize(
+          url: supabaseUrl,
+          publishableKey: supabaseKey,
+          jsonCodec: jsonCodec,
+        );
+
+        expect(Supabase.instance.isInitialized, isTrue);
+        expect(jsonCodec.isDisposed, isFalse);
+      });
+
+      test('leaves a supplied codec usable after dispose', () async {
+        final jsonCodec = _RecordingJsonCodec();
+
+        await Supabase.initialize(
+          url: supabaseUrl,
+          publishableKey: supabaseKey,
+          jsonCodec: jsonCodec,
+        );
+        await Supabase.instance.dispose();
+
+        // The caller owns it, so the client must not have disposed it.
+        expect(jsonCodec.isDisposed, isFalse);
+        expect(await jsonCodec.decode('{"a":1}'), {'a': 1});
       });
     });
 
@@ -189,4 +221,25 @@ void main() {
       });
     });
   });
+}
+
+/// An [AsyncJsonCodec] that works inline and records whether it was disposed,
+/// so a test can assert that a supplied codec stays the caller's to dispose.
+class _RecordingJsonCodec implements AsyncJsonCodec {
+  bool isDisposed = false;
+
+  @override
+  Future<dynamic> decode(String json) async => jsonDecode(json);
+
+  @override
+  Future<dynamic> decodeBytes(Uint8List encodedJson) async =>
+      jsonDecode(utf8.decode(encodedJson));
+
+  @override
+  Future<String> encode(Object? json) async => jsonEncode(json);
+
+  @override
+  Future<void> dispose() async {
+    isDisposed = true;
+  }
 }

--- a/packages/supabase_functions/lib/src/functions_client.dart
+++ b/packages/supabase_functions/lib/src/functions_client.dart
@@ -14,12 +14,14 @@ class FunctionsClient {
   final String _url;
   final Map<String, String> _headers;
   final http.Client? _httpClient;
-  final YAJsonIsolate _isolate;
-  final bool _hasCustomIsolate;
+  final AsyncJsonCodec _jsonCodec;
+  final bool _ownsJsonCodec;
   final String? _region;
 
-  /// In case you don't provide your own isolate, call [dispose] when you're
-  /// done
+  /// [jsonCodec] encodes the request body and decodes the response. The
+  /// default codec keeps large payloads off the calling isolate. A codec
+  /// passed here is owned by the caller, so [dispose] leaves it alone; call
+  /// [dispose] when you're done with a client that created its own.
   ///
   /// [accessToken] is resolved before every invocation and sent as
   /// `Authorization: Bearer <token>`. Use it when the token rotates, for
@@ -30,7 +32,7 @@ class FunctionsClient {
     String url,
     Map<String, String> headers, {
     http.Client? httpClient,
-    YAJsonIsolate? isolate,
+    AsyncJsonCodec? jsonCodec,
     String? region,
     Future<String?> Function()? accessToken,
   }) : assert(
@@ -40,10 +42,10 @@ class FunctionsClient {
        ),
        _url = url,
        _headers = {...FunctionsConstants.defaultHeaders, ...headers},
-       _isolate = isolate ?? (YAJsonIsolate()..initialize()),
-       _hasCustomIsolate = isolate != null,
+       _jsonCodec = jsonCodec ?? (YAJsonIsolate()..initialize()),
+       _ownsJsonCodec = jsonCodec == null,
        // The transport belongs to the caller, so the client never closes it,
-       // the same way it leaves a caller-provided isolate alone.
+       // the same way it leaves a caller-provided JSON codec alone.
        // ignore: dispose-class-fields
        _httpClient = accessToken == null
            ? httpClient
@@ -205,7 +207,7 @@ class FunctionsClient {
         } else if (body is Uint8List) {
           bodyRequest.bodyBytes = body;
         } else {
-          bodyRequest.body = await _isolate.encode(body);
+          bodyRequest.body = await _jsonCodec.encode(body);
         }
       }
       request = bodyRequest;
@@ -239,7 +241,7 @@ class FunctionsClient {
       } else {
         dynamic decoded;
         try {
-          decoded = await _isolate.decodeBytes(bodyBytes);
+          decoded = await _jsonCodec.decodeBytes(bodyBytes);
         } on FormatException {
           // A body labeled JSON that doesn't parse is only tolerated on an
           // error status, where the raw text still needs to reach the caller
@@ -282,13 +284,14 @@ class FunctionsClient {
     );
   }
 
-  /// Disposes the self created isolate for json encoding/decoding
+  /// Disposes the JSON codec the client created for itself.
   ///
-  /// Does nothing if you pass your own isolate
+  /// Does nothing when a codec was passed to the constructor, since that one
+  /// belongs to the caller.
   Future<void> dispose() async {
     functionsLogger.fine("Dispose FunctionsClient");
-    if (!_hasCustomIsolate) {
-      return _isolate.dispose();
+    if (_ownsJsonCodec) {
+      return _jsonCodec.dispose();
     }
   }
 }

--- a/packages/supabase_functions/lib/supabase_functions.dart
+++ b/packages/supabase_functions/lib/supabase_functions.dart
@@ -6,5 +6,8 @@ export 'package:http/http.dart'
 export 'package:supabase_common/supabase_common.dart'
     show HttpMethod, SupabaseApiException, SupabaseException;
 
+export 'package:yet_another_json_isolate/yet_another_json_isolate.dart'
+    show AsyncJsonCodec;
+
 export 'src/functions_client.dart';
 export 'src/types.dart';

--- a/packages/supabase_functions/test/functions_dart_test.dart
+++ b/packages/supabase_functions/test/functions_dart_test.dart
@@ -257,22 +257,45 @@ void main() {
       expect(response.statusCode, 200);
     });
 
-    test('dispose isolate', () async {
+    test('dispose the JSON codec it created itself', () async {
       await functionsCustomHttpClient.dispose();
       expect(functionsCustomHttpClient.invoke('function'), throwsStateError);
     });
 
-    test('do not dispose custom isolate', () async {
+    test('do not dispose a supplied JSON codec', () async {
       final client = FunctionsClient(
         "",
         {},
-        isolate: YAJsonIsolate(),
+        jsonCodec: YAJsonIsolate(),
         httpClient: CustomHttpClient(),
       );
 
       await client.dispose();
       final response = await client.invoke('function');
       expect(response.data, {'key': 'Hello World'});
+    });
+
+    test('encodes and decodes through a supplied JSON codec', () async {
+      final jsonCodec = _RecordingJsonCodec();
+      final client = FunctionsClient(
+        "",
+        {},
+        jsonCodec: jsonCodec,
+        httpClient: CustomHttpClient(),
+      );
+      addTearDown(client.dispose);
+
+      final response = await client.invoke(
+        'function',
+        body: {'name': 'Supabase'},
+      );
+
+      expect(response.data, {'key': 'Hello World'});
+      expect(jsonCodec.encodedValues, [
+        {'name': 'Supabase'},
+      ]);
+      expect(jsonCodec.decodedPayloads, 1);
+      expect(jsonCodec.isDisposed, isFalse);
     });
 
     test('Listen to SSE event', () async {
@@ -633,13 +656,12 @@ void main() {
 
     group('Constructor variations', () {
       test('constructor with all parameters', () {
-        final isolate = YAJsonIsolate();
         final httpClient = CustomHttpClient();
         final client = FunctionsClient(
           'https://example.com',
           {'X-Test': 'value'},
           httpClient: httpClient,
-          isolate: isolate,
+          jsonCodec: YAJsonIsolate(),
         );
 
         expect(client.headers['X-Test'], 'value');
@@ -784,4 +806,36 @@ void main() {
       );
     });
   });
+}
+
+/// An [AsyncJsonCodec] that works inline and records what it was asked to
+/// process, so a test can assert that the client routes its JSON through the
+/// codec it was given and leaves its disposal to the caller.
+class _RecordingJsonCodec implements AsyncJsonCodec {
+  final List<Object?> encodedValues = [];
+  int decodedPayloads = 0;
+  bool isDisposed = false;
+
+  @override
+  Future<dynamic> decode(String json) async {
+    decodedPayloads++;
+    return jsonDecode(json);
+  }
+
+  @override
+  Future<dynamic> decodeBytes(Uint8List encodedJson) async {
+    decodedPayloads++;
+    return jsonDecode(utf8.decode(encodedJson));
+  }
+
+  @override
+  Future<String> encode(Object? json) async {
+    encodedValues.add(json);
+    return jsonEncode(json);
+  }
+
+  @override
+  Future<void> dispose() async {
+    isDisposed = true;
+  }
 }

--- a/packages/yet_another_json_isolate/README.md
+++ b/packages/yet_another_json_isolate/README.md
@@ -37,6 +37,33 @@ final data = await isolate.decodeBytes(response.bodyBytes);
 isolate.dispose();
 ```
 
+## `AsyncJsonCodec`
+
+`YAJsonIsolate` implements `AsyncJsonCodec`, the interface the Supabase clients accept
+through their `jsonCodec` parameter. Implement it to process their JSON some other way, for
+example with a native parser, or to wrap the default implementation and measure it.
+
+```dart
+class TimedJsonCodec implements AsyncJsonCodec {
+  TimedJsonCodec(this._inner);
+
+  final AsyncJsonCodec _inner;
+
+  @override
+  Future<dynamic> decode(String json) => _time(() => _inner.decode(json));
+
+  @override
+  Future<dynamic> decodeBytes(Uint8List encodedJson) =>
+      _time(() => _inner.decodeBytes(encodedJson));
+
+  @override
+  Future<String> encode(Object? json) => _time(() => _inner.encode(json));
+
+  @override
+  Future<void> dispose() => _inner.dispose();
+}
+```
+
 ## License
 
 This repo is licensed under MIT.

--- a/packages/yet_another_json_isolate/lib/src/_isolates_io.dart
+++ b/packages/yet_another_json_isolate/lib/src/_isolates_io.dart
@@ -3,6 +3,8 @@ import 'dart:convert';
 import 'dart:isolate';
 import 'dart:typed_data';
 
+import 'async_json_codec.dart';
+
 /// Payloads estimated to be smaller than this are processed directly on the
 /// calling isolate.
 ///
@@ -26,7 +28,7 @@ final Converter<List<int>, Object?> _utf8JsonDecoder = const Utf8Decoder().fuse(
 /// an isolate round trip. Large payloads are processed on a short lived
 /// isolate spawned per call: its result is handed back through `Isolate.exit`
 /// without copying, and independent calls run in parallel.
-class YAJsonIsolate {
+class YAJsonIsolate implements AsyncJsonCodec {
   YAJsonIsolate({
     this.debugName,
   });
@@ -68,6 +70,7 @@ class YAJsonIsolate {
   /// was still in flight has finished. Safe to call more than once, and safe
   /// to call on an instance that was never used. Concurrent calls all await
   /// the same disposal. Using the instance afterwards throws a [StateError].
+  @override
   Future<void> dispose() => _disposal ??= _activeWork.isEmpty
       ? Future.value()
       : Future.wait(_activeWork.toList()).then((_) {});
@@ -90,6 +93,7 @@ class YAJsonIsolate {
   /// Small payloads are decoded inline, large ones on a short lived isolate.
   /// The threshold compares the length in UTF-16 code units, which is what
   /// the cost of parsing a string scales with.
+  @override
   Future<dynamic> decode(String json) async {
     _throwIfDisposed();
     if (json.length < _isolateThresholdBytes) {
@@ -109,6 +113,7 @@ class YAJsonIsolate {
   ///
   /// The bytes are read before control returns to the caller, so the buffer
   /// can be reused as soon as the call returns.
+  @override
   Future<dynamic> decodeBytes(Uint8List encodedJson) async {
     _throwIfDisposed();
     if (encodedJson.length < _isolateThresholdBytes) {
@@ -129,6 +134,7 @@ class YAJsonIsolate {
   ///
   /// The value is consumed before control returns to the caller, so it can
   /// be mutated as soon as the call returns.
+  @override
   Future<String> encode(Object? json) async {
     _throwIfDisposed();
     if (_remainingBudget(json, _isolateThresholdBytes, 0) >= 0) {

--- a/packages/yet_another_json_isolate/lib/src/_isolates_web.dart
+++ b/packages/yet_another_json_isolate/lib/src/_isolates_web.dart
@@ -1,6 +1,8 @@
 import 'dart:convert';
 import 'dart:typed_data';
 
+import 'async_json_codec.dart';
+
 final Converter<List<int>, Object?> _utf8JsonDecoder = const Utf8Decoder().fuse(
   const JsonDecoder(),
 );
@@ -10,24 +12,28 @@ final Converter<List<int>, Object?> _utf8JsonDecoder = const Utf8Decoder().fuse(
 /// The web platform has no isolates, so all work happens inline. Decoding
 /// from bytes still fuses the UTF-8 and JSON decoding steps, which avoids
 /// materializing the intermediate string.
-class YAJsonIsolate {
+class YAJsonIsolate implements AsyncJsonCodec {
   const YAJsonIsolate({
     String? debugName,
   });
 
   Future<void> initialize() => Future.value();
 
+  @override
   Future<void> dispose() => Future.value();
 
+  @override
   Future<dynamic> decode(String json) async {
     await null;
     return jsonDecode(json);
   }
 
+  @override
   Future<dynamic> decodeBytes(Uint8List encodedJson) {
     return Future.sync(() => _utf8JsonDecoder.convert(encodedJson));
   }
 
+  @override
   Future<String> encode(Object? json) async {
     await null;
     return jsonEncode(json);

--- a/packages/yet_another_json_isolate/lib/src/async_json_codec.dart
+++ b/packages/yet_another_json_isolate/lib/src/async_json_codec.dart
@@ -1,0 +1,40 @@
+import 'dart:typed_data';
+
+/// Encodes and decodes JSON asynchronously, so that a large payload does not
+/// block the calling isolate for long.
+///
+/// `YAJsonIsolate` is the implementation the Supabase clients use when none is
+/// supplied. Implement this interface to route their JSON work somewhere else,
+/// for example through a native parser or through an instrumented wrapper that
+/// records how long each payload takes.
+///
+/// Every method is asynchronous even when an implementation does the work
+/// inline, so that a caller cannot come to depend on the work happening
+/// synchronously.
+abstract interface class AsyncJsonCodec {
+  /// Decodes [json] into Dart values, like `jsonDecode`.
+  Future<dynamic> decode(String json);
+
+  /// Decodes UTF-8 encoded JSON in [encodedJson] into Dart values.
+  ///
+  /// Preferred by the clients over [decode] when the payload is available as
+  /// bytes, such as an HTTP response body, because it avoids materializing the
+  /// intermediate string.
+  ///
+  /// An implementation must read the bytes before returning control to the
+  /// caller, which is free to reuse the buffer as soon as the call returns.
+  Future<dynamic> decodeBytes(Uint8List encodedJson);
+
+  /// Encodes [json] into a JSON string, like `jsonEncode`.
+  ///
+  /// An implementation must consume the value before returning control to the
+  /// caller, which is free to mutate it as soon as the call returns.
+  Future<String> encode(Object? json);
+
+  /// Releases whatever the codec holds.
+  ///
+  /// A client only disposes a codec it created itself. One that is passed to a
+  /// client stays owned by whoever created it, and can be shared between
+  /// clients and disposed once they are all done with it.
+  Future<void> dispose();
+}

--- a/packages/yet_another_json_isolate/lib/yet_another_json_isolate.dart
+++ b/packages/yet_another_json_isolate/lib/yet_another_json_isolate.dart
@@ -3,5 +3,6 @@
 /// isolates that hand their result back without copying.
 library;
 
+export 'src/async_json_codec.dart';
 export 'src/_isolates_io.dart'
     if (dart.library.js_interop) 'src/_isolates_web.dart';

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -2136,6 +2136,11 @@ supporting_symbols:
   - AdminUserAttributes.phoneConfirm
   - AdminUserAttributes.toJson
   - AdminUserAttributes.userMetadata
+  - AsyncJsonCodec
+  - AsyncJsonCodec.decode
+  - AsyncJsonCodec.decodeBytes
+  - AsyncJsonCodec.dispose
+  - AsyncJsonCodec.encode
   - AuthApiException
   - AuthApiException.==
   - AuthApiException.AuthApiException


### PR DESCRIPTION
`YAJsonIsolate` was the type the clients named in their public API. That tied
them to one implementation, and on web to one that spawns no isolate at all, so
the parameter both misnamed what it takes and left no way to process JSON any
other way.

`YAJsonIsolate` now implements `AsyncJsonCodec`, a four method interface
(`decode`, `decodeBytes`, `encode`, `dispose`), and the clients take that
interface instead.

### Changes

- `yet_another_json_isolate`: new `AsyncJsonCodec` interface, implemented by
  both the io and the web `YAJsonIsolate`, and exported from the package.
- `SupabaseClient`, `PostgrestClient` and `FunctionsClient`: `isolate:` is now
  `jsonCodec:` and takes an `AsyncJsonCodec`. The same rename runs through
  `PostgrestBuilder`, `PostgrestQueryBuilder`, `PostgrestRpcBuilder`,
  `RawPostgrestBuilder`, `SupabaseQueryBuilder` and `SupabaseQuerySchema`.
- `postgrest` and `supabase_functions` export the interface, so the parameter is
  reachable without depending on `yet_another_json_isolate` directly, which the
  old parameter was not. `supabase` and `supabase_flutter` re-export it in turn.
  The concrete `YAJsonIsolate` stays unexported, so replacing the default
  implementation later is not a breaking change for the flagship package.
- Ownership is unchanged: a codec passed to a client belongs to the caller and
  is never disposed by it. A client that was not given one creates the default
  codec and disposes it with itself. `SupabaseClient` hands its codec to the
  rest and functions clients it builds, so one codec serves all three.
- `MIGRATION.md`: an entry for the rename.
- `sdk-compliance.yaml`: the interface registered under `supporting_symbols`.

### Why an interface rather than the concrete type

Since #1746 there is no long-lived worker isolate: small payloads are processed
inline and large ones on a short-lived isolate spawned per call. So sharing an
instance buys nothing measurable and there is nothing left to supervise, which
was what the old parameter was for. What survives is substituting an
implementation, for example a native parser or a wrapper that measures the
default one, and that needs a contract rather than a concrete class.

Keeping `YAJsonIsolate` out of the exports of `supabase` and `supabase_flutter`
also keeps `yet_another_json_isolate` out of their public API, so it can be
replaced without a breaking change. Applications that want to name the default
implementation can depend on the package directly.

This takes a different direction from #1750, which forwards the concrete type
through `Supabase.initialize` instead.

### Verification

- `flutter analyze` clean across the workspace, `dart format` clean, and
  `dcm analyze packages` clean, which is the command CI runs.
- `packages/supabase` (143 tests), `packages/supabase_functions` (55),
  `packages/supabase_flutter` (77), `packages/yet_another_json_isolate` and
  `packages/supabase_common` (109) suites pass, as do the `packages/postgrest`
  tests that do not need a local stack. The postgrest suites that do need one
  were not run.
- New tests: postgrest routes decoding through a supplied codec, leaves it for
  the caller to dispose, and disposes the one it created itself;
  `supabase_functions` routes both encoding and decoding through a supplied
  codec; `SupabaseClient` leaves a supplied codec alone on `dispose()`;
  `supabase_flutter` implements the interface through its own export, so the
  export chain is covered.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the public `AsyncJsonCodec` API for asynchronous JSON encoding and decoding.
  - Added optional `jsonCodec` support across Supabase, PostgREST, Functions, and initialization APIs.
  - Shared codecs are consistently reused across related client operations and managed according to ownership.
  - Realtime messages now use typed payloads with asynchronous encoding and decoding.
  - Added a shared typed sort direction for storage queries.

- **Documentation**
  - Updated migration guidance for codec usage, Realtime payloads, client headers, builders, and sorting.
  - Added guidance for customizing and timing JSON codec operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->