### PR TITLE
refactor(storage)!: share one SortDirection enum across the packages

### DIFF
--- a/.sdk-parse-ignore
+++ b/.sdk-parse-ignore
@@ -12,10 +12,11 @@
 # symbols are imported by the other packages, so they cannot be marked
 # @internal (that would trigger invalid_use_of_internal_member in the
 # consumers). Exclude its sources from the public-API scan instead, except for
-# the retry options, which every client re-exports as user facing API and so
-# are registered in the capability matrix.
+# the retry options and the sort direction, which the clients re-export as user
+# facing API and so are registered in the capability matrix.
 packages/supabase_common/lib/
 !packages/supabase_common/lib/src/retry_options.dart
+!packages/supabase_common/lib/src/sort_direction.dart
 
 # supabase_typegen is a development-time code generator, not SDK client surface,
 # so its public symbols are not capability-matrix symbols.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1466,3 +1466,28 @@ final client = RealtimeClient(realtimeUrl);
 Without `hierarchicalLoggingEnabled = true`, `package:logging` resolves the `onRecord` stream of a
 non-root logger to `Logger.root.onRecord`, which receives records from every logger in the
 application; in that case listen on `Logger.root` and filter on `LogRecord.loggerName` instead.
+
+### `SortBy.order` is a `FileSortOrder`
+
+`SearchOptions.sortBy` took its sort direction as a `String`, so a typo such as `'ascending'` only
+surfaced as a 400 from the storage server. `SortBy.order` is now the `FileSortOrder` enum that
+`listPaginated` already used, and it is non-nullable with `FileSortOrder.ascending` as its default.
+
+```dart
+// Before
+await supabase.storage.from('bucket').list(
+      searchOptions: const SearchOptions(
+        sortBy: SortBy(column: 'created_at', order: 'desc'),
+      ),
+    );
+
+// After
+await supabase.storage.from('bucket').list(
+      searchOptions: const SearchOptions(
+        sortBy: SortBy(column: 'created_at', order: FileSortOrder.descending),
+      ),
+    );
+```
+
+`SortBy(order: null)` no longer compiles; leave `order` out to sort ascending. `column` is
+unchanged, since `list()` accepts any column of a `FileObject`.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1467,11 +1467,33 @@ Without `hierarchicalLoggingEnabled = true`, `package:logging` resolves the `onR
 non-root logger to `Logger.root.onRecord`, which receives records from every logger in the
 application; in that case listen on `Logger.root` and filter on `LogRecord.loggerName` instead.
 
-### `SortBy.order` is a `FileSortOrder`
+### One shared `SortDirection` for every sort direction
 
-`SearchOptions.sortBy` took its sort direction as a `String`, so a typo such as `'ascending'` only
-surfaced as a 400 from the storage server. `SortBy.order` is now the `FileSortOrder` enum that
-`listPaginated` already used, and it is non-nullable with `FileSortOrder.ascending` as its default.
+Three enums described the same ascending or descending direction: `BucketSortOrder` and
+`FileSortOrder` in `supabase_storage`, and `SortDirection` in `iceberg`. They are now one
+`SortDirection`, shared by every package. The values are unchanged, so only the type name moves.
+
+| Before | After |
+| --- | --- |
+| `BucketSortOrder` | `SortDirection` |
+| `FileSortOrder` | `SortDirection` |
+| `SortDirection` | unchanged |
+
+```dart
+// Before
+await supabase.storage.listBuckets(
+  const ListBucketsOptions(sortOrder: BucketSortOrder.descending),
+);
+
+// After
+await supabase.storage.listBuckets(
+  const ListBucketsOptions(sortOrder: SortDirection.descending),
+);
+```
+
+`StorageFileApi.list()` took its direction as a `String`, so a typo such as `'ascending'` only
+surfaced as a 400 from the storage server. `SortBy.order` is a `SortDirection` too, non-nullable
+with `SortDirection.ascending` as its default:
 
 ```dart
 // Before
@@ -1484,7 +1506,7 @@ await supabase.storage.from('bucket').list(
 // After
 await supabase.storage.from('bucket').list(
       searchOptions: const SearchOptions(
-        sortBy: SortBy(column: 'created_at', order: FileSortOrder.descending),
+        sortBy: SortBy(column: 'created_at', order: SortDirection.descending),
       ),
     );
 ```

--- a/examples/storage_transforms/lib/storage_repository.dart
+++ b/examples/storage_transforms/lib/storage_repository.dart
@@ -41,7 +41,7 @@ class StorageRepository {
   Future<List<StoredImage>> listImages() async {
     final files = await _files.list(
       searchOptions: const SearchOptions(
-        sortBy: SortBy(column: 'created_at', order: FileSortOrder.descending),
+        sortBy: SortBy(column: 'created_at', order: SortDirection.descending),
       ),
     );
     return files

--- a/examples/storage_transforms/lib/storage_repository.dart
+++ b/examples/storage_transforms/lib/storage_repository.dart
@@ -41,7 +41,7 @@ class StorageRepository {
   Future<List<StoredImage>> listImages() async {
     final files = await _files.list(
       searchOptions: const SearchOptions(
-        sortBy: SortBy(column: 'created_at', order: 'desc'),
+        sortBy: SortBy(column: 'created_at', order: FileSortOrder.descending),
       ),
     );
     return files

--- a/packages/iceberg/lib/iceberg.dart
+++ b/packages/iceberg/lib/iceberg.dart
@@ -2,7 +2,7 @@
 library;
 
 export 'package:supabase_common/supabase_common.dart'
-    show SupabaseApiException, SupabaseException;
+    show SortDirection, SupabaseApiException, SupabaseException;
 
 export 'src/iceberg_error.dart';
 export 'src/iceberg_rest_catalog.dart';

--- a/packages/iceberg/lib/src/iceberg_types.dart
+++ b/packages/iceberg/lib/src/iceberg_types.dart
@@ -20,19 +20,6 @@ class TableIdentifier {
   Map<String, dynamic> toJson() => {'namespace': namespace, 'name': name};
 }
 
-/// The direction used when sorting a [SortField].
-enum SortDirection {
-  ascending('asc'),
-  descending('desc');
-
-  const SortDirection(this.value);
-
-  final String value;
-
-  static SortDirection fromValue(String value) =>
-      values.firstWhere((direction) => direction.value == value);
-}
-
 /// Where null values are ordered relative to non null values in a [SortField].
 enum NullOrder {
   nullsFirst('nulls-first'),

--- a/packages/supabase_common/lib/src/sort_direction.dart
+++ b/packages/supabase_common/lib/src/sort_direction.dart
@@ -1,0 +1,13 @@
+/// The direction that a sorted result set is ordered in.
+enum SortDirection {
+  ascending('asc'),
+  descending('desc');
+
+  const SortDirection(this.value);
+
+  /// The value sent to and received from the API.
+  final String value;
+
+  static SortDirection fromValue(String value) =>
+      values.firstWhere((direction) => direction.value == value);
+}

--- a/packages/supabase_common/lib/supabase_common.dart
+++ b/packages/supabase_common/lib/supabase_common.dart
@@ -23,6 +23,7 @@ export 'src/replay_subject.dart';
 export 'src/retry.dart';
 export 'src/retry_options.dart';
 export 'src/snake_case.dart';
+export 'src/sort_direction.dart';
 export 'src/supabase_exception.dart';
 export 'src/timestamp.dart';
 export 'src/uuid.dart';

--- a/packages/supabase_storage/lib/src/types.dart
+++ b/packages/supabase_storage/lib/src/types.dart
@@ -186,17 +186,6 @@ class BucketOptions {
 /// The column that [StorageBucketApi.listBuckets] can sort its results by.
 enum BucketSortColumn { id, name, createdAt, updatedAt }
 
-/// The direction that [StorageBucketApi.listBuckets] sorts its results in.
-enum BucketSortOrder {
-  ascending('asc'),
-  descending('desc');
-
-  const BucketSortOrder(this.value);
-
-  /// The value sent to the storage API.
-  final String value;
-}
-
 /// Filter, sort and pagination options for [StorageBucketApi.listBuckets].
 class ListBucketsOptions {
   /// The maximum number of buckets to return.
@@ -209,7 +198,7 @@ class ListBucketsOptions {
   final BucketSortColumn? sortColumn;
 
   /// The direction to sort the buckets in.
-  final BucketSortOrder? sortOrder;
+  final SortDirection? sortOrder;
 
   /// A search term used to filter buckets by name.
   final String? search;
@@ -306,11 +295,11 @@ class SortBy {
   final String? column;
 
   /// The sort direction.
-  final FileSortOrder order;
+  final SortDirection order;
 
   const SortBy({
     this.column = 'name',
-    this.order = FileSortOrder.ascending,
+    this.order = SortDirection.ascending,
   });
 
   Map<String, dynamic> toMap() {
@@ -324,18 +313,6 @@ class SortBy {
 /// The column that [StorageFileApi.listPaginated] can sort its results by.
 enum FileSortColumn { name, updatedAt, createdAt }
 
-/// The direction that [StorageFileApi.list] and
-/// [StorageFileApi.listPaginated] sort their results in.
-enum FileSortOrder {
-  ascending('asc'),
-  descending('desc');
-
-  const FileSortOrder(this.value);
-
-  /// The value sent to the storage API.
-  final String value;
-}
-
 /// The column and direction that [StorageFileApi.listPaginated] sorts its
 /// results by.
 class FileSort {
@@ -343,11 +320,11 @@ class FileSort {
   final FileSortColumn column;
 
   /// The sort direction.
-  final FileSortOrder order;
+  final SortDirection order;
 
   const FileSort({
     this.column = FileSortColumn.name,
-    this.order = FileSortOrder.ascending,
+    this.order = SortDirection.ascending,
   });
 
   Map<String, dynamic> toMap() {

--- a/packages/supabase_storage/lib/src/types.dart
+++ b/packages/supabase_storage/lib/src/types.dart
@@ -277,7 +277,7 @@ class SearchOptions {
   /// The starting position.
   final int? offset;
 
-  /// The column to sort by. Can be any column inside a FileObject.
+  /// The column and direction to sort by.
   final SortBy? sortBy;
 
   /// The search string to filter files by.
@@ -300,16 +300,23 @@ class SearchOptions {
   }
 }
 
+/// The column and direction that [StorageFileApi.list] sorts its results by.
 class SortBy {
+  /// The column to sort by. Can be any column inside a [FileObject].
   final String? column;
-  final String? order;
 
-  const SortBy({this.column = 'name', this.order = 'asc'});
+  /// The sort direction.
+  final FileSortOrder order;
+
+  const SortBy({
+    this.column = 'name',
+    this.order = FileSortOrder.ascending,
+  });
 
   Map<String, dynamic> toMap() {
     return {
       'column': column ?? 'name',
-      'order': order ?? 'asc',
+      'order': order.value,
     };
   }
 }
@@ -317,7 +324,8 @@ class SortBy {
 /// The column that [StorageFileApi.listPaginated] can sort its results by.
 enum FileSortColumn { name, updatedAt, createdAt }
 
-/// The direction that [StorageFileApi.listPaginated] sorts its results in.
+/// The direction that [StorageFileApi.list] and
+/// [StorageFileApi.listPaginated] sort their results in.
 enum FileSortOrder {
   ascending('asc'),
   descending('desc');

--- a/packages/supabase_storage/lib/supabase_storage.dart
+++ b/packages/supabase_storage/lib/supabase_storage.dart
@@ -3,7 +3,11 @@ library;
 
 export 'package:iceberg/iceberg.dart';
 export 'package:supabase_common/supabase_common.dart'
-    show SupabaseApiException, SupabaseException, SupabaseRetryOptions;
+    show
+        SortDirection,
+        SupabaseApiException,
+        SupabaseException,
+        SupabaseRetryOptions;
 
 export 'src/storage_client.dart';
 export 'src/storage_file_api.dart';

--- a/packages/supabase_storage/test/basic_test.dart
+++ b/packages/supabase_storage/test/basic_test.dart
@@ -87,7 +87,7 @@ void main() {
             offset: 5,
             search: 'prod',
             sortColumn: BucketSortColumn.createdAt,
-            sortOrder: BucketSortOrder.descending,
+            sortOrder: SortDirection.descending,
           ),
         );
 
@@ -220,7 +220,7 @@ void main() {
           offset: 5,
           search: 'ware',
           sortColumn: BucketSortColumn.createdAt,
-          sortOrder: BucketSortOrder.descending,
+          sortOrder: SortDirection.descending,
         ),
       );
 
@@ -443,7 +443,7 @@ void main() {
               withDelimiter: true,
               sortBy: FileSort(
                 column: FileSortColumn.createdAt,
-                order: FileSortOrder.descending,
+                order: SortDirection.descending,
               ),
             ),
           );

--- a/packages/supabase_storage/test/client_test.dart
+++ b/packages/supabase_storage/test/client_test.dart
@@ -948,7 +948,7 @@ void main() {
           .from('test-bucket')
           .list(
             searchOptions: const SearchOptions(
-              sortBy: SortBy(order: 'desc'),
+              sortBy: SortBy(order: FileSortOrder.descending),
             ),
           );
 
@@ -964,7 +964,7 @@ void main() {
       expect(sentSortBy(), {'column': 'name', 'order': 'asc'});
     });
 
-    test('fills in fields passed explicitly as null', () async {
+    test('fills in a column passed explicitly as null', () async {
       customHttpClient.response = [];
       customHttpClient.statusCode = 200;
 
@@ -972,7 +972,7 @@ void main() {
           .from('test-bucket')
           .list(
             searchOptions: const SearchOptions(
-              sortBy: SortBy(column: null, order: null),
+              sortBy: SortBy(column: null),
             ),
           );
 
@@ -987,7 +987,10 @@ void main() {
           .from('test-bucket')
           .list(
             searchOptions: const SearchOptions(
-              sortBy: SortBy(column: 'created_at', order: 'desc'),
+              sortBy: SortBy(
+                column: 'created_at',
+                order: FileSortOrder.descending,
+              ),
             ),
           );
 

--- a/packages/supabase_storage/test/client_test.dart
+++ b/packages/supabase_storage/test/client_test.dart
@@ -948,7 +948,7 @@ void main() {
           .from('test-bucket')
           .list(
             searchOptions: const SearchOptions(
-              sortBy: SortBy(order: FileSortOrder.descending),
+              sortBy: SortBy(order: SortDirection.descending),
             ),
           );
 
@@ -989,7 +989,7 @@ void main() {
             searchOptions: const SearchOptions(
               sortBy: SortBy(
                 column: 'created_at',
-                order: FileSortOrder.descending,
+                order: SortDirection.descending,
               ),
             ),
           );

--- a/packages/supabase_storage/test/types_test.dart
+++ b/packages/supabase_storage/test/types_test.dart
@@ -150,7 +150,7 @@ void main() {
         offset: 5,
         search: 'photo',
         sortColumn: BucketSortColumn.createdAt,
-        sortOrder: BucketSortOrder.descending,
+        sortOrder: SortDirection.descending,
       );
 
       expect(options.toQueryParameters(), {
@@ -184,7 +184,7 @@ void main() {
     test('serializes the order to its value', () {
       const sortBy = SortBy(
         column: 'updated_at',
-        order: FileSortOrder.descending,
+        order: SortDirection.descending,
       );
       expect(sortBy.toMap(), {'column': 'updated_at', 'order': 'desc'});
     });
@@ -194,7 +194,7 @@ void main() {
     test('serializes column to snake_case and order to its value', () {
       const sort = FileSort(
         column: FileSortColumn.updatedAt,
-        order: FileSortOrder.descending,
+        order: SortDirection.descending,
       );
       expect(sort.toMap(), {'column': 'updated_at', 'order': 'desc'});
     });

--- a/packages/supabase_storage/test/types_test.dart
+++ b/packages/supabase_storage/test/types_test.dart
@@ -176,9 +176,17 @@ void main() {
   });
 
   group('SortBy.toMap', () {
-    test('falls back to defaults when column and order are null', () {
-      const sortBy = SortBy(column: null, order: null);
+    test('falls back to the default column when it is null', () {
+      const sortBy = SortBy(column: null);
       expect(sortBy.toMap(), {'column': 'name', 'order': 'asc'});
+    });
+
+    test('serializes the order to its value', () {
+      const sortBy = SortBy(
+        column: 'updated_at',
+        order: FileSortOrder.descending,
+      );
+      expect(sortBy.toMap(), {'column': 'updated_at', 'order': 'desc'});
     });
   });
 

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -1078,9 +1078,6 @@ features:
       - FileSort.order
       - FileSort.toMap
       - FileSortColumn
-      - FileSortOrder
-      - FileSortOrder.FileSortOrder
-      - FileSortOrder.value
       - PaginatedFile
       - PaginatedFile.PaginatedFile
       - PaginatedFile.createdAt
@@ -1242,9 +1239,6 @@ features:
       - ListBucketsOptions.sortOrder
       - ListBucketsOptions.toQueryParameters
       - BucketSortColumn
-      - BucketSortOrder
-      - BucketSortOrder.BucketSortOrder
-      - BucketSortOrder.value
   storage.file_buckets.update_bucket:
     status: implemented
     symbols:


### PR DESCRIPTION
## What

`StorageFileApi.list()` took its sort direction as a `String`:

```dart
SortBy(column: 'created_at', order: 'desc')
```

Nothing validated that string, so `order: 'ascending'` or `order: 'DESC'` compiled fine and only
surfaced as a 400 from the storage server.

While fixing that, the same asc/desc direction turned out to be modelled three times over:

| Enum | Package | Used by |
| --- | --- | --- |
| `BucketSortOrder` | `supabase_storage` | `ListBucketsOptions.sortOrder` |
| `FileSortOrder` | `supabase_storage` | `FileSort.order` (`listPaginated`) |
| `SortDirection` | `iceberg` | `SortField.direction` |

All three had identical `ascending('asc')` / `descending('desc')` values.

## Change

One `SortDirection` in `supabase_common`, re-exported from `iceberg` and `supabase_storage` (and so
from `supabase` and `supabase_flutter`):

```dart
enum SortDirection {
  ascending('asc'),
  descending('desc');

  const SortDirection(this.value);

  /// The value sent to and received from the API.
  final String value;

  static SortDirection fromValue(String value) =>
      values.firstWhere((direction) => direction.value == value);
}
```

`SortBy.order` is now that enum, non-nullable and defaulting to `SortDirection.ascending`:

```dart
const SortBy({
  this.column = 'name',
  this.order = SortDirection.ascending,
});
```

`column` stays a `String?` with its `'name'` default, since `list()` accepts any column of a
`FileObject` while `FileSortColumn` only covers the three the paginated endpoint sorts by.
supabase-swift made the same `SortBy` change in its storage v3 rewrite
(supabase/supabase-swift#987).

`SortDirection` is the name that survives rather than `SortOrder`, because `package:iceberg`
already has a public `SortOrder` class (the Iceberg spec's sort-order object, with `orderId` and
`fields`) that `supabase_storage` re-exports, so a `SortOrder` enum would make the name ambiguous
for consumers.

The wire format is untouched: every serializer still emits `asc` / `desc`.

## Breaking changes

- `BucketSortOrder` and `FileSortOrder` are gone; use `SortDirection`, whose values are identical
- `SortBy(order: 'desc')` becomes `SortBy(order: SortDirection.descending)`
- `SortBy(order: null)` no longer compiles; leave `order` out to sort ascending

`iceberg` callers are unaffected: `SortDirection` keeps its name and is still exported from
`package:iceberg/iceberg.dart`.

Documented in `MIGRATION.md`. The default-filling behavior from #1490 is preserved: a partial
`SortBy` still sends both keys, and `order` can no longer be null at all.

## Query ordering keeps its bool

`PostgrestTransformBuilder.order()` and `SupabaseStreamBuilder.order()` deliberately keep
`ascending: bool` rather than taking a `SortDirection`. They build the `asc` / `desc` string
internally, so there was never an invalid value a caller could pass, and the bool matches
supabase-js (`{ ascending: false }`) and supabase-swift, which keeps shared docs and cross-SDK
examples portable. v3 already changed that call once by flipping the `ascending` default, so an
enum would make users touch the same line twice for no safety gain.

## Compliance matrix

`BucketSortOrder` and `FileSortOrder` are removed from the storage features. `SortDirection` was
already registered in the shared `supporting_symbols` block for iceberg, which is the right home
for it now that no single capability owns it. `.sdk-parse-ignore` gains an exception for
`sort_direction.dart`, alongside the existing one for `retry_options.dart`, since both are
`supabase_common` sources the clients re-export as user facing API.

## Tests

- `SortBy.toMap` covers the null column fallback and the enum serialization
- The `list sortBy defaults` group passes the enum, and its explicit-null case narrowed to `column`
  since `order` cannot be null anymore

`dart test` passes for `supabase_storage` (203), `iceberg` (30) and `supabase_common` (109), and
`dart analyze` is clean across `packages` and `examples`.

Closes #1491
Closes SDK-1549
