### PR TITLE
fix!: return unmodifiable header views with controlled replacement

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1531,7 +1531,7 @@ builds its sub-clients, so there is no `accessToken` callback to pass:
 
 ```dart
 supabase.storage.setHeader('Authorization', 'Bearer $jwt');
-supabase.functions.headers['Authorization'] = 'Bearer $jwt';
+supabase.headers = {...supabase.headers, 'Authorization': 'Bearer $jwt'};
 ```
 
 The rest client is stateless and its header map unmodifiable (see
@@ -1599,6 +1599,31 @@ await supabase.from('countries');
 // After: does not compile. Choose an operation first.
 await supabase.from('countries').select();
 ```
+
+### Client header maps are unmodifiable
+
+The auth, functions and storage clients used to hand out their internal header map, so any caller
+could rewrite the headers of a client from anywhere, including the sub-clients a `SupabaseClient`
+manages. Every `headers` getter now returns an unmodifiable view, the same way
+`PostgrestClient.headers` and `RealtimeClient.headers` already did.
+
+| Before | After |
+| --- | --- |
+| `supabase.auth.headers['X-Foo'] = 'bar'` | `supabase.headers = {...supabase.headers, 'X-Foo': 'bar'}` |
+| `supabase.functions.headers['X-Foo'] = 'bar'` | `supabase.headers = {...supabase.headers, 'X-Foo': 'bar'}` |
+| `supabase.storage.headers['X-Foo'] = 'bar'` | `supabase.storage.setHeader('X-Foo', 'bar')` |
+| `storage.from('bucket').headers['X-Foo'] = 'bar'` | `storage.from('bucket').setHeader('X-Foo', 'bar')` |
+| `AuthClient(...).headers['X-Foo'] = 'bar'` | `AuthClient(headers: {'X-Foo': 'bar'})` |
+| `FunctionsClient(...).headers['X-Foo'] = 'bar'` | `FunctionsClient(url, {'X-Foo': 'bar'})` |
+
+Mutating one of those maps now throws an `UnsupportedError`. Pass the headers to the constructor of
+a standalone client, and for a client managed by a `SupabaseClient` assign `SupabaseClient.headers`,
+which propagates the new headers to every sub-client. Storage keeps `setHeader()` for adding a
+single header to a client or to one bucket.
+
+`SupabaseStorageClient.vectors` is a getter that builds a client on each access instead of a cached
+instance, so it always carries the current headers. Hold on to the returned client only for as long
+as its headers should stay fixed.
 
 ### The SDK no longer prints logs
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1531,7 +1531,7 @@ builds its sub-clients, so there is no `accessToken` callback to pass:
 
 ```dart
 supabase.storage.setHeader('Authorization', 'Bearer $jwt');
-supabase.headers = {...supabase.headers, 'Authorization': 'Bearer $jwt'};
+supabase.functions.setHeader('Authorization', 'Bearer $jwt');
 ```
 
 The rest client is stateless and its header map unmodifiable (see
@@ -1613,13 +1613,13 @@ manages. Every `headers` getter now returns an unmodifiable view, the same way
 | `supabase.functions.headers['X-Foo'] = 'bar'` | `supabase.headers = {...supabase.headers, 'X-Foo': 'bar'}` |
 | `supabase.storage.headers['X-Foo'] = 'bar'` | `supabase.storage.setHeader('X-Foo', 'bar')` |
 | `storage.from('bucket').headers['X-Foo'] = 'bar'` | `storage.from('bucket').setHeader('X-Foo', 'bar')` |
-| `AuthClient(...).headers['X-Foo'] = 'bar'` | `AuthClient(headers: {'X-Foo': 'bar'})` |
-| `FunctionsClient(...).headers['X-Foo'] = 'bar'` | `FunctionsClient(url, {'X-Foo': 'bar'})` |
+| `authClient.headers['X-Foo'] = 'bar'` | `authClient.setHeader('X-Foo', 'bar')` |
+| `functionsClient.headers['X-Foo'] = 'bar'` | `functionsClient.setHeader('X-Foo', 'bar')` |
 
-Mutating one of those maps now throws an `UnsupportedError`. Pass the headers to the constructor of
-a standalone client, and for a client managed by a `SupabaseClient` assign `SupabaseClient.headers`,
-which propagates the new headers to every sub-client. Storage keeps `setHeader()` for adding a
-single header to a client or to one bucket.
+Mutating one of those maps now throws an `UnsupportedError`. To add a single header, the auth,
+functions and storage clients have a `setHeader()` method, and storage has one per bucket as well.
+A whole set of headers is passed to the constructor. For a client managed by a `SupabaseClient`,
+assign `SupabaseClient.headers`, which propagates the new headers to every sub-client at once.
 
 `SupabaseStorageClient.vectors` is a getter that builds a client on each access instead of a cached
 instance, so it always carries the current headers. Hold on to the returned client only for as long

--- a/packages/supabase/lib/src/supabase_client.dart
+++ b/packages/supabase/lib/src/supabase_client.dart
@@ -189,22 +189,19 @@ class SupabaseClient {
 
     _rest = _initRestClient();
 
-    functions.headers
-      ..clear()
-      ..addAll(_headers);
+    // ignore: invalid_use_of_internal_member
+    functions.replaceHeaders(_headers);
 
-    storage.headers
-      ..clear()
-      ..addAll(_headers);
+    // ignore: invalid_use_of_internal_member
+    storage.replaceHeaders(_headers);
 
     if (accessToken == null) {
-      auth.headers
-        ..clear()
-        ..addAll({
-          ...SupabaseConstants.defaultHeaders,
-          ..._getAuthHeaders(),
-          ...headers,
-        });
+      // ignore: invalid_use_of_internal_member
+      auth.replaceHeaders({
+        ...SupabaseConstants.defaultHeaders,
+        ..._getAuthHeaders(),
+        ..._headers,
+      });
     }
 
     // To apply the new headers in the realtime client,

--- a/packages/supabase/test/client_test.dart
+++ b/packages/supabase/test/client_test.dart
@@ -467,6 +467,33 @@ void main() {
         );
       });
 
+      test('sub-client headers cannot be mutated in place', () {
+        expect(
+          () => supabase.auth.headers['Custom-Header'] = 'custom-value',
+          throwsUnsupportedError,
+        );
+        expect(
+          () => supabase.functions.headers['Custom-Header'] = 'custom-value',
+          throwsUnsupportedError,
+        );
+        expect(
+          () => supabase.storage.headers['Custom-Header'] = 'custom-value',
+          throwsUnsupportedError,
+        );
+        expect(
+          () => supabase.storage.from('bucket').headers['Custom-Header'] =
+              'custom-value',
+          throwsUnsupportedError,
+        );
+      });
+
+      test('should propagate updated headers to the auth client', () {
+        supabase.headers = {'Custom-Header': 'custom-value'};
+
+        expect(supabase.auth.headers['Custom-Header'], 'custom-value');
+        expect(supabase.auth.headers['apikey'], supabaseKey);
+      });
+
       test('rpc leaves the rest client headers untouched', () {
         final headersBefore = {...supabase.rest.headers};
         unawaited(supabase.rpc('do_something'));

--- a/packages/supabase_auth/lib/src/auth_client.dart
+++ b/packages/supabase_auth/lib/src/auth_client.dart
@@ -225,8 +225,23 @@ class AuthClient {
 
   StreamSubscription<dynamic>? _broadcastChannelSubscription;
 
-  /// Getter for the headers
-  Map<String, String> get headers => _headers;
+  /// The headers sent with every request, as an unmodifiable view.
+  ///
+  /// Pass headers to the constructor instead of mutating them here. A client
+  /// managed by a `SupabaseClient` gets its headers replaced through the
+  /// internal [replaceHeaders] when `SupabaseClient.headers` is assigned.
+  Map<String, String> get headers => Map.unmodifiable(_headers);
+
+  /// Replaces the request headers with [newHeaders].
+  ///
+  /// The map is shared with [admin], so its requests pick up the new headers
+  /// as well.
+  @internal
+  void replaceHeaders(Map<String, String> newHeaders) {
+    _headers
+      ..clear()
+      ..addAll(newHeaders);
+  }
 
   /// Returns the current logged in user, associated to [currentSession] if any;
   User? get currentUser => _currentSession?.user;
@@ -936,7 +951,7 @@ class AuthClient {
     }
 
     final options = AuthRequestOptions(
-      headers: headers,
+      headers: _headers,
       jwt: session.accessToken,
     );
 
@@ -1397,7 +1412,7 @@ class AuthClient {
       '$_url/user/identities/${identity.identityId}',
       HttpMethod.delete,
       options: AuthRequestOptions(
-        headers: headers,
+        headers: _headers,
         jwt: _currentSession?.accessToken,
       ),
     );

--- a/packages/supabase_auth/lib/src/auth_client.dart
+++ b/packages/supabase_auth/lib/src/auth_client.dart
@@ -232,6 +232,21 @@ class AuthClient {
   /// internal [replaceHeaders] when `SupabaseClient.headers` is assigned.
   Map<String, String> get headers => Map.unmodifiable(_headers);
 
+  /// Sets an HTTP header for subsequent requests.
+  ///
+  /// The header is shared with [admin], so its requests carry it as well.
+  /// Returns this for method chaining. On a client managed by a
+  /// `SupabaseClient`, assign `SupabaseClient.headers` instead, so that every
+  /// client gets the header.
+  ///
+  /// ```dart
+  /// auth.setHeader('x-custom-header', 'value');
+  /// ```
+  AuthClient setHeader(String key, String value) {
+    _headers[key] = value;
+    return this;
+  }
+
   /// Replaces the request headers with [newHeaders].
   ///
   /// The map is shared with [admin], so its requests pick up the new headers

--- a/packages/supabase_auth/test/header_isolation_test.dart
+++ b/packages/supabase_auth/test/header_isolation_test.dart
@@ -73,5 +73,16 @@ void main() {
 
       expect(client.headers, before);
     });
+
+    test('headers cannot be mutated in place', () async {
+      expect(
+        () => client.headers['apikey'] = 'other-key',
+        throwsUnsupportedError,
+      );
+
+      await client.getUser('user-access-token');
+
+      expect(http.requestHeaders.single['apikey'], 'anon-key');
+    });
   });
 }

--- a/packages/supabase_auth/test/header_isolation_test.dart
+++ b/packages/supabase_auth/test/header_isolation_test.dart
@@ -84,5 +84,25 @@ void main() {
 
       expect(http.requestHeaders.single['apikey'], 'anon-key');
     });
+
+    test('setHeader adds a header to subsequent requests', () async {
+      expect(
+        identical(client.setHeader('x-custom-header', 'value'), client),
+        isTrue,
+      );
+
+      await client.getUser('user-access-token');
+
+      expect(http.requestHeaders.single['x-custom-header'], 'value');
+      expect(client.headers['x-custom-header'], 'value');
+    });
+
+    test('setHeader is picked up by the admin api', () async {
+      client.setHeader('x-custom-header', 'value');
+
+      await client.admin.getUserById('18bc7a4e-c095-4573-93dc-e0be29bada97');
+
+      expect(http.requestHeaders.single['x-custom-header'], 'value');
+    });
   });
 }

--- a/packages/supabase_functions/lib/src/functions_client.dart
+++ b/packages/supabase_functions/lib/src/functions_client.dart
@@ -6,6 +6,7 @@ import 'package:supabase_functions/src/types.dart';
 import 'package:supabase_functions/src/version.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/http.dart' show MultipartRequest;
+import 'package:meta/meta.dart';
 import 'package:supabase_functions/src/logger.dart';
 import 'package:supabase_common/supabase_common.dart';
 import 'package:yet_another_json_isolate/yet_another_json_isolate.dart';
@@ -58,9 +59,19 @@ class FunctionsClient {
   final bool _ownsJsonCodec;
   final String? _region;
 
-  /// Getter for the headers
-  Map<String, String> get headers {
-    return _headers;
+  /// The headers sent with every invocation, as an unmodifiable view.
+  ///
+  /// Pass headers to the constructor instead of mutating them here. A client
+  /// managed by a `SupabaseClient` gets its headers replaced through the
+  /// internal [replaceHeaders] when `SupabaseClient.headers` is assigned.
+  Map<String, String> get headers => Map.unmodifiable(_headers);
+
+  /// Replaces the invocation headers with [newHeaders].
+  @internal
+  void replaceHeaders(Map<String, String> newHeaders) {
+    _headers
+      ..clear()
+      ..addAll(newHeaders);
   }
 
   /// Invokes a function

--- a/packages/supabase_functions/lib/src/functions_client.dart
+++ b/packages/supabase_functions/lib/src/functions_client.dart
@@ -66,6 +66,21 @@ class FunctionsClient {
   /// internal [replaceHeaders] when `SupabaseClient.headers` is assigned.
   Map<String, String> get headers => Map.unmodifiable(_headers);
 
+  /// Sets an HTTP header for subsequent invocations.
+  ///
+  /// Returns this for method chaining. A header passed to [invoke] still wins
+  /// over it for that single call. On a client managed by a `SupabaseClient`,
+  /// assign `SupabaseClient.headers` instead, so that every client gets the
+  /// header.
+  ///
+  /// ```dart
+  /// functions.setHeader('x-custom-header', 'value');
+  /// ```
+  FunctionsClient setHeader(String key, String value) {
+    _headers[key] = value;
+    return this;
+  }
+
   /// Replaces the invocation headers with [newHeaders].
   @internal
   void replaceHeaders(Map<String, String> newHeaders) {

--- a/packages/supabase_functions/test/functions_dart_test.dart
+++ b/packages/supabase_functions/test/functions_dart_test.dart
@@ -479,6 +479,49 @@ void main() {
         expect(client.headers['apikey'], 'foo');
       });
 
+      test('setHeader adds a header to subsequent invocations', () async {
+        final httpClient = CustomHttpClient();
+        final client = FunctionsClient(
+          'http://localhost',
+          {'apikey': 'foo'},
+          httpClient: httpClient,
+        );
+        addTearDown(client.dispose);
+
+        expect(
+          identical(client.setHeader('x-custom-header', 'value'), client),
+          isTrue,
+        );
+        await client.invoke('function');
+
+        expect(
+          httpClient.receivedRequests.last.headers['x-custom-header'],
+          'value',
+        );
+      });
+
+      test('a header passed to invoke wins over setHeader', () async {
+        final httpClient = CustomHttpClient();
+        final client = FunctionsClient(
+          'http://localhost',
+          {'apikey': 'foo'},
+          httpClient: httpClient,
+        );
+        addTearDown(client.dispose);
+
+        client.setHeader('x-custom-header', 'value');
+        await client.invoke(
+          'function',
+          headers: {'x-custom-header': 'per-call'},
+        );
+
+        expect(
+          httpClient.receivedRequests.last.headers['x-custom-header'],
+          'per-call',
+        );
+        expect(client.headers['x-custom-header'], 'value');
+      });
+
       test('accessToken is resolved before every invocation', () async {
         var calls = 0;
         final client = FunctionsClient(

--- a/packages/supabase_functions/test/functions_dart_test.dart
+++ b/packages/supabase_functions/test/functions_dart_test.dart
@@ -469,6 +469,16 @@ void main() {
         expect(client.headers, contains('X-Client-Info'));
       });
 
+      test('headers cannot be mutated in place', () {
+        final client = FunctionsClient("", {'apikey': 'foo'});
+
+        expect(
+          () => client.headers['apikey'] = 'bar',
+          throwsUnsupportedError,
+        );
+        expect(client.headers['apikey'], 'foo');
+      });
+
       test('accessToken is resolved before every invocation', () async {
         var calls = 0;
         final client = FunctionsClient(

--- a/packages/supabase_storage/lib/src/storage_bucket_api.dart
+++ b/packages/supabase_storage/lib/src/storage_bucket_api.dart
@@ -5,13 +5,35 @@ import 'package:supabase_storage/src/types.dart';
 import 'package:supabase_common/supabase_common.dart';
 
 class StorageBucketApi {
-  StorageBucketApi(this.url, this.headers, {Client? httpClient}) {
+  StorageBucketApi(
+    this.url,
+    Map<String, String> headers, {
+    Client? httpClient,
+  }) : _headers = {...headers} {
     storageFetch = Fetch(httpClient);
   }
+
   final String url;
-  final Map<String, String> headers;
+
+  final Map<String, String> _headers;
+
+  /// The headers sent with every request, as an unmodifiable view.
+  ///
+  /// Pass headers to the constructor instead of mutating them here. Use
+  /// `SupabaseStorageClient.setHeader` to add one, or assign
+  /// `SupabaseClient.headers` to replace them all on a managed client.
+  Map<String, String> get headers => Map.unmodifiable(_headers);
+
   @internal
-  late Fetch storageFetch;
+  late final Fetch storageFetch;
+
+  /// Replaces the request headers with [newHeaders].
+  @internal
+  void replaceHeaders(Map<String, String> newHeaders) {
+    _headers
+      ..clear()
+      ..addAll(newHeaders);
+  }
 
   Map<String, dynamic> _bucketPayload(String id, BucketOptions bucketOptions) {
     return {
@@ -28,7 +50,7 @@ class StorageBucketApi {
   /// [options] optionally filters, sorts and paginates the returned buckets.
   /// Calling [listBuckets] without any options returns all buckets.
   Future<List<Bucket>> listBuckets([ListBucketsOptions? options]) async {
-    final FetchOptions fetchOptions = FetchOptions(headers);
+    final FetchOptions fetchOptions = FetchOptions(_headers);
     final queryParameters = options?.toQueryParameters() ?? const {};
     final uri = Uri.parse('$url/bucket').replace(
       queryParameters: queryParameters.isEmpty ? null : queryParameters,
@@ -49,7 +71,7 @@ class StorageBucketApi {
   ///
   /// [id] is the unique identifier of the bucket you would like to retrieve.
   Future<Bucket> getBucket(String id) async {
-    final FetchOptions options = FetchOptions(headers);
+    final FetchOptions options = FetchOptions(_headers);
     final response = await storageFetch.get(
       '$url/bucket/$id',
       options: options,
@@ -77,7 +99,7 @@ class StorageBucketApi {
     String id, [
     BucketOptions bucketOptions = const BucketOptions(public: false),
   ]) async {
-    final FetchOptions options = FetchOptions(headers);
+    final FetchOptions options = FetchOptions(_headers);
     final response = await storageFetch.post(
       '$url/bucket',
       _bucketPayload(id, bucketOptions),
@@ -96,7 +118,7 @@ class StorageBucketApi {
     String id,
     BucketOptions bucketOptions,
   ) async {
-    final FetchOptions options = FetchOptions(headers);
+    final FetchOptions options = FetchOptions(_headers);
     final response = await storageFetch.put(
       '$url/bucket/$id',
       _bucketPayload(id, bucketOptions),
@@ -110,7 +132,7 @@ class StorageBucketApi {
   ///
   /// [id] is the unique identifier of the bucket you would like to empty.
   Future<String> emptyBucket(String id) async {
-    final FetchOptions options = FetchOptions(headers);
+    final FetchOptions options = FetchOptions(_headers);
     final response = await storageFetch.post(
       '$url/bucket/$id/empty',
       {},
@@ -124,7 +146,7 @@ class StorageBucketApi {
   ///
   /// [id] is the unique identifier of the bucket you would like to delete.
   Future<String> deleteBucket(String id) async {
-    final FetchOptions options = FetchOptions(headers);
+    final FetchOptions options = FetchOptions(_headers);
     final response = await storageFetch.delete(
       '$url/bucket/$id',
       {},
@@ -157,7 +179,7 @@ class StorageBucketApi {
     final response = await storageFetch.delete(
       requestUrl.toString(),
       {},
-      options: FetchOptions(headers),
+      options: FetchOptions(_headers),
     );
     return (response as Map<String, dynamic>)['message'] as String;
   }
@@ -166,7 +188,7 @@ class StorageBucketApi {
   ///
   /// [id] is the unique identifier for the bucket you are creating.
   Future<AnalyticsBucket> createAnalyticsBucket(String id) async {
-    final FetchOptions options = FetchOptions(headers);
+    final FetchOptions options = FetchOptions(_headers);
     final response = await storageFetch.post(
       '$url/iceberg/bucket',
       {'name': id},
@@ -182,7 +204,7 @@ class StorageBucketApi {
   Future<List<AnalyticsBucket>> listAnalyticsBuckets([
     ListBucketsOptions? options,
   ]) async {
-    final FetchOptions fetchOptions = FetchOptions(headers);
+    final FetchOptions fetchOptions = FetchOptions(_headers);
     final queryParameters = options?.toQueryParameters() ?? const {};
     final uri = Uri.parse('$url/iceberg/bucket').replace(
       queryParameters: queryParameters.isEmpty ? null : queryParameters,
@@ -201,7 +223,7 @@ class StorageBucketApi {
   ///
   /// [id] is the unique identifier of the bucket you would like to delete.
   Future<String> deleteAnalyticsBucket(String id) async {
-    final FetchOptions options = FetchOptions(headers);
+    final FetchOptions options = FetchOptions(_headers);
     final response = await storageFetch.delete(
       '$url/iceberg/bucket/$id',
       {},

--- a/packages/supabase_storage/lib/src/storage_client.dart
+++ b/packages/supabase_storage/lib/src/storage_client.dart
@@ -149,7 +149,7 @@ class SupabaseStorageClient extends StorageBucketApi {
   /// await vectors.createBucket('embeddings');
   /// ```
   @experimental
-  late final SupabaseVectorsClient vectors = SupabaseVectorsClient(
+  SupabaseVectorsClient get vectors => SupabaseVectorsClient(
     '$url/vector',
     headers,
     storageFetch,
@@ -157,16 +157,15 @@ class SupabaseStorageClient extends StorageBucketApi {
 
   /// Sets an HTTP header for subsequent requests.
   ///
-  /// Mutates the headers map used by this client in place. Instances of
-  /// [StorageFileApi] already obtained through [from] hold their own copy of
-  /// the headers, so only calls to [from] made after this one will include
-  /// the new header. Returns this for method chaining.
+  /// Instances of [StorageFileApi] already obtained through [from] hold their
+  /// own copy of the headers, so only calls to [from] made after this one will
+  /// include the new header. Returns this for method chaining.
   ///
   /// ```dart
   /// storage.setHeader('x-custom-header', 'value').from('bucket').upload(...);
   /// ```
   SupabaseStorageClient setHeader(String key, String value) {
-    headers[key] = value;
+    replaceHeaders({...headers, key: value});
     return this;
   }
 }

--- a/packages/supabase_storage/lib/src/storage_file_api.dart
+++ b/packages/supabase_storage/lib/src/storage_file_api.dart
@@ -20,8 +20,10 @@ class StorageFileApi {
   final SupabaseRetryOptions _retryOptions;
   final Fetch _storageFetch;
 
-  /// The headers used for requests.
-  Map<String, String> get headers => _headers;
+  /// The headers used for requests, as an unmodifiable view.
+  ///
+  /// Use [setHeader] to add one instead of mutating them here.
+  Map<String, String> get headers => Map.unmodifiable(_headers);
 
   /// Sets an HTTP header for subsequent requests.
   ///
@@ -52,7 +54,7 @@ class StorageFileApi {
     return path.replaceAll(RegExp(r'/+'), '/').replaceAll(RegExp(r'^/|/$'), '');
   }
 
-  FetchOptions get _fetchOptions => FetchOptions(headers);
+  FetchOptions get _fetchOptions => FetchOptions(_headers);
 
   UploadResponse _uploadResponse(String cleanPath, Map<String, dynamic> data) {
     return UploadResponse(
@@ -235,7 +237,7 @@ class StorageFileApi {
       '$url/object/upload/sign/$finalPath',
       {},
       options: FetchOptions({
-        ...headers,
+        ..._headers,
         if (upsert) 'x-upsert': 'true',
       }),
     );
@@ -520,7 +522,7 @@ class StorageFileApi {
 
     return _storageFetch.get(
       fetchUrl.toString(),
-      options: FetchOptions(headers, noResolveJson: true),
+      options: FetchOptions(_headers, noResolveJson: true),
     );
   }
 
@@ -583,7 +585,7 @@ class StorageFileApi {
 
     return _storageFetch.getStream(
       fetchUrl.toString(),
-      options: FetchOptions(headers, noResolveJson: true),
+      options: FetchOptions(_headers, noResolveJson: true),
     );
   }
 

--- a/packages/supabase_storage/test/basic_test.dart
+++ b/packages/supabase_storage/test/basic_test.dart
@@ -922,6 +922,21 @@ void main() {
 
       expect(client.headers['X-Client-Info'], 'supabase-dart/0.0.0');
     });
+
+    test('headers cannot be mutated in place', () {
+      client = SupabaseStorageClient('$supabaseUrl/storage/v1', {
+        'Authorization': 'Bearer $supabaseKey',
+      });
+
+      expect(
+        () => client.headers['x-custom-header'] = 'value',
+        throwsUnsupportedError,
+      );
+      expect(
+        () => client.from('bucket').headers['x-custom-header'] = 'value',
+        throwsUnsupportedError,
+      );
+    });
   });
 
   group('accessToken', () {

--- a/packages/supabase_storage/test/client_test.dart
+++ b/packages/supabase_storage/test/client_test.dart
@@ -686,6 +686,20 @@ void main() {
       expect(identical(result, client), isTrue);
     });
 
+    test('sets custom header on the vectors client', () async {
+      customHttpClient.response = {'vectorBuckets': []};
+      customHttpClient.statusCode = 200;
+
+      client.setHeader('x-custom-header', 'custom-value');
+      await client.vectors.listBuckets();
+
+      expect(customHttpClient.receivedRequests.length, 1);
+      expect(
+        customHttpClient.receivedRequests.first.headers['x-custom-header'],
+        'custom-value',
+      );
+    });
+
     test('supports chaining multiple setHeader calls', () async {
       customHttpClient.response = [];
       customHttpClient.statusCode = 200;

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -2095,7 +2095,9 @@ features:
       - SupabaseClient.headers
     supporting_symbols:
       - FunctionsClient.headers
+      - FunctionsClient.setHeader
       - AuthClient.headers
+      - AuthClient.setHeader
       - PostgrestBuilder.setHeader
       - PostgrestClient.headers
       - PostgrestFilterBuilder.setHeader


### PR DESCRIPTION
## What kind of change does this PR introduce?

Breaking change, plus a small feature that keeps every header use case reachable.

## What is the current behavior?

`AuthClient.headers`, `FunctionsClient.headers`, `StorageBucketApi.headers` (so `SupabaseStorageClient.headers`) and `StorageFileApi.headers` all handed out the live internal header map, so any consumer could rewrite the headers of a client from anywhere, including the sub-clients a `SupabaseClient` manages:

```dart
supabase.functions.headers['Authorization'] = 'Bearer $jwt';
supabase.storage.headers.clear();
```

`SupabaseClient._replaceHeaders` depended on that leak, mutating each client with `..clear()..addAll(...)`. This is the same anti-pattern that was fixed for `RealtimeClient.headers` in #1758, and `PostgrestClient.headers` before that.

Closes SDK-1600.

## What is the new behavior?

- Every `headers` getter returns `Map.unmodifiable(_headers)`, so mutating one throws an `UnsupportedError`.
- Each client gained an `@internal void replaceHeaders(Map<String, String>)`, and `SupabaseClient.headers =` now calls that instead of mutating the maps in place. Propagation to all sub-clients is unchanged.
- `AuthClient` and `FunctionsClient` gained a public `setHeader(String, String)`, mirroring `SupabaseStorageClient.setHeader`. Without it, a standalone client built directly (not through `SupabaseClient`) would have had no way to add a header after construction, since in-place mutation was previously the only one. On auth the header map is shared with `admin`, so admin requests carry it too; on functions a header passed to `invoke()` still wins for that single call.
- `SupabaseStorageClient.setHeader()` goes through `replaceHeaders` as well, so it keeps working. `StorageBucketApi` copies the headers it is constructed with rather than aliasing the caller's map.
- `SupabaseStorageClient.vectors` is a getter that builds a client per access instead of a `late final` field, so it always carries the current headers. It used to alias the live map, which a cached snapshot would have silently broken.
- `StorageBucketApi.storageFetch` is `late final`.
- `MIGRATION.md` documents the change, and the outdated `supabase.functions.headers[...] = ...` advice in the `setAccessToken()` section is corrected to use `setHeader`.

Adding custom headers therefore stays possible everywhere: the constructor for a whole set, `setHeader()` for a single one on auth, functions and storage (and per bucket), `invoke(headers: …)` or a builder's `setHeader()` for a single call, and `SupabaseClient.headers =` to reach every sub-client at once.

## Additional context

`sdk-compliance.yaml` registers the two new `setHeader` symbols under `client.request_configuration.global_headers`. The symbol, drift and schema checks from supabase/sdk all pass locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added chainable `setHeader()` methods for authentication and Edge Functions clients.
  - Header updates now propagate consistently across related clients and requests.
  - Storage vector clients receive the latest configured headers on access.

- **Bug Fixes**
  - Prevented accidental in-place modification of client and bucket header maps.
  - Preserved custom headers while maintaining required API key headers.

- **Documentation**
  - Updated migration guidance with the new header configuration approach and immutable header behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->