### PR TITLE
docs(supabase): enable public_member_api_docs

### DIFF
--- a/packages/supabase/analysis_options.yaml
+++ b/packages/supabase/analysis_options.yaml
@@ -1,9 +1,5 @@
 include: package:supabase_lints/analysis_options.yaml
 
-linter:
-  rules:
-    public_member_api_docs: true
-
 analyzer:
   exclude:
     - build/**

--- a/packages/supabase/analysis_options.yaml
+++ b/packages/supabase/analysis_options.yaml
@@ -1,5 +1,9 @@
 include: package:supabase_lints/analysis_options.yaml
 
+linter:
+  rules:
+    public_member_api_docs: true
+
 analyzer:
   exclude:
     - build/**

--- a/packages/supabase/lib/src/supabase_client.dart
+++ b/packages/supabase/lib/src/supabase_client.dart
@@ -154,11 +154,17 @@ class SupabaseClient {
   /// Supabase Storage allows you to manage user-generated content, such as
   /// photos or videos.
   late final SupabaseStorageClient storage;
+
+  /// Supabase Realtime allows you to listen to database changes and
+  /// broadcast messages between clients.
   late final RealtimeClient realtime;
   late PostgrestClient _rest;
   StreamSubscription<AuthState>? _authStateSubscription;
   final AsyncJsonCodec _jsonCodec;
   final bool _ownsJsonCodec;
+
+  /// Resolves a third-party access token, replacing the built-in [auth]
+  /// client when set.
   final Future<String?> Function()? accessToken;
 
   /// Increment ID of the stream to create different realtime topic for each
@@ -213,6 +219,10 @@ class SupabaseClient {
     });
   }
 
+  /// Supabase Auth allows you to create and manage user sessions.
+  ///
+  /// Throws an [AuthException] when [accessToken] is set, since the built-in
+  /// auth client is not used in that case.
   AuthClient get auth {
     if (accessToken == null) {
       return _authInstance!;
@@ -296,6 +306,8 @@ class SupabaseClient {
     }
   }
 
+  /// Disconnects realtime, closes the auth state subscription, and disposes
+  /// the functions, PostgREST, and JSON codec resources.
   Future<void> dispose() async {
     clientLogger.fine('Dispose SupabaseClient');
     await realtime.disconnect();

--- a/packages/supabase/lib/src/supabase_client.dart
+++ b/packages/supabase/lib/src/supabase_client.dart
@@ -163,7 +163,7 @@ class SupabaseClient {
   final AsyncJsonCodec _jsonCodec;
   final bool _ownsJsonCodec;
 
-  /// Resolves a third-party access token, replacing the built-in [auth]
+  /// Resolves a third-party access token and bypasses the built-in [auth]
   /// client when set.
   final Future<String?> Function()? accessToken;
 
@@ -307,7 +307,7 @@ class SupabaseClient {
   }
 
   /// Disconnects realtime, closes the auth state subscription, and disposes
-  /// the functions, PostgREST, and JSON codec resources.
+  /// the functions, PostgREST, and its internally owned JSON codec.
   Future<void> dispose() async {
     clientLogger.fine('Dispose SupabaseClient');
     await realtime.disconnect();

--- a/packages/supabase/lib/src/supabase_client_options.dart
+++ b/packages/supabase/lib/src/supabase_client_options.dart
@@ -1,11 +1,15 @@
 import 'package:supabase/supabase.dart';
 
+/// Configuration for the PostgREST client used by `SupabaseClient.from` and
+/// `SupabaseClient.rpc`.
 class PostgrestClientOptions {
   const PostgrestClientOptions({
     this.schema = 'public',
     this.retryOptions = const SupabaseRetryOptions(),
     this.requestTimeout,
   });
+
+  /// The Postgres schema to query, must be exposed in your Supabase project.
   final String schema;
 
   /// Configures the automatic retry of GET and HEAD requests that fail with a
@@ -24,6 +28,7 @@ class PostgrestClientOptions {
   final Duration? requestTimeout;
 }
 
+/// Configuration for the auth client used by `SupabaseClient.auth`.
 class AuthClientOptions {
   const AuthClientOptions({
     this.autoRefreshToken = true,
@@ -32,6 +37,9 @@ class AuthClientOptions {
     this.appendPkceFlowIdToRedirects = false,
     this.retryOptions = const SupabaseRetryOptions(count: 8),
   });
+
+  /// Whether an expiring session is refreshed automatically in the
+  /// background.
   final bool autoRefreshToken;
 
   /// Configures how a token refresh that never reached the service is retried.
@@ -56,6 +64,8 @@ class AuthClientOptions {
   /// at a time, because the verifier is held under a single key that
   /// concurrent sign-ins overwrite.
   final AuthAsyncStorage? pkceAsyncStorage;
+
+  /// The auth flow used for sign-in, sign-up, and password recovery.
   final AuthFlowType authFlowType;
 
   /// Whether to append the reserved `sb_flow_id` query parameter to the
@@ -67,6 +77,7 @@ class AuthClientOptions {
   final bool appendPkceFlowIdToRedirects;
 }
 
+/// Configuration for the storage client used by `SupabaseClient.storage`.
 class StorageClientOptions {
   const StorageClientOptions({
     this.retryOptions = const SupabaseRetryOptions(count: 0),
@@ -90,7 +101,12 @@ class StorageClientOptions {
   final bool useNewHostname;
 }
 
+/// Configuration for the Edge Functions client used by
+/// `SupabaseClient.functions`.
 class FunctionsClientOptions {
   const FunctionsClientOptions({this.region});
+
+  /// The region to invoke functions in by default, overridable per call with
+  /// `FunctionsClient.invoke`'s own `region` parameter.
   final String? region;
 }

--- a/packages/supabase/lib/src/supabase_query_builder.dart
+++ b/packages/supabase/lib/src/supabase_query_builder.dart
@@ -1,5 +1,7 @@
 import 'package:supabase/supabase.dart';
 
+/// A [PostgrestQueryBuilder] that can also stream a table's rows over
+/// Realtime with [stream].
 class SupabaseQueryBuilder extends PostgrestQueryBuilder {
   SupabaseQueryBuilder(
     String url,

--- a/packages/supabase/lib/src/supabase_query_schema.dart
+++ b/packages/supabase/lib/src/supabase_query_schema.dart
@@ -59,6 +59,7 @@ class SupabaseQuerySchema {
     );
   }
 
+  /// Returns a copy of this scoped to [schema] instead.
   SupabaseQuerySchema schema(String schema) {
     final newRest = _rest.schema(schema);
     return SupabaseQuerySchema(

--- a/packages/supabase/lib/src/supabase_stream_builder.dart
+++ b/packages/supabase/lib/src/supabase_stream_builder.dart
@@ -19,7 +19,6 @@ typedef _Order = ({String column, bool ascending});
 /// Thrown by `SupabaseStreamBuilder.listen` when the underlying Realtime
 /// channel fails to subscribe.
 class RealtimeSubscribeException implements Exception {
-  /// Creates an exception.
   const RealtimeSubscribeException(this.status, [this.details]);
 
   /// The subscription status that caused this exception, always

--- a/packages/supabase/lib/src/supabase_stream_builder.dart
+++ b/packages/supabase/lib/src/supabase_stream_builder.dart
@@ -16,10 +16,18 @@ typedef _StreamPostgrestFilter = ({
 
 typedef _Order = ({String column, bool ascending});
 
+/// Thrown by `SupabaseStreamBuilder.listen` when the underlying Realtime
+/// channel fails to subscribe.
 class RealtimeSubscribeException implements Exception {
+  /// Creates an exception.
   const RealtimeSubscribeException(this.status, [this.details]);
 
+  /// The subscription status that caused this exception, always
+  /// [RealtimeSubscribeStatus.channelError] or
+  /// [RealtimeSubscribeStatus.timedOut].
   final RealtimeSubscribeStatus status;
+
+  /// The error reported alongside [status], if any.
   final Object? details;
 
   @override
@@ -29,8 +37,11 @@ class RealtimeSubscribeException implements Exception {
   }
 }
 
+/// A snapshot of the rows a `SupabaseStreamBuilder` stream emits.
 typedef SupabaseStreamEvent = List<Map<String, dynamic>>;
 
+/// A stream of a table's rows kept up to date over Realtime, created with
+/// `SupabaseQueryBuilder.stream`.
 class SupabaseStreamBuilder extends Stream<SupabaseStreamEvent> {
   SupabaseStreamBuilder({
     required PostgrestQueryBuilder queryBuilder,

--- a/packages/supabase/lib/src/supabase_stream_builder.dart
+++ b/packages/supabase/lib/src/supabase_stream_builder.dart
@@ -16,12 +16,14 @@ typedef _StreamPostgrestFilter = ({
 
 typedef _Order = ({String column, bool ascending});
 
-/// Thrown by `SupabaseStreamBuilder.listen` when the underlying Realtime
+/// Delivered to the stream's error handler when the underlying Realtime
 /// channel fails to subscribe.
 class RealtimeSubscribeException implements Exception {
   const RealtimeSubscribeException(this.status, [this.details]);
 
-  /// The subscription status that caused this exception, always
+  /// The subscription status that caused this exception.
+  ///
+  /// When emitted by [SupabaseStreamBuilder], this is always
   /// [RealtimeSubscribeStatus.channelError] or
   /// [RealtimeSubscribeStatus.timedOut].
   final RealtimeSubscribeStatus status;

--- a/packages/supabase/lib/src/supabase_stream_filter_builder.dart
+++ b/packages/supabase/lib/src/supabase_stream_filter_builder.dart
@@ -1,6 +1,9 @@
 part of './supabase_stream_builder.dart';
 
+/// A [SupabaseStreamBuilder] that can also filter which rows are streamed,
+/// created with `SupabaseQueryBuilder.stream`.
 class SupabaseStreamFilterBuilder extends SupabaseStreamBuilder {
+  /// Creates a stream builder for [table].
   SupabaseStreamFilterBuilder({
     required super.queryBuilder,
     required super.realtimeTopic,

--- a/packages/supabase/lib/src/supabase_stream_filter_builder.dart
+++ b/packages/supabase/lib/src/supabase_stream_filter_builder.dart
@@ -3,7 +3,6 @@ part of './supabase_stream_builder.dart';
 /// A [SupabaseStreamBuilder] that can also filter which rows are streamed,
 /// created with `SupabaseQueryBuilder.stream`.
 class SupabaseStreamFilterBuilder extends SupabaseStreamBuilder {
-  /// Creates a stream builder for [table].
   SupabaseStreamFilterBuilder({
     required super.queryBuilder,
     required super.realtimeTopic,

--- a/packages/supabase/lib/src/version.dart
+++ b/packages/supabase/lib/src/version.dart
@@ -1,1 +1,5 @@
+import 'package:meta/meta.dart';
+
+/// The published version of this package.
+@internal
 const version = '3.0.0-dev.1';

--- a/packages/supabase/lib/src/version.dart
+++ b/packages/supabase/lib/src/version.dart
@@ -1,1 +1,4 @@
+import 'package:meta/meta.dart';
+
+@internal
 const version = '3.0.0-dev.1';

--- a/packages/supabase/lib/src/version.dart
+++ b/packages/supabase/lib/src/version.dart
@@ -1,5 +1,1 @@
-import 'package:meta/meta.dart';
-
-/// The published version of this package.
-@internal
 const version = '3.0.0-dev.1';


### PR DESCRIPTION
## Summary
- Enables `public_member_api_docs` for `supabase`.
- Documents the `*ClientOptions` classes (`PostgrestClientOptions`, `AuthClientOptions`, `StorageClientOptions`, `FunctionsClientOptions`), `SupabaseClient`'s remaining undocumented members, `SupabaseQueryBuilder`, `SupabaseQuerySchema`, `SupabaseStreamBuilder`/`SupabaseStreamFilterBuilder`, `RealtimeSubscribeException`, and `TraceContext`/`TracePropagationOptions`.

## Context
Continues the package-by-package rollout for [SDK-1449](https://linear.app/supabase/issue/SDK-1449/enable-public-member-api-docs-and-document-the-public-api).

## Test plan
- [x] `dart analyze` reports no issues
- [x] `dart format .` produces no diff
- [x] `dart test` passes (147 tests)
- [x] Dependent package `supabase_flutter` still analyzes cleanly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added API documentation across client configuration, authentication, realtime streaming, schema queries, filtering, tracing, and version information.
  * Documented public properties, constructors, exceptions, and types to improve developer guidance.
* **Chores**
  * Enabled a lint rule requiring documentation for public members.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->