### PR TITLE
refactor(realtime)!: make RealtimeChannel internal mutable fields private with controlled accessors

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -330,6 +330,25 @@ final channels = client.channels;
 `setAccessToken()` is the intentional path for token rotation: unlike the removed field write, it
 also propagates the new token to every joined channel.
 
+### The mutable internals of `RealtimeChannel` are private
+
+`RealtimeChannel` received the same treatment as `RealtimeClient`. Its join bookkeeping used to be
+public mutable fields that were only marked `@internal`, so external code could reassign the join
+push, replace the presence tracker, or mutate the join parameters underneath the channel:
+
+| Before | After |
+| --- | --- |
+| `channel.joinedOnce = value` | removed, the getter remains (internal) |
+| `channel.joinPush = push` | removed, the getter remains (internal and test-only) |
+| `channel.presence` | removed |
+| `channel.parameters` (mutable map) | `channel.parameters` (unmodifiable view, internal) |
+
+These members were never part of the supported API surface, but they were reachable. If you read
+presence state through `channel.presence`, use `channel.presenceState()` and the
+`onPresenceSync`, `onPresenceJoin`, and `onPresenceLeave` streams instead. The join payload is
+only updated internally; there is no supported way to mutate `parameters` after the channel is
+created, so pass the configuration through `RealtimeChannelConfig` when creating the channel.
+
 ### Broadcasts no longer fall back to the REST API
 
 `sendBroadcastMessage()` used to silently post to the REST broadcast endpoint whenever the channel

--- a/packages/supabase_realtime/lib/src/push.dart
+++ b/packages/supabase_realtime/lib/src/push.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:collection';
 
 import 'package:supabase_realtime/supabase_realtime.dart';
 import 'package:supabase_realtime/src/constants.dart';
@@ -36,7 +37,11 @@ class Push {
 
   /// The payload, for example `{user_id: 123}`, replaced through
   /// [updatePayload].
-  Map<String, dynamic> get payload => _payload;
+  ///
+  /// The view is unmodifiable at the top level only: values can hold binary
+  /// data such as [Uint8List], which a recursive wrap would copy into plain
+  /// lists and thereby change its type.
+  Map<String, dynamic> get payload => UnmodifiableMapView(_payload);
 
   /// The push timeout
   Duration _timeout;

--- a/packages/supabase_realtime/lib/src/push.dart
+++ b/packages/supabase_realtime/lib/src/push.dart
@@ -17,10 +17,9 @@ class Push {
   Push(
     this._channel,
     this._event, [
-    this.payload = const {},
+    Map<String, dynamic> payload = const {},
     this._timeout = RealtimeConstants.defaultTimeout,
-  ]);
-  bool sent = false;
+  ]) : _payload = payload;
   Timer? _timeoutTimer;
   String _ref = '';
   Map<String, dynamic>? _receivedResponse;
@@ -33,8 +32,11 @@ class Push {
   /// The event, for example [ChannelEvent.join]
   final ChannelEvent _event;
 
-  /// The payload, for example `{user_id: 123}`
-  late Map<String, dynamic> payload;
+  Map<String, dynamic> _payload;
+
+  /// The payload, for example `{user_id: 123}`, replaced through
+  /// [updatePayload].
+  Map<String, dynamic> get payload => _payload;
 
   /// The push timeout
   Duration _timeout;
@@ -49,7 +51,6 @@ class Push {
     _ref = '';
     _refEvent = null;
     _receivedResponse = null;
-    sent = false;
     send();
   }
 
@@ -58,12 +59,11 @@ class Push {
       return;
     }
     startTimeout();
-    sent = true;
     _channel.socket.push(
       RealtimeMessage.outgoing(
         topic: _channel.topic,
         event: _event,
-        payload: payload,
+        payload: _payload,
         ref: ref,
         joinRef: _channel.joinRef,
       ),
@@ -71,7 +71,7 @@ class Push {
   }
 
   void updatePayload(Map<String, dynamic> newPayload) {
-    payload = {...payload, ...newPayload};
+    _payload = {..._payload, ...newPayload};
   }
 
   Push receive(String status, Callback callback) {

--- a/packages/supabase_realtime/lib/src/realtime_channel.dart
+++ b/packages/supabase_realtime/lib/src/realtime_channel.dart
@@ -20,7 +20,7 @@ class RealtimeChannel {
     this.socket, {
     RealtimeChannelConfig config = const RealtimeChannelConfig(),
   }) : _timeout = socket.timeout,
-       parameters = config.toMap(),
+       _parameters = config.toMap(),
        subTopic = topic.replaceFirst(
          RegExp(r"^realtime:", caseSensitive: false),
          "",
@@ -28,17 +28,17 @@ class RealtimeChannel {
     broadcastEndpointUrl = '${httpEndpointUrl(socket.endpoint)}/api/broadcast';
     _private = config.private;
 
-    joinPush = Push(
+    _joinPush = Push(
       this,
       ChannelEvent.join,
-      parameters,
+      _parameters,
       _timeout,
     );
     _rejoinTimer = RetryTimer(
       () => rejoinUntilConnected(),
       socket.reconnectAfter,
     );
-    joinPush.receive('ok', (_) {
+    _joinPush.receive('ok', (_) {
       _state = ChannelState.joined;
       _rejoinTimer.reset();
       for (final pushEvent in _pushBuffer) {
@@ -67,12 +67,12 @@ class RealtimeChannel {
       _rejoinTimer.scheduleTimeout();
     });
 
-    joinPush.receive('timeout', (_) {
+    _joinPush.receive('timeout', (_) {
       if (!isJoining) {
         return;
       }
       realtimeLogger.warning(
-        'Channel join timeout: $topic after ${joinPush.timeout}',
+        'Channel join timeout: $topic after ${_joinPush.timeout}',
       );
       _state = ChannelState.errored;
       _rejoinTimer.scheduleTimeout();
@@ -85,27 +85,43 @@ class RealtimeChannel {
       trigger(replyEventName(ref), payload);
     });
 
-    presence = RealtimePresence(this);
+    _presence = RealtimePresence(this);
   }
   final Map<String, List<Binding>> _bindings = {};
   final Duration _timeout;
   ChannelState _state = ChannelState.closed;
+  bool _joinedOnce = false;
+
+  /// Whether [subscribe] has been called on this channel.
   @internal
-  bool joinedOnce = false;
+  bool get joinedOnce => _joinedOnce;
+
+  late final Push _joinPush;
+
+  /// The push used to join this channel, exposed so tests can inspect and
+  /// trigger replies on it.
   @internal
-  late Push joinPush;
-  late RetryTimer _rejoinTimer;
+  @visibleForTesting
+  Push get joinPush => _joinPush;
+
+  late final RetryTimer _rejoinTimer;
   List<Push> _pushBuffer = [];
-  @internal
-  late RealtimePresence presence;
+  late final RealtimePresence _presence;
   @internal
   late final String broadcastEndpointUrl;
   @internal
   final String subTopic;
   @internal
   final String topic;
+  final Map<String, dynamic> _parameters;
+
+  /// The parameters sent when joining the channel.
+  ///
+  /// The returned view is unmodifiable; the join payload is updated internally
+  /// through [updateJoinPayload].
   @internal
-  Map<String, dynamic> parameters;
+  Map<String, dynamic> get parameters => UnmodifiableMapView(_parameters);
+
   @internal
   final RealtimeClient socket;
 
@@ -143,20 +159,20 @@ class RealtimeChannel {
 
   bool _shouldEnablePresence() {
     return (_bindings['presence']?.isNotEmpty == true) ||
-        (parameters['config']['presence']['enabled'] == true);
+        (_parameters['config']['presence']['enabled'] == true);
   }
 
   void _handlePresenceUpdate() {
-    if (joinedOnce && isJoined) {
+    if (_joinedOnce && isJoined) {
       final currentPresenceEnabled =
-          parameters['config']['presence']['enabled'];
+          _parameters['config']['presence']['enabled'];
       final shouldEnablePresence = _shouldEnablePresence();
 
       if (!currentPresenceEnabled && shouldEnablePresence) {
-        final config = Map<String, dynamic>.from(parameters['config']);
+        final config = Map<String, dynamic>.from(_parameters['config']);
         config['presence'] = Map<String, dynamic>.from(config['presence']);
         config['presence']['enabled'] = true;
-        parameters['config'] = config;
+        _parameters['config'] = config;
         updateJoinPayload({'config': config});
         rejoin();
       }
@@ -173,13 +189,13 @@ class RealtimeChannel {
     if (!socket.isConnected) {
       unawaited(socket.connect());
     }
-    if (joinedOnce == true) {
+    if (_joinedOnce == true) {
       throw "tried to subscribe multiple times. 'subscribe' can only be "
           "called a single time per channel instance";
     }
-    final broadcast = parameters['config']['broadcast'];
-    final presenceConfig = parameters['config']['presence'];
-    final isPrivate = parameters['config']['private'];
+    final broadcast = _parameters['config']['broadcast'];
+    final presenceConfig = _parameters['config']['presence'];
+    final isPrivate = _parameters['config']['private'];
 
     _onError((e) {
       _addStatus(RealtimeSubscribeStatus.channelError, e);
@@ -228,10 +244,10 @@ class RealtimeChannel {
 
     updateJoinPayload({'config': config, ...accessTokenPayload});
 
-    joinedOnce = true;
+    _joinedOnce = true;
     rejoin(timeout ?? _timeout);
 
-    joinPush
+    _joinPush
         .receive(
           'ok',
           (response) => unawaited(
@@ -350,7 +366,7 @@ class RealtimeChannel {
   }
 
   List<SinglePresenceState> presenceState() {
-    return presence.state.entries
+    return _presence.state.entries
         .map(
           (entry) =>
               SinglePresenceState(key: entry.key, presences: entry.value),
@@ -621,7 +637,7 @@ class RealtimeChannel {
     // Once a subscribed channel has closed it cannot be joined again, and the
     // one-shot cleanup that completes the event streams has already run, so
     // hand out an already-closed stream instead of one that never completes.
-    if (joinedOnce && isClosed) {
+    if (_joinedOnce && isClosed) {
       unawaited(controller.close());
       return controller.stream;
     }
@@ -684,7 +700,7 @@ class RealtimeChannel {
     Map<String, dynamic> payload, [
     Duration? timeout,
   ]) {
-    if (!joinedOnce) {
+    if (!_joinedOnce) {
       throw "tried to push '${event.eventName()}' to '$topic' before joining. "
           "Use channel.subscribe() before pushing events";
     }
@@ -853,8 +869,8 @@ class RealtimeChannel {
     }
 
     if (payload['type'] == 'broadcast' &&
-        (parameters['config']?['broadcast']?['ack'] == null ||
-            parameters['config']?['broadcast']?['ack'] == false)) {
+        (_parameters['config']?['broadcast']?['ack'] == null ||
+            _parameters['config']?['broadcast']?['ack'] == false)) {
       if (!completer.isCompleted) {
         completer.complete(ChannelResponse.ok);
       }
@@ -890,7 +906,7 @@ class RealtimeChannel {
 
   @internal
   void updateJoinPayload(Map<String, dynamic> payload) {
-    joinPush.updatePayload(payload);
+    _joinPush.updatePayload(payload);
   }
 
   /// Leaves the channel
@@ -912,7 +928,7 @@ class RealtimeChannel {
     }
 
     // Destroy joinPush to avoid connection timeouts during unsubscription phase
-    joinPush.destroy();
+    _joinPush.destroy();
 
     final completer = Completer<String>();
 
@@ -962,7 +978,7 @@ class RealtimeChannel {
   }
 
   @internal
-  String get joinRef => joinPush.ref;
+  String get joinRef => _joinPush.ref;
 
   @internal
   void rejoin([Duration? timeout]) {
@@ -971,7 +987,7 @@ class RealtimeChannel {
     }
     socket.leaveOpenTopic(topic);
     _state = ChannelState.joining;
-    joinPush.resend(timeout ?? _timeout);
+    _joinPush.resend(timeout ?? _timeout);
   }
 
   /// Resends [joinPush] to tell the server we join this channel again and marks
@@ -988,7 +1004,7 @@ class RealtimeChannel {
       return;
     }
     _state = ChannelState.joining;
-    joinPush.resend(timeout ?? _timeout);
+    _joinPush.resend(timeout ?? _timeout);
   }
 
   @internal

--- a/packages/supabase_realtime/lib/src/realtime_channel.dart
+++ b/packages/supabase_realtime/lib/src/realtime_channel.dart
@@ -117,10 +117,31 @@ class RealtimeChannel {
 
   /// The parameters sent when joining the channel.
   ///
-  /// The returned view is unmodifiable; the join payload is updated internally
-  /// through [updateJoinPayload].
+  /// The returned snapshot is unmodifiable all the way down; the join payload
+  /// is updated internally through [updateJoinPayload].
   @internal
-  Map<String, dynamic> get parameters => UnmodifiableMapView(_parameters);
+  Map<String, dynamic> get parameters => _deepUnmodifiableMap(_parameters);
+
+  static Map<String, dynamic> _deepUnmodifiableMap(Map<String, dynamic> map) {
+    return Map<String, dynamic>.unmodifiable(
+      map.map((key, value) => MapEntry(key, _deepUnmodifiable(value))),
+    );
+  }
+
+  static Object? _deepUnmodifiable(Object? value) {
+    if (value is Map<String, dynamic>) {
+      return _deepUnmodifiableMap(value);
+    }
+    if (value is Map) {
+      return Map.unmodifiable(
+        value.map((key, nested) => MapEntry(key, _deepUnmodifiable(nested))),
+      );
+    }
+    if (value is List) {
+      return List.unmodifiable(value.map(_deepUnmodifiable));
+    }
+    return value;
+  }
 
   @internal
   final RealtimeClient socket;
@@ -368,8 +389,10 @@ class RealtimeChannel {
   List<SinglePresenceState> presenceState() {
     return _presence.state.entries
         .map(
-          (entry) =>
-              SinglePresenceState(key: entry.key, presences: entry.value),
+          (entry) => SinglePresenceState(
+            key: entry.key,
+            presences: List.unmodifiable(entry.value),
+          ),
         )
         .toList();
   }

--- a/packages/supabase_realtime/lib/src/realtime_presence.dart
+++ b/packages/supabase_realtime/lib/src/realtime_presence.dart
@@ -86,43 +86,43 @@ class RealtimePresence {
         PresenceEvents(state: 'presence_state', diff: 'presence_diff');
 
     channel.onEvents(events.state, ChannelFilter(), (newState, [_]) {
-      final onJoin = caller['onJoin'];
-      final onLeave = caller['onLeave'];
-      final onSync = caller['onSync'];
+      final onJoin = _caller['onJoin'];
+      final onLeave = _caller['onLeave'];
+      final onSync = _caller['onSync'];
 
-      joinRef = channel.joinRef;
+      _joinRef = channel.joinRef;
 
-      state = RealtimePresence.syncState(
-        state,
+      _state = RealtimePresence.syncState(
+        _state,
         newState,
         onJoin,
         onLeave,
       );
 
-      for (final diff in pendingDiffs) {
-        state = RealtimePresence.syncDiff(
-          state,
+      for (final diff in _pendingDiffs) {
+        _state = RealtimePresence.syncDiff(
+          _state,
           diff,
           onJoin,
           onLeave,
         );
       }
 
-      pendingDiffs = [];
+      _pendingDiffs = [];
 
       onSync();
     });
 
     channel.onEvents(events.diff, ChannelFilter(), (diff, [_]) {
-      final onJoin = caller['onJoin'];
-      final onLeave = caller['onLeave'];
-      final onSync = caller['onSync'];
+      final onJoin = _caller['onJoin'];
+      final onLeave = _caller['onLeave'];
+      final onSync = _caller['onSync'];
 
       if (inPendingSyncState()) {
-        pendingDiffs.add(diff);
+        _pendingDiffs.add(diff);
       } else {
-        state = RealtimePresence.syncDiff(
-          state,
+        _state = RealtimePresence.syncDiff(
+          _state,
           diff,
           onJoin,
           onLeave,
@@ -158,10 +158,14 @@ class RealtimePresence {
 
     onSync(() => channel.trigger('presence', {'event': 'sync'}));
   }
-  Map<String, List<Presence>> state = <String, List<Presence>>{};
-  List<Map<String, dynamic>> pendingDiffs = [];
-  String? joinRef;
-  Map<String, dynamic> caller = {
+  Map<String, List<Presence>> _state = <String, List<Presence>>{};
+
+  /// The current presence state, keyed by presence key.
+  Map<String, List<Presence>> get state => _state;
+
+  List<Map<String, dynamic>> _pendingDiffs = [];
+  String? _joinRef;
+  final Map<String, dynamic> _caller = {
     'onJoin': (_, _, _) {},
     'onLeave': (_, _, _) {},
     'onSync': () {},
@@ -377,22 +381,22 @@ class RealtimePresence {
   }
 
   void onJoin(PresenceOnJoinCallback callback) {
-    caller['onJoin'] = callback;
+    _caller['onJoin'] = callback;
   }
 
   void onLeave(PresenceOnLeaveCallback callback) {
-    caller['onLeave'] = callback;
+    _caller['onLeave'] = callback;
   }
 
   void onSync(void Function() callback) {
-    caller['onSync'] = callback;
+    _caller['onSync'] = callback;
   }
 
   List<T> list<T>([PresenceChooser<T>? by]) {
-    return RealtimePresence._list(state, by);
+    return RealtimePresence._list(_state, by);
   }
 
   bool inPendingSyncState() {
-    return joinRef == null || joinRef != channel.joinRef;
+    return _joinRef == null || _joinRef != channel.joinRef;
   }
 }

--- a/packages/supabase_realtime/lib/src/realtime_presence.dart
+++ b/packages/supabase_realtime/lib/src/realtime_presence.dart
@@ -1,4 +1,6 @@
 // ignore_for_file: public_member_api_docs
+import 'dart:collection';
+
 import 'package:meta/meta.dart';
 import 'package:supabase_realtime/supabase_realtime.dart';
 import 'package:supabase_realtime/src/types.dart';
@@ -161,7 +163,7 @@ class RealtimePresence {
   Map<String, List<Presence>> _state = <String, List<Presence>>{};
 
   /// The current presence state, keyed by presence key.
-  Map<String, List<Presence>> get state => _state;
+  Map<String, List<Presence>> get state => UnmodifiableMapView(_state);
 
   List<Map<String, dynamic>> _pendingDiffs = [];
   String? _joinRef;


### PR DESCRIPTION
## What kind of change does this PR introduce?

Breaking change (v3), follow-up to #1758 / SDK-818.

## What is the current behavior?

#1758 privatized the mutable internals of `RealtimeClient`, but `RealtimeChannel` still exposes its join bookkeeping as public mutable fields that are only guarded by `@internal` annotations:

- `joinedOnce` is a mutable flag, so external code can unlock a second `subscribe()`.
- `joinPush` and `presence` are `late` and reassignable, so the join push or the presence tracker can be swapped out underneath the channel.
- `parameters` is both reassignable and a live mutable map, so callers can corrupt the join payload directly instead of going through `updateJoinPayload`.

The unexported `Push` and `RealtimePresence` classes have the same shape (`payload`/`sent`, `state`/`pendingDiffs`/`joinRef`/`caller`).

## What is the new behavior?

Same treatment as #1758, private backing fields with controlled accessors:

- `joinedOnce`: private `_joinedOnce`, read-only `@internal` getter (read by `RealtimeClient` and tests).
- `joinPush`: private `late final _joinPush`, read-only `@internal @visibleForTesting` getter (only tests need it).
- `presence`: fully private `late final _presence`, nothing outside the class read it; presence state is exposed through `presenceState()` and the presence streams.
- `parameters`: private final `_parameters`, the `@internal` getter returns an `UnmodifiableMapView`; internal mutation keeps going through `updateJoinPayload`.

Optional cleanup while in the area (both classes are `@internal` and not exported):

- `Push.payload` is a getter over a private field that is only replaced through `updatePayload`; `Push.sent` was write-only dead state and is removed.
- `RealtimePresence.state` is a getter over a private field; `pendingDiffs`, `joinRef`, and `caller` are private.

MIGRATION.md documents the change since the fields were reachable by consumers. No public symbols changed for the compliance matrix (everything involved is `@internal`), verified with the local symbol check.

## Additional context

Resolves SDK-1601.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Channel configuration and internal presence state are now read-only after creation.
  * Push payloads and session/auth request data can no longer be modified directly.
  * Configure channel parameters and request headers through supported APIs.

* **Documentation**
  * Added v2-to-v3 migration guidance, including replacements for removed mutable properties and updated configuration practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->