### PR TITLE
chore: publish packages as 3.0.0-dev.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,201 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 2026-08-21
+
+### Changes
+
+---
+
+Packages with breaking changes:
+
+ - [`supabase_common` - `v3.0.0-dev.1`](#supabase_common---v300-dev1)
+ - [`postgrest` - `v3.0.0-dev.1`](#postgrest---v300-dev1)
+ - [`supabase_auth` - `v3.0.0-dev.1`](#supabase_auth---v300-dev1)
+ - [`supabase_functions` - `v3.0.0-dev.1`](#supabase_functions---v300-dev1)
+ - [`supabase_realtime` - `v3.0.0-dev.1`](#supabase_realtime---v300-dev1)
+ - [`supabase_storage` - `v3.0.0-dev.1`](#supabase_storage---v300-dev1)
+ - [`supabase` - `v3.0.0-dev.1`](#supabase---v300-dev1)
+ - [`supabase_flutter` - `v3.0.0-dev.1`](#supabase_flutter---v300-dev1)
+
+Packages with other changes:
+
+ - [`iceberg` - `v0.1.0`](#iceberg---v010)
+
+---
+
+#### `supabase_common` - `v3.0.0-dev.1`
+
+ - **REFACTOR**: share the test helpers through supabase_common ([#1745](https://github.com/supabase/supabase-flutter/issues/1745)). ([bcb41fa4](https://github.com/supabase/supabase-flutter/commit/bcb41fa4d9ef840c0380e641d3e45968084090c8))
+ - **REFACTOR**: share the auth callback parameters and secure random helpers ([#1744](https://github.com/supabase/supabase-flutter/issues/1744)). ([66ac4901](https://github.com/supabase/supabase-flutter/commit/66ac4901c684b83faae96e13ac560d7efdac158e))
+ - **REFACTOR**: share the HTTP request pieces between the fetch layers ([#1647](https://github.com/supabase/supabase-flutter/issues/1647)). ([a2a9eeaa](https://github.com/supabase/supabase-flutter/commit/a2a9eeaac4f8cc5d98199945283245b697e07a19))
+ - **FIX**(supabase_lints): enable lines_longer_than_80_chars and fix all violations ([#1655](https://github.com/supabase/supabase-flutter/issues/1655)). ([a08b6577](https://github.com/supabase/supabase-flutter/commit/a08b6577d002d0c7ae0d484ddd6da802922be37b))
+ - **FIX**(supabase_common): accept uppercase and mixed-case UUIDs in validation ([#1656](https://github.com/supabase/supabase-flutter/issues/1656)). ([691690cf](https://github.com/supabase/supabase-flutter/commit/691690cfc748456794216028e92dd7075c263055))
+ - **FEAT**: introduce the supabase_testing package ([#1747](https://github.com/supabase/supabase-flutter/issues/1747)). ([5a3aa9b4](https://github.com/supabase/supabase-flutter/commit/5a3aa9b4265385e3d747ca70ad499102fa388ee9))
+ - **FEAT**: resolve an access token per request on the standalone clients ([#1742](https://github.com/supabase/supabase-flutter/issues/1742)). ([dd61782a](https://github.com/supabase/supabase-flutter/commit/dd61782a35f1a99af95f5457b5a3393b3d7939b9))
+ - **FEAT**(storage): expose the service error code on StorageException ([#1657](https://github.com/supabase/supabase-flutter/issues/1657)). ([4f9cabfe](https://github.com/supabase/supabase-flutter/commit/4f9cabfe94bec8800721f1153ed6c40f659157ec))
+ - **DOCS**: fix inaccurate dartdoc comments across all packages ([#1659](https://github.com/supabase/supabase-flutter/issues/1659)). ([090ee978](https://github.com/supabase/supabase-flutter/commit/090ee9781ccdc7a749902830697d51251aa9f052))
+ - **BREAKING** **REFACTOR**(storage): share one SortDirection enum across the packages ([#1752](https://github.com/supabase/supabase-flutter/issues/1752)). ([38396ed5](https://github.com/supabase/supabase-flutter/commit/38396ed5a40d04f24096a816bfead0d57f440394))
+ - **BREAKING** **REFACTOR**: rework logging to emit only through the supabase logger hierarchy ([#1741](https://github.com/supabase/supabase-flutter/issues/1741)). ([d1642c80](https://github.com/supabase/supabase-flutter/commit/d1642c80c60d93cf3bf7919b0cef775470275ed9))
+ - **BREAKING** **REFACTOR**: share one retry configuration across the clients ([#1738](https://github.com/supabase/supabase-flutter/issues/1738)). ([3b2a4855](https://github.com/supabase/supabase-flutter/commit/3b2a4855a5d2e83af17d3cd280189c6a89170741))
+ - **BREAKING** **REFACTOR**: spell out abbreviations in the public API ([#1712](https://github.com/supabase/supabase-flutter/issues/1712)). ([29286f43](https://github.com/supabase/supabase-flutter/commit/29286f4309a74da769ed7aad569daacba6dee7ae))
+ - **BREAKING** **REFACTOR**: share one exponential backoff calculation ([#1646](https://github.com/supabase/supabase-flutter/issues/1646)). ([8bc93f5d](https://github.com/supabase/supabase-flutter/commit/8bc93f5d8ccd72351dc1789e30a4aa9c8e8de1fa))
+ - **BREAKING** **REFACTOR**: split every service exception into a client and an api base ([#1644](https://github.com/supabase/supabase-flutter/issues/1644)). ([0202c332](https://github.com/supabase/supabase-flutter/commit/0202c33249828dc96a778af5fd72520ca5234a46))
+ - **BREAKING** **REFACTOR**: share a single HttpMethod enum across the packages ([#1678](https://github.com/supabase/supabase-flutter/issues/1678)). ([23d55c37](https://github.com/supabase/supabase-flutter/commit/23d55c376fe8e2aa0ff4083f2ff39488fe827979))
+ - **BREAKING** **FIX**(supabase_flutter): persist the session with SharedPreferencesAsync ([#1680](https://github.com/supabase/supabase-flutter/issues/1680)). ([41500b73](https://github.com/supabase/supabase-flutter/commit/41500b73e207cc812c2d42e4e4f4a79127e0502b))
+ - **BREAKING** **FEAT**: rename the storage_client package to supabase_storage ([#1715](https://github.com/supabase/supabase-flutter/issues/1715)). ([6b0388f2](https://github.com/supabase/supabase-flutter/commit/6b0388f209c87dc57ee7281d211fff241e13ec6a))
+ - **BREAKING** **FEAT**: rename the realtime_client package to supabase_realtime ([#1714](https://github.com/supabase/supabase-flutter/issues/1714)). ([d37bed56](https://github.com/supabase/supabase-flutter/commit/d37bed567711c8ed68590a002bb3f1a45432abcb))
+ - **BREAKING** **FEAT**: rename the functions_client package to supabase_functions ([#1713](https://github.com/supabase/supabase-flutter/issues/1713)). ([eb4f3773](https://github.com/supabase/supabase-flutter/commit/eb4f3773e74dd62be5a768433d0a2497d643f110))
+ - **BREAKING** **FEAT**: rename the gotrue package to supabase_auth ([#1697](https://github.com/supabase/supabase-flutter/issues/1697)). ([563b502e](https://github.com/supabase/supabase-flutter/commit/563b502ee64d161defddeceaaacc43615f39b75c))
+ - **BREAKING** **FEAT**: use DateTime for all timestamp fields ([#1663](https://github.com/supabase/supabase-flutter/issues/1663)). ([bad3af8f](https://github.com/supabase/supabase-flutter/commit/bad3af8f88735caac5334b6d0a6e21fa02a220fb))
+
+#### `postgrest` - `v3.0.0-dev.1`
+
+ - **REFACTOR**: share the test helpers through supabase_common ([#1745](https://github.com/supabase/supabase-flutter/issues/1745)). ([bcb41fa4](https://github.com/supabase/supabase-flutter/commit/bcb41fa4d9ef840c0380e641d3e45968084090c8))
+ - **REFACTOR**: share the auth callback parameters and secure random helpers ([#1744](https://github.com/supabase/supabase-flutter/issues/1744)). ([66ac4901](https://github.com/supabase/supabase-flutter/commit/66ac4901c684b83faae96e13ac560d7efdac158e))
+ - **REFACTOR**: share the HTTP request pieces between the fetch layers ([#1647](https://github.com/supabase/supabase-flutter/issues/1647)). ([a2a9eeaa](https://github.com/supabase/supabase-flutter/commit/a2a9eeaac4f8cc5d98199945283245b697e07a19))
+ - **PERF**(yet_another_json_isolate): process small payloads inline and large ones on short-lived isolates ([#1746](https://github.com/supabase/supabase-flutter/issues/1746)). ([7942c377](https://github.com/supabase/supabase-flutter/commit/7942c37770c5a12b18b27afc66b8595e67fdd22d))
+ - **FIX**(supabase_lints): enable lines_longer_than_80_chars and fix all violations ([#1655](https://github.com/supabase/supabase-flutter/issues/1655)). ([a08b6577](https://github.com/supabase/supabase-flutter/commit/a08b6577d002d0c7ae0d484ddd6da802922be37b))
+ - **FEAT**: introduce the supabase_testing package ([#1747](https://github.com/supabase/supabase-flutter/issues/1747)). ([5a3aa9b4](https://github.com/supabase/supabase-flutter/commit/5a3aa9b4265385e3d747ca70ad499102fa388ee9))
+ - **FEAT**: resolve an access token per request on the standalone clients ([#1742](https://github.com/supabase/supabase-flutter/issues/1742)). ([dd61782a](https://github.com/supabase/supabase-flutter/commit/dd61782a35f1a99af95f5457b5a3393b3d7939b9))
+ - **DOCS**: fix inaccurate dartdoc comments across all packages ([#1659](https://github.com/supabase/supabase-flutter/issues/1659)). ([090ee978](https://github.com/supabase/supabase-flutter/commit/090ee9781ccdc7a749902830697d51251aa9f052))
+ - **BREAKING** **REFACTOR**: process JSON through the AsyncJsonCodec interface ([#1751](https://github.com/supabase/supabase-flutter/issues/1751)). ([6969eb38](https://github.com/supabase/supabase-flutter/commit/6969eb3805cc1920f5a44902ae2ce660170c13b3))
+ - **BREAKING** **REFACTOR**(postgrest): make the rest client and builders stateless ([#1748](https://github.com/supabase/supabase-flutter/issues/1748)). ([4efb8ce4](https://github.com/supabase/supabase-flutter/commit/4efb8ce4fcff225d7b601af1a5b351da530cb34d))
+ - **BREAKING** **REFACTOR**: rework logging to emit only through the supabase logger hierarchy ([#1741](https://github.com/supabase/supabase-flutter/issues/1741)). ([d1642c80](https://github.com/supabase/supabase-flutter/commit/d1642c80c60d93cf3bf7919b0cef775470275ed9))
+ - **BREAKING** **REFACTOR**: remove the dead setAccessToken mutators ([#1739](https://github.com/supabase/supabase-flutter/issues/1739)). ([ced47232](https://github.com/supabase/supabase-flutter/commit/ced47232edead42ce57d27b76227723817ef2367))
+ - **BREAKING** **REFACTOR**: share one retry configuration across the clients ([#1738](https://github.com/supabase/supabase-flutter/issues/1738)). ([3b2a4855](https://github.com/supabase/supabase-flutter/commit/3b2a4855a5d2e83af17d3cd280189c6a89170741))
+ - **BREAKING** **REFACTOR**(postgrest): fix the retried status codes to 503 and 520 ([#1737](https://github.com/supabase/supabase-flutter/issues/1737)). ([17487ff5](https://github.com/supabase/supabase-flutter/commit/17487ff5ecc4ca5df74f08d48cdb0bfac767fe8f))
+ - **BREAKING** **REFACTOR**(postgrest): expose retry configuration as PostgrestRetryOptions ([#1731](https://github.com/supabase/supabase-flutter/issues/1731)). ([7c0cfe53](https://github.com/supabase/supabase-flutter/commit/7c0cfe53ca9366f703d52dd4a78105475439e4b8))
+ - **BREAKING** **REFACTOR**: spell out abbreviations in the public API ([#1712](https://github.com/supabase/supabase-flutter/issues/1712)). ([29286f43](https://github.com/supabase/supabase-flutter/commit/29286f4309a74da769ed7aad569daacba6dee7ae))
+ - **BREAKING** **REFACTOR**: share one exponential backoff calculation ([#1646](https://github.com/supabase/supabase-flutter/issues/1646)). ([8bc93f5d](https://github.com/supabase/supabase-flutter/commit/8bc93f5d8ccd72351dc1789e30a4aa9c8e8de1fa))
+ - **BREAKING** **REFACTOR**: split every service exception into a client and an api base ([#1644](https://github.com/supabase/supabase-flutter/issues/1644)). ([0202c332](https://github.com/supabase/supabase-flutter/commit/0202c33249828dc96a778af5fd72520ca5234a46))
+ - **BREAKING** **REFACTOR**: share a single HttpMethod enum across the packages ([#1678](https://github.com/supabase/supabase-flutter/issues/1678)). ([23d55c37](https://github.com/supabase/supabase-flutter/commit/23d55c376fe8e2aa0ff4083f2ff39488fe827979))
+ - **BREAKING** **REFACTOR**: remove analyzer ignores by fixing the underlying code ([#1675](https://github.com/supabase/supabase-flutter/issues/1675)). ([9f367d77](https://github.com/supabase/supabase-flutter/commit/9f367d77f8f1e1723a985885db0de45123dce6f4))
+ - **BREAKING** **REFACTOR**: remove all deprecated APIs and dead public surface for v3 ([#1661](https://github.com/supabase/supabase-flutter/issues/1661)). ([1ffa0deb](https://github.com/supabase/supabase-flutter/commit/1ffa0deba0371585c7a4ac93795cf199a58e2353))
+ - **BREAKING** **FIX**: make order() default to ascending ([#1658](https://github.com/supabase/supabase-flutter/issues/1658)). ([e06f2302](https://github.com/supabase/supabase-flutter/commit/e06f23025949dc2e8b1d4b3528619181ef8edde0))
+
+#### `supabase_auth` - `v3.0.0-dev.1`
+
+ - **REFACTOR**: share the test helpers through supabase_common ([#1745](https://github.com/supabase/supabase-flutter/issues/1745)). ([bcb41fa4](https://github.com/supabase/supabase-flutter/commit/bcb41fa4d9ef840c0380e641d3e45968084090c8))
+ - **REFACTOR**: share the auth callback parameters and secure random helpers ([#1744](https://github.com/supabase/supabase-flutter/issues/1744)). ([66ac4901](https://github.com/supabase/supabase-flutter/commit/66ac4901c684b83faae96e13ac560d7efdac158e))
+ - **FIX**(auth): fail with an AuthException when a redirect response has no url ([#1728](https://github.com/supabase/supabase-flutter/issues/1728)). ([1a4801f2](https://github.com/supabase/supabase-flutter/commit/1a4801f2d6a5c2d3e80ad590e5dac7589d4db57f))
+ - **FIX**(auth): parse expires_in as num in Session.fromJson ([#1716](https://github.com/supabase/supabase-flutter/issues/1716)). ([a0be8277](https://github.com/supabase/supabase-flutter/commit/a0be82772523d1906cfceb34a5392b77d29ae17e))
+ - **FEAT**: introduce the supabase_testing package ([#1747](https://github.com/supabase/supabase-flutter/issues/1747)). ([5a3aa9b4](https://github.com/supabase/supabase-flutter/commit/5a3aa9b4265385e3d747ca70ad499102fa388ee9))
+ - **FEAT**(auth): store PKCE verifiers per flow to survive overlapping flows ([#1662](https://github.com/supabase/supabase-flutter/issues/1662)). ([61bbbc5e](https://github.com/supabase/supabase-flutter/commit/61bbbc5e2fbd0e01a1efbcd4d0257286a6060934))
+ - **BREAKING** **REFACTOR**: rework logging to emit only through the supabase logger hierarchy ([#1741](https://github.com/supabase/supabase-flutter/issues/1741)). ([d1642c80](https://github.com/supabase/supabase-flutter/commit/d1642c80c60d93cf3bf7919b0cef775470275ed9))
+ - **BREAKING** **REFACTOR**: share one retry configuration across the clients ([#1738](https://github.com/supabase/supabase-flutter/issues/1738)). ([3b2a4855](https://github.com/supabase/supabase-flutter/commit/3b2a4855a5d2e83af17d3cd280189c6a89170741))
+ - **BREAKING** **REFACTOR**(postgrest): expose retry configuration as PostgrestRetryOptions ([#1731](https://github.com/supabase/supabase-flutter/issues/1731)). ([7c0cfe53](https://github.com/supabase/supabase-flutter/commit/7c0cfe53ca9366f703d52dd4a78105475439e4b8))
+ - **BREAKING** **REFACTOR**(auth): return a Uri from OAuthResponse.url instead of a String ([#1729](https://github.com/supabase/supabase-flutter/issues/1729)). ([c8a66f10](https://github.com/supabase/supabase-flutter/commit/c8a66f100c9e1e1c899829cddc63aa7f1d230e93))
+ - **BREAKING** **REFACTOR**: spell out abbreviations in the public API ([#1712](https://github.com/supabase/supabase-flutter/issues/1712)). ([29286f43](https://github.com/supabase/supabase-flutter/commit/29286f4309a74da769ed7aad569daacba6dee7ae))
+ - **BREAKING** **FIX**(gotrue): assert asyncStorage is provided for PKCE flow in the constructor ([#1489](https://github.com/supabase/supabase-flutter/issues/1489)). ([30729cc9](https://github.com/supabase/supabase-flutter/commit/30729cc9edcc3366504382dc5d7ba2dbe1e43251))
+ - **BREAKING** **FIX**(auth): return Uri from getSSOSignInUrl instead of String ([#1722](https://github.com/supabase/supabase-flutter/issues/1722)). ([9aa2e767](https://github.com/supabase/supabase-flutter/commit/9aa2e76788f74b7a890c9a0e2f45e3f4ca44424b))
+ - **BREAKING** **FEAT**: rename the gotrue package to supabase_auth ([#1697](https://github.com/supabase/supabase-flutter/issues/1697)). ([563b502e](https://github.com/supabase/supabase-flutter/commit/563b502ee64d161defddeceaaacc43615f39b75c))
+ - **BREAKING** **CHORE**: give each package's Constants class a package-specific name ([#1677](https://github.com/supabase/supabase-flutter/issues/1677)). ([40f6d89c](https://github.com/supabase/supabase-flutter/commit/40f6d89c7fad32e49f028b2644914807fd731b70))
+
+#### `supabase_functions` - `v3.0.0-dev.1`
+
+ - **REFACTOR**: share the test helpers through supabase_common ([#1745](https://github.com/supabase/supabase-flutter/issues/1745)). ([bcb41fa4](https://github.com/supabase/supabase-flutter/commit/bcb41fa4d9ef840c0380e641d3e45968084090c8))
+ - **PERF**(yet_another_json_isolate): process small payloads inline and large ones on short-lived isolates ([#1746](https://github.com/supabase/supabase-flutter/issues/1746)). ([7942c377](https://github.com/supabase/supabase-flutter/commit/7942c37770c5a12b18b27afc66b8595e67fdd22d))
+ - **FEAT**: introduce the supabase_testing package ([#1747](https://github.com/supabase/supabase-flutter/issues/1747)). ([5a3aa9b4](https://github.com/supabase/supabase-flutter/commit/5a3aa9b4265385e3d747ca70ad499102fa388ee9))
+ - **FEAT**: resolve an access token per request on the standalone clients ([#1742](https://github.com/supabase/supabase-flutter/issues/1742)). ([dd61782a](https://github.com/supabase/supabase-flutter/commit/dd61782a35f1a99af95f5457b5a3393b3d7939b9))
+ - **BREAKING** **REFACTOR**: process JSON through the AsyncJsonCodec interface ([#1751](https://github.com/supabase/supabase-flutter/issues/1751)). ([6969eb38](https://github.com/supabase/supabase-flutter/commit/6969eb3805cc1920f5a44902ae2ce660170c13b3))
+ - **BREAKING** **REFACTOR**: rework logging to emit only through the supabase logger hierarchy ([#1741](https://github.com/supabase/supabase-flutter/issues/1741)). ([d1642c80](https://github.com/supabase/supabase-flutter/commit/d1642c80c60d93cf3bf7919b0cef775470275ed9))
+ - **BREAKING** **REFACTOR**: remove the dead setAccessToken mutators ([#1739](https://github.com/supabase/supabase-flutter/issues/1739)). ([ced47232](https://github.com/supabase/supabase-flutter/commit/ced47232edead42ce57d27b76227723817ef2367))
+ - **BREAKING** **FEAT**(functions): make FunctionException a sealed class ([#1723](https://github.com/supabase/supabase-flutter/issues/1723)). ([cb128aaa](https://github.com/supabase/supabase-flutter/commit/cb128aaa2885397fa13c94dbac60a1bc6a3a8de4))
+ - **BREAKING** **FEAT**: rename the functions_client package to supabase_functions ([#1713](https://github.com/supabase/supabase-flutter/issues/1713)). ([eb4f3773](https://github.com/supabase/supabase-flutter/commit/eb4f3773e74dd62be5a768433d0a2497d643f110))
+ - **BREAKING** **CHORE**: give each package's Constants class a package-specific name ([#1677](https://github.com/supabase/supabase-flutter/issues/1677)). ([40f6d89c](https://github.com/supabase/supabase-flutter/commit/40f6d89c7fad32e49f028b2644914807fd731b70))
+
+#### `supabase_realtime` - `v3.0.0-dev.1`
+
+ - **REFACTOR**: share the test helpers through supabase_common ([#1745](https://github.com/supabase/supabase-flutter/issues/1745)). ([bcb41fa4](https://github.com/supabase/supabase-flutter/commit/bcb41fa4d9ef840c0380e641d3e45968084090c8))
+ - **FEAT**: introduce the supabase_testing package ([#1747](https://github.com/supabase/supabase-flutter/issues/1747)). ([5a3aa9b4](https://github.com/supabase/supabase-flutter/commit/5a3aa9b4265385e3d747ca70ad499102fa388ee9))
+ - **BREAKING** **REFACTOR**: rework logging to emit only through the supabase logger hierarchy ([#1741](https://github.com/supabase/supabase-flutter/issues/1741)). ([d1642c80](https://github.com/supabase/supabase-flutter/commit/d1642c80c60d93cf3bf7919b0cef775470275ed9))
+ - **BREAKING** **REFACTOR**(realtime): replace listener callbacks with streams ([#1706](https://github.com/supabase/supabase-flutter/issues/1706)). ([07345bf9](https://github.com/supabase/supabase-flutter/commit/07345bf9568a0ba495f1e34cb6ba542eddecc7e9))
+ - **BREAKING** **FEAT**(realtime): support asynchronous encode/decode codecs ([#1684](https://github.com/supabase/supabase-flutter/issues/1684)). ([5c496198](https://github.com/supabase/supabase-flutter/commit/5c496198fb0cfb874f2a036b02862834bc739572))
+ - **BREAKING** **FEAT**: rename the realtime_client package to supabase_realtime ([#1714](https://github.com/supabase/supabase-flutter/issues/1714)). ([d37bed56](https://github.com/supabase/supabase-flutter/commit/d37bed567711c8ed68590a002bb3f1a45432abcb))
+ - **BREAKING** **CHORE**: give each package's Constants class a package-specific name ([#1677](https://github.com/supabase/supabase-flutter/issues/1677)). ([40f6d89c](https://github.com/supabase/supabase-flutter/commit/40f6d89c7fad32e49f028b2644914807fd731b70))
+
+#### `supabase_storage` - `v3.0.0-dev.1`
+
+ - **REFACTOR**: share the test helpers through supabase_common ([#1745](https://github.com/supabase/supabase-flutter/issues/1745)). ([bcb41fa4](https://github.com/supabase/supabase-flutter/commit/bcb41fa4d9ef840c0380e641d3e45968084090c8))
+ - **FEAT**: introduce the supabase_testing package ([#1747](https://github.com/supabase/supabase-flutter/issues/1747)). ([5a3aa9b4](https://github.com/supabase/supabase-flutter/commit/5a3aa9b4265385e3d747ca70ad499102fa388ee9))
+ - **FEAT**: resolve an access token per request on the standalone clients ([#1742](https://github.com/supabase/supabase-flutter/issues/1742)). ([dd61782a](https://github.com/supabase/supabase-flutter/commit/dd61782a35f1a99af95f5457b5a3393b3d7939b9))
+ - **BREAKING** **REFACTOR**(storage): share one SortDirection enum across the packages ([#1752](https://github.com/supabase/supabase-flutter/issues/1752)). ([38396ed5](https://github.com/supabase/supabase-flutter/commit/38396ed5a40d04f24096a816bfead0d57f440394))
+ - **BREAKING** **REFACTOR**: rework logging to emit only through the supabase logger hierarchy ([#1741](https://github.com/supabase/supabase-flutter/issues/1741)). ([d1642c80](https://github.com/supabase/supabase-flutter/commit/d1642c80c60d93cf3bf7919b0cef775470275ed9))
+ - **BREAKING** **REFACTOR**: remove the dead setAccessToken mutators ([#1739](https://github.com/supabase/supabase-flutter/issues/1739)). ([ced47232](https://github.com/supabase/supabase-flutter/commit/ced47232edead42ce57d27b76227723817ef2367))
+ - **BREAKING** **REFACTOR**: share one retry configuration across the clients ([#1738](https://github.com/supabase/supabase-flutter/issues/1738)). ([3b2a4855](https://github.com/supabase/supabase-flutter/commit/3b2a4855a5d2e83af17d3cd280189c6a89170741))
+ - **BREAKING** **REFACTOR**(storage): move the Iceberg catalog into its own package ([#1711](https://github.com/supabase/supabase-flutter/issues/1711)). ([26fc503d](https://github.com/supabase/supabase-flutter/commit/26fc503d8a452f2ce6292c55bcee1f32784fb52d))
+ - **BREAKING** **FEAT**(storage): return the file id from upload and update methods ([#1730](https://github.com/supabase/supabase-flutter/issues/1730)). ([39ccfca3](https://github.com/supabase/supabase-flutter/commit/39ccfca363d03898ecfcb8f7ee2fd3eca92b671d))
+ - **BREAKING** **FEAT**: rename the storage_client package to supabase_storage ([#1715](https://github.com/supabase/supabase-flutter/issues/1715)). ([6b0388f2](https://github.com/supabase/supabase-flutter/commit/6b0388f209c87dc57ee7281d211fff241e13ec6a))
+ - **BREAKING** **CHORE**: give each package's Constants class a package-specific name ([#1677](https://github.com/supabase/supabase-flutter/issues/1677)). ([40f6d89c](https://github.com/supabase/supabase-flutter/commit/40f6d89c7fad32e49f028b2644914807fd731b70))
+
+#### `supabase` - `v3.0.0-dev.1`
+
+ - **REFACTOR**: share the test helpers through supabase_common ([#1745](https://github.com/supabase/supabase-flutter/issues/1745)). ([bcb41fa4](https://github.com/supabase/supabase-flutter/commit/bcb41fa4d9ef840c0380e641d3e45968084090c8))
+ - **PERF**(yet_another_json_isolate): process small payloads inline and large ones on short-lived isolates ([#1746](https://github.com/supabase/supabase-flutter/issues/1746)). ([7942c377](https://github.com/supabase/supabase-flutter/commit/7942c37770c5a12b18b27afc66b8595e67fdd22d))
+ - **FIX**(supabase_lints): enable lines_longer_than_80_chars and fix all violations ([#1655](https://github.com/supabase/supabase-flutter/issues/1655)). ([a08b6577](https://github.com/supabase/supabase-flutter/commit/a08b6577d002d0c7ae0d484ddd6da802922be37b))
+ - **FEAT**: introduce the supabase_testing package ([#1747](https://github.com/supabase/supabase-flutter/issues/1747)). ([5a3aa9b4](https://github.com/supabase/supabase-flutter/commit/5a3aa9b4265385e3d747ca70ad499102fa388ee9))
+ - **FEAT**(auth): store PKCE verifiers per flow to survive overlapping flows ([#1662](https://github.com/supabase/supabase-flutter/issues/1662)). ([61bbbc5e](https://github.com/supabase/supabase-flutter/commit/61bbbc5e2fbd0e01a1efbcd4d0257286a6060934))
+ - **DOCS**: fix inaccurate dartdoc comments across all packages ([#1659](https://github.com/supabase/supabase-flutter/issues/1659)). ([090ee978](https://github.com/supabase/supabase-flutter/commit/090ee9781ccdc7a749902830697d51251aa9f052))
+ - **BREAKING** **REFACTOR**: process JSON through the AsyncJsonCodec interface ([#1751](https://github.com/supabase/supabase-flutter/issues/1751)). ([6969eb38](https://github.com/supabase/supabase-flutter/commit/6969eb3805cc1920f5a44902ae2ce660170c13b3))
+ - **BREAKING** **REFACTOR**(postgrest): make the rest client and builders stateless ([#1748](https://github.com/supabase/supabase-flutter/issues/1748)). ([4efb8ce4](https://github.com/supabase/supabase-flutter/commit/4efb8ce4fcff225d7b601af1a5b351da530cb34d))
+ - **BREAKING** **REFACTOR**: rework logging to emit only through the supabase logger hierarchy ([#1741](https://github.com/supabase/supabase-flutter/issues/1741)). ([d1642c80](https://github.com/supabase/supabase-flutter/commit/d1642c80c60d93cf3bf7919b0cef775470275ed9))
+ - **BREAKING** **REFACTOR**: remove the dead setAccessToken mutators ([#1739](https://github.com/supabase/supabase-flutter/issues/1739)). ([ced47232](https://github.com/supabase/supabase-flutter/commit/ced47232edead42ce57d27b76227723817ef2367))
+ - **BREAKING** **REFACTOR**: share one retry configuration across the clients ([#1738](https://github.com/supabase/supabase-flutter/issues/1738)). ([3b2a4855](https://github.com/supabase/supabase-flutter/commit/3b2a4855a5d2e83af17d3cd280189c6a89170741))
+ - **BREAKING** **REFACTOR**(postgrest): fix the retried status codes to 503 and 520 ([#1737](https://github.com/supabase/supabase-flutter/issues/1737)). ([17487ff5](https://github.com/supabase/supabase-flutter/commit/17487ff5ecc4ca5df74f08d48cdb0bfac767fe8f))
+ - **BREAKING** **REFACTOR**(postgrest): expose retry configuration as PostgrestRetryOptions ([#1731](https://github.com/supabase/supabase-flutter/issues/1731)). ([7c0cfe53](https://github.com/supabase/supabase-flutter/commit/7c0cfe53ca9366f703d52dd4a78105475439e4b8))
+ - **BREAKING** **REFACTOR**(realtime): replace listener callbacks with streams ([#1706](https://github.com/supabase/supabase-flutter/issues/1706)). ([07345bf9](https://github.com/supabase/supabase-flutter/commit/07345bf9568a0ba495f1e34cb6ba542eddecc7e9))
+ - **BREAKING** **REFACTOR**: spell out abbreviations in the public API ([#1712](https://github.com/supabase/supabase-flutter/issues/1712)). ([29286f43](https://github.com/supabase/supabase-flutter/commit/29286f4309a74da769ed7aad569daacba6dee7ae))
+ - **BREAKING** **REFACTOR**: share a single HttpMethod enum across the packages ([#1678](https://github.com/supabase/supabase-flutter/issues/1678)). ([23d55c37](https://github.com/supabase/supabase-flutter/commit/23d55c376fe8e2aa0ff4083f2ff39488fe827979))
+ - **BREAKING** **REFACTOR**: remove all deprecated APIs and dead public surface for v3 ([#1661](https://github.com/supabase/supabase-flutter/issues/1661)). ([1ffa0deb](https://github.com/supabase/supabase-flutter/commit/1ffa0deba0371585c7a4ac93795cf199a58e2353))
+ - **BREAKING** **FIX**(gotrue): assert asyncStorage is provided for PKCE flow in the constructor ([#1489](https://github.com/supabase/supabase-flutter/issues/1489)). ([30729cc9](https://github.com/supabase/supabase-flutter/commit/30729cc9edcc3366504382dc5d7ba2dbe1e43251))
+ - **BREAKING** **FIX**: make order() default to ascending ([#1658](https://github.com/supabase/supabase-flutter/issues/1658)). ([e06f2302](https://github.com/supabase/supabase-flutter/commit/e06f23025949dc2e8b1d4b3528619181ef8edde0))
+ - **BREAKING** **FEAT**(realtime): support asynchronous encode/decode codecs ([#1684](https://github.com/supabase/supabase-flutter/issues/1684)). ([5c496198](https://github.com/supabase/supabase-flutter/commit/5c496198fb0cfb874f2a036b02862834bc739572))
+ - **BREAKING** **FEAT**: rename the storage_client package to supabase_storage ([#1715](https://github.com/supabase/supabase-flutter/issues/1715)). ([6b0388f2](https://github.com/supabase/supabase-flutter/commit/6b0388f209c87dc57ee7281d211fff241e13ec6a))
+ - **BREAKING** **FEAT**: rename the realtime_client package to supabase_realtime ([#1714](https://github.com/supabase/supabase-flutter/issues/1714)). ([d37bed56](https://github.com/supabase/supabase-flutter/commit/d37bed567711c8ed68590a002bb3f1a45432abcb))
+ - **BREAKING** **FEAT**: rename the functions_client package to supabase_functions ([#1713](https://github.com/supabase/supabase-flutter/issues/1713)). ([eb4f3773](https://github.com/supabase/supabase-flutter/commit/eb4f3773e74dd62be5a768433d0a2497d643f110))
+ - **BREAKING** **FEAT**: rename the gotrue package to supabase_auth ([#1697](https://github.com/supabase/supabase-flutter/issues/1697)). ([563b502e](https://github.com/supabase/supabase-flutter/commit/563b502ee64d161defddeceaaacc43615f39b75c))
+ - **BREAKING** **CHORE**: give each package's Constants class a package-specific name ([#1677](https://github.com/supabase/supabase-flutter/issues/1677)). ([40f6d89c](https://github.com/supabase/supabase-flutter/commit/40f6d89c7fad32e49f028b2644914807fd731b70))
+
+#### `supabase_flutter` - `v3.0.0-dev.1`
+
+ - **REFACTOR**: share the test helpers through supabase_common ([#1745](https://github.com/supabase/supabase-flutter/issues/1745)). ([bcb41fa4](https://github.com/supabase/supabase-flutter/commit/bcb41fa4d9ef840c0380e641d3e45968084090c8))
+ - **REFACTOR**: share the auth callback parameters and secure random helpers ([#1744](https://github.com/supabase/supabase-flutter/issues/1744)). ([66ac4901](https://github.com/supabase/supabase-flutter/commit/66ac4901c684b83faae96e13ac560d7efdac158e))
+ - **FIX**(supabase_lints): enable lines_longer_than_80_chars and fix all violations ([#1655](https://github.com/supabase/supabase-flutter/issues/1655)). ([a08b6577](https://github.com/supabase/supabase-flutter/commit/a08b6577d002d0c7ae0d484ddd6da802922be37b))
+ - **FEAT**: introduce the supabase_testing package ([#1747](https://github.com/supabase/supabase-flutter/issues/1747)). ([5a3aa9b4](https://github.com/supabase/supabase-flutter/commit/5a3aa9b4265385e3d747ca70ad499102fa388ee9))
+ - **FEAT**(auth): store PKCE verifiers per flow to survive overlapping flows ([#1662](https://github.com/supabase/supabase-flutter/issues/1662)). ([61bbbc5e](https://github.com/supabase/supabase-flutter/commit/61bbbc5e2fbd0e01a1efbcd4d0257286a6060934))
+ - **DOCS**: fix inaccurate dartdoc comments across all packages ([#1659](https://github.com/supabase/supabase-flutter/issues/1659)). ([090ee978](https://github.com/supabase/supabase-flutter/commit/090ee9781ccdc7a749902830697d51251aa9f052))
+ - **DOCS**: add a v2 to v3 migration guide ([#1660](https://github.com/supabase/supabase-flutter/issues/1660)). ([aa1c1497](https://github.com/supabase/supabase-flutter/commit/aa1c14978c765ff8a0bce3a42e3fe9ca083eab32))
+ - **BREAKING** **REFACTOR**: process JSON through the AsyncJsonCodec interface ([#1751](https://github.com/supabase/supabase-flutter/issues/1751)). ([6969eb38](https://github.com/supabase/supabase-flutter/commit/6969eb3805cc1920f5a44902ae2ce660170c13b3))
+ - **BREAKING** **REFACTOR**: rework logging to emit only through the supabase logger hierarchy ([#1741](https://github.com/supabase/supabase-flutter/issues/1741)). ([d1642c80](https://github.com/supabase/supabase-flutter/commit/d1642c80c60d93cf3bf7919b0cef775470275ed9))
+ - **BREAKING** **REFACTOR**: share one retry configuration across the clients ([#1738](https://github.com/supabase/supabase-flutter/issues/1738)). ([3b2a4855](https://github.com/supabase/supabase-flutter/commit/3b2a4855a5d2e83af17d3cd280189c6a89170741))
+ - **BREAKING** **REFACTOR**(realtime): replace listener callbacks with streams ([#1706](https://github.com/supabase/supabase-flutter/issues/1706)). ([07345bf9](https://github.com/supabase/supabase-flutter/commit/07345bf9568a0ba495f1e34cb6ba542eddecc7e9))
+ - **BREAKING** **REFACTOR**(auth): return a Uri from OAuthResponse.url instead of a String ([#1729](https://github.com/supabase/supabase-flutter/issues/1729)). ([c8a66f10](https://github.com/supabase/supabase-flutter/commit/c8a66f100c9e1e1c899829cddc63aa7f1d230e93))
+ - **BREAKING** **REFACTOR**: spell out abbreviations in the public API ([#1712](https://github.com/supabase/supabase-flutter/issues/1712)). ([29286f43](https://github.com/supabase/supabase-flutter/commit/29286f4309a74da769ed7aad569daacba6dee7ae))
+ - **BREAKING** **REFACTOR**: split every service exception into a client and an api base ([#1644](https://github.com/supabase/supabase-flutter/issues/1644)). ([0202c332](https://github.com/supabase/supabase-flutter/commit/0202c33249828dc96a778af5fd72520ca5234a46))
+ - **BREAKING** **REFACTOR**: remove analyzer ignores by fixing the underlying code ([#1675](https://github.com/supabase/supabase-flutter/issues/1675)). ([9f367d77](https://github.com/supabase/supabase-flutter/commit/9f367d77f8f1e1723a985885db0de45123dce6f4))
+ - **BREAKING** **REFACTOR**: remove all deprecated APIs and dead public surface for v3 ([#1661](https://github.com/supabase/supabase-flutter/issues/1661)). ([1ffa0deb](https://github.com/supabase/supabase-flutter/commit/1ffa0deba0371585c7a4ac93795cf199a58e2353))
+ - **BREAKING** **REFACTOR**(realtime): clean up connection naming on RealtimeClient ([#1404](https://github.com/supabase/supabase-flutter/issues/1404)). ([4344c346](https://github.com/supabase/supabase-flutter/commit/4344c346164f731ff394cf8384bebac21f743a94))
+ - **BREAKING** **FIX**(auth): return Uri from getSSOSignInUrl instead of String ([#1722](https://github.com/supabase/supabase-flutter/issues/1722)). ([9aa2e767](https://github.com/supabase/supabase-flutter/commit/9aa2e76788f74b7a890c9a0e2f45e3f4ca44424b))
+ - **BREAKING** **FIX**(supabase_flutter): persist the session with SharedPreferencesAsync ([#1680](https://github.com/supabase/supabase-flutter/issues/1680)). ([41500b73](https://github.com/supabase/supabase-flutter/commit/41500b73e207cc812c2d42e4e4f4a79127e0502b))
+ - **BREAKING** **FIX**: release retained resources on dispose ([#1668](https://github.com/supabase/supabase-flutter/issues/1668)). ([d21d8c03](https://github.com/supabase/supabase-flutter/commit/d21d8c03dd2ebbad5713f28157e2c9445e13c7e0))
+ - **BREAKING** **FIX**(gotrue): emit userUpdated instead of signedIn when an email change is confirmed ([#1664](https://github.com/supabase/supabase-flutter/issues/1664)). ([7a042416](https://github.com/supabase/supabase-flutter/commit/7a042416ce190f22f02d0683ecd1fdc84a29ec5a))
+ - **BREAKING** **FEAT**: rename the storage_client package to supabase_storage ([#1715](https://github.com/supabase/supabase-flutter/issues/1715)). ([6b0388f2](https://github.com/supabase/supabase-flutter/commit/6b0388f209c87dc57ee7281d211fff241e13ec6a))
+ - **BREAKING** **FEAT**: rename the realtime_client package to supabase_realtime ([#1714](https://github.com/supabase/supabase-flutter/issues/1714)). ([d37bed56](https://github.com/supabase/supabase-flutter/commit/d37bed567711c8ed68590a002bb3f1a45432abcb))
+ - **BREAKING** **FEAT**: rename the functions_client package to supabase_functions ([#1713](https://github.com/supabase/supabase-flutter/issues/1713)). ([eb4f3773](https://github.com/supabase/supabase-flutter/commit/eb4f3773e74dd62be5a768433d0a2497d643f110))
+ - **BREAKING** **FEAT**: rename the gotrue package to supabase_auth ([#1697](https://github.com/supabase/supabase-flutter/issues/1697)). ([563b502e](https://github.com/supabase/supabase-flutter/commit/563b502ee64d161defddeceaaacc43615f39b75c))
+ - **BREAKING** **CHORE**: give each package's Constants class a package-specific name ([#1677](https://github.com/supabase/supabase-flutter/issues/1677)). ([40f6d89c](https://github.com/supabase/supabase-flutter/commit/40f6d89c7fad32e49f028b2644914807fd731b70))
+
+#### `iceberg` - `v0.1.0`
+
+ - **REFACTOR**: share the test helpers through supabase_common ([#1745](https://github.com/supabase/supabase-flutter/issues/1745)). ([bcb41fa4](https://github.com/supabase/supabase-flutter/commit/bcb41fa4d9ef840c0380e641d3e45968084090c8))
+ - **REFACTOR**: share the auth callback parameters and secure random helpers ([#1744](https://github.com/supabase/supabase-flutter/issues/1744)). ([66ac4901](https://github.com/supabase/supabase-flutter/commit/66ac4901c684b83faae96e13ac560d7efdac158e))
+ - **FEAT**: introduce the supabase_testing package ([#1747](https://github.com/supabase/supabase-flutter/issues/1747)). ([5a3aa9b4](https://github.com/supabase/supabase-flutter/commit/5a3aa9b4265385e3d747ca70ad499102fa388ee9))
+ - **BREAKING** **REFACTOR**(storage): share one SortDirection enum across the packages ([#1752](https://github.com/supabase/supabase-flutter/issues/1752)). ([38396ed5](https://github.com/supabase/supabase-flutter/commit/38396ed5a40d04f24096a816bfead0d57f440394))
+ - **BREAKING** **REFACTOR**: rework logging to emit only through the supabase logger hierarchy ([#1741](https://github.com/supabase/supabase-flutter/issues/1741)). ([d1642c80](https://github.com/supabase/supabase-flutter/commit/d1642c80c60d93cf3bf7919b0cef775470275ed9))
+ - **BREAKING** **REFACTOR**(storage): move the Iceberg catalog into its own package ([#1711](https://github.com/supabase/supabase-flutter/issues/1711)). ([26fc503d](https://github.com/supabase/supabase-flutter/commit/26fc503d8a452f2ce6292c55bcee1f32784fb52d))
+
+
 ## 2026-08-05
 
 ### Changes

--- a/examples/authentication/pubspec.yaml
+++ b/examples/authentication/pubspec.yaml
@@ -14,7 +14,7 @@ resolution: workspace
 dependencies:
   flutter:
     sdk: flutter
-  supabase_flutter: ^2.17.1
+  supabase_flutter: ^3.0.0-dev.1
 
 dev_dependencies:
   supabase_lints: ^0.1.1

--- a/examples/database_crud/pubspec.yaml
+++ b/examples/database_crud/pubspec.yaml
@@ -14,7 +14,7 @@ resolution: workspace
 dependencies:
   flutter:
     sdk: flutter
-  supabase_flutter: ^2.17.1
+  supabase_flutter: ^3.0.0-dev.1
 
 dev_dependencies:
   supabase_lints: ^0.1.1

--- a/examples/edge_functions/pubspec.yaml
+++ b/examples/edge_functions/pubspec.yaml
@@ -14,7 +14,7 @@ resolution: workspace
 dependencies:
   flutter:
     sdk: flutter
-  supabase_flutter: ^2.17.1
+  supabase_flutter: ^3.0.0-dev.1
 
 dev_dependencies:
   supabase_lints: ^0.1.1

--- a/examples/passkeys/pubspec.yaml
+++ b/examples/passkeys/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   flutter:
     sdk: flutter
   passkeys: ^2.21.1
-  supabase_flutter: ^2.17.1
+  supabase_flutter: ^3.0.0-dev.1
 
 dev_dependencies:
   supabase_lints: ^0.1.1

--- a/examples/realtime_room/pubspec.yaml
+++ b/examples/realtime_room/pubspec.yaml
@@ -14,7 +14,7 @@ resolution: workspace
 dependencies:
   flutter:
     sdk: flutter
-  supabase_flutter: ^2.17.1
+  supabase_flutter: ^3.0.0-dev.1
 
 dev_dependencies:
   supabase_lints: ^0.1.1

--- a/examples/storage_transforms/pubspec.yaml
+++ b/examples/storage_transforms/pubspec.yaml
@@ -14,7 +14,7 @@ resolution: workspace
 dependencies:
   flutter:
     sdk: flutter
-  supabase_flutter: ^2.17.1
+  supabase_flutter: ^3.0.0-dev.1
 
 dev_dependencies:
   supabase_lints: ^0.1.1

--- a/packages/iceberg/CHANGELOG.md
+++ b/packages/iceberg/CHANGELOG.md
@@ -1,3 +1,9 @@
 ## 0.1.0
 
  - Initial release. Apache Iceberg REST Catalog client extracted from storage_client.
+ - **REFACTOR**: share the test helpers through supabase_common ([#1745](https://github.com/supabase/supabase-flutter/issues/1745)). ([bcb41fa4](https://github.com/supabase/supabase-flutter/commit/bcb41fa4d9ef840c0380e641d3e45968084090c8))
+ - **REFACTOR**: share the auth callback parameters and secure random helpers ([#1744](https://github.com/supabase/supabase-flutter/issues/1744)). ([66ac4901](https://github.com/supabase/supabase-flutter/commit/66ac4901c684b83faae96e13ac560d7efdac158e))
+ - **FEAT**: introduce the supabase_testing package ([#1747](https://github.com/supabase/supabase-flutter/issues/1747)). ([5a3aa9b4](https://github.com/supabase/supabase-flutter/commit/5a3aa9b4265385e3d747ca70ad499102fa388ee9))
+ - **BREAKING** **REFACTOR**(storage): share one SortDirection enum across the packages ([#1752](https://github.com/supabase/supabase-flutter/issues/1752)). ([38396ed5](https://github.com/supabase/supabase-flutter/commit/38396ed5a40d04f24096a816bfead0d57f440394))
+ - **BREAKING** **REFACTOR**: rework logging to emit only through the supabase logger hierarchy ([#1741](https://github.com/supabase/supabase-flutter/issues/1741)). ([d1642c80](https://github.com/supabase/supabase-flutter/commit/d1642c80c60d93cf3bf7919b0cef775470275ed9))
+ - **BREAKING** **REFACTOR**(storage): move the Iceberg catalog into its own package ([#1711](https://github.com/supabase/supabase-flutter/issues/1711)). ([26fc503d](https://github.com/supabase/supabase-flutter/commit/26fc503d8a452f2ce6292c55bcee1f32784fb52d))

--- a/packages/iceberg/pubspec.yaml
+++ b/packages/iceberg/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
   http: ^1.6.0
   logging: ^1.3.0
   meta: ^1.15.0
-  supabase_common: 0.1.2
+  supabase_common: 3.0.0-dev.1
 
 dev_dependencies:
   test: ^1.25.0

--- a/packages/postgrest/CHANGELOG.md
+++ b/packages/postgrest/CHANGELOG.md
@@ -1,3 +1,30 @@
+## 3.0.0-dev.1
+
+> Note: This release has breaking changes.
+
+ - **REFACTOR**: share the test helpers through supabase_common ([#1745](https://github.com/supabase/supabase-flutter/issues/1745)). ([bcb41fa4](https://github.com/supabase/supabase-flutter/commit/bcb41fa4d9ef840c0380e641d3e45968084090c8))
+ - **REFACTOR**: share the auth callback parameters and secure random helpers ([#1744](https://github.com/supabase/supabase-flutter/issues/1744)). ([66ac4901](https://github.com/supabase/supabase-flutter/commit/66ac4901c684b83faae96e13ac560d7efdac158e))
+ - **REFACTOR**: share the HTTP request pieces between the fetch layers ([#1647](https://github.com/supabase/supabase-flutter/issues/1647)). ([a2a9eeaa](https://github.com/supabase/supabase-flutter/commit/a2a9eeaac4f8cc5d98199945283245b697e07a19))
+ - **PERF**(yet_another_json_isolate): process small payloads inline and large ones on short-lived isolates ([#1746](https://github.com/supabase/supabase-flutter/issues/1746)). ([7942c377](https://github.com/supabase/supabase-flutter/commit/7942c37770c5a12b18b27afc66b8595e67fdd22d))
+ - **FIX**(supabase_lints): enable lines_longer_than_80_chars and fix all violations ([#1655](https://github.com/supabase/supabase-flutter/issues/1655)). ([a08b6577](https://github.com/supabase/supabase-flutter/commit/a08b6577d002d0c7ae0d484ddd6da802922be37b))
+ - **FEAT**: introduce the supabase_testing package ([#1747](https://github.com/supabase/supabase-flutter/issues/1747)). ([5a3aa9b4](https://github.com/supabase/supabase-flutter/commit/5a3aa9b4265385e3d747ca70ad499102fa388ee9))
+ - **FEAT**: resolve an access token per request on the standalone clients ([#1742](https://github.com/supabase/supabase-flutter/issues/1742)). ([dd61782a](https://github.com/supabase/supabase-flutter/commit/dd61782a35f1a99af95f5457b5a3393b3d7939b9))
+ - **DOCS**: fix inaccurate dartdoc comments across all packages ([#1659](https://github.com/supabase/supabase-flutter/issues/1659)). ([090ee978](https://github.com/supabase/supabase-flutter/commit/090ee9781ccdc7a749902830697d51251aa9f052))
+ - **BREAKING** **REFACTOR**: process JSON through the AsyncJsonCodec interface ([#1751](https://github.com/supabase/supabase-flutter/issues/1751)). ([6969eb38](https://github.com/supabase/supabase-flutter/commit/6969eb3805cc1920f5a44902ae2ce660170c13b3))
+ - **BREAKING** **REFACTOR**(postgrest): make the rest client and builders stateless ([#1748](https://github.com/supabase/supabase-flutter/issues/1748)). ([4efb8ce4](https://github.com/supabase/supabase-flutter/commit/4efb8ce4fcff225d7b601af1a5b351da530cb34d))
+ - **BREAKING** **REFACTOR**: rework logging to emit only through the supabase logger hierarchy ([#1741](https://github.com/supabase/supabase-flutter/issues/1741)). ([d1642c80](https://github.com/supabase/supabase-flutter/commit/d1642c80c60d93cf3bf7919b0cef775470275ed9))
+ - **BREAKING** **REFACTOR**: remove the dead setAccessToken mutators ([#1739](https://github.com/supabase/supabase-flutter/issues/1739)). ([ced47232](https://github.com/supabase/supabase-flutter/commit/ced47232edead42ce57d27b76227723817ef2367))
+ - **BREAKING** **REFACTOR**: share one retry configuration across the clients ([#1738](https://github.com/supabase/supabase-flutter/issues/1738)). ([3b2a4855](https://github.com/supabase/supabase-flutter/commit/3b2a4855a5d2e83af17d3cd280189c6a89170741))
+ - **BREAKING** **REFACTOR**(postgrest): fix the retried status codes to 503 and 520 ([#1737](https://github.com/supabase/supabase-flutter/issues/1737)). ([17487ff5](https://github.com/supabase/supabase-flutter/commit/17487ff5ecc4ca5df74f08d48cdb0bfac767fe8f))
+ - **BREAKING** **REFACTOR**(postgrest): expose retry configuration as PostgrestRetryOptions ([#1731](https://github.com/supabase/supabase-flutter/issues/1731)). ([7c0cfe53](https://github.com/supabase/supabase-flutter/commit/7c0cfe53ca9366f703d52dd4a78105475439e4b8))
+ - **BREAKING** **REFACTOR**: spell out abbreviations in the public API ([#1712](https://github.com/supabase/supabase-flutter/issues/1712)). ([29286f43](https://github.com/supabase/supabase-flutter/commit/29286f4309a74da769ed7aad569daacba6dee7ae))
+ - **BREAKING** **REFACTOR**: share one exponential backoff calculation ([#1646](https://github.com/supabase/supabase-flutter/issues/1646)). ([8bc93f5d](https://github.com/supabase/supabase-flutter/commit/8bc93f5d8ccd72351dc1789e30a4aa9c8e8de1fa))
+ - **BREAKING** **REFACTOR**: split every service exception into a client and an api base ([#1644](https://github.com/supabase/supabase-flutter/issues/1644)). ([0202c332](https://github.com/supabase/supabase-flutter/commit/0202c33249828dc96a778af5fd72520ca5234a46))
+ - **BREAKING** **REFACTOR**: share a single HttpMethod enum across the packages ([#1678](https://github.com/supabase/supabase-flutter/issues/1678)). ([23d55c37](https://github.com/supabase/supabase-flutter/commit/23d55c376fe8e2aa0ff4083f2ff39488fe827979))
+ - **BREAKING** **REFACTOR**: remove analyzer ignores by fixing the underlying code ([#1675](https://github.com/supabase/supabase-flutter/issues/1675)). ([9f367d77](https://github.com/supabase/supabase-flutter/commit/9f367d77f8f1e1723a985885db0de45123dce6f4))
+ - **BREAKING** **REFACTOR**: remove all deprecated APIs and dead public surface for v3 ([#1661](https://github.com/supabase/supabase-flutter/issues/1661)). ([1ffa0deb](https://github.com/supabase/supabase-flutter/commit/1ffa0deba0371585c7a4ac93795cf199a58e2353))
+ - **BREAKING** **FIX**: make order() default to ascending ([#1658](https://github.com/supabase/supabase-flutter/issues/1658)). ([e06f2302](https://github.com/supabase/supabase-flutter/commit/e06f23025949dc2e8b1d4b3528619181ef8edde0))
+
 ## 2.9.1
 
  - **REFACTOR**(supabase_common): share the local stack test configuration ([#1640](https://github.com/supabase/supabase-flutter/issues/1640)). ([a08f06d3](https://github.com/supabase/supabase-flutter/commit/a08f06d3b746d1fa5e3cd17c3370fe10466cb69b))

--- a/packages/postgrest/lib/src/version.dart
+++ b/packages/postgrest/lib/src/version.dart
@@ -1,1 +1,1 @@
-const version = '2.9.1';
+const version = '3.0.0-dev.1';

--- a/packages/postgrest/pubspec.yaml
+++ b/packages/postgrest/pubspec.yaml
@@ -1,6 +1,6 @@
 name: postgrest
 description: PostgREST client for Dart. This library provides an ORM interface to PostgREST.
-version: 2.9.1
+version: 3.0.0-dev.1
 homepage: 'https://supabase.com'
 repository: 'https://github.com/supabase/supabase-flutter/tree/main/packages/postgrest'
 issue_tracker: 'https://github.com/supabase/supabase-flutter/issues'
@@ -22,7 +22,7 @@ dependencies:
   yet_another_json_isolate: 2.1.1
   meta: ^1.16.0
   logging: ^1.3.0
-  supabase_common: 0.1.2
+  supabase_common: 3.0.0-dev.1
 
 dev_dependencies:
   collection: ^1.19.0

--- a/packages/supabase/CHANGELOG.md
+++ b/packages/supabase/CHANGELOG.md
@@ -1,3 +1,33 @@
+## 3.0.0-dev.1
+
+> Note: This release has breaking changes.
+
+ - **REFACTOR**: share the test helpers through supabase_common ([#1745](https://github.com/supabase/supabase-flutter/issues/1745)). ([bcb41fa4](https://github.com/supabase/supabase-flutter/commit/bcb41fa4d9ef840c0380e641d3e45968084090c8))
+ - **PERF**(yet_another_json_isolate): process small payloads inline and large ones on short-lived isolates ([#1746](https://github.com/supabase/supabase-flutter/issues/1746)). ([7942c377](https://github.com/supabase/supabase-flutter/commit/7942c37770c5a12b18b27afc66b8595e67fdd22d))
+ - **FIX**(supabase_lints): enable lines_longer_than_80_chars and fix all violations ([#1655](https://github.com/supabase/supabase-flutter/issues/1655)). ([a08b6577](https://github.com/supabase/supabase-flutter/commit/a08b6577d002d0c7ae0d484ddd6da802922be37b))
+ - **FEAT**: introduce the supabase_testing package ([#1747](https://github.com/supabase/supabase-flutter/issues/1747)). ([5a3aa9b4](https://github.com/supabase/supabase-flutter/commit/5a3aa9b4265385e3d747ca70ad499102fa388ee9))
+ - **FEAT**(auth): store PKCE verifiers per flow to survive overlapping flows ([#1662](https://github.com/supabase/supabase-flutter/issues/1662)). ([61bbbc5e](https://github.com/supabase/supabase-flutter/commit/61bbbc5e2fbd0e01a1efbcd4d0257286a6060934))
+ - **DOCS**: fix inaccurate dartdoc comments across all packages ([#1659](https://github.com/supabase/supabase-flutter/issues/1659)). ([090ee978](https://github.com/supabase/supabase-flutter/commit/090ee9781ccdc7a749902830697d51251aa9f052))
+ - **BREAKING** **REFACTOR**: process JSON through the AsyncJsonCodec interface ([#1751](https://github.com/supabase/supabase-flutter/issues/1751)). ([6969eb38](https://github.com/supabase/supabase-flutter/commit/6969eb3805cc1920f5a44902ae2ce660170c13b3))
+ - **BREAKING** **REFACTOR**(postgrest): make the rest client and builders stateless ([#1748](https://github.com/supabase/supabase-flutter/issues/1748)). ([4efb8ce4](https://github.com/supabase/supabase-flutter/commit/4efb8ce4fcff225d7b601af1a5b351da530cb34d))
+ - **BREAKING** **REFACTOR**: rework logging to emit only through the supabase logger hierarchy ([#1741](https://github.com/supabase/supabase-flutter/issues/1741)). ([d1642c80](https://github.com/supabase/supabase-flutter/commit/d1642c80c60d93cf3bf7919b0cef775470275ed9))
+ - **BREAKING** **REFACTOR**: remove the dead setAccessToken mutators ([#1739](https://github.com/supabase/supabase-flutter/issues/1739)). ([ced47232](https://github.com/supabase/supabase-flutter/commit/ced47232edead42ce57d27b76227723817ef2367))
+ - **BREAKING** **REFACTOR**: share one retry configuration across the clients ([#1738](https://github.com/supabase/supabase-flutter/issues/1738)). ([3b2a4855](https://github.com/supabase/supabase-flutter/commit/3b2a4855a5d2e83af17d3cd280189c6a89170741))
+ - **BREAKING** **REFACTOR**(postgrest): fix the retried status codes to 503 and 520 ([#1737](https://github.com/supabase/supabase-flutter/issues/1737)). ([17487ff5](https://github.com/supabase/supabase-flutter/commit/17487ff5ecc4ca5df74f08d48cdb0bfac767fe8f))
+ - **BREAKING** **REFACTOR**(postgrest): expose retry configuration as PostgrestRetryOptions ([#1731](https://github.com/supabase/supabase-flutter/issues/1731)). ([7c0cfe53](https://github.com/supabase/supabase-flutter/commit/7c0cfe53ca9366f703d52dd4a78105475439e4b8))
+ - **BREAKING** **REFACTOR**(realtime): replace listener callbacks with streams ([#1706](https://github.com/supabase/supabase-flutter/issues/1706)). ([07345bf9](https://github.com/supabase/supabase-flutter/commit/07345bf9568a0ba495f1e34cb6ba542eddecc7e9))
+ - **BREAKING** **REFACTOR**: spell out abbreviations in the public API ([#1712](https://github.com/supabase/supabase-flutter/issues/1712)). ([29286f43](https://github.com/supabase/supabase-flutter/commit/29286f4309a74da769ed7aad569daacba6dee7ae))
+ - **BREAKING** **REFACTOR**: share a single HttpMethod enum across the packages ([#1678](https://github.com/supabase/supabase-flutter/issues/1678)). ([23d55c37](https://github.com/supabase/supabase-flutter/commit/23d55c376fe8e2aa0ff4083f2ff39488fe827979))
+ - **BREAKING** **REFACTOR**: remove all deprecated APIs and dead public surface for v3 ([#1661](https://github.com/supabase/supabase-flutter/issues/1661)). ([1ffa0deb](https://github.com/supabase/supabase-flutter/commit/1ffa0deba0371585c7a4ac93795cf199a58e2353))
+ - **BREAKING** **FIX**(gotrue): assert asyncStorage is provided for PKCE flow in the constructor ([#1489](https://github.com/supabase/supabase-flutter/issues/1489)). ([30729cc9](https://github.com/supabase/supabase-flutter/commit/30729cc9edcc3366504382dc5d7ba2dbe1e43251))
+ - **BREAKING** **FIX**: make order() default to ascending ([#1658](https://github.com/supabase/supabase-flutter/issues/1658)). ([e06f2302](https://github.com/supabase/supabase-flutter/commit/e06f23025949dc2e8b1d4b3528619181ef8edde0))
+ - **BREAKING** **FEAT**(realtime): support asynchronous encode/decode codecs ([#1684](https://github.com/supabase/supabase-flutter/issues/1684)). ([5c496198](https://github.com/supabase/supabase-flutter/commit/5c496198fb0cfb874f2a036b02862834bc739572))
+ - **BREAKING** **FEAT**: rename the storage_client package to supabase_storage ([#1715](https://github.com/supabase/supabase-flutter/issues/1715)). ([6b0388f2](https://github.com/supabase/supabase-flutter/commit/6b0388f209c87dc57ee7281d211fff241e13ec6a))
+ - **BREAKING** **FEAT**: rename the realtime_client package to supabase_realtime ([#1714](https://github.com/supabase/supabase-flutter/issues/1714)). ([d37bed56](https://github.com/supabase/supabase-flutter/commit/d37bed567711c8ed68590a002bb3f1a45432abcb))
+ - **BREAKING** **FEAT**: rename the functions_client package to supabase_functions ([#1713](https://github.com/supabase/supabase-flutter/issues/1713)). ([eb4f3773](https://github.com/supabase/supabase-flutter/commit/eb4f3773e74dd62be5a768433d0a2497d643f110))
+ - **BREAKING** **FEAT**: rename the gotrue package to supabase_auth ([#1697](https://github.com/supabase/supabase-flutter/issues/1697)). ([563b502e](https://github.com/supabase/supabase-flutter/commit/563b502ee64d161defddeceaaacc43615f39b75c))
+ - **BREAKING** **CHORE**: give each package's Constants class a package-specific name ([#1677](https://github.com/supabase/supabase-flutter/issues/1677)). ([40f6d89c](https://github.com/supabase/supabase-flutter/commit/40f6d89c7fad32e49f028b2644914807fd731b70))
+
 ## 2.16.0
 
  - **REFACTOR**(supabase_common): share the local stack test configuration ([#1640](https://github.com/supabase/supabase-flutter/issues/1640)). ([a08f06d3](https://github.com/supabase/supabase-flutter/commit/a08f06d3b746d1fa5e3cd17c3370fe10466cb69b))

--- a/packages/supabase/example/pubspec.yaml
+++ b/packages/supabase/example/pubspec.yaml
@@ -10,7 +10,7 @@ resolution: workspace
 
 dependencies:
   web: '>=1.0.0 <2.0.0'
-  supabase: ^2.16.0
+  supabase: ^3.0.0-dev.1
 
 dev_dependencies:
   build_runner: any

--- a/packages/supabase/lib/src/version.dart
+++ b/packages/supabase/lib/src/version.dart
@@ -1,1 +1,1 @@
-const version = '2.16.0';
+const version = '3.0.0-dev.1';

--- a/packages/supabase/pubspec.yaml
+++ b/packages/supabase/pubspec.yaml
@@ -1,6 +1,6 @@
 name: supabase
 description: A dart client for Supabase. This client makes it simple for developers to build secure and scalable products.
-version: 2.16.0
+version: 3.0.0-dev.1
 homepage: 'https://supabase.com'
 repository: 'https://github.com/supabase/supabase-flutter/tree/main/packages/supabase'
 issue_tracker: 'https://github.com/supabase/supabase-flutter/issues'
@@ -20,9 +20,9 @@ resolution: workspace
 dependencies:
   http: ^1.6.0
   meta: ^1.7.0
-  postgrest: 2.9.1
+  postgrest: 3.0.0-dev.1
   supabase_auth: 3.0.0-dev.1
-  supabase_common: 0.1.2
+  supabase_common: 3.0.0-dev.1
   supabase_functions: 3.0.0-dev.1
   supabase_realtime: 3.0.0-dev.1
   supabase_storage: 3.0.0-dev.1

--- a/packages/supabase_auth/CHANGELOG.md
+++ b/packages/supabase_auth/CHANGELOG.md
@@ -1,3 +1,23 @@
+## 3.0.0-dev.1
+
+> Note: This release has breaking changes.
+
+ - **REFACTOR**: share the test helpers through supabase_common ([#1745](https://github.com/supabase/supabase-flutter/issues/1745)). ([bcb41fa4](https://github.com/supabase/supabase-flutter/commit/bcb41fa4d9ef840c0380e641d3e45968084090c8))
+ - **REFACTOR**: share the auth callback parameters and secure random helpers ([#1744](https://github.com/supabase/supabase-flutter/issues/1744)). ([66ac4901](https://github.com/supabase/supabase-flutter/commit/66ac4901c684b83faae96e13ac560d7efdac158e))
+ - **FIX**(auth): fail with an AuthException when a redirect response has no url ([#1728](https://github.com/supabase/supabase-flutter/issues/1728)). ([1a4801f2](https://github.com/supabase/supabase-flutter/commit/1a4801f2d6a5c2d3e80ad590e5dac7589d4db57f))
+ - **FIX**(auth): parse expires_in as num in Session.fromJson ([#1716](https://github.com/supabase/supabase-flutter/issues/1716)). ([a0be8277](https://github.com/supabase/supabase-flutter/commit/a0be82772523d1906cfceb34a5392b77d29ae17e))
+ - **FEAT**: introduce the supabase_testing package ([#1747](https://github.com/supabase/supabase-flutter/issues/1747)). ([5a3aa9b4](https://github.com/supabase/supabase-flutter/commit/5a3aa9b4265385e3d747ca70ad499102fa388ee9))
+ - **FEAT**(auth): store PKCE verifiers per flow to survive overlapping flows ([#1662](https://github.com/supabase/supabase-flutter/issues/1662)). ([61bbbc5e](https://github.com/supabase/supabase-flutter/commit/61bbbc5e2fbd0e01a1efbcd4d0257286a6060934))
+ - **BREAKING** **REFACTOR**: rework logging to emit only through the supabase logger hierarchy ([#1741](https://github.com/supabase/supabase-flutter/issues/1741)). ([d1642c80](https://github.com/supabase/supabase-flutter/commit/d1642c80c60d93cf3bf7919b0cef775470275ed9))
+ - **BREAKING** **REFACTOR**: share one retry configuration across the clients ([#1738](https://github.com/supabase/supabase-flutter/issues/1738)). ([3b2a4855](https://github.com/supabase/supabase-flutter/commit/3b2a4855a5d2e83af17d3cd280189c6a89170741))
+ - **BREAKING** **REFACTOR**(postgrest): expose retry configuration as PostgrestRetryOptions ([#1731](https://github.com/supabase/supabase-flutter/issues/1731)). ([7c0cfe53](https://github.com/supabase/supabase-flutter/commit/7c0cfe53ca9366f703d52dd4a78105475439e4b8))
+ - **BREAKING** **REFACTOR**(auth): return a Uri from OAuthResponse.url instead of a String ([#1729](https://github.com/supabase/supabase-flutter/issues/1729)). ([c8a66f10](https://github.com/supabase/supabase-flutter/commit/c8a66f100c9e1e1c899829cddc63aa7f1d230e93))
+ - **BREAKING** **REFACTOR**: spell out abbreviations in the public API ([#1712](https://github.com/supabase/supabase-flutter/issues/1712)). ([29286f43](https://github.com/supabase/supabase-flutter/commit/29286f4309a74da769ed7aad569daacba6dee7ae))
+ - **BREAKING** **FIX**(gotrue): assert asyncStorage is provided for PKCE flow in the constructor ([#1489](https://github.com/supabase/supabase-flutter/issues/1489)). ([30729cc9](https://github.com/supabase/supabase-flutter/commit/30729cc9edcc3366504382dc5d7ba2dbe1e43251))
+ - **BREAKING** **FIX**(auth): return Uri from getSSOSignInUrl instead of String ([#1722](https://github.com/supabase/supabase-flutter/issues/1722)). ([9aa2e767](https://github.com/supabase/supabase-flutter/commit/9aa2e76788f74b7a890c9a0e2f45e3f4ca44424b))
+ - **BREAKING** **FEAT**: rename the gotrue package to supabase_auth ([#1697](https://github.com/supabase/supabase-flutter/issues/1697)). ([563b502e](https://github.com/supabase/supabase-flutter/commit/563b502ee64d161defddeceaaacc43615f39b75c))
+ - **BREAKING** **CHORE**: give each package's Constants class a package-specific name ([#1677](https://github.com/supabase/supabase-flutter/issues/1677)). ([40f6d89c](https://github.com/supabase/supabase-flutter/commit/40f6d89c7fad32e49f028b2644914807fd731b70))
+
 ## 2.27.1
 
  - **REFACTOR**(supabase_common): share the local stack test configuration ([#1640](https://github.com/supabase/supabase-flutter/issues/1640)). ([a08f06d3](https://github.com/supabase/supabase-flutter/commit/a08f06d3b746d1fa5e3cd17c3370fe10466cb69b))

--- a/packages/supabase_auth/pubspec.yaml
+++ b/packages/supabase_auth/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
   http: ^1.6.0
   meta: ^1.16.0
   logging: ^1.3.0
-  supabase_common: 0.1.2
+  supabase_common: 3.0.0-dev.1
   web: ">=1.0.0 <2.0.0"
   dart_jsonwebtoken: ">=3.0.0 <4.0.0"
 

--- a/packages/supabase_common/CHANGELOG.md
+++ b/packages/supabase_common/CHANGELOG.md
@@ -1,3 +1,30 @@
+## 3.0.0-dev.1
+
+> Note: This release has breaking changes.
+
+ - **REFACTOR**: share the test helpers through supabase_common ([#1745](https://github.com/supabase/supabase-flutter/issues/1745)). ([bcb41fa4](https://github.com/supabase/supabase-flutter/commit/bcb41fa4d9ef840c0380e641d3e45968084090c8))
+ - **REFACTOR**: share the auth callback parameters and secure random helpers ([#1744](https://github.com/supabase/supabase-flutter/issues/1744)). ([66ac4901](https://github.com/supabase/supabase-flutter/commit/66ac4901c684b83faae96e13ac560d7efdac158e))
+ - **REFACTOR**: share the HTTP request pieces between the fetch layers ([#1647](https://github.com/supabase/supabase-flutter/issues/1647)). ([a2a9eeaa](https://github.com/supabase/supabase-flutter/commit/a2a9eeaac4f8cc5d98199945283245b697e07a19))
+ - **FIX**(supabase_lints): enable lines_longer_than_80_chars and fix all violations ([#1655](https://github.com/supabase/supabase-flutter/issues/1655)). ([a08b6577](https://github.com/supabase/supabase-flutter/commit/a08b6577d002d0c7ae0d484ddd6da802922be37b))
+ - **FIX**(supabase_common): accept uppercase and mixed-case UUIDs in validation ([#1656](https://github.com/supabase/supabase-flutter/issues/1656)). ([691690cf](https://github.com/supabase/supabase-flutter/commit/691690cfc748456794216028e92dd7075c263055))
+ - **FEAT**: introduce the supabase_testing package ([#1747](https://github.com/supabase/supabase-flutter/issues/1747)). ([5a3aa9b4](https://github.com/supabase/supabase-flutter/commit/5a3aa9b4265385e3d747ca70ad499102fa388ee9))
+ - **FEAT**: resolve an access token per request on the standalone clients ([#1742](https://github.com/supabase/supabase-flutter/issues/1742)). ([dd61782a](https://github.com/supabase/supabase-flutter/commit/dd61782a35f1a99af95f5457b5a3393b3d7939b9))
+ - **FEAT**(storage): expose the service error code on StorageException ([#1657](https://github.com/supabase/supabase-flutter/issues/1657)). ([4f9cabfe](https://github.com/supabase/supabase-flutter/commit/4f9cabfe94bec8800721f1153ed6c40f659157ec))
+ - **DOCS**: fix inaccurate dartdoc comments across all packages ([#1659](https://github.com/supabase/supabase-flutter/issues/1659)). ([090ee978](https://github.com/supabase/supabase-flutter/commit/090ee9781ccdc7a749902830697d51251aa9f052))
+ - **BREAKING** **REFACTOR**(storage): share one SortDirection enum across the packages ([#1752](https://github.com/supabase/supabase-flutter/issues/1752)). ([38396ed5](https://github.com/supabase/supabase-flutter/commit/38396ed5a40d04f24096a816bfead0d57f440394))
+ - **BREAKING** **REFACTOR**: rework logging to emit only through the supabase logger hierarchy ([#1741](https://github.com/supabase/supabase-flutter/issues/1741)). ([d1642c80](https://github.com/supabase/supabase-flutter/commit/d1642c80c60d93cf3bf7919b0cef775470275ed9))
+ - **BREAKING** **REFACTOR**: share one retry configuration across the clients ([#1738](https://github.com/supabase/supabase-flutter/issues/1738)). ([3b2a4855](https://github.com/supabase/supabase-flutter/commit/3b2a4855a5d2e83af17d3cd280189c6a89170741))
+ - **BREAKING** **REFACTOR**: spell out abbreviations in the public API ([#1712](https://github.com/supabase/supabase-flutter/issues/1712)). ([29286f43](https://github.com/supabase/supabase-flutter/commit/29286f4309a74da769ed7aad569daacba6dee7ae))
+ - **BREAKING** **REFACTOR**: share one exponential backoff calculation ([#1646](https://github.com/supabase/supabase-flutter/issues/1646)). ([8bc93f5d](https://github.com/supabase/supabase-flutter/commit/8bc93f5d8ccd72351dc1789e30a4aa9c8e8de1fa))
+ - **BREAKING** **REFACTOR**: split every service exception into a client and an api base ([#1644](https://github.com/supabase/supabase-flutter/issues/1644)). ([0202c332](https://github.com/supabase/supabase-flutter/commit/0202c33249828dc96a778af5fd72520ca5234a46))
+ - **BREAKING** **REFACTOR**: share a single HttpMethod enum across the packages ([#1678](https://github.com/supabase/supabase-flutter/issues/1678)). ([23d55c37](https://github.com/supabase/supabase-flutter/commit/23d55c376fe8e2aa0ff4083f2ff39488fe827979))
+ - **BREAKING** **FIX**(supabase_flutter): persist the session with SharedPreferencesAsync ([#1680](https://github.com/supabase/supabase-flutter/issues/1680)). ([41500b73](https://github.com/supabase/supabase-flutter/commit/41500b73e207cc812c2d42e4e4f4a79127e0502b))
+ - **BREAKING** **FEAT**: rename the storage_client package to supabase_storage ([#1715](https://github.com/supabase/supabase-flutter/issues/1715)). ([6b0388f2](https://github.com/supabase/supabase-flutter/commit/6b0388f209c87dc57ee7281d211fff241e13ec6a))
+ - **BREAKING** **FEAT**: rename the realtime_client package to supabase_realtime ([#1714](https://github.com/supabase/supabase-flutter/issues/1714)). ([d37bed56](https://github.com/supabase/supabase-flutter/commit/d37bed567711c8ed68590a002bb3f1a45432abcb))
+ - **BREAKING** **FEAT**: rename the functions_client package to supabase_functions ([#1713](https://github.com/supabase/supabase-flutter/issues/1713)). ([eb4f3773](https://github.com/supabase/supabase-flutter/commit/eb4f3773e74dd62be5a768433d0a2497d643f110))
+ - **BREAKING** **FEAT**: rename the gotrue package to supabase_auth ([#1697](https://github.com/supabase/supabase-flutter/issues/1697)). ([563b502e](https://github.com/supabase/supabase-flutter/commit/563b502ee64d161defddeceaaacc43615f39b75c))
+ - **BREAKING** **FEAT**: use DateTime for all timestamp fields ([#1663](https://github.com/supabase/supabase-flutter/issues/1663)). ([bad3af8f](https://github.com/supabase/supabase-flutter/commit/bad3af8f88735caac5334b6d0a6e21fa02a220fb))
+
 ## 0.1.2
 
  - **REFACTOR**(supabase_common): share the local stack test configuration ([#1640](https://github.com/supabase/supabase-flutter/issues/1640)). ([a08f06d3](https://github.com/supabase/supabase-flutter/commit/a08f06d3b746d1fa5e3cd17c3370fe10466cb69b))

--- a/packages/supabase_common/pubspec.yaml
+++ b/packages/supabase_common/pubspec.yaml
@@ -1,6 +1,6 @@
 name: supabase_common
 description: Shared internal utilities used across the Supabase Dart and Flutter client packages.
-version: 0.1.2
+version: 3.0.0-dev.1
 homepage: 'https://supabase.com'
 repository: 'https://github.com/supabase/supabase-flutter/tree/main/packages/supabase_common'
 issue_tracker: 'https://github.com/supabase/supabase-flutter/issues'

--- a/packages/supabase_flutter/CHANGELOG.md
+++ b/packages/supabase_flutter/CHANGELOG.md
@@ -1,3 +1,34 @@
+## 3.0.0-dev.1
+
+> Note: This release has breaking changes.
+
+ - **REFACTOR**: share the test helpers through supabase_common ([#1745](https://github.com/supabase/supabase-flutter/issues/1745)). ([bcb41fa4](https://github.com/supabase/supabase-flutter/commit/bcb41fa4d9ef840c0380e641d3e45968084090c8))
+ - **REFACTOR**: share the auth callback parameters and secure random helpers ([#1744](https://github.com/supabase/supabase-flutter/issues/1744)). ([66ac4901](https://github.com/supabase/supabase-flutter/commit/66ac4901c684b83faae96e13ac560d7efdac158e))
+ - **FIX**(supabase_lints): enable lines_longer_than_80_chars and fix all violations ([#1655](https://github.com/supabase/supabase-flutter/issues/1655)). ([a08b6577](https://github.com/supabase/supabase-flutter/commit/a08b6577d002d0c7ae0d484ddd6da802922be37b))
+ - **FEAT**: introduce the supabase_testing package ([#1747](https://github.com/supabase/supabase-flutter/issues/1747)). ([5a3aa9b4](https://github.com/supabase/supabase-flutter/commit/5a3aa9b4265385e3d747ca70ad499102fa388ee9))
+ - **FEAT**(auth): store PKCE verifiers per flow to survive overlapping flows ([#1662](https://github.com/supabase/supabase-flutter/issues/1662)). ([61bbbc5e](https://github.com/supabase/supabase-flutter/commit/61bbbc5e2fbd0e01a1efbcd4d0257286a6060934))
+ - **DOCS**: fix inaccurate dartdoc comments across all packages ([#1659](https://github.com/supabase/supabase-flutter/issues/1659)). ([090ee978](https://github.com/supabase/supabase-flutter/commit/090ee9781ccdc7a749902830697d51251aa9f052))
+ - **DOCS**: add a v2 to v3 migration guide ([#1660](https://github.com/supabase/supabase-flutter/issues/1660)). ([aa1c1497](https://github.com/supabase/supabase-flutter/commit/aa1c14978c765ff8a0bce3a42e3fe9ca083eab32))
+ - **BREAKING** **REFACTOR**: process JSON through the AsyncJsonCodec interface ([#1751](https://github.com/supabase/supabase-flutter/issues/1751)). ([6969eb38](https://github.com/supabase/supabase-flutter/commit/6969eb3805cc1920f5a44902ae2ce660170c13b3))
+ - **BREAKING** **REFACTOR**: rework logging to emit only through the supabase logger hierarchy ([#1741](https://github.com/supabase/supabase-flutter/issues/1741)). ([d1642c80](https://github.com/supabase/supabase-flutter/commit/d1642c80c60d93cf3bf7919b0cef775470275ed9))
+ - **BREAKING** **REFACTOR**: share one retry configuration across the clients ([#1738](https://github.com/supabase/supabase-flutter/issues/1738)). ([3b2a4855](https://github.com/supabase/supabase-flutter/commit/3b2a4855a5d2e83af17d3cd280189c6a89170741))
+ - **BREAKING** **REFACTOR**(realtime): replace listener callbacks with streams ([#1706](https://github.com/supabase/supabase-flutter/issues/1706)). ([07345bf9](https://github.com/supabase/supabase-flutter/commit/07345bf9568a0ba495f1e34cb6ba542eddecc7e9))
+ - **BREAKING** **REFACTOR**(auth): return a Uri from OAuthResponse.url instead of a String ([#1729](https://github.com/supabase/supabase-flutter/issues/1729)). ([c8a66f10](https://github.com/supabase/supabase-flutter/commit/c8a66f100c9e1e1c899829cddc63aa7f1d230e93))
+ - **BREAKING** **REFACTOR**: spell out abbreviations in the public API ([#1712](https://github.com/supabase/supabase-flutter/issues/1712)). ([29286f43](https://github.com/supabase/supabase-flutter/commit/29286f4309a74da769ed7aad569daacba6dee7ae))
+ - **BREAKING** **REFACTOR**: split every service exception into a client and an api base ([#1644](https://github.com/supabase/supabase-flutter/issues/1644)). ([0202c332](https://github.com/supabase/supabase-flutter/commit/0202c33249828dc96a778af5fd72520ca5234a46))
+ - **BREAKING** **REFACTOR**: remove analyzer ignores by fixing the underlying code ([#1675](https://github.com/supabase/supabase-flutter/issues/1675)). ([9f367d77](https://github.com/supabase/supabase-flutter/commit/9f367d77f8f1e1723a985885db0de45123dce6f4))
+ - **BREAKING** **REFACTOR**: remove all deprecated APIs and dead public surface for v3 ([#1661](https://github.com/supabase/supabase-flutter/issues/1661)). ([1ffa0deb](https://github.com/supabase/supabase-flutter/commit/1ffa0deba0371585c7a4ac93795cf199a58e2353))
+ - **BREAKING** **REFACTOR**(realtime): clean up connection naming on RealtimeClient ([#1404](https://github.com/supabase/supabase-flutter/issues/1404)). ([4344c346](https://github.com/supabase/supabase-flutter/commit/4344c346164f731ff394cf8384bebac21f743a94))
+ - **BREAKING** **FIX**(auth): return Uri from getSSOSignInUrl instead of String ([#1722](https://github.com/supabase/supabase-flutter/issues/1722)). ([9aa2e767](https://github.com/supabase/supabase-flutter/commit/9aa2e76788f74b7a890c9a0e2f45e3f4ca44424b))
+ - **BREAKING** **FIX**(supabase_flutter): persist the session with SharedPreferencesAsync ([#1680](https://github.com/supabase/supabase-flutter/issues/1680)). ([41500b73](https://github.com/supabase/supabase-flutter/commit/41500b73e207cc812c2d42e4e4f4a79127e0502b))
+ - **BREAKING** **FIX**: release retained resources on dispose ([#1668](https://github.com/supabase/supabase-flutter/issues/1668)). ([d21d8c03](https://github.com/supabase/supabase-flutter/commit/d21d8c03dd2ebbad5713f28157e2c9445e13c7e0))
+ - **BREAKING** **FIX**(gotrue): emit userUpdated instead of signedIn when an email change is confirmed ([#1664](https://github.com/supabase/supabase-flutter/issues/1664)). ([7a042416](https://github.com/supabase/supabase-flutter/commit/7a042416ce190f22f02d0683ecd1fdc84a29ec5a))
+ - **BREAKING** **FEAT**: rename the storage_client package to supabase_storage ([#1715](https://github.com/supabase/supabase-flutter/issues/1715)). ([6b0388f2](https://github.com/supabase/supabase-flutter/commit/6b0388f209c87dc57ee7281d211fff241e13ec6a))
+ - **BREAKING** **FEAT**: rename the realtime_client package to supabase_realtime ([#1714](https://github.com/supabase/supabase-flutter/issues/1714)). ([d37bed56](https://github.com/supabase/supabase-flutter/commit/d37bed567711c8ed68590a002bb3f1a45432abcb))
+ - **BREAKING** **FEAT**: rename the functions_client package to supabase_functions ([#1713](https://github.com/supabase/supabase-flutter/issues/1713)). ([eb4f3773](https://github.com/supabase/supabase-flutter/commit/eb4f3773e74dd62be5a768433d0a2497d643f110))
+ - **BREAKING** **FEAT**: rename the gotrue package to supabase_auth ([#1697](https://github.com/supabase/supabase-flutter/issues/1697)). ([563b502e](https://github.com/supabase/supabase-flutter/commit/563b502ee64d161defddeceaaacc43615f39b75c))
+ - **BREAKING** **CHORE**: give each package's Constants class a package-specific name ([#1677](https://github.com/supabase/supabase-flutter/issues/1677)). ([40f6d89c](https://github.com/supabase/supabase-flutter/commit/40f6d89c7fad32e49f028b2644914807fd731b70))
+
 ## 2.17.1
 
  - Update a dependency to the latest release.

--- a/packages/supabase_flutter/example/pubspec.yaml
+++ b/packages/supabase_flutter/example/pubspec.yaml
@@ -13,7 +13,7 @@ resolution: workspace
 dependencies:
   flutter:
     sdk: flutter
-  supabase_flutter: ^2.17.1
+  supabase_flutter: ^3.0.0-dev.1
 
 dev_dependencies:
   flutter_test:

--- a/packages/supabase_flutter/lib/src/version.dart
+++ b/packages/supabase_flutter/lib/src/version.dart
@@ -1,1 +1,1 @@
-const version = '2.17.1';
+const version = '3.0.0-dev.1';

--- a/packages/supabase_flutter/pubspec.yaml
+++ b/packages/supabase_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: supabase_flutter
 description: Flutter integration for Supabase. This package makes it simple for developers to build secure and scalable products.
-version: 2.17.1
+version: 3.0.0-dev.1
 homepage: 'https://supabase.com'
 repository: 'https://github.com/supabase/supabase-flutter/tree/main/packages/supabase_flutter'
 issue_tracker: 'https://github.com/supabase/supabase-flutter/issues'
@@ -26,8 +26,8 @@ dependencies:
   http: ^1.6.0
   meta: ^1.16.0
   passkeys_platform_interface: ^2.8.0
-  supabase: 2.16.0
-  supabase_common: 0.1.2
+  supabase: 3.0.0-dev.1
+  supabase_common: 3.0.0-dev.1
   url_launcher: ^6.3.2
   shared_preferences: ^2.5.5
   logging: ^1.3.0

--- a/packages/supabase_functions/CHANGELOG.md
+++ b/packages/supabase_functions/CHANGELOG.md
@@ -1,3 +1,18 @@
+## 3.0.0-dev.1
+
+> Note: This release has breaking changes.
+
+ - **REFACTOR**: share the test helpers through supabase_common ([#1745](https://github.com/supabase/supabase-flutter/issues/1745)). ([bcb41fa4](https://github.com/supabase/supabase-flutter/commit/bcb41fa4d9ef840c0380e641d3e45968084090c8))
+ - **PERF**(yet_another_json_isolate): process small payloads inline and large ones on short-lived isolates ([#1746](https://github.com/supabase/supabase-flutter/issues/1746)). ([7942c377](https://github.com/supabase/supabase-flutter/commit/7942c37770c5a12b18b27afc66b8595e67fdd22d))
+ - **FEAT**: introduce the supabase_testing package ([#1747](https://github.com/supabase/supabase-flutter/issues/1747)). ([5a3aa9b4](https://github.com/supabase/supabase-flutter/commit/5a3aa9b4265385e3d747ca70ad499102fa388ee9))
+ - **FEAT**: resolve an access token per request on the standalone clients ([#1742](https://github.com/supabase/supabase-flutter/issues/1742)). ([dd61782a](https://github.com/supabase/supabase-flutter/commit/dd61782a35f1a99af95f5457b5a3393b3d7939b9))
+ - **BREAKING** **REFACTOR**: process JSON through the AsyncJsonCodec interface ([#1751](https://github.com/supabase/supabase-flutter/issues/1751)). ([6969eb38](https://github.com/supabase/supabase-flutter/commit/6969eb3805cc1920f5a44902ae2ce660170c13b3))
+ - **BREAKING** **REFACTOR**: rework logging to emit only through the supabase logger hierarchy ([#1741](https://github.com/supabase/supabase-flutter/issues/1741)). ([d1642c80](https://github.com/supabase/supabase-flutter/commit/d1642c80c60d93cf3bf7919b0cef775470275ed9))
+ - **BREAKING** **REFACTOR**: remove the dead setAccessToken mutators ([#1739](https://github.com/supabase/supabase-flutter/issues/1739)). ([ced47232](https://github.com/supabase/supabase-flutter/commit/ced47232edead42ce57d27b76227723817ef2367))
+ - **BREAKING** **FEAT**(functions): make FunctionException a sealed class ([#1723](https://github.com/supabase/supabase-flutter/issues/1723)). ([cb128aaa](https://github.com/supabase/supabase-flutter/commit/cb128aaa2885397fa13c94dbac60a1bc6a3a8de4))
+ - **BREAKING** **FEAT**: rename the functions_client package to supabase_functions ([#1713](https://github.com/supabase/supabase-flutter/issues/1713)). ([eb4f3773](https://github.com/supabase/supabase-flutter/commit/eb4f3773e74dd62be5a768433d0a2497d643f110))
+ - **BREAKING** **CHORE**: give each package's Constants class a package-specific name ([#1677](https://github.com/supabase/supabase-flutter/issues/1677)). ([40f6d89c](https://github.com/supabase/supabase-flutter/commit/40f6d89c7fad32e49f028b2644914807fd731b70))
+
 ## 2.7.1
 
  - Update a dependency to the latest release.

--- a/packages/supabase_functions/pubspec.yaml
+++ b/packages/supabase_functions/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
   http: ^1.6.0
   logging: ^1.3.0
   meta: ^1.16.0
-  supabase_common: 0.1.2
+  supabase_common: 3.0.0-dev.1
   yet_another_json_isolate: 2.1.1
 
 dev_dependencies:

--- a/packages/supabase_realtime/CHANGELOG.md
+++ b/packages/supabase_realtime/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 3.0.0-dev.1
+
+> Note: This release has breaking changes.
+
+ - **REFACTOR**: share the test helpers through supabase_common ([#1745](https://github.com/supabase/supabase-flutter/issues/1745)). ([bcb41fa4](https://github.com/supabase/supabase-flutter/commit/bcb41fa4d9ef840c0380e641d3e45968084090c8))
+ - **FEAT**: introduce the supabase_testing package ([#1747](https://github.com/supabase/supabase-flutter/issues/1747)). ([5a3aa9b4](https://github.com/supabase/supabase-flutter/commit/5a3aa9b4265385e3d747ca70ad499102fa388ee9))
+ - **BREAKING** **REFACTOR**: rework logging to emit only through the supabase logger hierarchy ([#1741](https://github.com/supabase/supabase-flutter/issues/1741)). ([d1642c80](https://github.com/supabase/supabase-flutter/commit/d1642c80c60d93cf3bf7919b0cef775470275ed9))
+ - **BREAKING** **REFACTOR**(realtime): replace listener callbacks with streams ([#1706](https://github.com/supabase/supabase-flutter/issues/1706)). ([07345bf9](https://github.com/supabase/supabase-flutter/commit/07345bf9568a0ba495f1e34cb6ba542eddecc7e9))
+ - **BREAKING** **FEAT**(realtime): support asynchronous encode/decode codecs ([#1684](https://github.com/supabase/supabase-flutter/issues/1684)). ([5c496198](https://github.com/supabase/supabase-flutter/commit/5c496198fb0cfb874f2a036b02862834bc739572))
+ - **BREAKING** **FEAT**: rename the realtime_client package to supabase_realtime ([#1714](https://github.com/supabase/supabase-flutter/issues/1714)). ([d37bed56](https://github.com/supabase/supabase-flutter/commit/d37bed567711c8ed68590a002bb3f1a45432abcb))
+ - **BREAKING** **CHORE**: give each package's Constants class a package-specific name ([#1677](https://github.com/supabase/supabase-flutter/issues/1677)). ([40f6d89c](https://github.com/supabase/supabase-flutter/commit/40f6d89c7fad32e49f028b2644914807fd731b70))
+
 ## 2.13.0
 
  - **REFACTOR**(supabase_common): share the local stack test configuration ([#1640](https://github.com/supabase/supabase-flutter/issues/1640)). ([a08f06d3](https://github.com/supabase/supabase-flutter/commit/a08f06d3b746d1fa5e3cd17c3370fe10466cb69b))

--- a/packages/supabase_realtime/pubspec.yaml
+++ b/packages/supabase_realtime/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
   http: ^1.6.0
   logging: ^1.3.0
   meta: ^1.16.0
-  supabase_common: 0.1.2
+  supabase_common: 3.0.0-dev.1
   web_socket_channel: ^3.0.3
 
 dev_dependencies:

--- a/packages/supabase_storage/CHANGELOG.md
+++ b/packages/supabase_storage/CHANGELOG.md
@@ -1,3 +1,19 @@
+## 3.0.0-dev.1
+
+> Note: This release has breaking changes.
+
+ - **REFACTOR**: share the test helpers through supabase_common ([#1745](https://github.com/supabase/supabase-flutter/issues/1745)). ([bcb41fa4](https://github.com/supabase/supabase-flutter/commit/bcb41fa4d9ef840c0380e641d3e45968084090c8))
+ - **FEAT**: introduce the supabase_testing package ([#1747](https://github.com/supabase/supabase-flutter/issues/1747)). ([5a3aa9b4](https://github.com/supabase/supabase-flutter/commit/5a3aa9b4265385e3d747ca70ad499102fa388ee9))
+ - **FEAT**: resolve an access token per request on the standalone clients ([#1742](https://github.com/supabase/supabase-flutter/issues/1742)). ([dd61782a](https://github.com/supabase/supabase-flutter/commit/dd61782a35f1a99af95f5457b5a3393b3d7939b9))
+ - **BREAKING** **REFACTOR**(storage): share one SortDirection enum across the packages ([#1752](https://github.com/supabase/supabase-flutter/issues/1752)). ([38396ed5](https://github.com/supabase/supabase-flutter/commit/38396ed5a40d04f24096a816bfead0d57f440394))
+ - **BREAKING** **REFACTOR**: rework logging to emit only through the supabase logger hierarchy ([#1741](https://github.com/supabase/supabase-flutter/issues/1741)). ([d1642c80](https://github.com/supabase/supabase-flutter/commit/d1642c80c60d93cf3bf7919b0cef775470275ed9))
+ - **BREAKING** **REFACTOR**: remove the dead setAccessToken mutators ([#1739](https://github.com/supabase/supabase-flutter/issues/1739)). ([ced47232](https://github.com/supabase/supabase-flutter/commit/ced47232edead42ce57d27b76227723817ef2367))
+ - **BREAKING** **REFACTOR**: share one retry configuration across the clients ([#1738](https://github.com/supabase/supabase-flutter/issues/1738)). ([3b2a4855](https://github.com/supabase/supabase-flutter/commit/3b2a4855a5d2e83af17d3cd280189c6a89170741))
+ - **BREAKING** **REFACTOR**(storage): move the Iceberg catalog into its own package ([#1711](https://github.com/supabase/supabase-flutter/issues/1711)). ([26fc503d](https://github.com/supabase/supabase-flutter/commit/26fc503d8a452f2ce6292c55bcee1f32784fb52d))
+ - **BREAKING** **FEAT**(storage): return the file id from upload and update methods ([#1730](https://github.com/supabase/supabase-flutter/issues/1730)). ([39ccfca3](https://github.com/supabase/supabase-flutter/commit/39ccfca363d03898ecfcb8f7ee2fd3eca92b671d))
+ - **BREAKING** **FEAT**: rename the storage_client package to supabase_storage ([#1715](https://github.com/supabase/supabase-flutter/issues/1715)). ([6b0388f2](https://github.com/supabase/supabase-flutter/commit/6b0388f209c87dc57ee7281d211fff241e13ec6a))
+ - **BREAKING** **CHORE**: give each package's Constants class a package-specific name ([#1677](https://github.com/supabase/supabase-flutter/issues/1677)). ([40f6d89c](https://github.com/supabase/supabase-flutter/commit/40f6d89c7fad32e49f028b2644914807fd731b70))
+
 ## 2.8.0
 
  - **REFACTOR**(supabase_common): share the local stack test configuration ([#1640](https://github.com/supabase/supabase-flutter/issues/1640)). ([a08f06d3](https://github.com/supabase/supabase-flutter/commit/a08f06d3b746d1fa5e3cd17c3370fe10466cb69b))

--- a/packages/supabase_storage/pubspec.yaml
+++ b/packages/supabase_storage/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
   mime: '>=2.0.0 <3.0.0'
   meta: ^1.16.0
   logging: ^1.3.0
-  supabase_common: 0.1.2
+  supabase_common: 3.0.0-dev.1
 
 dev_dependencies:
   test: ^1.25.0

--- a/packages/supabase_testing/pubspec.yaml
+++ b/packages/supabase_testing/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   crypto: ^3.0.7
   http: ^1.6.0
   meta: ^1.16.0
-  supabase: 2.16.0
+  supabase: 3.0.0-dev.1
 
 dev_dependencies:
   supabase_lints: ^0.1.1


### PR DESCRIPTION
Pre-release versioning run for the v3 train. Every published SDK package lands on `3.0.0-dev.1` so the whole set can go to pub.dev as a coherent prerelease.

## Versions

| Package | Before | After |
| --- | --- | --- |
| `supabase_common` | 0.1.2 | 3.0.0-dev.1 |
| `postgrest` | 2.9.1 | 3.0.0-dev.1 |
| `supabase_auth` | 3.0.0-dev.1 | 3.0.0-dev.1 |
| `supabase_functions` | 3.0.0-dev.1 | 3.0.0-dev.1 |
| `supabase_realtime` | 3.0.0-dev.1 | 3.0.0-dev.1 |
| `supabase_storage` | 3.0.0-dev.1 | 3.0.0-dev.1 |
| `supabase` | 2.16.0 | 3.0.0-dev.1 |
| `supabase_flutter` | 2.17.1 | 3.0.0-dev.1 |

`supabase_auth`, `supabase_functions`, `supabase_realtime` and `supabase_storage` already carried `3.0.0-dev.1` in their pubspec, but that number was hand-set during the package renames and never published, so no matching changelog section existed. This run generates it and leaves the version where it is.

## iceberg

`iceberg` stays on `0.1.0`. It has never been published, so its accumulated changes are folded into the existing `## 0.1.0` changelog section instead of opening a new one. `supabase_storage` keeps its `iceberg: 0.1.0` constraint.

## Not versioned

- `yet_another_json_isolate` stays on 2.1.1
- `supabase_testing` stays on 0.1.0
- `supabase_lints` and `supabase_typegen` stay on 0.1.1, they version on their own tooling track

Their pubspec versions and changelogs are untouched, as are the constraints pointing at them (`yet_another_json_isolate: 2.1.1`, `supabase_lints: ^0.1.1`).

## What changed

- Package `pubspec.yaml` versions plus the intra-workspace dependency constraints between them
- `lib/src/version.dart` for `postgrest`, `supabase` and `supabase_flutter`, regenerated by the `update-version` melos hook
- Per-package `CHANGELOG.md` and the workspace `CHANGELOG.md`
- `supabase_flutter: ^3.0.0-dev.1` and `supabase: ^3.0.0-dev.1` in the example apps

## How it was generated

`melos version` with an explicit `--manual-version` entry for every package that had versionable commits, so nothing was auto-bumped by conventional-commit inference. Packages held back from the release were passed their current version to stop melos auto-versioning them, and the resulting no-op changelog sections were dropped again.

## Verification

- `flutter pub get` resolves the workspace, `pubspec.lock` needs no change
- `dart analyze --fatal-infos` reports no issues

Tagging and publishing are left to `release-tag.yml` and `release-publish.yml` once this merges.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced the Supabase Flutter v3.0.0-dev.1 release, including improved realtime streams, asynchronous codecs, per-flow PKCE storage, unified retry configuration, and enhanced JSON performance.
  - Added shared testing utilities and the new `supabase_testing` package.
  - Added Iceberg package v0.1.0.

- **Bug Fixes**
  - Improved authentication redirect and session parsing, access-token handling, storage behavior, and resource disposal.

- **Documentation**
  - Added comprehensive changelogs, breaking-change notes, and a v2-to-v3 migration guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->