### PR TITLE
docs(supabase_flutter): enable public_member_api_docs

### DIFF
--- a/packages/supabase_flutter/analysis_options.yaml
+++ b/packages/supabase_flutter/analysis_options.yaml
@@ -1,9 +1,5 @@
 include: package:supabase_lints/analysis_options_flutter.yaml
 
-linter:
-  rules:
-    public_member_api_docs: true
-
 analyzer:
   exclude:
     - build/**

--- a/packages/supabase_flutter/analysis_options.yaml
+++ b/packages/supabase_flutter/analysis_options.yaml
@@ -1,5 +1,9 @@
 include: package:supabase_lints/analysis_options_flutter.yaml
 
+linter:
+  rules:
+    public_member_api_docs: true
+
 analyzer:
   exclude:
     - build/**

--- a/packages/supabase_flutter/lib/src/flutter_auth_client_options.dart
+++ b/packages/supabase_flutter/lib/src/flutter_auth_client_options.dart
@@ -1,5 +1,8 @@
 import 'package:supabase_flutter/supabase_flutter.dart';
 
+/// Configuration for the auth client used by `Supabase.instance.client.auth`,
+/// extending [AuthClientOptions] with Flutter-specific session persistence
+/// and deep link handling.
 class FlutterAuthClientOptions extends AuthClientOptions {
   const FlutterAuthClientOptions({
     super.authFlowType,
@@ -11,6 +14,11 @@ class FlutterAuthClientOptions extends AuthClientOptions {
     this.detectSessionInUriPredicate,
     this.persistSession = true,
   });
+
+  /// Where the session is persisted.
+  ///
+  /// Defaults to shared preferences when [persistSession] is `true`, and to
+  /// an in-memory-only storage otherwise.
   final LocalStorage? localStorage;
 
   /// If true, the client will start the deep link observer and obtain sessions

--- a/packages/supabase_flutter/lib/src/local_storage.dart
+++ b/packages/supabase_flutter/lib/src/local_storage.dart
@@ -17,7 +17,6 @@ import './local_storage_stub.dart'
 ///   * [SharedPreferencesLocalStorage], that implements SharedPreferencesAsync
 ///     as storage method
 abstract class LocalStorage {
-  /// Const constructor for subclasses.
   const LocalStorage();
 
   /// Initialize the storage to persist session.
@@ -175,7 +174,6 @@ class SharedPreferencesLocalStorage extends LocalStorage {
 
 /// local storage to store pkce flow code verifier.
 class SharedPreferencesAuthAsyncStorage extends AuthAsyncStorage {
-  /// Creates a storage backed by shared preferences.
   SharedPreferencesAuthAsyncStorage() {
     WidgetsFlutterBinding.ensureInitialized();
   }

--- a/packages/supabase_flutter/lib/src/local_storage.dart
+++ b/packages/supabase_flutter/lib/src/local_storage.dart
@@ -17,6 +17,7 @@ import './local_storage_stub.dart'
 ///   * [SharedPreferencesLocalStorage], that implements SharedPreferencesAsync
 ///     as storage method
 abstract class LocalStorage {
+  /// Const constructor for subclasses.
   const LocalStorage();
 
   /// Initialize the storage to persist session.
@@ -67,6 +68,7 @@ class SharedPreferencesLocalStorage extends LocalStorage {
   SharedPreferencesLocalStorage({required this.persistSessionKey});
   late final SharedPreferencesAsync _preferences;
 
+  /// The shared preferences key the session is stored under.
   final String persistSessionKey;
   static const _useWebLocalStorage =
       kIsWeb && bool.fromEnvironment("dart.library.js_interop");
@@ -173,6 +175,7 @@ class SharedPreferencesLocalStorage extends LocalStorage {
 
 /// local storage to store pkce flow code verifier.
 class SharedPreferencesAuthAsyncStorage extends AuthAsyncStorage {
+  /// Creates a storage backed by shared preferences.
   SharedPreferencesAuthAsyncStorage() {
     WidgetsFlutterBinding.ensureInitialized();
   }

--- a/packages/supabase_flutter/lib/src/supabase_auth.dart
+++ b/packages/supabase_flutter/lib/src/supabase_auth.dart
@@ -340,6 +340,7 @@ class SupabaseAuth with WidgetsBindingObserver {
   }
 }
 
+/// Sign-in methods that open a browser or webview, such as OAuth and SSO.
 extension AuthClientSignInProvider on AuthClient {
   /// Signs the user in using a third party providers.
   ///
@@ -445,6 +446,8 @@ extension AuthClientSignInProvider on AuthClient {
     );
   }
 
+  /// Generates a random nonce to pass to a native sign-in SDK before hashing
+  /// it and sending the ID token to `signInWithIdToken`.
   String generateRawNonce() => base64Url.encode(randomBytes(16));
 
   /// Links an oauth identity to an existing user.

--- a/packages/supabase_flutter/lib/src/supabase_auth.dart
+++ b/packages/supabase_flutter/lib/src/supabase_auth.dart
@@ -446,8 +446,9 @@ extension AuthClientSignInProvider on AuthClient {
     );
   }
 
-  /// Generates a random nonce to pass to a native sign-in SDK before hashing
-  /// it and sending the ID token to `signInWithIdToken`.
+  /// Generates a random nonce. Hash it and pass the hash to the native
+  /// sign-in SDK, then pass this raw nonce as `nonce` to `signInWithIdToken`,
+  /// which hashes it again to compare against the value in the ID token.
   String generateRawNonce() => base64Url.encode(randomBytes(16));
 
   /// Links an oauth identity to an existing user.

--- a/packages/supabase_flutter/lib/src/version.dart
+++ b/packages/supabase_flutter/lib/src/version.dart
@@ -1,1 +1,5 @@
+import 'package:meta/meta.dart';
+
+/// The published version of this package.
+@internal
 const version = '3.0.0-dev.1';

--- a/packages/supabase_flutter/lib/src/version.dart
+++ b/packages/supabase_flutter/lib/src/version.dart
@@ -1,5 +1,4 @@
 import 'package:meta/meta.dart';
 
-/// The published version of this package.
 @internal
 const version = '3.0.0-dev.1';


### PR DESCRIPTION
## Summary
- Enables `public_member_api_docs` for `supabase_flutter`.
- Documents `FlutterAuthClientOptions`, `LocalStorage` and its `EmptyLocalStorage`/`SharedPreferencesLocalStorage`/`SharedPreferencesAuthAsyncStorage` implementations, the `AuthClientSignInProvider` extension, and `generateRawNonce`.

## Context
Continues the package-by-package rollout for [SDK-1449](https://linear.app/supabase/issue/SDK-1449/enable-public-member-api-docs-and-document-the-public-api).

## Test plan
- [x] `dart analyze` reports no issues
- [x] `dart format .` produces no diff
- [x] `flutter test` passes (80 tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added API documentation for Flutter authentication options, local storage, and authentication methods.
  * Clarified nonce generation guidance for native sign-in integrations.
  * Enabled lint checks requiring documentation for public members.
* **Refactor**
  * Marked the package version constant as internal API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->