### PR TITLE
fix(storage): normalize object paths consistently across all file operations

### DIFF
--- a/packages/supabase_storage/lib/src/storage_file_api.dart
+++ b/packages/supabase_storage/lib/src/storage_file_api.dart
@@ -353,8 +353,8 @@ class StorageFileApi {
       '$url/object/move',
       {
         'bucketId': bucketId,
-        'sourceKey': fromPath,
-        'destinationKey': toPath,
+        'sourceKey': _removeEmptyFolders(fromPath),
+        'destinationKey': _removeEmptyFolders(toPath),
         'destinationBucket': ?destinationBucket,
       },
       options: options,
@@ -382,8 +382,8 @@ class StorageFileApi {
       '$url/object/copy',
       {
         'bucketId': bucketId,
-        'sourceKey': fromPath,
-        'destinationKey': toPath,
+        'sourceKey': _removeEmptyFolders(fromPath),
+        'destinationKey': _removeEmptyFolders(toPath),
         'destinationBucket': ?destinationBucket,
       },
       options: options,
@@ -470,7 +470,7 @@ class StorageFileApi {
       '$url/object/sign/$bucketId',
       {
         'expiresIn': expiresIn,
-        'paths': paths,
+        'paths': paths.map(_removeEmptyFolders).toList(),
       },
       options: options,
     );
@@ -688,7 +688,7 @@ class StorageFileApi {
     final options = _fetchOptions;
     final response = await _storageFetch.delete<List<dynamic>>(
       '$url/object/$bucketId',
-      {'prefixes': paths},
+      {'prefixes': paths.map(_removeEmptyFolders).toList()},
       options: options,
     );
     final fileObjects = List<FileObject>.from(
@@ -740,7 +740,7 @@ class StorageFileApi {
     SearchOptions searchOptions = const SearchOptions(),
   }) async {
     final Map<String, dynamic> body = {
-      'prefix': path ?? '',
+      'prefix': _removeEmptyFolders(path ?? ''),
       ...searchOptions.toMap(),
     };
     final options = _fetchOptions;

--- a/packages/supabase_storage/lib/src/storage_file_api.dart
+++ b/packages/supabase_storage/lib/src/storage_file_api.dart
@@ -44,12 +44,13 @@ class StorageFileApi {
     // separators, the bucket id, and characters that are already valid in a
     // path segment (such as `:` in ISO-8601 timestamps) are preserved, so URLs
     // for existing valid keys are unchanged.
-    final encodedPath = Uri(pathSegments: path.split('/')).path;
+    final cleanPath = _removeEmptyFolders(path);
+    final encodedPath = Uri(pathSegments: cleanPath.split('/')).path;
     return '$bucketId/$encodedPath';
   }
 
   String _removeEmptyFolders(String path) {
-    return path.replaceAll(RegExp(r'^/|/$'), '').replaceAll(RegExp(r'/+'), '/');
+    return path.replaceAll(RegExp(r'/+'), '/').replaceAll(RegExp(r'^/|/$'), '');
   }
 
   FetchOptions get _fetchOptions => FetchOptions(headers);
@@ -228,7 +229,8 @@ class StorageFileApi {
     String path, {
     bool upsert = false,
   }) async {
-    final finalPath = _getFinalPath(path);
+    final cleanPath = _removeEmptyFolders(path);
+    final finalPath = _getFinalPath(cleanPath);
 
     final data = await _storageFetch.post<Map<String, dynamic>>(
       '$url/object/upload/sign/$finalPath',
@@ -249,7 +251,7 @@ class StorageFileApi {
 
     return SignedUploadURLResponse(
       signedUrl: signedUrl.toString(),
-      path: path,
+      path: cleanPath,
       token: token,
     );
   }

--- a/packages/supabase_storage/lib/src/storage_file_api.dart
+++ b/packages/supabase_storage/lib/src/storage_file_api.dart
@@ -769,9 +769,14 @@ class StorageFileApi {
   Future<PaginatedListResult> listPaginated({
     PaginatedSearchOptions options = const PaginatedSearchOptions(),
   }) async {
+    final body = options.toMap();
+    final prefix = body['prefix'] as String?;
+    if (prefix != null) {
+      body['prefix'] = _removeEmptyFolders(prefix);
+    }
     final response = await _storageFetch.post<Map<String, dynamic>>(
       '$url/object/list-v2/$bucketId',
-      options.toMap(),
+      body,
       options: _fetchOptions,
     );
     return PaginatedListResult.fromJson(response);

--- a/packages/supabase_storage/test/basic_test.dart
+++ b/packages/supabase_storage/test/basic_test.dart
@@ -451,7 +451,7 @@ void main() {
       final request = customHttpClient.receivedRequests.single;
       expect(request.url.toString(), '$objectUrl/list-v2/public');
       expect(jsonDecode((request as Request).body), {
-        'prefix': 'prefix/',
+        'prefix': 'prefix',
         'limit': 100,
         'with_delimiter': true,
         'sortBy': {'column': 'created_at', 'order': 'desc'},

--- a/packages/supabase_storage/test/path_normalization_test.dart
+++ b/packages/supabase_storage/test/path_normalization_test.dart
@@ -1,0 +1,207 @@
+import 'dart:typed_data';
+
+import 'package:supabase_storage/supabase_storage.dart';
+import 'package:test/test.dart';
+
+import 'custom_http_client.dart';
+
+const storageUrl = 'http://localhost/storage/v1';
+const headers = {'Authorization': 'Bearer token'};
+
+void main() {
+  late CustomHttpClient mockClient;
+  late SupabaseStorageClient client;
+
+  setUp(() {
+    mockClient = CustomHttpClient();
+    client = SupabaseStorageClient(
+      storageUrl,
+      headers,
+      httpClient: mockClient,
+    );
+  });
+
+  Uri requestUrl() => mockClient.receivedRequests.single.url;
+
+  const unnormalizedPaths = [
+    '/folder/file.txt',
+    'folder/file.txt/',
+    'folder//file.txt',
+    '//folder//file.txt//',
+  ];
+
+  for (final path in unnormalizedPaths) {
+    group('path "$path" is normalized', () {
+      test('by download', () async {
+        mockClient.response = Uint8List.fromList([1, 2, 3]);
+        mockClient.statusCode = 200;
+
+        await client.from('bucket').download(path);
+
+        expect(
+          requestUrl().path,
+          '/storage/v1/object/bucket/folder/file.txt',
+        );
+      });
+
+      test('by downloadStream', () async {
+        mockClient.response = Uint8List.fromList([1, 2, 3]);
+        mockClient.statusCode = 200;
+
+        await client.from('bucket').downloadStream(path).drain<void>();
+
+        expect(
+          requestUrl().path,
+          '/storage/v1/object/bucket/folder/file.txt',
+        );
+      });
+
+      test('by createSignedUrl', () async {
+        mockClient.response = {
+          'signedURL': '/object/sign/bucket/folder/file.txt?token=abc',
+        };
+        mockClient.statusCode = 200;
+
+        final signedUrl = await client.from('bucket').createSignedUrl(path, 60);
+
+        expect(
+          requestUrl().path,
+          '/storage/v1/object/sign/bucket/folder/file.txt',
+        );
+        expect(signedUrl, contains('bucket/folder/file.txt'));
+      });
+
+      test('by createSignedUploadUrl, including the returned path', () async {
+        mockClient.response = {
+          'url': '/object/upload/sign/bucket/folder/file.txt?token=abc',
+        };
+        mockClient.statusCode = 200;
+
+        final response = await client
+            .from('bucket')
+            .createSignedUploadUrl(path);
+
+        expect(
+          requestUrl().path,
+          '/storage/v1/object/upload/sign/bucket/folder/file.txt',
+        );
+        expect(response.path, 'folder/file.txt');
+      });
+
+      test('by getMetadata', () async {
+        mockClient.response = {
+          'id': 'id',
+          'version': '1',
+          'name': 'folder/file.txt',
+          'bucket_id': 'bucket',
+          'updated_at': '2024-01-01T00:00:00Z',
+          'created_at': '2024-01-01T00:00:00Z',
+          'size': 3,
+          'cache_control': 'no-cache',
+          'content_type': 'text/plain',
+          'etag': 'etag',
+          'last_modified': '2024-01-01T00:00:00Z',
+          'metadata': <String, dynamic>{},
+        };
+        mockClient.statusCode = 200;
+
+        await client.from('bucket').getMetadata(path);
+
+        expect(
+          requestUrl().path,
+          '/storage/v1/object/info/bucket/folder/file.txt',
+        );
+      });
+
+      test('by exists', () async {
+        mockClient.response = Uint8List.fromList([]);
+        mockClient.statusCode = 200;
+
+        final exists = await client.from('bucket').exists(path);
+
+        expect(exists, isTrue);
+        expect(
+          requestUrl().path,
+          '/storage/v1/object/bucket/folder/file.txt',
+        );
+      });
+
+      test('by purgeCache', () async {
+        mockClient.response = {'message': 'ok'};
+        mockClient.statusCode = 200;
+
+        await client.from('bucket').purgeCache(path);
+
+        expect(
+          requestUrl().path,
+          '/storage/v1/cdn/bucket/folder/file.txt',
+        );
+      });
+
+      test('by getPublicUrl', () {
+        final publicUrl = client.from('bucket').getPublicUrl(path);
+
+        expect(
+          publicUrl,
+          '$storageUrl/object/public/bucket/folder/file.txt',
+        );
+      });
+
+      test('by uploadBinary, including the returned path', () async {
+        mockClient.response = {
+          'Id': 'id',
+          'Key': 'bucket/folder/file.txt',
+        };
+
+        final response = await client
+            .from('bucket')
+            .uploadBinary(path, Uint8List.fromList([1, 2, 3]));
+
+        expect(
+          requestUrl().path,
+          '/storage/v1/object/bucket/folder/file.txt',
+        );
+        expect(response.path, 'folder/file.txt');
+      });
+
+      test('by updateBinary, including the returned path', () async {
+        mockClient.response = {
+          'Id': 'id',
+          'Key': 'bucket/folder/file.txt',
+        };
+        mockClient.statusCode = 200;
+
+        final response = await client
+            .from('bucket')
+            .updateBinary(path, Uint8List.fromList([1, 2, 3]));
+
+        expect(
+          requestUrl().path,
+          '/storage/v1/object/bucket/folder/file.txt',
+        );
+        expect(response.path, 'folder/file.txt');
+      });
+
+      test('by uploadBinaryToSignedUrl, including the returned path', () async {
+        mockClient.response = {
+          'Key': 'bucket/folder/file.txt',
+        };
+        mockClient.statusCode = 200;
+
+        final response = await client
+            .from('bucket')
+            .uploadBinaryToSignedUrl(
+              path,
+              'token',
+              Uint8List.fromList([1, 2, 3]),
+            );
+
+        expect(
+          requestUrl().path,
+          '/storage/v1/object/upload/sign/bucket/folder/file.txt',
+        );
+        expect(response.path, 'folder/file.txt');
+      });
+    });
+  }
+}

--- a/packages/supabase_storage/test/path_normalization_test.dart
+++ b/packages/supabase_storage/test/path_normalization_test.dart
@@ -244,6 +244,23 @@ void main() {
         expect(body['prefix'], 'folder/file.txt');
       });
 
+      test('by listPaginated, in the request body', () async {
+        mockClient.response = {
+          'hasNext': false,
+          'objects': <dynamic>[],
+        };
+        mockClient.statusCode = 200;
+
+        await client
+            .from('bucket')
+            .listPaginated(
+              options: PaginatedSearchOptions(prefix: path),
+            );
+
+        final body = requestBody() as Map<String, dynamic>;
+        expect(body['prefix'], 'folder/file.txt');
+      });
+
       test('by uploadBinaryToSignedUrl, including the returned path', () async {
         mockClient.response = {
           'Key': 'bucket/folder/file.txt',

--- a/packages/supabase_storage/test/path_normalization_test.dart
+++ b/packages/supabase_storage/test/path_normalization_test.dart
@@ -1,5 +1,7 @@
+import 'dart:convert';
 import 'dart:typed_data';
 
+import 'package:http/http.dart' as http;
 import 'package:supabase_storage/supabase_storage.dart';
 import 'package:test/test.dart';
 
@@ -22,6 +24,9 @@ void main() {
   });
 
   Uri requestUrl() => mockClient.receivedRequests.single.url;
+
+  dynamic requestBody() =>
+      jsonDecode((mockClient.receivedRequests.single as http.Request).body);
 
   const unnormalizedPaths = [
     '/folder/file.txt',
@@ -180,6 +185,63 @@ void main() {
           '/storage/v1/object/bucket/folder/file.txt',
         );
         expect(response.path, 'folder/file.txt');
+      });
+
+      test('by move, in the request body', () async {
+        mockClient.response = {'message': 'ok'};
+        mockClient.statusCode = 200;
+
+        await client.from('bucket').move(path, path);
+
+        final body = requestBody() as Map<String, dynamic>;
+        expect(body['sourceKey'], 'folder/file.txt');
+        expect(body['destinationKey'], 'folder/file.txt');
+      });
+
+      test('by copy, in the request body', () async {
+        mockClient.response = {'Key': 'bucket/folder/file.txt'};
+        mockClient.statusCode = 200;
+
+        await client.from('bucket').copy(path, path);
+
+        final body = requestBody() as Map<String, dynamic>;
+        expect(body['sourceKey'], 'folder/file.txt');
+        expect(body['destinationKey'], 'folder/file.txt');
+      });
+
+      test('by remove, in the request body', () async {
+        mockClient.response = <dynamic>[];
+        mockClient.statusCode = 200;
+
+        await client.from('bucket').remove([path]);
+
+        final body = requestBody() as Map<String, dynamic>;
+        expect(body['prefixes'], ['folder/file.txt']);
+      });
+
+      test('by createSignedUrls, in the request body', () async {
+        mockClient.response = [
+          {
+            'signedURL': '/object/sign/bucket/folder/file.txt?token=abc',
+            'path': 'folder/file.txt',
+          },
+        ];
+        mockClient.statusCode = 200;
+
+        await client.from('bucket').createSignedUrls([path], 60);
+
+        final body = requestBody() as Map<String, dynamic>;
+        expect(body['paths'], ['folder/file.txt']);
+      });
+
+      test('by list, in the request body', () async {
+        mockClient.response = <dynamic>[];
+        mockClient.statusCode = 200;
+
+        await client.from('bucket').list(path: path);
+
+        final body = requestBody() as Map<String, dynamic>;
+        expect(body['prefix'], 'folder/file.txt');
       });
 
       test('by uploadBinaryToSignedUrl, including the returned path', () async {


### PR DESCRIPTION
## Problem

Path normalization (`_removeEmptyFolders`, which strips leading and trailing `/` and collapses `//`) was applied only to `upload`, `uploadBinary`, `uploadToSignedUrl`, `uploadBinaryToSignedUrl`, `update`, and `updateBinary`.

It was not applied to `createSignedUrl`, `createSignedUploadUrl`, `download`, `downloadStream`, `getMetadata`, `exists`, `getPublicUrl`, or `purgeCache`; those only went through `_getFinalPath`, which percent-encodes segments but did not strip slashes. The payload-based operations `move`, `copy`, `remove`, `list`, and `createSignedUrls` sent raw paths in their JSON bodies as well.

Result: `upload('/folder/a.png')` stores the object under `folder/a.png`, but a subsequent `createSignedUrl('/folder/a.png')`, `download('/folder/a.png')`, or `remove(['/folder/a.png'])` targeted a different key and failed.

This mirrors the fixes in supabase-swift ([supabase/supabase-swift#1111](https://github.com/supabase/supabase-swift/pull/1111), [supabase/supabase-swift#1108](https://github.com/supabase/supabase-swift/pull/1108)) and extends them to the payload-based operations.

## Fix

- `_getFinalPath` now runs `_removeEmptyFolders` before percent-encoding, so every operation that builds an object URL through it normalizes the path the same way as the upload methods.
- `_removeEmptyFolders` now collapses duplicate slashes before stripping leading and trailing ones, so inputs like `//folder//file.txt//` fully normalize to `folder/file.txt` (the previous order left a leading slash behind for doubled leading slashes).
- `createSignedUploadUrl` cleans the path before building the request URL and returns the cleaned path in `SignedUploadURLResponse.path`, so the returned path matches the stored object key, mirroring the Swift fix.
- `move`, `copy`, `remove`, `list`, `listPaginated`, and `createSignedUrls` normalize the paths in their JSON bodies, so payload-based operations target the same object keys as the URL-based ones.

## Tests

Added `path_normalization_test.dart`, which runs leading slash, trailing slash, duplicate slash, and combined inputs through `download`, `downloadStream`, `createSignedUrl`, `createSignedUrls`, `createSignedUploadUrl`, `getMetadata`, `exists`, `purgeCache`, `getPublicUrl`, `uploadBinary`, `updateBinary`, `uploadBinaryToSignedUrl`, `move`, `copy`, `remove`, `list`, and `listPaginated`, asserting the request URL or body targets `folder/file.txt` and that returned paths are cleaned. Full `supabase_storage` suite passes (267 tests, including the integration tests against a local storage server).

Fixes SDK-1594


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Normalized storage paths now consistently remove leading, trailing, and duplicate slashes.
  * Improved consistency for uploads, downloads, signed URLs, listing, copying, moving, removing, and metadata operations.
  * Signed upload responses now return the normalized path.

* **Tests**
  * Added comprehensive coverage to verify path normalization across Storage operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
