### PR TITLE
refactor(auth)!: make Session.expiresAt read-only and auth DTO fields final

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1772,3 +1772,37 @@ await supabase.storage.from('bucket').list(
 
 `SortBy(order: null)` no longer compiles; leave `order` out to sort ascending. `column` is
 unchanged, since `list()` accepts any column of a `FileObject`.
+
+### Session and auth request objects are immutable
+
+`Session.expiresAt` is `late final`, so it can be read but no longer assigned. It has always been
+derived from the `exp` claim of the access token rather than the login response body, so
+overwriting it only desynchronized the value from the token that the auto refresh logic acts on.
+Mint a new session, or call `copyWith` with a different `accessToken`, to change the expiry:
+
+```dart
+// Before
+session.expiresAt = DateTime.now().add(const Duration(hours: 1));
+
+// After
+final refreshed = session.copyWith(accessToken: newAccessToken);
+print(refreshed.expiresAt);
+```
+
+`ResendResponse.messageId` is `final` too, matching every other response type.
+
+The request fields on `UserAttributes` and `AdminUserAttributes` are `final`, so pass them to the
+constructor instead of assigning after construction:
+
+```dart
+// Before
+final attributes = UserAttributes();
+attributes.email = 'new@example.com';
+attributes.data = {'name': 'Alice'};
+await supabase.auth.updateUser(attributes);
+
+// After
+await supabase.auth.updateUser(
+  UserAttributes(email: 'new@example.com', data: {'name': 'Alice'}),
+);
+```

--- a/packages/supabase_auth/lib/src/types/auth_response.dart
+++ b/packages/supabase_auth/lib/src/types/auth_response.dart
@@ -82,9 +82,9 @@ class ListUsersResponse {
 
 class ResendResponse {
   /// Only set for phone resend
-  String? messageId;
+  final String? messageId;
 
-  ResendResponse({
+  const ResendResponse({
     this.messageId,
   });
 }

--- a/packages/supabase_auth/lib/src/types/session.dart
+++ b/packages/supabase_auth/lib/src/types/session.dart
@@ -77,7 +77,7 @@ class Session {
   /// Derived from the `exp` claim of [accessToken], not read from the login
   /// response's JSON body. `null` when [accessToken] carries no expiry or
   /// cannot be decoded.
-  late DateTime? expiresAt = _expiresAt;
+  late final DateTime? expiresAt = _expiresAt;
 
   DateTime? get _expiresAt {
     try {

--- a/packages/supabase_auth/lib/src/types/user_attributes.dart
+++ b/packages/supabase_auth/lib/src/types/user_attributes.dart
@@ -2,26 +2,26 @@ import 'package:collection/collection.dart';
 
 class UserAttributes {
   /// The user's email.
-  String? email;
+  final String? email;
 
   /// The user's phone.
-  String? phone;
+  final String? phone;
 
   /// The user's password.
-  String? password;
+  final String? password;
 
   /// The nonce sent for reauthentication if the user's password is to be
   /// updated.
   ///
   /// Call reauthenticate() to obtain the nonce first.
-  String? nonce;
+  final String? nonce;
 
   /// A custom data object to store the user's metadata. This maps to the
   /// `auth.users.user_metadata` column.
   ///
   /// The `data` should be a JSON object that includes user-specific info, such
   /// as their first and last name.
-  Object? data;
+  final Object? data;
 
   /// The user's current password.
   ///
@@ -29,7 +29,7 @@ class UserAttributes {
   /// `GOTRUE_SECURITY_UPDATE_PASSWORD_REQUIRE_CURRENT_PASSWORD` setting is
   /// enabled on the auth server, in which case the current password is required
   /// to verify the change.
-  String? currentPassword;
+  final String? currentPassword;
 
   UserAttributes({
     this.email,

--- a/packages/supabase_auth/test/src/types/session_test.dart
+++ b/packages/supabase_auth/test/src/types/session_test.dart
@@ -226,6 +226,21 @@ void main() {
         expect(session.expiresAt!.isUtc, isTrue);
       });
 
+      test('is derived once and cached across reads', () {
+        final expiresAt =
+            (DateTime.now().millisecondsSinceEpoch / 1000).floor() + 3600;
+        final header = base64Encode(utf8.encode('{"alg":"HS256","typ":"JWT"}'));
+        final payload = base64Encode(utf8.encode('{"exp":$expiresAt}'));
+
+        final session = Session(
+          accessToken: '$header.$payload.signature',
+          tokenType: 'bearer',
+          user: mockUser,
+        );
+
+        expect(identical(session.expiresAt, session.expiresAt), isTrue);
+      });
+
       test('handles malformed JWT gracefully', () {
         final session = Session(
           accessToken: 'not.a.jwt',


### PR DESCRIPTION
Closes SDK-1602.

A few mutable public fields were left in `supabase_auth`. This makes them immutable.

## `Session.expiresAt`

`expiresAt` is derived from the `exp` claim of the access token, not from the login response body, so a public setter only let a consumer desynchronize the value from the token that the auto refresh logic acts on. It is now `late final`, which keeps the lazy derivation and its caching while making assignment a compile error.

## `ResendResponse.messageId`

Now `final`, like every other response type in the package.

## `UserAttributes` and `AdminUserAttributes`

All six inherited request fields (`email`, `phone`, `password`, `nonce`, `data`, `currentPassword`) are `final`. `AdminUserAttributes` already declared its own additions as `final`, so the two halves of the class now agree.

## Breaking change

Assigning to any of these fields no longer compiles. `MIGRATION.md` documents the change and shows constructing the request objects instead of mutating them after construction.

## Testing

`dart analyze` is clean across the workspace and the full `supabase_auth` suite passes (530 tests, run with `-j 1` against a local GoTrue). Added a test that pins `Session.expiresAt` to a single cached derivation across reads.

No capability matrix changes: the field names are unchanged, and `check-api-symbols` against the base reports no new uncovered symbols.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added v2-to-v3 migration guidance for immutable session, authentication response, and user attribute fields.
  - Documented using constructors and `copyWith` when updating these values.

- **Refactor**
  - Session expiration, resend response IDs, and user attribute request fields are now immutable.
  - Session expiration is derived from the access token and remains consistent across repeated reads.

- **Tests**
  - Added coverage confirming stable session expiration values for valid tokens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->