### PR TITLE
feat(realtime): process frame JSON through the client codec

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -533,11 +533,12 @@ await Supabase.initialize(
 );
 ```
 
-`encode` and `decode` are now `null` unless you pass one; `RealtimeClient` uses the built-in codec
-for whichever of the two is `null`. That codec is synchronous, so a client that overrides neither
-still writes and dispatches without a microtask hop. Reading a custom codec back off the client
-changed accordingly; the built-in codec has no public accessor, so this only applies when you
-passed your own:
+`encode` and `decode` are now `null` unless you pass one. For whichever of the two is `null`,
+`RealtimeClient` hands the JSON to its `jsonCodec`, and falls back to the built-in codec when it
+has no codec either. That built-in codec is synchronous, so a client that overrides neither and is
+given no codec still writes and dispatches without a microtask hop. Reading a custom codec back off
+the client changed accordingly; neither the codec nor the built-in one has a public accessor here,
+so this only applies when you passed your own:
 
 ```dart
 // Before

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -493,15 +493,17 @@ call that never completes fails after `RealtimeClient.timeout` instead of stalli
 dispatch queued behind it:
 
 ```dart
-final isolate = YAJsonIsolate();
-
 final client = RealtimeClient(
   'wss://project.supabase.co/realtime/v1',
-  encode: (message) => isolate.encode(message.toJson()),
-  decode: (frame) async =>
-      RealtimeMessage.fromJson(await isolate.decode(frame as String)),
+  encode: (message) async => myFormat.serialize(message.toJson()),
+  decode: (frame) async => RealtimeMessage.fromJson(myFormat.deserialize(frame)),
 );
 ```
+
+Keeping the JSON off the calling isolate does not need these two, though. The
+`jsonCodec` of the client already handles the JSON of every frame, so reach for `encode` and
+`decode` only to put something other than the Realtime wire format on the socket. They take
+precedence over the codec, so a message either goes through them or through it.
 
 `RealtimeClient.onMessage` now emits `RealtimeMessage` instead of `Map<String, dynamic>`, so a
 listener that reads fields off the map needs to switch to properties:
@@ -523,11 +525,10 @@ on `Supabase.initialize` without constructing a `RealtimeClient` yourself:
 ```dart
 await Supabase.initialize(
   url: url,
-  anonKey: anonKey,
+  publishableKey: publishableKey,
   realtimeClientOptions: RealtimeClientOptions(
-    encode: (message) => isolate.encode(message.toJson()),
-    decode: (frame) async =>
-        RealtimeMessage.fromJson(await isolate.decode(frame as String)),
+    encode: (message) async => myFormat.serialize(message.toJson()),
+    decode: (frame) async => RealtimeMessage.fromJson(myFormat.deserialize(frame)),
   ),
 );
 ```
@@ -1629,6 +1630,10 @@ class TimedJsonCodec implements AsyncJsonCodec {
   Future<void> dispose() => _inner.dispose();
 }
 ```
+
+The realtime client uses the same codec for the JSON of its frames, so one codec covers
+every client. Its `RealtimeClientOptions.encode` and `decode` hooks stay for putting a
+different wire format on the socket, and take precedence over the codec.
 
 A codec passed to a client belongs to the caller, so `dispose()` leaves it alone, exactly
 as the old `isolate:` parameter did. A client that was not given one creates the default

--- a/packages/supabase/lib/src/realtime_client_options.dart
+++ b/packages/supabase/lib/src/realtime_client_options.dart
@@ -26,25 +26,29 @@ class RealtimeClientOptions {
   /// heartbeat interval.
   final Duration? disconnectOnEmptyChannelsAfter;
 
-  /// Serializes outgoing messages, for example on a background isolate so
-  /// that a large payload does not block the event loop.
+  /// Serializes outgoing messages into the frames written to the socket.
   ///
-  /// Defaults to the built-in synchronous codec.
+  /// The JSON of a frame already goes through the `jsonCodec` of
+  /// `SupabaseClient`, which keeps a large payload off the calling isolate, so
+  /// this is only needed to put something other than the Realtime wire format
+  /// on the socket, for example a different serialization format altogether.
   ///
   /// ```dart
-  /// final isolate = YAJsonIsolate();
-  ///
   /// RealtimeClientOptions(
-  ///   encode: (message) => isolate.encode(message.toJson()),
+  ///   encode: (message) async => myFormat.serialize(message.toJson()),
   ///   decode: (frame) async =>
-  ///       RealtimeMessage.fromJson(await isolate.decode(frame as String)),
+  ///       RealtimeMessage.fromJson(myFormat.deserialize(frame)),
   /// );
   /// ```
+  ///
+  /// Takes precedence over the codec, so a message passed here is not handed
+  /// to it.
   final RealtimeEncode? encode;
 
-  /// Deserializes incoming frames, for example on a background isolate.
+  /// Deserializes incoming frames into messages.
   ///
-  /// Defaults to the built-in synchronous codec. See [encode] for an example.
+  /// See [encode], which describes when to reach for this and what it takes
+  /// precedence over.
   final RealtimeDecode? decode;
 
   /// {@macro realtime_client_options}

--- a/packages/supabase/lib/src/supabase_client.dart
+++ b/packages/supabase/lib/src/supabase_client.dart
@@ -396,6 +396,7 @@ class SupabaseClient {
       disconnectOnEmptyChannelsAfter: options.disconnectOnEmptyChannelsAfter,
       encode: options.encode,
       decode: options.decode,
+      jsonCodec: _jsonCodec,
     );
   }
 

--- a/packages/supabase/test/client_test.dart
+++ b/packages/supabase/test/client_test.dart
@@ -541,6 +541,28 @@ void main() {
         },
       );
 
+      test('hands its codec to the realtime client', () async {
+        final jsonCodec = YAJsonIsolate();
+        final client = SupabaseClient(
+          supabaseUrl,
+          supabaseKey,
+          jsonCodec: jsonCodec,
+        );
+        addTearDown(jsonCodec.dispose);
+
+        expect(client.realtime.jsonCodec, same(jsonCodec));
+
+        await client.dispose();
+      });
+
+      test('gives the realtime client the codec it created for itself', () {
+        final client = SupabaseClient(supabaseUrl, supabaseKey);
+
+        expect(client.realtime.jsonCodec, isNotNull);
+
+        expect(client.dispose(), completes);
+      });
+
       test(
         'creates a single codec shared across rest and functions clients',
         () async {

--- a/packages/supabase_realtime/lib/src/realtime_client.dart
+++ b/packages/supabase_realtime/lib/src/realtime_client.dart
@@ -185,10 +185,24 @@ class RealtimeClient {
   /// [version].
   final RealtimeDecode? decode;
 
-  /// Codec used while [encode] and [decode] are `null`.
+  /// Encodes and decodes the JSON of the frames while [encode] and [decode]
+  /// are `null`, so that a large payload does not block the calling isolate.
   ///
-  /// It is synchronous, so a client that does not override the codec writes
-  /// and dispatches without a microtask hop.
+  /// `null` leaves the JSON to the synchronous built-in codec below.
+  /// `SupabaseClient` passes the codec it gives the rest and functions
+  /// clients, so one codec serves every client.
+  final AsyncJsonCodec? jsonCodec;
+
+  /// [jsonCodec] wired up as an [encode], or `null` when no codec was given.
+  final RealtimeEncode? _codecEncode;
+
+  /// [jsonCodec] wired up as a [decode], or `null` when no codec was given.
+  final RealtimeDecode? _codecDecode;
+
+  /// Codec used while [encode], [decode] and [jsonCodec] are all `null`.
+  ///
+  /// It is synchronous, so a client that overrides nothing writes and
+  /// dispatches without a microtask hop.
   final Object Function(RealtimeMessage) _builtInEncode;
   final RealtimeMessage Function(Object) _builtInDecode;
   late TimerCalculation reconnectAfter;
@@ -247,11 +261,16 @@ class RealtimeClient {
   /// reused. Pass [Duration.zero] to disconnect immediately. Defaults to twice
   /// the heartbeat interval.
   ///
-  /// [encode] Overrides how outgoing messages are serialized, for example to
-  /// serialize on a background isolate. Defaults to the codec for [version].
+  /// [encode] Overrides how outgoing messages are serialized, for example into
+  /// a format other than the Realtime wire format. Defaults to the codec for
+  /// [version].
   ///
   /// [decode] Overrides how incoming frames are deserialized. Defaults to the
   /// codec for [version].
+  ///
+  /// [jsonCodec] Encodes and decodes the JSON of the frames, so that a large
+  /// payload does not block the calling isolate. Ignored for a message that
+  /// [encode] or [decode] handles. Without it the JSON is processed inline.
   ///
   /// [reconnectAfter] The optional function that returns the reconnect
   /// interval. Defaults to the stepped backoff of
@@ -272,6 +291,7 @@ class RealtimeClient {
     Duration? disconnectOnEmptyChannelsAfter,
     this.encode,
     this.decode,
+    this.jsonCodec,
     TimerCalculation? reconnectAfter,
     Map<String, String>? headers,
     this.parameters = const {},
@@ -291,6 +311,8 @@ class RealtimeClient {
          ...?headers,
        },
        transport = transport ?? createWebSocketClient,
+       _codecEncode = _codecEncoder(jsonCodec, version),
+       _codecDecode = _codecDecoder(jsonCodec, version),
        _builtInEncode = version == RealtimeProtocolVersion.v1
            ? _encodeLegacy
            : _serializer.encode,
@@ -592,8 +614,8 @@ class RealtimeClient {
   /// encode never overtakes a slow one that was pushed before it.
   void _write(RealtimeMessage message) {
     final connection = this.connection;
-    final encode = this.encode;
-    if (encode == null) {
+    final effectiveEncode = encode ?? _codecEncode;
+    if (effectiveEncode == null) {
       Object frame;
       try {
         frame = _builtInEncode(message);
@@ -611,7 +633,7 @@ class RealtimeClient {
 
     final Future<Object> encoded;
     try {
-      encoded = encode(message).timeout(timeout);
+      encoded = effectiveEncode(message).timeout(timeout);
     } catch (error) {
       realtimeLogger.warning('Failed to encode message', error);
       return;
@@ -676,8 +698,8 @@ class RealtimeClient {
   /// fast decode never overtakes a slow one that was received before it.
   void onConnectionMessage(Object rawMessage) {
     final connection = this.connection;
-    final decode = this.decode;
-    if (decode == null) {
+    final effectiveDecode = decode ?? _codecDecode;
+    if (effectiveDecode == null) {
       final RealtimeMessage message;
       try {
         message = _builtInDecode(rawMessage);
@@ -695,7 +717,7 @@ class RealtimeClient {
 
     final Future<RealtimeMessage> decoded;
     try {
-      decoded = decode(rawMessage).timeout(timeout);
+      decoded = effectiveDecode(rawMessage).timeout(timeout);
     } catch (error) {
       realtimeLogger.warning('Failed to decode message', error);
       return;
@@ -784,6 +806,40 @@ class RealtimeClient {
           ),
         );
     _messageController.add(message);
+  }
+
+  /// Wires [codec] up as an [encode] for [version], or returns `null` when
+  /// there is no codec to wire up.
+  static RealtimeEncode? _codecEncoder(
+    AsyncJsonCodec? codec,
+    RealtimeProtocolVersion version,
+  ) {
+    if (codec == null) {
+      return null;
+    }
+    if (version == RealtimeProtocolVersion.v1) {
+      return (message) =>
+          codec.encode(message.toJson(RealtimeProtocolVersion.v1));
+    }
+    return (message) => _serializer.encodeWith(codec, message);
+  }
+
+  /// Wires [codec] up as a [decode] for [version], or returns `null` when
+  /// there is no codec to wire up.
+  static RealtimeDecode? _codecDecoder(
+    AsyncJsonCodec? codec,
+    RealtimeProtocolVersion version,
+  ) {
+    if (codec == null) {
+      return null;
+    }
+    if (version == RealtimeProtocolVersion.v1) {
+      return (frame) async => RealtimeMessage.fromJson(
+        await codec.decode(frame as String),
+        RealtimeProtocolVersion.v1,
+      );
+    }
+    return (frame) => _serializer.decodeWith(codec, frame);
   }
 
   static Object _encodeLegacy(RealtimeMessage message) =>

--- a/packages/supabase_realtime/lib/src/serializer.dart
+++ b/packages/supabase_realtime/lib/src/serializer.dart
@@ -3,6 +3,7 @@ import 'dart:typed_data';
 
 import 'package:meta/meta.dart';
 import 'package:supabase_realtime/src/realtime_message.dart';
+import 'package:yet_another_json_isolate/yet_another_json_isolate.dart';
 
 /// Encodes and decodes Realtime protocol `2.0.0` frames.
 ///
@@ -54,6 +55,44 @@ class Serializer {
     }
 
     return jsonEncode(message.toJson());
+  }
+
+  /// Encodes [message] like [encode], handing the JSON work to [codec] so that
+  /// a large payload does not block the calling isolate.
+  ///
+  /// A binary broadcast carries its user payload as raw bytes and its metadata
+  /// in the frame header, so that path holds no JSON body worth handing over
+  /// and is built here as [encode] builds it.
+  Future<Object> encodeWith(
+    AsyncJsonCodec codec,
+    RealtimeMessage message,
+  ) async {
+    final payload = message.payload;
+    if (message.event == broadcastEvent &&
+        payload is Map &&
+        payload['event'] is String &&
+        _isBinary(payload['payload'])) {
+      return _encodeBinaryUserBroadcastPush(message, payload);
+    }
+
+    return codec.encode(message.toJson());
+  }
+
+  /// Decodes a raw WebSocket frame like [decode], handing the JSON work of a
+  /// text frame to [codec].
+  ///
+  /// Binary frames are decoded here as [decode] decodes them: their payload is
+  /// either raw bytes or a body small enough that the frame header could carry
+  /// its size, so there is nothing worth an isolate.
+  Future<RealtimeMessage> decodeWith(
+    AsyncJsonCodec codec,
+    Object rawPayload,
+  ) async {
+    if (rawPayload is String) {
+      return RealtimeMessage.fromJson(await codec.decode(rawPayload));
+    }
+
+    return decode(rawPayload);
   }
 
   /// Decodes a raw WebSocket frame into a message.

--- a/packages/supabase_realtime/lib/supabase_realtime.dart
+++ b/packages/supabase_realtime/lib/supabase_realtime.dart
@@ -2,6 +2,9 @@
 /// changes, broadcast messages, and presence over a websocket connection.
 library;
 
+export 'package:yet_another_json_isolate/yet_another_json_isolate.dart'
+    show AsyncJsonCodec;
+
 export 'src/constants.dart'
     show RealtimeLogLevel, RealtimeProtocolVersion, SocketState;
 export 'src/realtime_channel.dart';

--- a/packages/supabase_realtime/pubspec.yaml
+++ b/packages/supabase_realtime/pubspec.yaml
@@ -24,6 +24,7 @@ dependencies:
   meta: ^1.16.0
   supabase_common: 0.1.2
   web_socket_channel: ^3.0.3
+  yet_another_json_isolate: 2.1.1
 
 dev_dependencies:
   supabase_lints: ^0.1.1

--- a/packages/supabase_realtime/test/json_codec_test.dart
+++ b/packages/supabase_realtime/test/json_codec_test.dart
@@ -1,0 +1,240 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:mocktail/mocktail.dart';
+import 'package:supabase_realtime/supabase_realtime.dart';
+import 'package:test/test.dart';
+
+import 'socket_test_stubs.dart';
+
+void main() {
+  const socketEndpoint = 'wss://localhost:0/';
+
+  late MockIOWebSocketChannel mockedChannel;
+  late MockWebSocketSink mockedSink;
+  late List<Object?> written;
+
+  setUp(() {
+    mockedChannel = MockIOWebSocketChannel();
+    mockedSink = MockWebSocketSink();
+    written = [];
+
+    when(() => mockedChannel.sink).thenReturn(mockedSink);
+    when(() => mockedChannel.ready).thenAnswer((_) => Future.value());
+    when(() => mockedSink.close()).thenAnswer((_) => Future.value());
+    when(() => mockedSink.add(any())).thenAnswer((invocation) {
+      written.add(invocation.positionalArguments.first);
+    });
+  });
+
+  RealtimeClient createClient({
+    AsyncJsonCodec? jsonCodec,
+    RealtimeEncode? encode,
+    RealtimeDecode? decode,
+    RealtimeProtocolVersion version = RealtimeProtocolVersion.v2,
+  }) {
+    final client = RealtimeClient(
+      socketEndpoint,
+      transport: (url, headers) => mockedChannel,
+      jsonCodec: jsonCodec,
+      encode: encode,
+      decode: decode,
+      version: version,
+    );
+    unawaited(client.connect());
+    client.connectionState = SocketState.open;
+    return client;
+  }
+
+  RealtimeMessage messageWithRef(String ref) => RealtimeMessage(
+    topic: 'realtime:room',
+    event: 'broadcast',
+    payload: const {'type': 'broadcast', 'event': 'cursor'},
+    ref: ref,
+  );
+
+  String frameWithRef(String ref) => jsonEncode([
+    null,
+    ref,
+    'realtime:room',
+    'broadcast',
+    const {'type': 'broadcast', 'event': 'cursor'},
+  ]);
+
+  group('outgoing frames', () {
+    test('are encoded by the codec', () async {
+      final jsonCodec = _RecordingJsonCodec();
+      final client = createClient(jsonCodec: jsonCodec);
+
+      client.push(messageWithRef('1'));
+      await pumpEventQueue();
+
+      expect(written, [jsonEncode(messageWithRef('1').toJson())]);
+      expect(jsonCodec.encoded, hasLength(1));
+    });
+
+    test('are encoded by the codec on the legacy protocol', () async {
+      final jsonCodec = _RecordingJsonCodec();
+      final client = createClient(
+        jsonCodec: jsonCodec,
+        version: RealtimeProtocolVersion.v1,
+      );
+
+      client.push(messageWithRef('1'));
+      await pumpEventQueue();
+
+      expect(written, [
+        jsonEncode(messageWithRef('1').toJson(RealtimeProtocolVersion.v1)),
+      ]);
+      expect(jsonCodec.encoded, hasLength(1));
+    });
+
+    test('bypass the codec for a binary broadcast', () async {
+      final jsonCodec = _RecordingJsonCodec();
+      final client = createClient(jsonCodec: jsonCodec);
+
+      client.push(
+        RealtimeMessage(
+          topic: 'realtime:room',
+          event: 'broadcast',
+          payload: {
+            'type': 'broadcast',
+            'event': 'cursor',
+            'payload': Uint8List.fromList([1, 2, 3]),
+          },
+          ref: '1',
+        ),
+      );
+      await pumpEventQueue();
+
+      expect(written.single, isA<Uint8List>());
+      expect(jsonCodec.encoded, isEmpty);
+    });
+
+    test('use a custom encode over the codec', () async {
+      final jsonCodec = _RecordingJsonCodec();
+      final client = createClient(
+        jsonCodec: jsonCodec,
+        encode: (message) async => 'custom-${message.ref}',
+      );
+
+      client.push(messageWithRef('1'));
+      await pumpEventQueue();
+
+      expect(written, ['custom-1']);
+      expect(jsonCodec.encoded, isEmpty);
+    });
+  });
+
+  group('incoming frames', () {
+    test('are decoded by the codec', () async {
+      final jsonCodec = _RecordingJsonCodec();
+      final client = createClient(jsonCodec: jsonCodec);
+      final received = <String?>[];
+      client.onMessage.listen((message) => received.add(message.ref));
+
+      client.onConnectionMessage(frameWithRef('1'));
+      await pumpEventQueue();
+
+      expect(received, ['1']);
+      expect(jsonCodec.decoded, [frameWithRef('1')]);
+    });
+
+    test('are dispatched in arrival order', () async {
+      final jsonCodec = _GatedJsonCodec();
+      final client = createClient(jsonCodec: jsonCodec);
+      final received = <String?>[];
+      client.onMessage.listen((message) => received.add(message.ref));
+
+      client.onConnectionMessage(frameWithRef('1'));
+      client.onConnectionMessage(frameWithRef('2'));
+      await pumpEventQueue();
+
+      jsonCodec.completeDecode(frameWithRef('2'));
+      await pumpEventQueue();
+
+      expect(received, isEmpty);
+
+      jsonCodec.completeDecode(frameWithRef('1'));
+      await pumpEventQueue();
+
+      expect(received, ['1', '2']);
+    });
+
+    test('use a custom decode over the codec', () async {
+      final jsonCodec = _RecordingJsonCodec();
+      final client = createClient(
+        jsonCodec: jsonCodec,
+        decode: (frame) async => messageWithRef('custom'),
+      );
+      final received = <String?>[];
+      client.onMessage.listen((message) => received.add(message.ref));
+
+      client.onConnectionMessage(frameWithRef('1'));
+      await pumpEventQueue();
+
+      expect(received, ['custom']);
+      expect(jsonCodec.decoded, isEmpty);
+    });
+  });
+
+  test('without a codec the built-in one writes without a microtask hop', () {
+    final client = createClient();
+
+    client.push(messageWithRef('1'));
+
+    expect(written, hasLength(1));
+  });
+}
+
+/// An [AsyncJsonCodec] that works inline and records what it processed.
+class _RecordingJsonCodec implements AsyncJsonCodec {
+  final List<Object?> encoded = [];
+  final List<String> decoded = [];
+
+  @override
+  Future<dynamic> decode(String json) async {
+    decoded.add(json);
+    return jsonDecode(json);
+  }
+
+  @override
+  Future<dynamic> decodeBytes(Uint8List encodedJson) =>
+      decode(utf8.decode(encodedJson));
+
+  @override
+  Future<String> encode(Object? json) async {
+    encoded.add(json);
+    return jsonEncode(json);
+  }
+
+  @override
+  Future<void> dispose() async {}
+}
+
+/// An [AsyncJsonCodec] whose decodes complete only when the test says so, so
+/// that frames can be completed out of the order they arrived in.
+class _GatedJsonCodec implements AsyncJsonCodec {
+  final Map<String, Completer<dynamic>> _gates = {};
+
+  void completeDecode(String json) {
+    _gate(json).complete(jsonDecode(json));
+  }
+
+  Completer<dynamic> _gate(String json) =>
+      _gates.putIfAbsent(json, Completer<dynamic>.new);
+
+  @override
+  Future<dynamic> decode(String json) => _gate(json).future;
+
+  @override
+  Future<dynamic> decodeBytes(Uint8List encodedJson) =>
+      decode(utf8.decode(encodedJson));
+
+  @override
+  Future<String> encode(Object? json) async => jsonEncode(json);
+
+  @override
+  Future<void> dispose() async {}
+}

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -1936,6 +1936,7 @@ features:
     symbols:
       - RealtimeClient.encode
       - RealtimeClient.decode
+      - RealtimeClient.jsonCodec
       - RealtimeClientOptions.encode
       - RealtimeClientOptions.decode
     supporting_symbols:


### PR DESCRIPTION
Stacked on #1751. Review that one first; this diff is only the realtime part.

#1684 gave realtime asynchronous codec hooks, and #1751 gave the rest and
functions clients an `AsyncJsonCodec`. That left two mechanisms for the same
concern and made the common case (keep large JSON off the calling isolate) the
caller's job for realtime only, through `message.toJson()` and
`RealtimeMessage.fromJson` glue written by hand.

`RealtimeClient` now takes an `AsyncJsonCodec` too, and `SupabaseClient` hands it
the codec it already gives postgrest and functions. So one `jsonCodec:` on
`Supabase.initialize` covers all three clients, and `RealtimeClientOptions.encode`
and `decode` go back to being what their name suggests: hooks for putting a
different wire format on the socket.

### Changes

- `supabase_realtime`: `RealtimeClient(jsonCodec:)`, plus `Serializer.encodeWith`
  and `decodeWith`, which hand the JSON of a frame to the codec. The package
  exports `AsyncJsonCodec` so the parameter is reachable.
- `supabase`: `SupabaseClient` passes its codec to the realtime client.
- Precedence is unchanged and explicit: a custom `encode` or `decode` wins, then
  the codec, then the synchronous built-in codec.
- `MIGRATION.md`: the #1684 entry no longer teaches the isolate glue, since
  `jsonCodec` covers it. Its `Supabase.initialize` snippet also said
  `anonKey:`, which v3 removed, so that is now `publishableKey:`.
- `sdk-compliance.yaml`: `RealtimeClient.jsonCodec` registered.

### What stays on the synchronous path

- **A client with no codec.** `RealtimeClient` built by hand without a
  `jsonCodec` behaves exactly as before, so the existing "the built-in codec
  writes without a microtask hop" test still passes unchanged.
- **Binary broadcast frames.** They carry raw bytes and header metadata rather
  than a JSON body, which is the whole point of that frame kind, so they are
  built and parsed as before and never reach the codec. There is a test.

### The trade-off worth arguing about

For a client that does have a codec, every frame now costs one microtask hop and
goes through the `_pendingWrite` and `_pendingDispatch` chains, where the
built-in codec used to write and dispatch synchronously. That is deliberate but
it is the reverse of the note in `realtime_client.dart` that the built-in codec
exists to avoid the hop.

Payload size does not change it: the default codec processes anything under
64 KB inline, so an ordinary frame pays a microtask, not an isolate. Ordering is
unaffected, since the async path is the one #1684 built the chains for, and there
is a test that two frames completing out of order still dispatch in arrival
order.

The alternative is a size-gated hybrid: keep the synchronous path for small
frames and hand only large ones to the codec. It preserves the hop-free hot path
but needs the sync path to chain behind anything already pending, or a small
frame overtakes a large one. Happy to build that instead if the microtask matters
more than the simpler control flow.

### Verification

`dart analyze packages/` clean, `dart format` clean, `dcm analyze packages`
clean. `supabase_realtime` 253 tests (8 new), `supabase` 149 (2 new),
`supabase_flutter` 79, all passing.

New tests: outgoing frames encoded through the codec on both protocol versions,
binary broadcasts bypassing it, incoming frames decoded through it, arrival order
preserved when decodes complete out of order, custom `encode`/`decode` taking
precedence, and `SupabaseClient` handing its codec to the realtime client.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for asynchronous JSON codecs in Realtime communication.
  * Exposed `AsyncJsonCodec` for custom serialization and deserialization.
  * Custom encoding and decoding callbacks now support asynchronous processing.
  * Shared JSON codecs are used for Realtime frames, while custom callbacks take precedence.
* **Documentation**
  * Updated migration and API guidance with asynchronous codec configuration examples.
* **Bug Fixes**
  * Improved handling and ordering of asynchronously decoded incoming messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->