### PR TITLE
ci: group dependabot github-actions updates into fewer pull requests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,17 @@ updates:
       supabase-sdk-workflows:
         patterns:
           - "supabase/sdk*"
+      # Same story for the reusable workflows we call from supabase/actions,
+      # which are all pinned to a single commit of that repository.
+      supabase-actions-workflows:
+        patterns:
+          - "supabase/actions*"
+      # Everything else that cannot break a workflow on its own, batched into a
+      # single pull request. Major bumps deliberately match no group so they
+      # still arrive individually and get reviewed on their own.
+      actions-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,8 @@ updates:
       codeql-action:
         patterns:
           - "github/codeql-action*"
+      # Every reusable workflow we call from supabase/sdk shares that
+      # repository's release tags, so they always move in lockstep.
+      supabase-sdk-workflows:
+        patterns:
+          - "supabase/sdk*"


### PR DESCRIPTION
## What

Replaces the mostly ungrouped `github-actions` Dependabot config with four groups:

| Group | Pattern | Purpose |
| --- | --- | --- |
| `codeql-action` | `github/codeql-action*` | Pre-existing. `init` and `analyze` must run the same version. |
| `supabase-sdk-workflows` | `supabase/sdk*` | New. Reusable workflows sharing one repository's release tags. |
| `supabase-actions-workflows` | `supabase/actions*` | New. Same, for the three workflows pinned to one commit. |
| `actions-minor-patch` | `*` (minor, patch) | New. Batches every remaining non-breaking bump. |

Group order matters: Dependabot assigns each dependency to the first group it matches, so the three specific groups are listed before the catch-all.

## Why

**Lockstep dependencies were being split.** Dependabot treats each reusable workflow as its own dependency, named by its full path. The `supabase/sdk` v1.1.1 to v1.2.0 bump therefore arrived as two pull requests, #1755 and #1756, and between the two merges the repository had two callers pointing at different releases of the same source. `supabase/actions` has the same exposure but larger: three reusable workflows in `stale.yml`, `label-issues.yml` and `block-merge.yml`, all pinned to commit `2e898cb`, so its first bump would have landed as three separate pull requests.

**Volume.** Ten individual bump pull requests merged across 2026-08-12 and 2026-08-13, five on each day. The catch-all collapses that into roughly one per week.

## Deliberately not grouped

Major bumps match no group and keep arriving as individual pull requests. A bump like the earlier `actions/upload-artifact` 4.6.2 to 7.0.1 should be reviewed and revertable on its own rather than buried in a batch.

## Verification

- `.github/dependabot.yml` parses, and the four groups resolve in the intended order.
- Confirmed the existing `codeql-action` group is already working: `codeql.yml:41` and `codeql.yml:47` are both pinned to `ff2f1c62` at v4.37.7. Past bump titles name only `analyze` because Dependabot titles a group after a single member when only that member moved.
- Audited all 19 `uses:` references across `.github/workflows/`. Apart from the three groups above, no remaining action is coupled to another.

## Note

Grouping takes effect on the next Dependabot run. Both #1755 and #1756 have since been merged, and `supabase/sdk` is back in sync at v1.2.0 in both callers, so nothing needs recreating.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured automated updates to group reusable workflow dependencies by repository.
  * Grouped minor and patch updates for GitHub Actions, while keeping major updates separate for review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->