### PR TITLE
refactor(realtime)!: make RealtimeClient internal mutable fields private

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -268,6 +268,53 @@ final WebSocketChannel? socket = client.connection;
 client.onConnectionMessage(rawMessage);
 ```
 
+### The mutable internals of `RealtimeClient` are private
+
+`RealtimeClient` used to expose its internal state machine as public mutable fields, so external
+code could reset the message counter, cancel the heartbeat timer, or add channels to the internal
+list, bypassing all lifecycle management. The internals are now private and the remaining public
+surface is read-only:
+
+| Before | After |
+| --- | --- |
+| `client.channels` (mutable list) | `client.channels` (unmodifiable view) |
+| `client.getChannels()` | `client.channels` |
+| `supabase.getChannels()` | `supabase.channels` |
+| `client.accessToken = token` | `await client.setAccessToken(token)` |
+| `client.heartbeatInterval = interval` | `RealtimeClient(heartbeatInterval: interval)` |
+| `client.customAccessToken = getter` | `RealtimeClient(customAccessToken: getter)` |
+| `client.reconnectAfter = calculation` | `RealtimeClient(reconnectAfter: calculation)` |
+| `client.connection = channel` | removed, the getter remains |
+| `client.connectionState = state` | removed, the getter remains |
+| `client.headers['key'] = value` | `RealtimeClient(headers: headers)` |
+| `client.ref`, `client.pendingHeartbeatRef`, `client.heartbeatTimer`, `client.reconnectTimer`, `client.sendBuffer` | removed |
+
+`channels`, `accessToken`, `connection` and `connectionState` are still readable, and everything
+that used to be mutated after construction is either a constructor parameter or has a dedicated
+method. Channels are added with `channel()` and removed with `removeChannel()` or
+`removeAllChannels()`; the returned `channels` list is an unmodifiable snapshot, so mutating it
+throws an `UnsupportedError`. The `headers` and `parameters` maps are also unmodifiable now; pass
+them to the constructor instead, or assign `SupabaseClient.headers` when the client is managed by
+a `SupabaseClient`.
+
+```dart
+// Before
+client.accessToken = newToken;
+client.heartbeatInterval = const Duration(seconds: 60);
+final channels = client.getChannels();
+
+// After
+await client.setAccessToken(newToken);
+final client = RealtimeClient(
+  realtimeUrl,
+  heartbeatInterval: const Duration(seconds: 60),
+);
+final channels = client.channels;
+```
+
+`setAccessToken()` is the intentional path for token rotation: unlike the removed field write, it
+also propagates the new token to every joined channel.
+
 ### Broadcasts no longer fall back to the REST API
 
 `sendBroadcastMessage()` used to silently post to the REST broadcast endpoint whenever the channel

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -287,7 +287,8 @@ surface is read-only:
 | `client.connection = channel` | removed, the getter remains |
 | `client.connectionState = state` | removed, the getter remains |
 | `client.headers['key'] = value` | `RealtimeClient(headers: headers)` |
-| `client.ref`, `client.pendingHeartbeatRef`, `client.heartbeatTimer`, `client.reconnectTimer`, `client.sendBuffer` | removed |
+| `client.heartbeatTimer`, `client.reconnectTimer` | removed |
+| `client.ref`, `client.pendingHeartbeatRef`, `client.sendBuffer` | internal and test-only |
 
 `channels`, `accessToken`, `connection` and `connectionState` are still readable, and everything
 that used to be mutated after construction is either a constructor parameter or has a dedicated
@@ -297,18 +298,32 @@ throws an `UnsupportedError`. The `headers` and `parameters` maps are also unmod
 them to the constructor instead, or assign `SupabaseClient.headers` when the client is managed by
 a `SupabaseClient`.
 
+When the client is managed by a `SupabaseClient`, pass the heartbeat interval and the reconnect
+backoff through `RealtimeClientOptions` instead:
+
+```dart
+final supabase = SupabaseClient(
+  supabaseUrl,
+  supabaseKey,
+  realtimeClientOptions: const RealtimeClientOptions(
+    heartbeatInterval: Duration(seconds: 60),
+  ),
+);
+```
+
 ```dart
 // Before
-client.accessToken = newToken;
+final client = RealtimeClient(realtimeUrl);
 client.heartbeatInterval = const Duration(seconds: 60);
+client.accessToken = newToken;
 final channels = client.getChannels();
 
 // After
-await client.setAccessToken(newToken);
 final client = RealtimeClient(
   realtimeUrl,
   heartbeatInterval: const Duration(seconds: 60),
 );
+await client.setAccessToken(newToken);
 final channels = client.channels;
 ```
 

--- a/packages/supabase/lib/src/realtime_client_options.dart
+++ b/packages/supabase/lib/src/realtime_client_options.dart
@@ -14,6 +14,14 @@ class RealtimeClientOptions {
   /// result.
   final Duration? connectionCloseTimeout;
 
+  /// The interval at which to send a heartbeat message.
+  final Duration? heartbeatInterval;
+
+  /// Returns the reconnect interval per attempt.
+  ///
+  /// Defaults to the stepped backoff of the RealtimeClient.
+  final TimerCalculation? reconnectAfter;
+
   /// Custom WebSocket transport factory for the RealtimeClient.
   final WebSocketTransport? transport;
 
@@ -52,6 +60,8 @@ class RealtimeClientOptions {
     this.logLevel,
     this.timeout,
     this.connectionCloseTimeout,
+    this.heartbeatInterval,
+    this.reconnectAfter,
     this.transport,
     this.disconnectOnEmptyChannelsAfter,
     this.encode,

--- a/packages/supabase/lib/src/supabase_client.dart
+++ b/packages/supabase/lib/src/supabase_client.dart
@@ -388,6 +388,10 @@ class SupabaseClient {
       connectionCloseTimeout:
           options.connectionCloseTimeout ??
           RealtimeConstants.defaultConnectionCloseTimeout,
+      heartbeatInterval:
+          options.heartbeatInterval ??
+          RealtimeConstants.defaultHeartbeatInterval,
+      reconnectAfter: options.reconnectAfter,
       customAccessToken: accessToken,
       transport: options.transport,
       disconnectOnEmptyChannelsAfter: options.disconnectOnEmptyChannelsAfter,

--- a/packages/supabase/lib/src/supabase_client.dart
+++ b/packages/supabase/lib/src/supabase_client.dart
@@ -133,12 +133,11 @@ class SupabaseClient {
 
     // To apply the new headers in the realtime client,
     // manually unsubscribe and resubscribe to all channels.
-    realtime.headers
-      ..clear()
-      ..addAll({
-        'apikey': _supabaseKey,
-        ..._headers,
-      });
+    // ignore: invalid_use_of_internal_member
+    realtime.replaceHeaders({
+      'apikey': _supabaseKey,
+      ..._headers,
+    });
   }
 
   /// {@macro supabase_client}
@@ -265,10 +264,8 @@ class SupabaseClient {
     return realtime.channel(name, options);
   }
 
-  /// Returns all Realtime channels.
-  List<RealtimeChannel> getChannels() {
-    return realtime.getChannels();
-  }
+  /// All Realtime channels, as an unmodifiable view.
+  List<RealtimeChannel> get channels => realtime.channels;
 
   /// Unsubscribes and removes Realtime channel from Realtime client.
   ///

--- a/packages/supabase/test/realtime_test.dart
+++ b/packages/supabase/test/realtime_test.dart
@@ -75,7 +75,7 @@ void main() {
     test('two realtime channels', () {
       supabase.channel('anotherChannel');
 
-      final channels = supabase.getChannels();
+      final channels = supabase.channels;
 
       expect(
         channels,
@@ -98,7 +98,7 @@ void main() {
       anotherChannel.subscribe();
 
       expect(
-        supabase.getChannels(),
+        supabase.channels,
         hasLength(2),
       );
 
@@ -107,7 +107,7 @@ void main() {
       expect(status, 'ok');
 
       expect(
-        supabase.getChannels(),
+        supabase.channels,
         hasLength(1),
       );
     });
@@ -140,7 +140,7 @@ void main() {
       );
 
       expect(
-        supabase.getChannels(),
+        supabase.channels,
         isEmpty,
       );
     });
@@ -168,7 +168,7 @@ void main() {
       );
 
       expect(
-        supabase.getChannels(),
+        supabase.channels,
         isEmpty,
       );
     });

--- a/packages/supabase/test/stream_integration_test.dart
+++ b/packages/supabase/test/stream_integration_test.dart
@@ -603,7 +603,7 @@ Future<void> _expectSnapshots({
 /// are being streamed yet.
 Future<void> _waitUntilJoined() async {
   for (var attempt = 0; attempt < 200; attempt++) {
-    final channels = _supabase.getChannels();
+    final channels = _supabase.channels;
     if (channels.isNotEmpty &&
         // ignore: invalid_use_of_internal_member
         channels.every((channel) => channel.isJoined)) {

--- a/packages/supabase_realtime/lib/src/realtime_client.dart
+++ b/packages/supabase_realtime/lib/src/realtime_client.dart
@@ -154,7 +154,9 @@ class RealtimeClient {
 
   /// The headers sent when connecting, as an unmodifiable view.
   ///
-  /// Replaced wholesale with [replaceHeaders].
+  /// Pass headers to the constructor instead of mutating them here. A client
+  /// managed by a `SupabaseClient` gets its headers replaced through the
+  /// internal [replaceHeaders] when `SupabaseClient.headers` is assigned.
   Map<String, String> get headers => Map.unmodifiable(_headers);
   final Map<String, String> _headers;
 
@@ -189,10 +191,6 @@ class RealtimeClient {
   @internal
   @visibleForTesting
   String? get pendingHeartbeatRef => _pendingHeartbeatRef;
-
-  @internal
-  @visibleForTesting
-  set pendingHeartbeatRef(String? value) => _pendingHeartbeatRef = value;
 
   /// Counter used by [makeRef] to generate a unique reference ID for every
   /// pushed message, including heartbeats.
@@ -261,10 +259,6 @@ class RealtimeClient {
   /// The current state of the socket, or `null` before the first [connect].
   SocketState? get connectionState => _connectionState;
   SocketState? _connectionState;
-
-  @internal
-  @visibleForTesting
-  set connectionState(SocketState? value) => _connectionState = value;
 
   final Future<String?> Function()? customAccessToken;
 
@@ -572,11 +566,13 @@ class RealtimeClient {
     return newChannel;
   }
 
-  /// Registers [channel] directly, bypassing [channel]'s construction and
-  /// lifecycle handling, so tests can inject mock channels.
+  /// Registers [channel] with the same lifecycle handling as [channel]'s
+  /// registration, without constructing one, so tests can inject mock
+  /// channels.
   @internal
   @visibleForTesting
   void addChannelForTesting(RealtimeChannel channel) {
+    _cancelPendingDisconnect();
     _channels.add(channel);
   }
 
@@ -896,7 +892,9 @@ class RealtimeClient {
 
     _accessToken = tokenToSend;
 
-    for (final channel in _channels) {
+    // Snapshot before pushing, in case a push synchronously removes a channel
+    // from [_channels].
+    for (final channel in _channels.toList()) {
       if (tokenToSend != null) {
         channel.updateJoinPayload({
           'access_token': tokenToSend,
@@ -1038,11 +1036,14 @@ class RealtimeClient {
         await setAccessToken(null);
         final resolvedToken = _accessToken;
         if (resolvedToken != null) {
-          for (final channel in _channels) {
+          // Snapshot before patching and rejoining, in case either removes a
+          // channel from [_channels] synchronously.
+          final channelsSnapshot = _channels.toList();
+          for (final channel in channelsSnapshot) {
             channel.updateJoinPayload({'access_token': resolvedToken});
           }
           _sendBuffer.clear();
-          for (final channel in _channels) {
+          for (final channel in channelsSnapshot) {
             if (channel.isJoining) {
               channel.forceRejoin();
             }

--- a/packages/supabase_realtime/lib/src/realtime_client.dart
+++ b/packages/supabase_realtime/lib/src/realtime_client.dart
@@ -135,11 +135,30 @@ class RealtimeConnectionStatusChange {
 /// - Works on all Dart platforms (Flutter mobile/desktop, web, server).
 /// - On web, the underlying [WebSocketChannel] uses the browser WebSocket API.
 class RealtimeClient {
-  String? accessToken;
-  List<RealtimeChannel> channels = [];
+  /// The JWT access token used for channel subscription authorization and
+  /// Realtime RLS.
+  ///
+  /// Set it with [setAccessToken], which also propagates the token to every
+  /// joined channel.
+  String? get accessToken => _accessToken;
+  String? _accessToken;
+
+  /// The channels registered on this client, as an unmodifiable view.
+  ///
+  /// Create channels with [channel] and remove them with [removeChannel] or
+  /// [removeAllChannels].
+  List<RealtimeChannel> get channels => List.unmodifiable(_channels);
+  final List<RealtimeChannel> _channels = [];
+
   final String endpoint;
 
-  final Map<String, String> headers;
+  /// The headers sent when connecting, as an unmodifiable view.
+  ///
+  /// Replaced wholesale with [replaceHeaders].
+  Map<String, String> get headers => Map.unmodifiable(_headers);
+  final Map<String, String> _headers;
+
+  /// The query parameters sent when connecting, as an unmodifiable map.
   final Map<String, dynamic> parameters;
 
   final RealtimeProtocolVersion version;
@@ -147,9 +166,8 @@ class RealtimeClient {
   final Duration timeout;
   final WebSocketTransport transport;
   final Client? httpClient;
-  Duration heartbeatInterval = RealtimeConstants.defaultHeartbeatInterval;
-  @internal
-  Timer? heartbeatTimer;
+  final Duration heartbeatInterval;
+  Timer? _heartbeatTimer;
 
   /// Delay before the socket is disconnected once the last channel has been
   /// removed. [Duration.zero] disconnects immediately. Defaults to twice the
@@ -163,18 +181,32 @@ class RealtimeClient {
   /// it fires, so that quickly switching channels reuses the open socket.
   Timer? _pendingDisconnectTimer;
 
-  /// reference ID of the most recently sent heartbeat.
+  /// Reference ID of the most recently sent heartbeat.
   ///
   /// Used to keep track of whether the client is connected to the server.
+  String? _pendingHeartbeatRef;
+
   @internal
-  String? pendingHeartbeatRef;
+  @visibleForTesting
+  String? get pendingHeartbeatRef => _pendingHeartbeatRef;
+
+  @internal
+  @visibleForTesting
+  set pendingHeartbeatRef(String? value) => _pendingHeartbeatRef = value;
 
   /// Counter used by [makeRef] to generate a unique reference ID for every
   /// pushed message, including heartbeats.
+  int _ref = 0;
+
   @internal
-  int ref = 0;
+  @visibleForTesting
+  int get ref => _ref;
+
   @internal
-  late RetryTimer reconnectTimer;
+  @visibleForTesting
+  set ref(int value) => _ref = value;
+
+  late final RetryTimer _reconnectTimer;
   static final Serializer _serializer = Serializer();
 
   /// Serializes outgoing messages, or `null` to use the built-in codec for
@@ -191,11 +223,21 @@ class RealtimeClient {
   /// and dispatches without a microtask hop.
   final Object Function(RealtimeMessage) _builtInEncode;
   final RealtimeMessage Function(Object) _builtInDecode;
-  late TimerCalculation reconnectAfter;
-  WebSocketChannel? connection;
+  late final TimerCalculation reconnectAfter;
+
+  /// The underlying WebSocket connection, or `null` when disconnected.
+  WebSocketChannel? get connection => _connection;
+  WebSocketChannel? _connection;
+
   StreamSubscription<dynamic>? _connectionSubscription;
+
+  /// Messages pushed while the socket was not connected, sent out once a
+  /// connection is next established.
+  final List<void Function()> _sendBuffer = [];
+
   @internal
-  List<dynamic> sendBuffer = [];
+  @visibleForTesting
+  List<void Function()> get sendBuffer => List.unmodifiable(_sendBuffer);
 
   final _statusController =
       StreamController<RealtimeConnectionStatusChange>.broadcast();
@@ -217,8 +259,14 @@ class RealtimeClient {
   Future<void>? _pendingDispatch;
 
   /// The current state of the socket, or `null` before the first [connect].
-  SocketState? connectionState;
-  Future<String?> Function()? customAccessToken;
+  SocketState? get connectionState => _connectionState;
+  SocketState? _connectionState;
+
+  @internal
+  @visibleForTesting
+  set connectionState(SocketState? value) => _connectionState = value;
+
+  final Future<String?> Function()? customAccessToken;
 
   /// Initializes the Socket
   ///
@@ -274,7 +322,7 @@ class RealtimeClient {
     this.decode,
     TimerCalculation? reconnectAfter,
     Map<String, String>? headers,
-    this.parameters = const {},
+    Map<String, dynamic> parameters = const {},
     RealtimeLogLevel? logLevel,
     this.httpClient,
     this.customAccessToken,
@@ -286,10 +334,11 @@ class RealtimeClient {
                  : {'log_level': logLevel.name},
            )
            .toString(),
-       headers = {
+       _headers = {
          ...RealtimeConstants.defaultHeaders,
          ...?headers,
        },
+       parameters = Map.unmodifiable(parameters),
        transport = transport ?? createWebSocketClient,
        _builtInEncode = version == RealtimeProtocolVersion.v1
            ? _encodeLegacy
@@ -304,17 +353,17 @@ class RealtimeClient {
       'logLevel: ${logLevel?.name}',
     );
     realtimeLogger.finest(
-      'Initialize with headers: ${this.headers.redacted}, '
+      'Initialize with headers: ${_headers.redacted}, '
       'parameters: ${redactedPayload(parameters)}',
     );
-    final customJWT = this.headers['Authorization']?.split(' ').last;
-    accessToken = customJWT ?? parameters['apikey'];
+    final customJWT = _headers['Authorization']?.split(' ').last;
+    _accessToken = customJWT ?? parameters['apikey'];
 
     this.disconnectOnEmptyChannelsAfter =
         disconnectOnEmptyChannelsAfter ?? (heartbeatInterval * 2);
 
     this.reconnectAfter = reconnectAfter ?? RetryTimer.createRetryFunction();
-    reconnectTimer = RetryTimer(
+    _reconnectTimer = RetryTimer(
       () => unawaited(_reconnect()),
       this.reconnectAfter,
     );
@@ -323,8 +372,8 @@ class RealtimeClient {
   /// Connects the socket.
   @internal
   Future<void> connect() async {
-    if (connection != null) {
-      if (connectionState != SocketState.closed) {
+    if (_connection != null) {
+      if (_connectionState != SocketState.closed) {
         return;
       }
       await disconnect();
@@ -333,36 +382,39 @@ class RealtimeClient {
     try {
       realtimeLogger.fine('Connecting');
       realtimeLogger.finest('Connecting to $_redactedEndpointUrl');
-      connectionState = SocketState.connecting;
-      final WebSocketChannel localConnection = transport(endpointUrl, headers);
-      connection = localConnection;
+      _connectionState = SocketState.connecting;
+      final WebSocketChannel localConnection = transport(
+        endpointUrl,
+        Map.of(_headers),
+      );
+      _connection = localConnection;
 
       try {
         await localConnection.ready;
       } catch (error) {
         // Bail out if disconnect() ran or a new connect() started during await
-        if (connection != localConnection) {
+        if (_connection != localConnection) {
           return;
         }
         // Don't schedule a reconnect and emit error if connection has been
         // closed by the user or [disconnect] waits for the connection to be
         // ready before closing it.
-        if (connectionState != SocketState.disconnected &&
-            connectionState != SocketState.disconnecting) {
-          connectionState = SocketState.closed;
+        if (_connectionState != SocketState.disconnected &&
+            _connectionState != SocketState.disconnecting) {
+          _connectionState = SocketState.closed;
           _onConnectionError(error);
-          reconnectTimer.scheduleTimeout();
+          _reconnectTimer.scheduleTimeout();
         }
         return;
       }
 
       // Guard: bail out if disconnect() ran during the await
-      if (connection != localConnection ||
-          connectionState != SocketState.connecting) {
+      if (_connection != localConnection ||
+          _connectionState != SocketState.connecting) {
         return;
       }
 
-      connectionState = SocketState.open;
+      _connectionState = SocketState.open;
 
       _onConnectionOpen();
       _connectionSubscription = localConnection.stream.listen(
@@ -370,9 +422,9 @@ class RealtimeClient {
         onError: _onConnectionError,
         onDone: () {
           // communication has been closed
-          if (connectionState != SocketState.disconnected &&
-              connectionState != SocketState.disconnecting) {
-            connectionState = SocketState.closed;
+          if (_connectionState != SocketState.disconnected &&
+              _connectionState != SocketState.disconnecting) {
+            _connectionState = SocketState.closed;
           }
           _onConnectionClose();
         },
@@ -391,15 +443,15 @@ class RealtimeClient {
   /// Disconnects the socket with status [code] and [reason] for the disconnect
   Future<void> disconnect({int? code, String? reason}) async {
     _cancelPendingDisconnect();
-    final connection = this.connection;
-    if (connection != null) {
-      final oldState = connectionState;
+    final localConnection = _connection;
+    if (localConnection != null) {
+      final oldState = _connectionState;
       final shouldCloseSink =
           oldState == SocketState.open || oldState == SocketState.connecting;
       if (shouldCloseSink) {
         // Don't set the state to `disconnecting` if the connection is already
         // closed.
-        connectionState = SocketState.disconnecting;
+        _connectionState = SocketState.disconnecting;
         realtimeLogger.fine('Disconnecting (code: $code, reason: $reason)');
       }
 
@@ -410,7 +462,7 @@ class RealtimeClient {
           // avoid hanging the client. This is done by mimicking the onDone
           // callback of the connection stream. By canceling the subscription,
           // we avoid calling the onDone too.
-          connectionState = SocketState.disconnected;
+          _connectionState = SocketState.disconnected;
           _onConnectionClose();
         }
 
@@ -419,16 +471,16 @@ class RealtimeClient {
           // is wrong with the connection. The Dart SDK has a timeout of 5
           // seconds for closing the IO WebSocket connection, so we set a
           // timeout of 6 seconds here to avoid hanging indefinitely.
-          await connection.sink
+          await localConnection.sink
               .close(code, reason ?? '')
               .timeout(connectionCloseTimeout, onTimeout: onTimeout);
         } else {
-          await connection.sink.close().timeout(
+          await localConnection.sink.close().timeout(
             connectionCloseTimeout,
             onTimeout: onTimeout,
           );
         }
-        connectionState = SocketState.disconnected;
+        _connectionState = SocketState.disconnected;
         realtimeLogger.fine('Disconnected');
       }
 
@@ -436,9 +488,9 @@ class RealtimeClient {
       // has already dropped (`connectionState == closed`) the block above is
       // skipped, so without this an armed backoff timer would fire after the
       // user explicitly disconnected and silently reopen the connection.
-      reconnectTimer.cancel();
+      _reconnectTimer.cancel();
 
-      this.connection = null;
+      _connection = null;
       await _connectionSubscription?.cancel();
       _connectionSubscription = null;
 
@@ -449,12 +501,8 @@ class RealtimeClient {
       _pendingDispatch = null;
 
       // remove open handles
-      if (heartbeatTimer != null) heartbeatTimer?.cancel();
+      _heartbeatTimer?.cancel();
     }
-  }
-
-  List<RealtimeChannel> getChannels() {
-    return channels;
   }
 
   Future<String> removeChannel(RealtimeChannel channel) async {
@@ -464,7 +512,7 @@ class RealtimeClient {
 
   Future<List<String>> removeAllChannels() async {
     final values = await Future.wait(
-      channels.map((channel) => channel.unsubscribe()),
+      _channels.toList().map((channel) => channel.unsubscribe()),
     );
     await disconnect();
     return values;
@@ -498,7 +546,7 @@ class RealtimeClient {
       _heartbeatController.stream;
 
   /// Returns `true` is the connection is open.
-  bool get isConnected => connectionState == SocketState.open;
+  bool get isConnected => _connectionState == SocketState.open;
 
   /// Removes a subscription from the socket.
   ///
@@ -507,8 +555,8 @@ class RealtimeClient {
   /// by every channel that has not joined yet.
   @internal
   void remove(RealtimeChannel channel) {
-    channels = channels.where((c) => !identical(c, channel)).toList();
-    if (channels.isEmpty) {
+    _channels.removeWhere((c) => identical(c, channel));
+    if (_channels.isEmpty) {
       realtimeLogger.fine('No channels remaining, scheduling disconnect');
       _schedulePendingDisconnect();
     }
@@ -520,8 +568,16 @@ class RealtimeClient {
   ]) {
     final newChannel = RealtimeChannel('realtime:$topic', this, config: config);
     _cancelPendingDisconnect();
-    channels.add(newChannel);
+    _channels.add(newChannel);
     return newChannel;
+  }
+
+  /// Registers [channel] directly, bypassing [channel]'s construction and
+  /// lifecycle handling, so tests can inject mock channels.
+  @internal
+  @visibleForTesting
+  void addChannelForTesting(RealtimeChannel channel) {
+    _channels.add(channel);
   }
 
   /// Schedules a disconnect once the last channel is removed.
@@ -540,7 +596,7 @@ class RealtimeClient {
       disconnectOnEmptyChannelsAfter,
       () {
         _pendingDisconnectTimer = null;
-        if (channels.isEmpty) {
+        if (_channels.isEmpty) {
           realtimeLogger.fine(
             'Deferred disconnect fired with no channels remaining, '
             'disconnecting',
@@ -580,7 +636,7 @@ class RealtimeClient {
     if (isConnected) {
       _write(message);
     } else {
-      sendBuffer.add(() => _write(message));
+      _sendBuffer.add(() => _write(message));
     }
   }
 
@@ -591,7 +647,7 @@ class RealtimeClient {
   /// forever, and its write is chained onto [_pendingWrite] so that a fast
   /// encode never overtakes a slow one that was pushed before it.
   void _write(RealtimeMessage message) {
-    final connection = this.connection;
+    final originConnection = _connection;
     final encode = this.encode;
     if (encode == null) {
       Object frame;
@@ -602,7 +658,7 @@ class RealtimeClient {
         return;
       }
       try {
-        connection?.sink.add(frame);
+        originConnection?.sink.add(frame);
       } catch (error) {
         realtimeLogger.warning('Failed to write message', error);
       }
@@ -617,7 +673,7 @@ class RealtimeClient {
       return;
     }
 
-    final write = _writeWhenReady(connection, _pendingWrite, encoded);
+    final write = _writeWhenReady(originConnection, _pendingWrite, encoded);
     _pendingWrite = write;
     unawaited(
       write.whenComplete(() {
@@ -654,7 +710,7 @@ class RealtimeClient {
       return;
     }
 
-    if (!identical(originConnection, connection)) {
+    if (!identical(originConnection, _connection)) {
       realtimeLogger.finest(
         'Dropping an encoded frame from a superseded connection',
       );
@@ -675,7 +731,7 @@ class RealtimeClient {
   /// forever, and its dispatch is chained onto [_pendingDispatch] so that a
   /// fast decode never overtakes a slow one that was received before it.
   void onConnectionMessage(Object rawMessage) {
-    final connection = this.connection;
+    final originConnection = _connection;
     final decode = this.decode;
     if (decode == null) {
       final RealtimeMessage message;
@@ -701,7 +757,11 @@ class RealtimeClient {
       return;
     }
 
-    final dispatch = _dispatchWhenReady(connection, _pendingDispatch, decoded);
+    final dispatch = _dispatchWhenReady(
+      originConnection,
+      _pendingDispatch,
+      decoded,
+    );
     _pendingDispatch = dispatch;
     unawaited(
       dispatch.whenComplete(() {
@@ -738,7 +798,7 @@ class RealtimeClient {
       return;
     }
 
-    if (!identical(originConnection, connection)) {
+    if (!identical(originConnection, _connection)) {
       realtimeLogger.finest(
         'Dropping a decoded message from a superseded connection',
       );
@@ -757,8 +817,8 @@ class RealtimeClient {
     final event = message.event;
     final payload = message.payload;
     final messageRef = message.ref;
-    if (messageRef != null && messageRef == pendingHeartbeatRef) {
-      pendingHeartbeatRef = null;
+    if (messageRef != null && messageRef == _pendingHeartbeatRef) {
+      _pendingHeartbeatRef = null;
       final heartbeatStatus = payload is Map ? payload['status'] : null;
       _heartbeatController.add(
         heartbeatStatus == 'ok'
@@ -774,15 +834,19 @@ class RealtimeClient {
       "${redactedPayload(payload)}",
     );
 
-    channels
+    // Snapshot the members before triggering: a close event removes the
+    // channel from [_channels] synchronously, which must not invalidate this
+    // iteration.
+    final members = _channels
         .where((channel) => channel.isMember(topic))
-        .forEach(
-          (channel) => channel.trigger(
-            event,
-            payload,
-            messageRef,
-          ),
-        );
+        .toList();
+    for (final channel in members) {
+      channel.trigger(
+        event,
+        payload,
+        messageRef,
+      );
+    }
     _messageController.add(message);
   }
 
@@ -809,13 +873,13 @@ class RealtimeClient {
   /// Return the next message ref, accounting for overflows
   @internal
   String makeRef() {
-    final int newRef = ref + 1;
+    final int newRef = _ref + 1;
     if (newRef < 0) {
-      ref = 0;
+      _ref = 0;
     } else {
-      ref = newRef;
+      _ref = newRef;
     }
-    return ref.toString();
+    return _ref.toString();
   }
 
   /// Sets the JWT access token used for channel subscription authorization and
@@ -824,15 +888,15 @@ class RealtimeClient {
   /// `token` A JWT strings.
   Future<void> setAccessToken(String? token) async {
     final tokenToSend =
-        token ?? (await customAccessToken?.call()) ?? accessToken;
+        token ?? (await customAccessToken?.call()) ?? _accessToken;
 
-    if (accessToken == tokenToSend) {
+    if (_accessToken == tokenToSend) {
       return;
     }
 
-    accessToken = tokenToSend;
+    _accessToken = tokenToSend;
 
-    for (final channel in channels) {
+    for (final channel in _channels) {
       if (tokenToSend != null) {
         channel.updateJoinPayload({
           'access_token': tokenToSend,
@@ -845,10 +909,21 @@ class RealtimeClient {
     }
   }
 
+  /// Replaces the connection headers with [newHeaders].
+  ///
+  /// Only affects connections opened afterwards; an open socket keeps the
+  /// headers it connected with until it reconnects.
+  @internal
+  void replaceHeaders(Map<String, String> newHeaders) {
+    _headers
+      ..clear()
+      ..addAll(newHeaders);
+  }
+
   /// Unsubscribe from joined or joining channels with the specified topic.
   @internal
   void leaveOpenTopic(String topic) {
-    final dupChannel = channels.firstWhereOrNull(
+    final dupChannel = _channels.firstWhereOrNull(
       (c) => c.topic == topic && (c.isJoined || c.isJoining),
     );
     if (dupChannel != null) {
@@ -861,15 +936,17 @@ class RealtimeClient {
     realtimeLogger.fine('Connected');
     realtimeLogger.finest('Connected to $_redactedEndpointUrl');
     unawaited(_resolveAccessTokenAndFlush());
-    reconnectTimer.reset();
-    if (heartbeatTimer != null) heartbeatTimer!.cancel();
-    heartbeatTimer = Timer.periodic(
+    _reconnectTimer.reset();
+    _heartbeatTimer?.cancel();
+    _heartbeatTimer = Timer.periodic(
       heartbeatInterval,
       (Timer t) => unawaited(sendHeartbeat()),
     );
 
     try {
-      for (final channel in channels) {
+      // Snapshot before rejoining: a rejoin can synchronously unsubscribe a
+      // duplicate topic, which removes it from [_channels].
+      for (final channel in _channels.toList()) {
         if (channel.isErrored) {
           channel.rejoin();
         }
@@ -885,23 +962,23 @@ class RealtimeClient {
 
   /// communication has been closed
   void _onConnectionClose() {
-    final statusCode = connection?.closeCode;
+    final statusCode = _connection?.closeCode;
     RealtimeCloseEvent? event;
     if (statusCode != null) {
       event = RealtimeCloseEvent(
         code: statusCode,
-        reason: connection?.closeReason,
+        reason: _connection?.closeReason,
       );
     }
     realtimeLogger.fine('Connection closed: $event');
 
     /// SocketState.disconnected: by user with socket.disconnect()
     /// SocketState.closed: NOT by user, should try to reconnect
-    if (connectionState == SocketState.closed) {
+    if (_connectionState == SocketState.closed) {
       _triggerChanError(event);
-      reconnectTimer.scheduleTimeout();
+      _reconnectTimer.scheduleTimeout();
     }
-    if (heartbeatTimer != null) heartbeatTimer!.cancel();
+    _heartbeatTimer?.cancel();
     _statusController.add(
       RealtimeConnectionStatusChange(RealtimeConnectionStatus.closed, event),
     );
@@ -914,7 +991,9 @@ class RealtimeClient {
   }
 
   void _triggerChanError([dynamic error]) {
-    for (final channel in channels) {
+    // Snapshot before triggering, in case a trigger removes its channel from
+    // [_channels] synchronously.
+    for (final channel in _channels.toList()) {
       channel.trigger(ChannelEvent.error.eventName(), error);
     }
   }
@@ -936,11 +1015,11 @@ class RealtimeClient {
   }
 
   void _flushSendBuffer() {
-    if (isConnected && sendBuffer.isNotEmpty) {
-      for (final callback in sendBuffer) {
+    if (isConnected && _sendBuffer.isNotEmpty) {
+      for (final callback in _sendBuffer) {
         callback();
       }
-      sendBuffer = [];
+      _sendBuffer.clear();
     }
   }
 
@@ -957,12 +1036,13 @@ class RealtimeClient {
     try {
       if (customAccessToken != null) {
         await setAccessToken(null);
-        if (accessToken != null) {
-          for (final channel in channels) {
-            channel.updateJoinPayload({'access_token': accessToken!});
+        final resolvedToken = _accessToken;
+        if (resolvedToken != null) {
+          for (final channel in _channels) {
+            channel.updateJoinPayload({'access_token': resolvedToken});
           }
-          sendBuffer = [];
-          for (final channel in channels) {
+          _sendBuffer.clear();
+          for (final channel in _channels) {
             if (channel.isJoining) {
               channel.forceRejoin();
             }
@@ -986,30 +1066,31 @@ class RealtimeClient {
     }
 
     // If the previous heartbeat hasn't received a reply, close the connection.
-    if (pendingHeartbeatRef != null) {
-      pendingHeartbeatRef = null;
+    if (_pendingHeartbeatRef != null) {
+      _pendingHeartbeatRef = null;
       realtimeLogger.warning(
         'Heartbeat timeout, attempting to re-establish connection',
       );
       _heartbeatController.add(RealtimeHeartbeatStatus.timeout);
       unawaited(
-        connection?.sink.close(
+        _connection?.sink.close(
           RealtimeConstants.webSocketCloseNormal,
           'heartbeat timeout',
         ),
       );
       return;
     }
-    pendingHeartbeatRef = makeRef();
+    final heartbeatRef = makeRef();
+    _pendingHeartbeatRef = heartbeatRef;
     push(
       RealtimeMessage.outgoing(
         topic: 'phoenix',
         event: ChannelEvent.heartbeat,
         payload: {},
-        ref: pendingHeartbeatRef!,
+        ref: heartbeatRef,
       ),
     );
     _heartbeatController.add(RealtimeHeartbeatStatus.sent);
-    await setAccessToken(accessToken);
+    await setAccessToken(_accessToken);
   }
 }

--- a/packages/supabase_realtime/lib/src/realtime_constants.dart
+++ b/packages/supabase_realtime/lib/src/realtime_constants.dart
@@ -5,8 +5,6 @@ import 'package:supabase_common/supabase_common.dart';
 class RealtimeConstants {
   static const Duration defaultTimeout = Duration(milliseconds: 10000);
   static const Duration defaultConnectionCloseTimeout = Duration(seconds: 6);
-
-  @internal
   static const Duration defaultHeartbeatInterval = Duration(seconds: 25);
 
   @internal

--- a/packages/supabase_realtime/lib/src/retry_timer.dart
+++ b/packages/supabase_realtime/lib/src/retry_timer.dart
@@ -5,7 +5,9 @@ import 'package:supabase_common/supabase_common.dart';
 
 @internal
 typedef TimerCallback = void Function();
-@internal
+
+/// Returns the delay before the next retry, given the number of [tries] so
+/// far.
 typedef TimerCalculation = Duration Function(int tries);
 
 /// Creates a timer that accepts a `timerCalculation` function to perform

--- a/packages/supabase_realtime/lib/supabase_realtime.dart
+++ b/packages/supabase_realtime/lib/supabase_realtime.dart
@@ -9,6 +9,7 @@ export 'src/realtime_client.dart';
 export 'src/realtime_constants.dart';
 export 'src/realtime_message.dart';
 export 'src/realtime_presence.dart' show Presence;
+export 'src/retry_timer.dart' show TimerCalculation;
 export 'src/transformers.dart' show PostgresColumn, PostgresType;
 export 'src/types.dart'
     hide Binding, BindingCallback, ChannelFilter, RealtimeListenType;

--- a/packages/supabase_realtime/test/async_codec_test.dart
+++ b/packages/supabase_realtime/test/async_codec_test.dart
@@ -20,17 +20,20 @@ void main() {
 
     when(() => mockedChannel.sink).thenReturn(mockedSink);
     when(() => mockedChannel.ready).thenAnswer((_) => Future.value());
+    when(
+      () => mockedChannel.stream,
+    ).thenAnswer((_) => StreamController<dynamic>.broadcast().stream);
     when(() => mockedSink.close()).thenAnswer((_) => Future.value());
     when(() => mockedSink.add(any())).thenAnswer((invocation) {
       written.add(invocation.positionalArguments.first);
     });
   });
 
-  RealtimeClient createClient({
+  Future<RealtimeClient> createClient({
     RealtimeEncode? encode,
     RealtimeDecode? decode,
     Duration? timeout,
-  }) {
+  }) async {
     final client = RealtimeClient(
       socketEndpoint,
       transport: (url, headers) => mockedChannel,
@@ -38,8 +41,7 @@ void main() {
       decode: decode,
       timeout: timeout ?? RealtimeConstants.defaultTimeout,
     );
-    unawaited(client.connect());
-    client.connectionState = SocketState.open;
+    await client.connect();
     return client;
   }
 
@@ -53,7 +55,7 @@ void main() {
   group('asynchronous encode', () {
     test('writes the frame once the encode completes', () async {
       final completer = Completer<Object>();
-      final client = createClient(encode: (_) => completer.future);
+      final client = await createClient(encode: (_) => completer.future);
 
       client.push(messageWithRef('1'));
       await pumpEventQueue();
@@ -72,7 +74,7 @@ void main() {
         '2': Completer<Object>(),
         '3': Completer<Object>(),
       };
-      final client = createClient(
+      final client = await createClient(
         encode: (message) => completers[message.ref]!.future,
       );
 
@@ -94,7 +96,7 @@ void main() {
 
     test('an immediate encode waits for the messages before it', () async {
       final completer = Completer<Object>();
-      final client = createClient(
+      final client = await createClient(
         encode: (message) => message.ref == '1'
             ? completer.future
             : Future.value('frame-${message.ref}'),
@@ -113,7 +115,7 @@ void main() {
     });
 
     test('a failed encode drops only its own message', () async {
-      final client = createClient(
+      final client = await createClient(
         encode: (message) => message.ref == '1'
             ? Future<Object>.error(StateError('encode failed'))
             : Future<Object>.value('frame-${message.ref}'),
@@ -129,7 +131,7 @@ void main() {
     test(
       'a synchronously throwing encode drops only its own message',
       () async {
-        final client = createClient(
+        final client = await createClient(
           encode: (message) => message.ref == '1'
               ? throw StateError('encode failed')
               : Future<Object>.value('frame-${message.ref}'),
@@ -145,22 +147,24 @@ void main() {
 
     test('buffered messages are written in order once connected', () async {
       final completer = Completer<Object>();
-      final client = createClient(
+      final client = RealtimeClient(
+        socketEndpoint,
+        transport: (url, headers) => mockedChannel,
         encode: (message) => message.ref == '1'
             ? completer.future
             : Future.value('frame-${message.ref}'),
       );
-      client.connectionState = SocketState.connecting;
 
       client.push(messageWithRef('1'));
       client.push(messageWithRef('2'));
 
       expect(client.sendBuffer, hasLength(2));
 
-      client.connectionState = SocketState.open;
-      for (final callback in client.sendBuffer) {
-        callback();
-      }
+      await client.connect();
+      await pumpEventQueue();
+
+      expect(written, isEmpty);
+
       completer.complete('frame-1');
       await pumpEventQueue();
 
@@ -172,7 +176,7 @@ void main() {
       'stalling later writes',
       () async {
         final neverCompletes = Completer<Object>();
-        final client = createClient(
+        final client = await createClient(
           encode: (message) => message.ref == '1'
               ? neverCompletes.future
               : Future.value('frame-${message.ref}'),
@@ -189,16 +193,16 @@ void main() {
       },
     );
 
-    test('the built-in codec writes without a microtask hop', () {
-      final client = createClient();
+    test('the built-in codec writes without a microtask hop', () async {
+      final client = await createClient();
 
       client.push(messageWithRef('1'));
 
       expect(written, hasLength(1));
     });
 
-    test('the built-in codec logs and swallows an encode failure', () {
-      final client = createClient();
+    test('the built-in codec logs and swallows an encode failure', () async {
+      final client = await createClient();
 
       expect(
         () => client.push(
@@ -213,8 +217,8 @@ void main() {
       expect(written, isEmpty);
     });
 
-    test('the built-in codec logs and swallows a write failure', () {
-      final client = createClient();
+    test('the built-in codec logs and swallows a write failure', () async {
+      final client = await createClient();
       when(() => mockedSink.add(any())).thenThrow(StateError('boom'));
 
       expect(() => client.push(messageWithRef('1')), returnsNormally);
@@ -234,6 +238,9 @@ void main() {
             final writtenHere = <Object?>[];
             when(() => channel.sink).thenReturn(sink);
             when(() => channel.ready).thenAnswer((_) => Future.value());
+            when(
+              () => channel.stream,
+            ).thenAnswer((_) => StreamController<dynamic>.broadcast().stream);
             when(() => sink.close()).thenAnswer((_) => Future.value());
             when(() => sink.add(any())).thenAnswer((invocation) {
               writtenHere.add(invocation.positionalArguments.first);
@@ -245,16 +252,14 @@ void main() {
               ? completer.future
               : Future.value('frame-${message.ref}'),
         );
-        unawaited(client.connect());
-        client.connectionState = SocketState.open;
+        await client.connect();
 
         client.push(messageWithRef('1'));
         await pumpEventQueue();
 
         // Reconnect to a new connection while the encode above is pending.
         await client.disconnect();
-        unawaited(client.connect());
-        client.connectionState = SocketState.open;
+        await client.connect();
 
         // The new connection keeps working while the stale encode is
         // pending, so it is not the encode itself stalling forever.
@@ -281,7 +286,7 @@ void main() {
 
     test('dispatches the message once the decode completes', () async {
       final completer = Completer<RealtimeMessage>();
-      final client = createClient(decode: (_) => completer.future);
+      final client = await createClient(decode: (_) => completer.future);
 
       final received = <String?>[];
       client.onMessage.listen((message) => received.add(message.ref));
@@ -305,7 +310,7 @@ void main() {
           '2': Completer<RealtimeMessage>(),
           '3': Completer<RealtimeMessage>(),
         };
-        final client = createClient(
+        final client = await createClient(
           decode: (rawMessage) => completers[rawMessage]!.future,
         );
 
@@ -331,7 +336,7 @@ void main() {
 
     test('an immediate decode waits for the frames before it', () async {
       final completer = Completer<RealtimeMessage>();
-      final client = createClient(
+      final client = await createClient(
         decode: (rawMessage) => rawMessage == '1'
             ? completer.future
             : Future.value(frameWithRef(rawMessage as String)),
@@ -353,7 +358,7 @@ void main() {
     });
 
     test('a failed decode drops only its own frame', () async {
-      final client = createClient(
+      final client = await createClient(
         decode: (rawMessage) => rawMessage == '1'
             ? Future<RealtimeMessage>.error(FormatException('decode failed'))
             : Future.value(frameWithRef(rawMessage as String)),
@@ -370,7 +375,7 @@ void main() {
     });
 
     test('a synchronously throwing decode drops only its own frame', () async {
-      final client = createClient(
+      final client = await createClient(
         decode: (rawMessage) => rawMessage == '1'
             ? throw FormatException('decode failed')
             : Future.value(frameWithRef(rawMessage as String)),
@@ -391,7 +396,7 @@ void main() {
       'stalling later dispatches',
       () async {
         final neverCompletes = Completer<RealtimeMessage>();
-        final client = createClient(
+        final client = await createClient(
           decode: (rawMessage) => rawMessage == '1'
               ? neverCompletes.future
               : Future.value(frameWithRef(rawMessage as String)),
@@ -411,8 +416,8 @@ void main() {
       },
     );
 
-    test('the built-in codec dispatches without a microtask hop', () {
-      final client = createClient();
+    test('the built-in codec dispatches without a microtask hop', () async {
+      final client = await createClient();
 
       final channel = MockChannel();
       when(() => channel.isMember('realtime:room')).thenReturn(true);
@@ -423,8 +428,8 @@ void main() {
       verify(() => channel.trigger('broadcast', any(), '1')).called(1);
     });
 
-    test('the built-in codec logs and swallows a dispatch failure', () {
-      final client = createClient();
+    test('the built-in codec logs and swallows a dispatch failure', () async {
+      final client = await createClient();
 
       final channel = MockChannel();
       when(() => channel.isMember('realtime:room')).thenReturn(true);
@@ -454,6 +459,9 @@ void main() {
             final sink = MockWebSocketSink();
             when(() => channel.sink).thenReturn(sink);
             when(() => channel.ready).thenAnswer((_) => Future.value());
+            when(
+              () => channel.stream,
+            ).thenAnswer((_) => StreamController<dynamic>.broadcast().stream);
             when(() => sink.close()).thenAnswer((_) => Future.value());
             when(() => sink.add(any())).thenAnswer((_) {});
             return channel;
@@ -462,8 +470,7 @@ void main() {
               ? completer.future
               : Future.value(frameWithRef(rawMessage as String)),
         );
-        unawaited(client.connect());
-        client.connectionState = SocketState.open;
+        await client.connect();
 
         final received = <String?>[];
         client.onMessage.listen((message) => received.add(message.ref));
@@ -473,8 +480,7 @@ void main() {
 
         // Reconnect to a new connection while the decode above is pending.
         await client.disconnect();
-        unawaited(client.connect());
-        client.connectionState = SocketState.open;
+        await client.connect();
 
         // The new connection keeps dispatching while the stale decode is
         // pending, so it is not the decode itself stalling forever.

--- a/packages/supabase_realtime/test/async_codec_test.dart
+++ b/packages/supabase_realtime/test/async_codec_test.dart
@@ -416,7 +416,7 @@ void main() {
 
       final channel = MockChannel();
       when(() => channel.isMember('realtime:room')).thenReturn(true);
-      client.channels.add(channel);
+      client.addChannelForTesting(channel);
 
       client.onConnectionMessage('[null,"1","realtime:room","broadcast",{}]');
 
@@ -431,7 +431,7 @@ void main() {
       when(
         () => channel.trigger(any(), any(), any()),
       ).thenThrow(StateError('boom'));
-      client.channels.add(channel);
+      client.addChannelForTesting(channel);
 
       expect(
         () => client.onConnectionMessage(

--- a/packages/supabase_realtime/test/channel_test.dart
+++ b/packages/supabase_realtime/test/channel_test.dart
@@ -138,8 +138,8 @@ void main() {
           thrown: const FormatException(
             'InvalidJWTToken: Invalid value for JWT claim "exp" with value 0',
           ),
+          headers: {'Authorization': 'Bearer expired-token'},
         );
-        throwingSocket.accessToken = 'expired-token';
 
         final localChannel = throwingSocket.channel('topic');
 
@@ -170,8 +170,8 @@ void main() {
         final throwingSocket = _SetAuthThrowingSocket(
           '/socket',
           thrown: const FormatException('some other parsing failure'),
+          headers: {'Authorization': 'Bearer some-token'},
         );
-        throwingSocket.accessToken = 'some-token';
 
         final localChannel = throwingSocket.channel('topic');
 
@@ -1459,7 +1459,11 @@ void main() {
 }
 
 class _SetAuthThrowingSocket extends RealtimeClient {
-  _SetAuthThrowingSocket(super.endpoint, {required this.thrown});
+  _SetAuthThrowingSocket(
+    super.endpoint, {
+    required this.thrown,
+    super.headers,
+  });
 
   final FormatException thrown;
   int setAuthCalls = 0;

--- a/packages/supabase_realtime/test/heartbeat_test.dart
+++ b/packages/supabase_realtime/test/heartbeat_test.dart
@@ -1,8 +1,11 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:mocktail/mocktail.dart';
 import 'package:supabase_realtime/supabase_realtime.dart';
 import 'package:test/test.dart';
+
+import 'socket_test_stubs.dart';
 
 void main() {
   late RealtimeClient client;
@@ -10,8 +13,22 @@ void main() {
   late StreamSubscription<RealtimeHeartbeatStatus> subscription;
 
   setUp(() {
+    final mockedChannel = MockIOWebSocketChannel();
+    final mockedSink = MockWebSocketSink();
+    when(() => mockedChannel.sink).thenReturn(mockedSink);
+    when(() => mockedChannel.ready).thenAnswer((_) => Future.value());
+    when(
+      () => mockedChannel.stream,
+    ).thenAnswer((_) => StreamController<dynamic>.broadcast().stream);
+    when(() => mockedSink.add(any())).thenAnswer((_) {});
+    when(() => mockedSink.close()).thenAnswer((_) => Future.value());
+    when(
+      () => mockedSink.close(any(), any()),
+    ).thenAnswer((_) => Future.value());
+
     client = RealtimeClient(
       'wss://localhost:0/',
+      transport: (url, headers) => mockedChannel,
       decode: (rawMessage) async => RealtimeMessage.fromJson(
         jsonDecode(rawMessage as String),
         RealtimeProtocolVersion.v1,
@@ -23,9 +40,10 @@ void main() {
 
   tearDown(() async {
     await subscription.cancel();
+    await client.disconnect();
   });
 
-  String heartbeatReply(String ref, String status) {
+  String heartbeatReply(String? ref, String status) {
     return jsonEncode({
       'topic': 'phoenix',
       'event': 'phoenix_reply',
@@ -42,7 +60,7 @@ void main() {
   });
 
   test('emits sent when a heartbeat is pushed', () async {
-    client.connectionState = SocketState.open;
+    await client.connect();
 
     await client.sendHeartbeat();
     await pumpEventQueue();
@@ -54,45 +72,61 @@ void main() {
   test(
     'emits timeout when the previous heartbeat was not acknowledged',
     () async {
-      client.connectionState = SocketState.open;
-      client.pendingHeartbeatRef = 'stale-ref';
+      await client.connect();
+      await client.sendHeartbeat();
 
       await client.sendHeartbeat();
       await pumpEventQueue();
 
-      expect(statuses, [RealtimeHeartbeatStatus.timeout]);
+      expect(statuses, [
+        RealtimeHeartbeatStatus.sent,
+        RealtimeHeartbeatStatus.timeout,
+      ]);
       expect(client.pendingHeartbeatRef, isNull);
     },
   );
 
   test('emits ok when the heartbeat reply succeeds', () async {
-    client.pendingHeartbeatRef = 'ref-1';
+    await client.connect();
+    await client.sendHeartbeat();
 
-    client.onConnectionMessage(heartbeatReply('ref-1', 'ok'));
+    client.onConnectionMessage(
+      heartbeatReply(client.pendingHeartbeatRef, 'ok'),
+    );
     await pumpEventQueue();
 
-    expect(statuses, [RealtimeHeartbeatStatus.ok]);
+    expect(statuses, [
+      RealtimeHeartbeatStatus.sent,
+      RealtimeHeartbeatStatus.ok,
+    ]);
     expect(client.pendingHeartbeatRef, isNull);
   });
 
   test('emits error when the heartbeat reply fails', () async {
-    client.pendingHeartbeatRef = 'ref-2';
+    await client.connect();
+    await client.sendHeartbeat();
 
-    client.onConnectionMessage(heartbeatReply('ref-2', 'error'));
+    client.onConnectionMessage(
+      heartbeatReply(client.pendingHeartbeatRef, 'error'),
+    );
     await pumpEventQueue();
 
-    expect(statuses, [RealtimeHeartbeatStatus.error]);
+    expect(statuses, [
+      RealtimeHeartbeatStatus.sent,
+      RealtimeHeartbeatStatus.error,
+    ]);
   });
 
   test(
     'does not emit for messages that are not the pending heartbeat',
     () async {
-      client.pendingHeartbeatRef = 'ref-3';
+      await client.connect();
+      await client.sendHeartbeat();
 
       client.onConnectionMessage(heartbeatReply('other-ref', 'ok'));
       await pumpEventQueue();
 
-      expect(statuses, isEmpty);
+      expect(statuses, [RealtimeHeartbeatStatus.sent]);
     },
   );
 }

--- a/packages/supabase_realtime/test/socket_test.dart
+++ b/packages/supabase_realtime/test/socket_test.dart
@@ -273,6 +273,10 @@ void main() {
       final mockedSink = MockWebSocketSink();
 
       when(() => mockedSocketChannel.sink).thenReturn(mockedSink);
+      when(() => mockedSocketChannel.ready).thenAnswer((_) => Future.value());
+      when(
+        () => mockedSocketChannel.stream,
+      ).thenAnswer((_) => StreamController<dynamic>.broadcast().stream);
       when(
         () => mockedSink.close(any(), any()),
       ).thenAnswer((_) => Future.value());
@@ -281,7 +285,6 @@ void main() {
       const tReason = 'reason';
 
       await mockedSocket.connect();
-      mockedSocket.connectionState = SocketState.open;
       await Future.delayed(const Duration(milliseconds: 200));
       await mockedSocket.disconnect(code: tCode, reason: tReason);
       await Future.delayed(const Duration(milliseconds: 200));
@@ -836,12 +839,14 @@ void main() {
 
       when(() => mockedSocketChannel.sink).thenReturn(mockedSink);
       when(() => mockedSocketChannel.ready).thenAnswer((_) => Future.value());
+      when(
+        () => mockedSocketChannel.stream,
+      ).thenAnswer((_) => StreamController<dynamic>.broadcast().stream);
       when(() => mockedSink.close()).thenAnswer((_) => Future.value());
     });
 
-    test('sends data to connection when connected', () {
-      unawaited(mockedSocket.connect());
-      mockedSocket.connectionState = SocketState.open;
+    test('sends data to connection when connected', () async {
+      await mockedSocket.connect();
 
       final message = RealtimeMessage.outgoing(
         topic: topic,
@@ -856,10 +861,7 @@ void main() {
       ).called(1);
     });
 
-    test('buffers data when not connected', () async {
-      unawaited(mockedSocket.connect());
-      mockedSocket.connectionState = SocketState.connecting;
-
+    test('buffers data when not connected and flushes on connect', () async {
       expect(mockedSocket.sendBuffer, isEmpty);
 
       final message = RealtimeMessage.outgoing(
@@ -873,16 +875,17 @@ void main() {
       verifyNever(() => mockedSink.add(any()));
       expect(mockedSocket.sendBuffer, hasLength(1));
 
-      final callback = mockedSocket.sendBuffer[0];
-      callback();
+      await mockedSocket.connect();
+      await pumpEventQueue();
+
       verify(
         () => mockedSink.add(captureAny(that: equals(jsonData))),
       ).called(1);
+      expect(mockedSocket.sendBuffer, isEmpty);
     });
 
-    test('sends a broadcast with a binary payload as a binary frame', () {
-      unawaited(mockedSocket.connect());
-      mockedSocket.connectionState = SocketState.open;
+    test('sends a broadcast with a binary payload as a binary frame', () async {
+      await mockedSocket.connect();
 
       final binaryPayload = Uint8List.fromList([1, 2, 3]);
       final message = RealtimeMessage.outgoing(
@@ -901,11 +904,14 @@ void main() {
       ).called(1);
     });
 
-    test('encodes with the legacy object format when version is v1', () {
+    test('encodes with the legacy object format when version is v1', () async {
       final legacyChannel = MockIOWebSocketChannel();
       final legacySink = MockWebSocketSink();
       when(() => legacyChannel.sink).thenReturn(legacySink);
       when(() => legacyChannel.ready).thenAnswer((_) => Future.value());
+      when(
+        () => legacyChannel.stream,
+      ).thenAnswer((_) => StreamController<dynamic>.broadcast().stream);
       when(() => legacySink.close()).thenAnswer((_) => Future.value());
 
       final legacySocket = RealtimeClient(
@@ -913,8 +919,7 @@ void main() {
         transport: (url, headers) => legacyChannel,
         version: RealtimeProtocolVersion.v1,
       );
-      unawaited(legacySocket.connect());
-      legacySocket.connectionState = SocketState.open;
+      await legacySocket.connect();
 
       final legacyData = json.encode({
         'topic': topic,
@@ -941,6 +946,9 @@ void main() {
       final customSink = MockWebSocketSink();
       when(() => customChannel.sink).thenReturn(customSink);
       when(() => customChannel.ready).thenAnswer((_) => Future.value());
+      when(
+        () => customChannel.stream,
+      ).thenAnswer((_) => StreamController<dynamic>.broadcast().stream);
       when(() => customSink.close()).thenAnswer((_) => Future.value());
 
       final customSocket = RealtimeClient(
@@ -948,8 +956,7 @@ void main() {
         transport: (url, headers) => customChannel,
         encode: (_) async => 'custom-frame',
       );
-      unawaited(customSocket.connect());
-      customSocket.connectionState = SocketState.open;
+      await customSocket.connect();
 
       customSocket.push(
         RealtimeMessage.outgoing(
@@ -1331,15 +1338,16 @@ void main() {
       when(() => mockedSocketChannel.sink).thenReturn(mockedSink);
       when(() => mockedSink.close()).thenAnswer((_) => Future.value());
       when(() => mockedSocketChannel.ready).thenAnswer((_) => Future.value());
-
-      unawaited(mockedSocket.connect());
+      when(
+        () => mockedSocketChannel.stream,
+      ).thenAnswer((_) => StreamController<dynamic>.broadcast().stream);
     });
 
     //! Unimplemented Test: closes socket when heartbeat is not ack'd within
     //! heartbeat window
 
     test('pushes heartbeat data when connected', () async {
-      mockedSocket.connectionState = SocketState.open;
+      await mockedSocket.connect();
 
       await mockedSocket.sendHeartbeat();
 
@@ -1347,9 +1355,8 @@ void main() {
     });
 
     test('no ops when not connected', () async {
-      mockedSocket.connectionState = SocketState.connecting;
-
       await mockedSocket.sendHeartbeat();
+
       verifyNever(() => mockedSink.add(any()));
     });
   });

--- a/packages/supabase_realtime/test/socket_test.dart
+++ b/packages/supabase_realtime/test/socket_test.dart
@@ -627,6 +627,19 @@ void main() {
 
       expect(socket.channels, [channel2]);
     });
+
+    test('a close message that removes its channels does not break the '
+        'dispatch to the other members of the topic', () {
+      // A phx_close trigger removes its channel from the client synchronously,
+      // which must not invalidate the dispatch iteration over the members.
+      final socket = RealtimeClient(socketEndpoint);
+      socket.channel('topic');
+      socket.channel('topic');
+
+      socket.onConnectionMessage('[null,null,"realtime:topic","phx_close",{}]');
+
+      expect(socket.channels, isEmpty);
+    });
   });
 
   group('deferred disconnect', () {
@@ -1214,7 +1227,8 @@ void main() {
       when(() => healthyChannel.isErrored).thenReturn(false);
       when(() => erroredChannel.rejoin()).thenReturn(null);
 
-      socket.channels.addAll([erroredChannel, healthyChannel]);
+      socket.addChannelForTesting(erroredChannel);
+      socket.addChannelForTesting(healthyChannel);
       await socket.connect();
 
       verify(() => erroredChannel.rejoin()).called(1);

--- a/packages/supabase_realtime/test/socket_test_stubs.dart
+++ b/packages/supabase_realtime/test/socket_test_stubs.dart
@@ -23,7 +23,7 @@ class SocketWithMockedChannel extends RealtimeClient {
     RealtimeChannelConfig config = const RealtimeChannelConfig(),
   ]) {
     if (mockedChannelLooker.containsKey(topic)) {
-      channels.add(mockedChannelLooker[topic]!);
+      addChannelForTesting(mockedChannelLooker[topic]!);
       return mockedChannelLooker[topic]!;
     }
     return super.channel(topic, config);

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -1914,10 +1914,16 @@ features:
     status: implemented
     symbols:
       - RealtimeClient.reconnectAfter
+      - RealtimeClientOptions.reconnectAfter
+    supporting_symbols:
+      - TimerCalculation
   realtime.configuration.heartbeat_interval:
     status: implemented
     symbols:
       - RealtimeClient.heartbeatInterval
+      - RealtimeClientOptions.heartbeatInterval
+    supporting_symbols:
+      - RealtimeConstants.defaultHeartbeatInterval
   realtime.configuration.access_token_callback:
     status: implemented
     note: "On connect the access token is resolved before the send buffer is flushed; buffered channel join payloads are patched with the token and re-sent so subscriptions authenticate correctly when the token resolves asynchronously (e.g. read from async storage)."

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -1733,10 +1733,8 @@ features:
   realtime.client.get_channels:
     status: implemented
     symbols:
-      - RealtimeClient.getChannels
-      - SupabaseClient.getChannels
-    supporting_symbols:
       - RealtimeClient.channels
+      - SupabaseClient.channels
   realtime.client.remove_channel:
     status: implemented
     symbols:


### PR DESCRIPTION
## What kind of change does this PR introduce?

Breaking change for v3, implementing [SDK-818](https://linear.app/supabase/issue/SDK-818/breakingrealtime-make-realtimeclient-internal-mutable-fields-private).

## What is the current behavior?

`RealtimeClient` exposes its internal state machine as public mutable fields: external code can mutate `channels` directly (bypassing all lifecycle management), reset `ref`, cancel `heartbeatTimer` or `reconnectTimer`, overwrite `connection`/`connectionState`, and reassign `accessToken` without the token propagating to joined channels.

## What is the new behavior?

The internals are private and the remaining public surface is read-only, with mutation going through intentional paths only:

- `channels` is an unmodifiable view; channels are added with `channel()` and removed with `removeChannel()`/`removeAllChannels()`.
- `accessToken` is a getter; token rotation goes through `setAccessToken()`, which also propagates the token to every joined channel (a raw setter would silently skip that, so the ticket's proposed setter was intentionally not added).
- `heartbeatInterval`, `customAccessToken` and `reconnectAfter` are final and settable only via the constructor. `RealtimeClientOptions` gains `heartbeatInterval` and `reconnectAfter` so a client managed by `SupabaseClient` keeps those knobs, and the `TimerCalculation` typedef plus `RealtimeConstants.defaultHeartbeatInterval` are exported to support them.
- `connection` and `connectionState` are read-only getters with no setters at all; the tests that used to fake socket state now drive the real `connect()` flow through the mocked transport.
- `ref`, `pendingHeartbeatRef`, `heartbeatTimer`, `reconnectTimer` and `sendBuffer` are private. The few read accessors tests still need (plus the `ref` setter for the overflow test, which has no transport-driven equivalent) are kept behind `@internal` `@visibleForTesting`.
- `headers` and `parameters` are unmodifiable; `SupabaseClient` replaces realtime headers through the new `@internal` `replaceHeaders()` instead of mutating the map in place.
- `getChannels()` on `RealtimeClient` and `SupabaseClient` is removed in favour of the idiomatic `channels` getter (compliance matrix updated accordingly).

Privatizing `channels` surfaced a latent iteration hazard: `remove()` now mutates the backing list in place, and a `phx_close` trigger removes its channel synchronously while `_dispatch` is iterating. Every loop over the channel list that can re-enter `remove()` now iterates a snapshot, with a regression test that fails without the fix.

The migration guide documents every removed or changed member with before/after snippets, including the `RealtimeClientOptions` path.

## Additional context

A self-review pass (find plus adversarial verify) was run on the diff and all seven surviving findings were fixed in the second commit. All realtime, supabase and supabase_flutter tests pass, and `dart analyze --fatal-infos`, DCM, formatting, and the local compliance symbol/drift/schema checks are clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Breaking Changes**
  - Realtime channels, headers, parameters, and connection state are now exposed through read-only views.
  - Replace `getChannels()` with the `channels` property.
  - Configure heartbeat and reconnect behavior through constructor options.
  - Use `setAccessToken()` for asynchronous token updates.

- **Bug Fixes**
  - Improved connection, buffering, and channel handling during reconnects and asynchronous events.
  - Duplicate-topic channels are now removed correctly when closed.
  - Access-token updates propagate to joined channels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->