### PR TITLE
feat(postgrest): add a notInFilter filter method

### DIFF
--- a/packages/postgrest/lib/src/postgrest_filter_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_filter_builder.dart
@@ -260,6 +260,24 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
     );
   }
 
+  /// Finds all rows whose value on the stated [column] is not found on the
+  /// specified [values].
+  ///
+  /// ```dart
+  /// await supabase
+  ///     .from('users')
+  ///     .select()
+  ///     .notInFilter('status', ['ONLINE', 'OFFLINE']);
+  /// ```
+  PostgrestFilterBuilder<T> notInFilter(String column, List<dynamic> values) {
+    return copyWithUrl(
+      _url.appendSearchParameters(
+        column,
+        'not.in.(${_cleanFilterList(values)})',
+      ),
+    );
+  }
+
   /// Finds all rows whose json, array, or range value on the stated [column]
   /// contains the values specified in [value].
   ///

--- a/packages/postgrest/test/filter_escape_test.dart
+++ b/packages/postgrest/test/filter_escape_test.dart
@@ -32,4 +32,25 @@ void main() {
     // well-formed quoted value rather than `in.("a"b\c")`.
     expect(mock.lastUrl!.queryParameters['name'], r'in.("a\"b\\c")');
   });
+
+  test(
+    'escapes double quotes and backslashes in negated list filter values',
+    () async {
+      final mock = _CapturingClient();
+      final client = PostgrestClient('http://localhost:3000', httpClient: mock);
+
+      await client.from('t').select().notInFilter('name', [r'a"b\c']);
+
+      expect(mock.lastUrl!.queryParameters['name'], r'not.in.("a\"b\\c")');
+    },
+  );
+
+  test('does not quote numeric negated list filter values', () async {
+    final mock = _CapturingClient();
+    final client = PostgrestClient('http://localhost:3000', httpClient: mock);
+
+    await client.from('t').select().notInFilter('id', [1, 2, 3]);
+
+    expect(mock.lastUrl!.queryParameters['id'], 'not.in.(1,2,3)');
+  });
 }

--- a/packages/postgrest/test/filter_test.dart
+++ b/packages/postgrest/test/filter_test.dart
@@ -273,6 +273,17 @@ void main() {
     }
   });
 
+  test('not in', () async {
+    final response = await postgrest.from('users').select('status').notInFilter(
+      'status',
+      ['ONLINE'],
+    );
+    expect(response, isNotEmpty);
+    for (final item in response) {
+      expect(item['status'], isNot('ONLINE'));
+    }
+  });
+
   test('immutable filter', () async {
     final query = postgrest.from("users").select();
     final firstResponse = await query.eq("status", "OFFLINE");

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -839,6 +839,7 @@ features:
   database.using_filters.not_in:
     status: implemented
     symbols:
+      - PostgrestFilterBuilder.notInFilter
       - PostgrestFilterBuilder.not
   database.using_filters.contains:
     status: implemented


### PR DESCRIPTION
## Summary

Adds `PostgrestFilterBuilder.notInFilter(String column, List values)`, the negated counterpart of the existing `inFilter`. It emits `not.in.(...)` and reuses the same `_cleanFilterList` quoting and escaping, so callers no longer have to hand-format PostgREST list syntax through the generic `not('column', 'in', '(a,b,c)')` escape hatch.

```dart
await supabase
    .from('users')
    .select()
    .notInFilter('status', ['ONLINE', 'OFFLINE']);
```

The name mirrors `inFilter` because `in` is a reserved word in Dart.

## Outcome

Implemented. Additive, no breaking change.

## Tests

- `filter_test.dart`: live `not in` test against the local backend.
- `filter_escape_test.dart`: asserts the exact query string for escaped string values (`not.in.("a\"b\\c")`) and for unquoted numeric values (`not.in.(1,2,3)`).

All 208 `postgrest` tests pass locally.

## Reference

Ports the behavior added in supabase-swift: https://github.com/supabase/supabase-swift/pull/1114

## Compliance matrix

`database.using_filters.not_in` → `implemented`, with `PostgrestFilterBuilder.notInFilter` registered alongside the existing `PostgrestFilterBuilder.not`.

Closes SDK-1595

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for negated list filters, allowing records matching specified values to be excluded.
  * Supports both text and numeric values with appropriate escaping.

* **Bug Fixes**
  * Ensured special characters in negated list filters are handled safely and consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->