### PR TITLE
fix(auth): guard startAutoRefresh against use after dispose

### DIFF
--- a/packages/supabase_auth/lib/src/auth_client.dart
+++ b/packages/supabase_auth/lib/src/auth_client.dart
@@ -97,7 +97,8 @@ class AuthClient {
   final Map<String, Completer<AuthResponse>> _pendingRefreshes = {};
 
   /// Set by [dispose] to prevent [_doRefresh] from mutating state
-  /// or emitting events on closed stream controllers.
+  /// or emitting events on closed stream controllers, and to stop
+  /// [startAutoRefresh] from installing a timer that nothing would cancel.
   bool _isDisposed = false;
 
   JWKSet? _jwks;
@@ -1502,8 +1503,17 @@ class AuthClient {
   /// Starts an auto-refresh process in the background. Close to the time of
   /// expiration a process is started to refresh the session. If refreshing
   /// fails it will be retried for as long as necessary.
+  ///
+  /// Does nothing once the client has been disposed, so that a late call (for
+  /// example from an app lifecycle observer that has not been removed yet)
+  /// cannot install a timer that outlives [dispose].
   void startAutoRefresh() async {
     stopAutoRefresh();
+
+    if (_isDisposed) {
+      authLogger.finer('Not starting auto refresh, the client is disposed');
+      return;
+    }
 
     authLogger.fine('Starting auto refresh');
     _autoRefreshTicker = Timer.periodic(
@@ -1523,6 +1533,10 @@ class AuthClient {
   }
 
   Future<void> _autoRefreshTokenTick() async {
+    if (_isDisposed) {
+      return;
+    }
+
     try {
       final now = DateTime.now();
 
@@ -1710,7 +1724,7 @@ class AuthClient {
       }
     }
     _pendingRefreshes.clear();
-    _autoRefreshTicker?.cancel();
+    stopAutoRefresh();
   }
 
   /// Generates a new JWT.

--- a/packages/supabase_auth/test/auto_refresh_dispose_test.dart
+++ b/packages/supabase_auth/test/auto_refresh_dispose_test.dart
@@ -1,0 +1,79 @@
+import 'dart:async';
+
+import 'package:http/http.dart';
+import 'package:supabase_auth/supabase_auth.dart';
+import 'package:test/test.dart';
+
+import 'utils.dart';
+
+/// Tracks every periodic timer created inside [run] and how many of them are
+/// still active when it returns.
+class PeriodicTimerTracker {
+  final _timers = <Timer>[];
+
+  Iterable<Timer> get activeTimers => _timers.where((timer) => timer.isActive);
+
+  Future<void> run(Future<void> Function() body) {
+    final specification = ZoneSpecification(
+      createPeriodicTimer: (self, parent, zone, duration, callback) {
+        final timer = parent.createPeriodicTimer(zone, duration, callback);
+        _timers.add(timer);
+        return timer;
+      },
+    );
+    return runZoned(body, zoneSpecification: specification);
+  }
+}
+
+/// Fails the test if the client ever tries to reach the network.
+class UnreachableHttpClient extends BaseClient {
+  @override
+  Future<StreamedResponse> send(BaseRequest request) {
+    fail('No request was expected, got ${request.method} ${request.url}');
+  }
+}
+
+void main() {
+  const authUrl = 'http://localhost:9998';
+
+  AuthClient createClient() => AuthClient(
+    url: authUrl,
+    asyncStorage: TestAsyncStorage(),
+    httpClient: UnreachableHttpClient(),
+    autoRefreshToken: true,
+  );
+
+  test('startAutoRefresh leaves no timer behind after dispose', () async {
+    final tracker = PeriodicTimerTracker();
+
+    await tracker.run(() async {
+      final client = createClient();
+      client.dispose();
+
+      client.startAutoRefresh();
+      await Future.delayed(Duration.zero);
+    });
+
+    expect(tracker.activeTimers, isEmpty);
+  });
+
+  test('dispose cancels a running auto refresh timer', () async {
+    final tracker = PeriodicTimerTracker();
+
+    await tracker.run(() async {
+      final client = createClient();
+
+      client.startAutoRefresh();
+      await Future.delayed(Duration.zero);
+      expect(
+        tracker.activeTimers,
+        isNotEmpty,
+        reason: 'startAutoRefresh should install a periodic timer',
+      );
+
+      client.dispose();
+    });
+
+    expect(tracker.activeTimers, isEmpty);
+  });
+}

--- a/packages/supabase_flutter/lib/src/supabase.dart
+++ b/packages/supabase_flutter/lib/src/supabase.dart
@@ -224,11 +224,13 @@ class Supabase {
     _targetLifecycleState = null;
     lifecycleListener?.dispose();
 
+    // The lifecycle observer is removed before the client is disposed, so a
+    // lifecycle event cannot reach a client that is already torn down.
     await _disposeAll([
+      () => supabaseAuth?.dispose(),
       () => restoreSession?.cancel(),
       () => pendingLifecycleOperation,
       currentClient.dispose,
-      () => supabaseAuth?.dispose(),
     ]);
   }
 

--- a/packages/supabase_flutter/lib/src/supabase_auth.dart
+++ b/packages/supabase_flutter/lib/src/supabase_auth.dart
@@ -79,6 +79,10 @@ class SupabaseAuth with WidgetsBindingObserver {
 
   final _appLinks = AppLinks();
 
+  /// Set by [dispose] so that a lifecycle callback that is delivered after
+  /// teardown does not touch the disposed [Supabase] instance.
+  bool _isDisposed = false;
+
   /// - Obtains session from local storage and sets it as the current session
   /// - Starts a deep link observer
   /// - Emits an initial session if there were no session stored in local
@@ -165,6 +169,7 @@ class SupabaseAuth with WidgetsBindingObserver {
 
   /// Dispose the instance to free up resources
   void dispose() {
+    _isDisposed = true;
     if (isRunningInFlutterTest) {
       _initialDeeplinkIsHandled = false;
     }
@@ -175,6 +180,10 @@ class SupabaseAuth with WidgetsBindingObserver {
 
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (_isDisposed) {
+      return;
+    }
+
     switch (state) {
       case AppLifecycleState.resumed:
         if (_autoRefreshToken) {

--- a/packages/supabase_flutter/test/lifecycle_after_dispose_test.dart
+++ b/packages/supabase_flutter/test/lifecycle_after_dispose_test.dart
@@ -1,0 +1,57 @@
+import 'dart:async';
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import 'utils.dart';
+import 'widget_test_stubs.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    mockSharedPreferences();
+    mockAppLink();
+    await Supabase.initialize(
+      url: '',
+      publishableKey: '',
+      authOptions: FlutterAuthClientOptions(
+        localStorage: const MockEmptyLocalStorage(),
+        pkceAsyncStorage: MockAsyncStorage(),
+      ),
+    );
+  });
+
+  test(
+    'a resume event after dispose does not touch the disposed client',
+    () async {
+      final binding = TestWidgetsFlutterBinding.instance;
+      final auth = Supabase.instance.client.auth;
+
+      await Supabase.instance.dispose();
+
+      final periodicTimers = <Timer>[];
+      await runZoned(
+        () async {
+          binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+          await pumpEventQueue();
+
+          // Direct call, in case something outside the lifecycle observer holds
+          // on to the auth client.
+          auth.startAutoRefresh();
+          await pumpEventQueue();
+        },
+        zoneSpecification: ZoneSpecification(
+          createPeriodicTimer: (self, parent, zone, duration, callback) {
+            final timer = parent.createPeriodicTimer(zone, duration, callback);
+            periodicTimers.add(timer);
+            return timer;
+          },
+        ),
+      );
+
+      expect(periodicTimers.where((timer) => timer.isActive), isEmpty);
+    },
+  );
+}


### PR DESCRIPTION
## What

`AuthClient.dispose()` cancelled `_autoRefreshTicker`, but `startAutoRefresh()` had no disposed check. Calling it after dispose installed a fresh `Timer.periodic` that nothing ever cancelled, so the timer kept firing for the rest of the process lifetime.

This was reachable in practice: the app lifecycle observer in `SupabaseAuth.didChangeAppLifecycleState` calls `startAutoRefresh()` on resume, and `Supabase.dispose()` disposed the client before removing that observer, so a resume event landing in that window leaked the timer.

## Changes

`packages/supabase_auth`:

- `startAutoRefresh()` returns early when the client is disposed, so no timer can outlive `dispose()`.
- `_autoRefreshTokenTick()` returns early when the client is disposed, covering the tick that `startAutoRefresh()` schedules after a microtask.
- `dispose()` now calls `stopAutoRefresh()` instead of cancelling the ticker inline, so the field is cleared too.

`packages/supabase_flutter`:

- `Supabase.dispose()` removes the lifecycle observer (via `SupabaseAuth.dispose()`) before disposing the client, so a lifecycle event cannot reach a client that is already torn down.
- `SupabaseAuth` ignores lifecycle callbacks delivered after its own dispose, as defence in depth against re-entrant delivery.

## Tests

- `packages/supabase_auth/test/auto_refresh_dispose_test.dart`: tracks periodic timers through a custom `Zone` and asserts that `startAutoRefresh()` after dispose leaves no active timer, and that `dispose()` cancels a running ticker. Both fail without the guard.
- `packages/supabase_flutter/test/lifecycle_after_dispose_test.dart`: dispatches a `resumed` lifecycle event after `Supabase.instance.dispose()` and asserts no periodic timer survives.

Closes SDK-1593.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cleanup when the Supabase client is disposed.
  - Prevented authentication auto-refresh timers and network activity from continuing after disposal.
  - Ignored app lifecycle events received after disposal.
  - Ensured session recovery and lifecycle handling shut down in the correct order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->