### PR TITLE
docs(functions_client): enable public_member_api_docs

### DIFF
--- a/packages/supabase_functions/analysis_options.yaml
+++ b/packages/supabase_functions/analysis_options.yaml
@@ -1,9 +1,5 @@
 include: package:supabase_lints/analysis_options.yaml
 
-linter:
-  rules:
-    public_member_api_docs: true
-
 analyzer:
   exclude:
     - build/**

--- a/packages/supabase_functions/analysis_options.yaml
+++ b/packages/supabase_functions/analysis_options.yaml
@@ -1,5 +1,9 @@
 include: package:supabase_lints/analysis_options.yaml
 
+linter:
+  rules:
+    public_member_api_docs: true
+
 analyzer:
   exclude:
     - build/**

--- a/packages/supabase_functions/lib/src/functions_client.dart
+++ b/packages/supabase_functions/lib/src/functions_client.dart
@@ -11,6 +11,7 @@ import 'package:supabase_functions/src/logger.dart';
 import 'package:supabase_common/supabase_common.dart';
 import 'package:yet_another_json_isolate/yet_another_json_isolate.dart';
 
+/// Client for invoking Supabase Edge Functions.
 class FunctionsClient {
   /// [jsonCodec] encodes the request body and decodes the response. The
   /// default codec keeps large payloads off the calling isolate. A codec

--- a/packages/supabase_functions/lib/src/types.dart
+++ b/packages/supabase_functions/lib/src/types.dart
@@ -54,7 +54,6 @@ sealed class FunctionException extends SupabaseException {
 ///
 /// The originating error is available in [details].
 class FunctionsFetchException extends FunctionException {
-  /// Creates a fetch exception.
   const FunctionsFetchException({
     super.details,
     String? message,
@@ -90,7 +89,6 @@ class FunctionsApiException extends FunctionException
 ///
 /// The function itself may never have run.
 class FunctionsRelayException extends FunctionsApiException {
-  /// Creates a relay exception.
   const FunctionsRelayException({
     required super.statusCode,
     super.details,

--- a/packages/supabase_functions/lib/src/types.dart
+++ b/packages/supabase_functions/lib/src/types.dart
@@ -4,6 +4,7 @@ import 'dart:typed_data';
 import 'package:http/http.dart';
 import 'package:supabase_common/supabase_common.dart';
 
+/// The response of a successful [FunctionsClient.invoke] call.
 class FunctionResponse {
   const FunctionResponse({
     this.data,
@@ -39,6 +40,9 @@ sealed class FunctionException extends SupabaseException {
     required String message,
     this.details,
   }) : super(message);
+
+  /// The response body, or the originating error when no response was
+  /// received.
   final dynamic details;
 
   @override
@@ -50,6 +54,7 @@ sealed class FunctionException extends SupabaseException {
 ///
 /// The originating error is available in [details].
 class FunctionsFetchException extends FunctionException {
+  /// Creates a fetch exception.
   const FunctionsFetchException({
     super.details,
     String? message,
@@ -70,6 +75,7 @@ class FunctionsApiException extends FunctionException
   }) : super(
          message: message ?? 'Edge Function returned a non-2xx status code',
        );
+
   @override
   final int statusCode;
 
@@ -84,6 +90,7 @@ class FunctionsApiException extends FunctionException
 ///
 /// The function itself may never have run.
 class FunctionsRelayException extends FunctionsApiException {
+  /// Creates a relay exception.
   const FunctionsRelayException({
     required super.statusCode,
     super.details,

--- a/packages/supabase_functions/lib/src/version.dart
+++ b/packages/supabase_functions/lib/src/version.dart
@@ -1,1 +1,5 @@
+import 'package:meta/meta.dart';
+
+/// The published version of this package.
+@internal
 const version = '3.0.0-dev.1';

--- a/packages/supabase_functions/lib/src/version.dart
+++ b/packages/supabase_functions/lib/src/version.dart
@@ -1,1 +1,4 @@
+import 'package:meta/meta.dart';
+
+@internal
 const version = '3.0.0-dev.1';

--- a/packages/supabase_functions/lib/src/version.dart
+++ b/packages/supabase_functions/lib/src/version.dart
@@ -1,5 +1,1 @@
-import 'package:meta/meta.dart';
-
-/// The published version of this package.
-@internal
 const version = '3.0.0-dev.1';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -51,12 +51,6 @@ melos:
           version=$(awk '/version:/ {
             pos=match($2, /[0-9]+\.[0-9]+\.[0-9]+/);
             print substr($2, pos); }' $d/pubspec.yaml)
-          {
-            echo "import 'package:meta/meta.dart';"
-            echo
-            echo "/// The published version of this package."
-            echo "@internal"
-            echo "const version = '$version';"
-          } > $d/lib/src/version.dart
+          echo "const version = '$version';" > $d/lib/src/version.dart
         done
         git add packages/*/lib/src/version.dart

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -51,6 +51,11 @@ melos:
           version=$(awk '/version:/ {
             pos=match($2, /[0-9]+\.[0-9]+\.[0-9]+/);
             print substr($2, pos); }' $d/pubspec.yaml)
-          echo "const version = '$version';" > $d/lib/src/version.dart
+          {
+            echo "import 'package:meta/meta.dart';"
+            echo
+            echo "@internal"
+            echo "const version = '$version';"
+          } > $d/lib/src/version.dart
         done
         git add packages/*/lib/src/version.dart

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -51,6 +51,12 @@ melos:
           version=$(awk '/version:/ {
             pos=match($2, /[0-9]+\.[0-9]+\.[0-9]+/);
             print substr($2, pos); }' $d/pubspec.yaml)
-          echo "const version = '$version';" > $d/lib/src/version.dart
+          {
+            echo "import 'package:meta/meta.dart';"
+            echo
+            echo "/// The published version of this package."
+            echo "@internal"
+            echo "const version = '$version';"
+          } > $d/lib/src/version.dart
         done
         git add packages/*/lib/src/version.dart


### PR DESCRIPTION
## Summary
- Enables `public_member_api_docs` for `supabase_functions`.
- Documents `FunctionsClient`, `FunctionResponse`, and the `FunctionException` hierarchy (`FunctionException`, `FunctionsFetchException`, `FunctionsApiException`, `FunctionsRelayException`).
- Marks the generated `version` constant `@internal` and documents it, since it isn't part of the package's exported API.
- Updates the root `pubspec.yaml` melos `update-version` script so it regenerates `version.dart` with that doc comment and annotation going forward, instead of overwriting them on the next commit.

## Context
Continues the package-by-package rollout for [SDK-1449](https://linear.app/supabase/issue/SDK-1449/enable-public-member-api-docs-and-document-the-public-api).

## Test plan
- [x] `dart analyze` reports no issues
- [x] `dart format .` produces no diff
- [x] `dart test` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added documentation for the Edge Functions client, successful invocation responses, and function error details.
  * Documented the package version and clarified its internal status.

* **Chores**
  * Updated version generation to include the appropriate internal visibility annotation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->