### PR TITLE
fix(realtime): surface access-token provider errors on connect instead of logging and continuing

### DIFF
--- a/packages/supabase_realtime/lib/src/realtime_client.dart
+++ b/packages/supabase_realtime/lib/src/realtime_client.dart
@@ -1014,27 +1014,16 @@ class RealtimeClient {
   }
 
   /// Resolves the access token before rejoining errored channels and flushing
-  /// the send buffer, so that joins and buffered channel join payloads carry
-  /// the correct token.
+  /// the send buffer, so that every join carries the resolved identity rather
+  /// than the stale payload captured while the socket was disconnected.
   ///
-  /// When [RealtimeChannel.subscribe] runs before an asynchronous access token
-  /// has resolved (common when [customAccessToken] reads from async storage),
-  /// the buffered join payload has no `access_token`. That buffered message
-  /// captured the stale payload, so once auth has settled the join payloads are
-  /// patched with the resolved token, the stale buffered joins are dropped, and
-  /// the join is re-sent for any channel still joining.
-  ///
-  /// A throwing [customAccessToken] fails the connect instead of silently
-  /// downgrading the buffered messages to the identity the socket already has:
-  /// the error reaches the channels as a `channelError` status and
-  /// [onStatusChange] as a stream error, the buffer is kept unsent, and the
-  /// connection is closed so the reconnect backoff retries the provider.
-  ///
-  /// A resolution that outlives its connection is dropped entirely, whether it
-  /// succeeded or failed: a stale token must not overwrite the identity of a
-  /// newer connection (whose own resolution applies the current token), and a
-  /// stale error must not be surfaced for a connection the user already
-  /// disconnected.
+  /// On success the join payloads are patched with the token, the stale
+  /// buffered joins are dropped, and the join is re-sent for any channel still
+  /// joining. A throwing [customAccessToken] instead fails the connect: the
+  /// error surfaces as a `channelError` status and on [onStatusChange], the
+  /// buffer stays unsent, and the connection is closed so the reconnect
+  /// backoff retries the provider. A resolution that outlives its connection
+  /// is dropped entirely, success and error alike.
   Future<void> _resolveAccessTokenAndFlush() async {
     final customAccessToken = this.customAccessToken;
     if (customAccessToken != null) {

--- a/packages/supabase_realtime/lib/src/realtime_client.dart
+++ b/packages/supabase_realtime/lib/src/realtime_client.dart
@@ -885,7 +885,11 @@ class RealtimeClient {
   Future<void> setAccessToken(String? token) async {
     final tokenToSend =
         token ?? (await customAccessToken?.call()) ?? _accessToken;
+    _applyAccessToken(tokenToSend);
+  }
 
+  /// Applies an already resolved access token to the socket and its channels.
+  void _applyAccessToken(String? tokenToSend) {
     if (_accessToken == tokenToSend) {
       return;
     }
@@ -1025,15 +1029,21 @@ class RealtimeClient {
   /// the error reaches the channels as a `channelError` status and
   /// [onStatusChange] as a stream error, the buffer is kept unsent, and the
   /// connection is closed so the reconnect backoff retries the provider.
+  ///
+  /// A resolution that outlives its connection is dropped entirely, whether it
+  /// succeeded or failed: a stale token must not overwrite the identity of a
+  /// newer connection (whose own resolution applies the current token), and a
+  /// stale error must not be surfaced for a connection the user already
+  /// disconnected.
   Future<void> _resolveAccessTokenAndFlush() async {
-    final originConnection = _connection;
+    final customAccessToken = this.customAccessToken;
     if (customAccessToken != null) {
+      final originConnection = _connection;
+      final String? providedToken;
       try {
-        await setAccessToken(null);
+        providedToken = await customAccessToken();
       } catch (error) {
-        // Bail out if disconnect() ran or a reconnect replaced the connection
-        // while the token was resolving.
-        if (!identical(_connection, originConnection)) {
+        if (!_isCurrentOpenConnection(originConnection)) {
           return;
         }
         realtimeLogger.warning(
@@ -1050,6 +1060,10 @@ class RealtimeClient {
         );
         return;
       }
+      if (!_isCurrentOpenConnection(originConnection)) {
+        return;
+      }
+      _applyAccessToken(providedToken ?? _accessToken);
       final resolvedToken = _accessToken;
       if (resolvedToken != null) {
         // Snapshot before patching and rejoining, in case either removes a
@@ -1069,6 +1083,17 @@ class RealtimeClient {
     _rejoinErroredChannels();
     _flushSendBuffer();
   }
+
+  /// Whether [originConnection] is still the connection in use and open, so
+  /// that work started on it (such as an access token resolution) may still
+  /// apply its result.
+  ///
+  /// The state check matters on its own: while [disconnect] awaits the sink
+  /// close, [connection] still points at the old connection even though the
+  /// state has already left [SocketState.open].
+  bool _isCurrentOpenConnection(WebSocketChannel? originConnection) =>
+      identical(_connection, originConnection) &&
+      _connectionState == SocketState.open;
 
   /// Rejoins the channels that errored on a previous connection, once the
   /// access token has resolved so the joins carry the correct identity.

--- a/packages/supabase_realtime/lib/src/realtime_client.dart
+++ b/packages/supabase_realtime/lib/src/realtime_client.dart
@@ -938,7 +938,6 @@ class RealtimeClient {
     realtimeLogger.fine('Connected');
     realtimeLogger.finest('Connected to $_redactedEndpointUrl');
     unawaited(_resolveAccessTokenAndFlush());
-    _reconnectTimer.reset();
     _heartbeatTimer?.cancel();
     _heartbeatTimer = Timer.periodic(
       heartbeatInterval,
@@ -1069,6 +1068,10 @@ class RealtimeClient {
         }
       }
     }
+    // The backoff is only reset here, once the connection is usable: a
+    // connect whose provider threw above counts as a failed attempt, so
+    // repeated provider failures keep growing the reconnect delay.
+    _reconnectTimer.reset();
     _rejoinErroredChannels();
     _flushSendBuffer();
   }

--- a/packages/supabase_realtime/lib/src/realtime_client.dart
+++ b/packages/supabase_realtime/lib/src/realtime_client.dart
@@ -941,18 +941,6 @@ class RealtimeClient {
       (Timer t) => unawaited(sendHeartbeat()),
     );
 
-    try {
-      // Snapshot before rejoining: a rejoin can synchronously unsubscribe a
-      // duplicate topic, which removes it from [_channels].
-      for (final channel in _channels.toList()) {
-        if (channel.isErrored) {
-          channel.rejoin();
-        }
-      }
-    } catch (error) {
-      realtimeLogger.warning('Error while rejoining channels', error);
-    }
-
     _statusController.add(
       const RealtimeConnectionStatusChange(RealtimeConnectionStatus.open),
     );
@@ -1021,8 +1009,9 @@ class RealtimeClient {
     }
   }
 
-  /// Resolves the access token before flushing the send buffer so that
-  /// buffered channel join payloads carry the correct token.
+  /// Resolves the access token before rejoining errored channels and flushing
+  /// the send buffer, so that joins and buffered channel join payloads carry
+  /// the correct token.
   ///
   /// When [RealtimeChannel.subscribe] runs before an asynchronous access token
   /// has resolved (common when [customAccessToken] reads from async storage),
@@ -1030,33 +1019,70 @@ class RealtimeClient {
   /// captured the stale payload, so once auth has settled the join payloads are
   /// patched with the resolved token, the stale buffered joins are dropped, and
   /// the join is re-sent for any channel still joining.
+  ///
+  /// A throwing [customAccessToken] fails the connect instead of silently
+  /// downgrading the buffered messages to the identity the socket already has:
+  /// the error reaches the channels as a `channelError` status and
+  /// [onStatusChange] as a stream error, the buffer is kept unsent, and the
+  /// connection is closed so the reconnect backoff retries the provider.
   Future<void> _resolveAccessTokenAndFlush() async {
-    try {
-      if (customAccessToken != null) {
+    final originConnection = _connection;
+    if (customAccessToken != null) {
+      try {
         await setAccessToken(null);
-        final resolvedToken = _accessToken;
-        if (resolvedToken != null) {
-          // Snapshot before patching and rejoining, in case either removes a
-          // channel from [_channels] synchronously.
-          final channelsSnapshot = _channels.toList();
-          for (final channel in channelsSnapshot) {
-            channel.updateJoinPayload({'access_token': resolvedToken});
-          }
-          _sendBuffer.clear();
-          for (final channel in channelsSnapshot) {
-            if (channel.isJoining) {
-              channel.forceRejoin();
-            }
+      } catch (error) {
+        // Bail out if disconnect() ran or a reconnect replaced the connection
+        // while the token was resolving.
+        if (!identical(_connection, originConnection)) {
+          return;
+        }
+        realtimeLogger.warning(
+          'Error resolving access token on connect, closing connection',
+          error,
+        );
+        _triggerChanError(error);
+        _statusController.addError(error);
+        unawaited(
+          _connection?.sink.close(
+            RealtimeConstants.webSocketCloseNormal,
+            'access token resolution failed',
+          ),
+        );
+        return;
+      }
+      final resolvedToken = _accessToken;
+      if (resolvedToken != null) {
+        // Snapshot before patching and rejoining, in case either removes a
+        // channel from [_channels] synchronously.
+        final channelsSnapshot = _channels.toList();
+        for (final channel in channelsSnapshot) {
+          channel.updateJoinPayload({'access_token': resolvedToken});
+        }
+        _sendBuffer.clear();
+        for (final channel in channelsSnapshot) {
+          if (channel.isJoining) {
+            channel.forceRejoin();
           }
         }
       }
+    }
+    _rejoinErroredChannels();
+    _flushSendBuffer();
+  }
+
+  /// Rejoins the channels that errored on a previous connection, once the
+  /// access token has resolved so the joins carry the correct identity.
+  void _rejoinErroredChannels() {
+    try {
+      // Snapshot before rejoining: a rejoin can synchronously unsubscribe a
+      // duplicate topic, which removes it from [_channels].
+      for (final channel in _channels.toList()) {
+        if (channel.isErrored) {
+          channel.rejoin();
+        }
+      }
     } catch (error) {
-      realtimeLogger.warning(
-        'Error resolving access token on connect',
-        error,
-      );
-    } finally {
-      _flushSendBuffer();
+      realtimeLogger.warning('Error while rejoining channels', error);
     }
   }
 

--- a/packages/supabase_realtime/test/socket_test.dart
+++ b/packages/supabase_realtime/test/socket_test.dart
@@ -1565,13 +1565,17 @@ void main() {
         expect(socket.connectionState, SocketState.open);
 
         await socket.disconnect();
-        tokenCompleter.completeError(Exception('provider failed late'));
+        tokenCompleter.completeError(
+          Exception('provider failed late'),
+          StackTrace.current,
+        );
         await Future<void>.delayed(Duration.zero);
 
         // The stale error is not surfaced for a user-initiated disconnect and
         // the failure close is never issued.
         expect(channelErrors, isEmpty);
         expect(socketErrors, isEmpty);
+        expect(capturedMessages, isEmpty);
         verifyNever(
           () => mockedSink.close(
             RealtimeConstants.webSocketCloseNormal,

--- a/packages/supabase_realtime/test/socket_test.dart
+++ b/packages/supabase_realtime/test/socket_test.dart
@@ -1469,6 +1469,119 @@ void main() {
         await socket.disconnect();
       },
     );
+
+    test(
+      'ignores a token resolution that completes after a disconnect',
+      () async {
+        final tokenCompleter = Completer<String?>();
+        final capturedMessages = <String>[];
+        final streamController = StreamController<dynamic>.broadcast();
+
+        final mockedChannel = MockIOWebSocketChannel();
+        final mockedSink = MockWebSocketSink();
+        when(() => mockedChannel.sink).thenReturn(mockedSink);
+        when(() => mockedChannel.ready).thenAnswer((_) => Future.value());
+        when(
+          () => mockedChannel.stream,
+        ).thenAnswer((_) => streamController.stream);
+        when(
+          () => mockedSink.close(any(), any()),
+        ).thenAnswer((_) => Future.value());
+        when(() => mockedSink.close()).thenAnswer((_) => Future.value());
+        when(() => mockedSink.add(any())).thenAnswer((invocation) {
+          capturedMessages.add(invocation.positionalArguments.first as String);
+        });
+
+        final socket = RealtimeClient(
+          socketEndpoint,
+          transport: (url, headers) => mockedChannel,
+          reconnectAfter: (tries) => const Duration(minutes: 5),
+          customAccessToken: () => tokenCompleter.future,
+        );
+
+        final channel = socket.channel('realtime:test');
+        channel.subscribe();
+
+        // Let the connection open and the token resolution start.
+        await Future<void>.delayed(Duration.zero);
+        expect(socket.connectionState, SocketState.open);
+
+        await socket.disconnect();
+        tokenCompleter.complete(generateJwt());
+        await Future<void>.delayed(Duration.zero);
+
+        // The stale resolution did not overwrite the identity of the socket
+        // and nothing was rejoined or flushed with it.
+        expect(socket.accessToken, isNull);
+        expect(capturedMessages, isEmpty);
+
+        await streamController.close();
+      },
+    );
+
+    test(
+      'does not surface a provider error that completes after a disconnect',
+      () async {
+        final tokenCompleter = Completer<String?>();
+        final capturedMessages = <String>[];
+        final streamController = StreamController<dynamic>.broadcast();
+
+        final mockedChannel = MockIOWebSocketChannel();
+        final mockedSink = MockWebSocketSink();
+        when(() => mockedChannel.sink).thenReturn(mockedSink);
+        when(() => mockedChannel.ready).thenAnswer((_) => Future.value());
+        when(
+          () => mockedChannel.stream,
+        ).thenAnswer((_) => streamController.stream);
+        when(
+          () => mockedSink.close(any(), any()),
+        ).thenAnswer((_) => Future.value());
+        when(() => mockedSink.close()).thenAnswer((_) => Future.value());
+        when(() => mockedSink.add(any())).thenAnswer((invocation) {
+          capturedMessages.add(invocation.positionalArguments.first as String);
+        });
+
+        final socket = RealtimeClient(
+          socketEndpoint,
+          transport: (url, headers) => mockedChannel,
+          reconnectAfter: (tries) => const Duration(minutes: 5),
+          customAccessToken: () => tokenCompleter.future,
+        );
+
+        final socketErrors = <Object>[];
+        socket.onStatusChange.listen((_) {}, onError: socketErrors.add);
+
+        final channel = socket.channel('realtime:test');
+        final channelErrors = <RealtimeSubscribeStatusChange>[];
+        channel.onStatusChange
+            .where(
+              (change) => change.status == RealtimeSubscribeStatus.channelError,
+            )
+            .listen(channelErrors.add);
+        channel.subscribe();
+
+        // Let the connection open and the token resolution start.
+        await Future<void>.delayed(Duration.zero);
+        expect(socket.connectionState, SocketState.open);
+
+        await socket.disconnect();
+        tokenCompleter.completeError(Exception('provider failed late'));
+        await Future<void>.delayed(Duration.zero);
+
+        // The stale error is not surfaced for a user-initiated disconnect and
+        // the failure close is never issued.
+        expect(channelErrors, isEmpty);
+        expect(socketErrors, isEmpty);
+        verifyNever(
+          () => mockedSink.close(
+            RealtimeConstants.webSocketCloseNormal,
+            'access token resolution failed',
+          ),
+        );
+
+        await streamController.close();
+      },
+    );
   });
 
   group('sendHeartbeat', () {

--- a/packages/supabase_realtime/test/socket_test.dart
+++ b/packages/supabase_realtime/test/socket_test.dart
@@ -1586,6 +1586,146 @@ void main() {
         await streamController.close();
       },
     );
+
+    test(
+      'ignores a stale token resolution once a newer connection owns the '
+      'socket',
+      () async {
+        final staleToken = generateJwt(4102444800);
+        final freshToken = generateJwt(4102448400);
+        var tokenCallbackCalls = 0;
+        final staleCompleter = Completer<String?>();
+
+        final capturedMessages = <String>[];
+        final joinSent = Completer<Map<dynamic, dynamic>>();
+        final controllers = <StreamController<dynamic>>[];
+
+        WebSocketChannel makeConnection() {
+          final mockedChannel = MockIOWebSocketChannel();
+          final mockedSink = MockWebSocketSink();
+          final controller = StreamController<dynamic>.broadcast();
+          controllers.add(controller);
+          when(() => mockedChannel.sink).thenReturn(mockedSink);
+          when(() => mockedChannel.ready).thenAnswer((_) => Future.value());
+          when(
+            () => mockedChannel.stream,
+          ).thenAnswer((_) => controller.stream);
+          when(() => mockedSink.close()).thenAnswer((_) async {
+            await controller.close();
+          });
+          when(() => mockedSink.close(any(), any())).thenAnswer((_) async {
+            await controller.close();
+          });
+          when(() => mockedSink.add(any())).thenAnswer((invocation) {
+            final raw = invocation.positionalArguments.first as String;
+            capturedMessages.add(raw);
+            final frame = json.decode(raw) as List;
+            if (frame[3] == ChannelEvent.join.eventName() &&
+                !joinSent.isCompleted) {
+              joinSent.complete(frame[4] as Map);
+            }
+          });
+          return mockedChannel;
+        }
+
+        final socket = RealtimeClient(
+          socketEndpoint,
+          transport: (url, headers) => makeConnection(),
+          reconnectAfter: (tries) => const Duration(milliseconds: 10),
+          customAccessToken: () {
+            tokenCallbackCalls++;
+            if (tokenCallbackCalls == 1) {
+              return staleCompleter.future;
+            }
+            return Future.value(freshToken);
+          },
+        );
+
+        final channel = socket.channel('realtime:test');
+        channel.subscribe();
+
+        // Let the first connection open; its token resolution stays pending.
+        await Future<void>.delayed(Duration.zero);
+        expect(socket.connectionState, SocketState.open);
+        expect(tokenCallbackCalls, 1);
+
+        // Drop the first connection so the client reconnects and resolves the
+        // fresh token on the replacement connection.
+        await controllers.first.close();
+        final joinPayload = await joinSent.future.timeout(
+          const Duration(seconds: 5),
+        );
+        expect(joinPayload['access_token'], freshToken);
+
+        // The stale resolution completing now must not overwrite the identity
+        // of the replacement connection.
+        staleCompleter.complete(staleToken);
+        await Future<void>.delayed(Duration.zero);
+
+        expect(socket.accessToken, freshToken);
+        for (final raw in capturedMessages) {
+          final frame = json.decode(raw) as List;
+          if (frame[3] == ChannelEvent.join.eventName()) {
+            expect((frame[4] as Map)['access_token'], freshToken);
+          }
+        }
+
+        await socket.disconnect();
+      },
+    );
+
+    test(
+      'grows the reconnect backoff while the access token provider keeps '
+      'failing',
+      () async {
+        final triesSeen = <int>[];
+
+        WebSocketChannel makeConnection() {
+          final mockedChannel = MockIOWebSocketChannel();
+          final mockedSink = MockWebSocketSink();
+          final controller = StreamController<dynamic>.broadcast();
+          when(() => mockedChannel.sink).thenReturn(mockedSink);
+          when(() => mockedChannel.ready).thenAnswer((_) => Future.value());
+          when(
+            () => mockedChannel.stream,
+          ).thenAnswer((_) => controller.stream);
+          when(() => mockedSink.close()).thenAnswer((_) async {
+            await controller.close();
+          });
+          when(() => mockedSink.close(any(), any())).thenAnswer((_) async {
+            await controller.close();
+          });
+          return mockedChannel;
+        }
+
+        final socket = RealtimeClient(
+          socketEndpoint,
+          transport: (url, headers) => makeConnection(),
+          reconnectAfter: (tries) {
+            triesSeen.add(tries);
+            return const Duration(milliseconds: 10);
+          },
+          customAccessToken: () async {
+            throw Exception('provider is persistently down');
+          },
+        );
+        socket.onStatusChange.listen((_) {}, onError: (_) {});
+
+        unawaited(socket.connect());
+
+        // Each failed resolution closes the socket and schedules a reconnect
+        // with a growing attempt count instead of restarting the backoff.
+        final deadline = DateTime.now().add(const Duration(seconds: 5));
+        while (triesSeen.length < 3 && DateTime.now().isBefore(deadline)) {
+          await Future<void>.delayed(const Duration(milliseconds: 10));
+        }
+
+        expect(triesSeen.length, greaterThanOrEqualTo(3));
+        expect(triesSeen.sublist(0, 3), [1, 2, 3]);
+
+        await socket.disconnect();
+      },
+    );
   });
 
   group('sendHeartbeat', () {

--- a/packages/supabase_realtime/test/socket_test.dart
+++ b/packages/supabase_realtime/test/socket_test.dart
@@ -1317,6 +1317,158 @@ void main() {
         await streamController.close();
       },
     );
+
+    test(
+      'fails the connect and keeps the buffer unsent when the access token '
+      'provider throws',
+      () async {
+        final providerError = Exception('third-party auth provider is down');
+
+        final streamController = StreamController<dynamic>.broadcast();
+        final readyCompleter = Completer<void>();
+        final capturedMessages = <String>[];
+
+        final mockedChannel = MockIOWebSocketChannel();
+        final mockedSink = MockWebSocketSink();
+        when(() => mockedChannel.sink).thenReturn(mockedSink);
+        when(
+          () => mockedChannel.ready,
+        ).thenAnswer((_) => readyCompleter.future);
+        when(
+          () => mockedChannel.stream,
+        ).thenAnswer((_) => streamController.stream);
+        when(
+          () => mockedSink.close(any(), any()),
+        ).thenAnswer((_) => Future.value());
+        when(() => mockedSink.close()).thenAnswer((_) => Future.value());
+        when(() => mockedSink.add(any())).thenAnswer((invocation) {
+          capturedMessages.add(invocation.positionalArguments.first as String);
+        });
+
+        final socket = RealtimeClient(
+          socketEndpoint,
+          transport: (url, headers) => mockedChannel,
+          reconnectAfter: (tries) => const Duration(minutes: 5),
+          customAccessToken: () async => throw providerError,
+        );
+
+        final socketErrors = <Object>[];
+        socket.onStatusChange.listen((_) {}, onError: socketErrors.add);
+
+        final channel = socket.channel('realtime:test');
+        final channelError = Completer<RealtimeSubscribeStatusChange>();
+        channel.onStatusChange
+            .where(
+              (change) => change.status == RealtimeSubscribeStatus.channelError,
+            )
+            .listen((change) {
+              if (!channelError.isCompleted) {
+                channelError.complete(change);
+              }
+            });
+        channel.subscribe();
+
+        // The join is buffered while the socket is still connecting.
+        expect(socket.sendBuffer, isNotEmpty);
+
+        readyCompleter.complete();
+        final change = await channelError.future.timeout(
+          const Duration(seconds: 5),
+        );
+        // Let the socket status stream deliver the error as well.
+        await Future<void>.delayed(Duration.zero);
+
+        expect(change.error, providerError);
+        expect(socketErrors, contains(providerError));
+        // The buffered join was never flushed with the wrong identity and the
+        // connection was closed so a reconnect retries the provider.
+        expect(capturedMessages, isEmpty);
+        expect(socket.sendBuffer, isNotEmpty);
+        verify(
+          () => mockedSink.close(
+            RealtimeConstants.webSocketCloseNormal,
+            'access token resolution failed',
+          ),
+        ).called(1);
+
+        await socket.disconnect();
+        await streamController.close();
+      },
+    );
+
+    test(
+      'retries a failed access token provider on reconnect and only ever '
+      'joins with the resolved token',
+      () async {
+        final token = generateJwt();
+        var tokenCallbackCalls = 0;
+
+        final capturedMessages = <String>[];
+        final joinSent = Completer<Map<dynamic, dynamic>>();
+
+        WebSocketChannel makeConnection() {
+          final mockedChannel = MockIOWebSocketChannel();
+          final mockedSink = MockWebSocketSink();
+          final controller = StreamController<dynamic>.broadcast();
+          when(() => mockedChannel.sink).thenReturn(mockedSink);
+          when(() => mockedChannel.ready).thenAnswer((_) => Future.value());
+          when(
+            () => mockedChannel.stream,
+          ).thenAnswer((_) => controller.stream);
+          when(() => mockedSink.close()).thenAnswer((_) async {
+            await controller.close();
+          });
+          when(() => mockedSink.close(any(), any())).thenAnswer((_) async {
+            await controller.close();
+          });
+          when(() => mockedSink.add(any())).thenAnswer((invocation) {
+            final raw = invocation.positionalArguments.first as String;
+            capturedMessages.add(raw);
+            final frame = json.decode(raw) as List;
+            if (frame[3] == ChannelEvent.join.eventName() &&
+                !joinSent.isCompleted) {
+              joinSent.complete(frame[4] as Map);
+            }
+          });
+          return mockedChannel;
+        }
+
+        final socket = RealtimeClient(
+          socketEndpoint,
+          transport: (url, headers) => makeConnection(),
+          reconnectAfter: (tries) => const Duration(milliseconds: 10),
+          customAccessToken: () async {
+            tokenCallbackCalls++;
+            if (tokenCallbackCalls == 1) {
+              throw Exception('transient provider failure');
+            }
+            return token;
+          },
+        );
+
+        final channel = socket.channel('realtime:test');
+        channel.subscribe();
+
+        final joinPayload = await joinSent.future.timeout(
+          const Duration(seconds: 5),
+        );
+
+        expect(tokenCallbackCalls, 2);
+        expect(socket.accessToken, token);
+        expect(joinPayload['access_token'], token);
+
+        // No frame was ever written without the resolved token: the buffered
+        // join from the failed first connect was dropped, not flushed.
+        for (final raw in capturedMessages) {
+          final frame = json.decode(raw) as List;
+          if (frame[3] == ChannelEvent.join.eventName()) {
+            expect((frame[4] as Map)['access_token'], token);
+          }
+        }
+
+        await socket.disconnect();
+      },
+    );
   });
 
   group('sendHeartbeat', () {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

When a custom `accessToken` provider throws while the realtime socket connects, `_resolveAccessTokenAndFlush` logs `Error resolving access token on connect` and flushes the send buffer anyway. The buffered channel joins are then sent with whatever identity the socket already has (typically the anon/publishable key), so a transient third-party auth failure silently downgrades the connection instead of failing it. The HTTP path already propagates these errors, and supabase-swift adopted the same behavior citing supabase-flutter as the reference implementation, so realtime was the odd one out.

## What is the new behavior?

A throwing access-token provider now fails the connect and surfaces the error on both levels:

- Pending subscriptions receive a `channelError` status carrying the provider's actual error through `RealtimeChannel.onStatusChange`.
- `RealtimeClient.onStatusChange` receives the error as a stream error, consistent with other connection errors.
- The send buffer is kept unsent, so buffered joins are never flushed with the wrong identity, and the connection is closed so the existing reconnect backoff retries the provider on each attempt. Transient provider failures self-heal, and a provider that returns `null` (no signed-in user) still proceeds unauthenticated.

The errored-channel rejoin loop also moved from `_onConnectionOpen` to after the token resolution, so rejoins always carry the resolved identity. Previously an errored channel rejoined immediately on reconnect with the stale payload, which both reintroduced the wrong-identity join after a provider failure and, on the success path, sent a stale join that was corrected by a second one.

A guard bails out of the error handling when a disconnect or reconnect replaced the connection while the token was resolving, so a stale provider error cannot close a newer connection.

## Additional context

Regression tests:

- A throwing provider leaves the buffer unsent, writes nothing to the socket, delivers the error to both status streams, and closes the connection with the expected code and reason.
- A provider that fails once and then succeeds is retried on reconnect, and every join frame ever written carries the resolved token.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection handling when access-token retrieval fails.
  * Channel subscriptions now report token errors correctly and avoid incomplete join requests.
  * Reconnection attempts retry failed token retrieval with increasing backoff.
  * Late token results and messages from closed or replaced connections are safely ignored.
  * Buffered messages are preserved for retry after temporary connection failures.

* **Tests**
  * Expanded coverage for token failures, reconnects, closures, buffered messages, and stale connection results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->