### PR TITLE
fix(realtime): parse Postgres array literals instead of splitting on commas

### DIFF
--- a/packages/supabase_realtime/lib/src/transformers.dart
+++ b/packages/supabase_realtime/lib/src/transformers.dart
@@ -346,12 +346,21 @@ dynamic toArray(dynamic value, String type) {
     return value;
   }
 
+  // Postgres prefixes the literal with explicit dimensions, for example
+  // `[0:1]={1,2}`, when a dimension's lower bound is not 1.
+  final literal = value.replaceFirst(_arrayDimensions, '');
+
   // Confirm value is a Postgres array by checking curly brackets
-  if (value.length < 2 || !value.startsWith('{') || !value.endsWith('}')) {
+  if (literal.length < 2 ||
+      !literal.startsWith('{') ||
+      !literal.endsWith('}')) {
     return value;
   }
 
-  final elements = _ArrayLiteralParser(value).parse();
+  final elements = _ArrayLiteralParser(
+    literal,
+    _elementDelimiter(type),
+  ).parse();
   if (elements == null) {
     // Not a literal this parser understands, hand the raw value back rather
     // than splitting it into something that looks like data but isn't.
@@ -360,6 +369,15 @@ dynamic toArray(dynamic value, String type) {
 
   return _convertElements(elements, type);
 }
+
+/// The explicit dimension decoration of an array literal, such as
+/// `[0:1]=` or `[1:2][3:4]=`.
+final _arrayDimensions = RegExp(r'^(\[-?\d+:-?\d+\])+=');
+
+/// The character separating two elements of an array literal, which is the
+/// element type's `typdelim`. That is a comma for every built-in type except
+/// `box`, whose values use commas internally and are separated by semicolons.
+String _elementDelimiter(String type) => type == 'box' ? ';' : ',';
 
 /// Runs [convertCell] over every leaf of a parsed array literal, leaving nulls
 /// and the shape of nested arrays intact.
@@ -376,14 +394,15 @@ dynamic _convertElements(dynamic element, String type) {
 /// Parses the array literal Postgres sends on the wire, for example
 /// `{"a,b",c}` or `{{1,2},{3,4}}`.
 ///
-/// Elements are separated by commas, may be quoted with `"` (in which case `\`
-/// escapes the next character), and unquoted whitespace around an element is
-/// not part of its value. An unquoted `NULL` is the null element, while a
-/// quoted `"NULL"` is the four character string.
+/// Elements are separated by [_delimiter], may be quoted with `"` (in which
+/// case `\` escapes the next character), and unquoted whitespace around an
+/// element is not part of its value. An unquoted `NULL` is the null element,
+/// while a quoted `"NULL"` is the four character string.
 class _ArrayLiteralParser {
-  _ArrayLiteralParser(this._literal);
+  _ArrayLiteralParser(this._literal, this._delimiter);
 
   final String _literal;
+  final String _delimiter;
   int _position = 0;
 
   bool get _isAtEnd => _position >= _literal.length;
@@ -414,7 +433,7 @@ class _ArrayLiteralParser {
       if (_consume('}')) {
         return elements;
       }
-      _expect(',');
+      _expect(_delimiter);
     }
   }
 
@@ -441,7 +460,7 @@ class _ArrayLiteralParser {
   dynamic _parseUnquoted() {
     final start = _position;
     while (!_isAtEnd &&
-        _literal[_position] != ',' &&
+        _literal[_position] != _delimiter &&
         _literal[_position] != '}') {
       _position++;
     }

--- a/packages/supabase_realtime/lib/src/transformers.dart
+++ b/packages/supabase_realtime/lib/src/transformers.dart
@@ -346,28 +346,141 @@ dynamic toArray(dynamic value, String type) {
     return value;
   }
 
-  // trim Postgres array curly brackets
-  final lastIndex = value.length - 1;
-  final closeBrace = value[lastIndex];
-  final openBrace = value[0];
-
   // Confirm value is a Postgres array by checking curly brackets
-  if (openBrace == '{' && closeBrace == '}') {
-    final trimmedValue = value.substring(1, lastIndex);
-    List<dynamic> array;
-
-    // TODO: find a better solution to separate Postgres array data
-    try {
-      array = json.decode('[$trimmedValue]') as List;
-    } catch (_) {
-      // WARNING: splitting on comma does not cover all edge cases
-      array = trimmedValue != '' ? trimmedValue.split(',') : [];
-    }
-
-    return array.map((element) => convertCell(type, element)).toList();
+  if (value.length < 2 || !value.startsWith('{') || !value.endsWith('}')) {
+    return value;
   }
 
-  return value;
+  final elements = _parseArrayLiteral(value);
+  if (elements == null) {
+    // Not a literal this parser understands, hand the raw value back rather
+    // than splitting it into something that looks like data but isn't.
+    return value;
+  }
+
+  return _convertElements(elements, type);
+}
+
+/// Runs [convertCell] over every leaf of a parsed array literal, leaving nulls
+/// and the shape of nested arrays intact.
+dynamic _convertElements(dynamic element, String type) {
+  if (element is List) {
+    return element.map((child) => _convertElements(child, type)).toList();
+  }
+  if (element == null) {
+    return null;
+  }
+  return convertCell(type, element);
+}
+
+/// Parses the array literal Postgres sends on the wire, for example
+/// `{"a,b",c}` or `{{1,2},{3,4}}`.
+///
+/// Elements are separated by commas, may be quoted with `"` (in which case `\`
+/// escapes the next character), and unquoted whitespace around an element is
+/// not part of its value. An unquoted `NULL` is the null element, while a
+/// quoted `"NULL"` is the four character string.
+///
+/// Returns null when [literal] doesn't parse, so the caller can fall back to
+/// the raw value instead of silently returning corrupted data.
+List<dynamic>? _parseArrayLiteral(String literal) {
+  var index = 0;
+
+  void skipWhitespace() {
+    while (index < literal.length && literal[index].trim().isEmpty) {
+      index++;
+    }
+  }
+
+  String? parseQuoted() {
+    final buffer = StringBuffer();
+    index++; // opening quote
+    while (index < literal.length) {
+      final char = literal[index];
+      if (char == r'\') {
+        index++;
+        if (index >= literal.length) {
+          return null;
+        }
+        buffer.write(literal[index]);
+      } else if (char == '"') {
+        index++; // closing quote
+        return buffer.toString();
+      } else {
+        buffer.write(char);
+      }
+      index++;
+    }
+    return null; // unterminated
+  }
+
+  List<dynamic>? parseArray() {
+    if (index >= literal.length || literal[index] != '{') {
+      return null;
+    }
+    index++;
+
+    final elements = <dynamic>[];
+    skipWhitespace();
+    if (index < literal.length && literal[index] == '}') {
+      index++;
+      return elements;
+    }
+
+    while (index < literal.length) {
+      skipWhitespace();
+      if (index >= literal.length) {
+        return null;
+      }
+
+      final dynamic element;
+      switch (literal[index]) {
+        case '{':
+          final nested = parseArray();
+          if (nested == null) {
+            return null;
+          }
+          element = nested;
+        case '"':
+          final quoted = parseQuoted();
+          if (quoted == null) {
+            return null;
+          }
+          element = quoted;
+        default:
+          final start = index;
+          while (index < literal.length &&
+              literal[index] != ',' &&
+              literal[index] != '}') {
+            index++;
+          }
+          final raw = literal.substring(start, index).trim();
+          element = raw.toUpperCase() == 'NULL' ? null : raw;
+      }
+      elements.add(element);
+
+      skipWhitespace();
+      if (index >= literal.length) {
+        return null;
+      }
+      if (literal[index] == ',') {
+        index++;
+        continue;
+      }
+      if (literal[index] == '}') {
+        index++;
+        return elements;
+      }
+      return null; // junk between an element and the next separator
+    }
+    return null; // unterminated
+  }
+
+  final parsed = parseArray();
+  if (parsed == null || index != literal.length) {
+    return null;
+  }
+  return parsed;
 }
 
 /// Fixes timestamp to be ISO-8601. Swaps the space between the date and time

--- a/packages/supabase_realtime/lib/src/transformers.dart
+++ b/packages/supabase_realtime/lib/src/transformers.dart
@@ -348,7 +348,7 @@ dynamic toArray(dynamic value, String type) {
 
   // Postgres prefixes the literal with explicit dimensions, for example
   // `[0:1]={1,2}`, when a dimension's lower bound is not 1.
-  final literal = value.replaceFirst(_arrayDimensions, '');
+  final literal = value.trim().replaceFirst(_arrayDimensions, '');
 
   // Confirm value is a Postgres array by checking curly brackets
   if (literal.length < 2 ||
@@ -462,9 +462,19 @@ class _ArrayLiteralParser {
     while (!_isAtEnd &&
         _literal[_position] != _delimiter &&
         _literal[_position] != '}') {
+      // Postgres quotes any element containing a backslash, so this is not a
+      // literal it produced.
+      if (_literal[_position] == r'\') {
+        throw const FormatException();
+      }
       _position++;
     }
     final raw = _literal.substring(start, _position).trim();
+    // Postgres quotes the empty string, so a zero length unquoted element is
+    // not a valid literal.
+    if (raw.isEmpty) {
+      throw const FormatException();
+    }
     return raw.toUpperCase() == 'NULL' ? null : raw;
   }
 

--- a/packages/supabase_realtime/lib/src/transformers.dart
+++ b/packages/supabase_realtime/lib/src/transformers.dart
@@ -351,7 +351,7 @@ dynamic toArray(dynamic value, String type) {
     return value;
   }
 
-  final elements = _parseArrayLiteral(value);
+  final elements = _ArrayLiteralParser(value).parse();
   if (elements == null) {
     // Not a literal this parser understands, hand the raw value back rather
     // than splitting it into something that looks like data but isn't.
@@ -380,107 +380,108 @@ dynamic _convertElements(dynamic element, String type) {
 /// escapes the next character), and unquoted whitespace around an element is
 /// not part of its value. An unquoted `NULL` is the null element, while a
 /// quoted `"NULL"` is the four character string.
-///
-/// Returns null when [literal] doesn't parse, so the caller can fall back to
-/// the raw value instead of silently returning corrupted data.
-List<dynamic>? _parseArrayLiteral(String literal) {
-  var index = 0;
+class _ArrayLiteralParser {
+  _ArrayLiteralParser(this._literal);
 
-  void skipWhitespace() {
-    while (index < literal.length && literal[index].trim().isEmpty) {
-      index++;
-    }
-  }
+  final String _literal;
+  int _position = 0;
 
-  String? parseQuoted() {
-    final buffer = StringBuffer();
-    index++; // opening quote
-    while (index < literal.length) {
-      final char = literal[index];
-      if (char == r'\') {
-        index++;
-        if (index >= literal.length) {
-          return null;
-        }
-        buffer.write(literal[index]);
-      } else if (char == '"') {
-        index++; // closing quote
-        return buffer.toString();
-      } else {
-        buffer.write(char);
-      }
-      index++;
-    }
-    return null; // unterminated
-  }
+  bool get _isAtEnd => _position >= _literal.length;
 
-  List<dynamic>? parseArray() {
-    if (index >= literal.length || literal[index] != '{') {
+  /// Returns the parsed elements, or null when [_literal] is not a single
+  /// well-formed array so the caller can fall back to the raw value instead
+  /// of silently returning corrupted data.
+  List<dynamic>? parse() {
+    try {
+      final elements = _parseArray();
+      return _isAtEnd ? elements : null;
+    } on FormatException {
       return null;
     }
-    index++;
+  }
 
+  List<dynamic> _parseArray() {
+    _expect('{');
     final elements = <dynamic>[];
-    skipWhitespace();
-    if (index < literal.length && literal[index] == '}') {
-      index++;
+    _skipWhitespace();
+    if (_consume('}')) {
       return elements;
     }
-
-    while (index < literal.length) {
-      skipWhitespace();
-      if (index >= literal.length) {
-        return null;
-      }
-
-      final dynamic element;
-      switch (literal[index]) {
-        case '{':
-          final nested = parseArray();
-          if (nested == null) {
-            return null;
-          }
-          element = nested;
-        case '"':
-          final quoted = parseQuoted();
-          if (quoted == null) {
-            return null;
-          }
-          element = quoted;
-        default:
-          final start = index;
-          while (index < literal.length &&
-              literal[index] != ',' &&
-              literal[index] != '}') {
-            index++;
-          }
-          final raw = literal.substring(start, index).trim();
-          element = raw.toUpperCase() == 'NULL' ? null : raw;
-      }
-      elements.add(element);
-
-      skipWhitespace();
-      if (index >= literal.length) {
-        return null;
-      }
-      if (literal[index] == ',') {
-        index++;
-        continue;
-      }
-      if (literal[index] == '}') {
-        index++;
+    while (true) {
+      _skipWhitespace();
+      elements.add(_parseElement());
+      _skipWhitespace();
+      if (_consume('}')) {
         return elements;
       }
-      return null; // junk between an element and the next separator
+      _expect(',');
     }
-    return null; // unterminated
   }
 
-  final parsed = parseArray();
-  if (parsed == null || index != literal.length) {
-    return null;
+  dynamic _parseElement() {
+    return switch (_peek()) {
+      '{' => _parseArray(),
+      '"' => _parseQuoted(),
+      _ => _parseUnquoted(),
+    };
   }
-  return parsed;
+
+  String _parseQuoted() {
+    _expect('"');
+    final buffer = StringBuffer();
+    while (true) {
+      final char = _next();
+      if (char == '"') {
+        return buffer.toString();
+      }
+      buffer.write(char == r'\' ? _next() : char);
+    }
+  }
+
+  dynamic _parseUnquoted() {
+    final start = _position;
+    while (!_isAtEnd &&
+        _literal[_position] != ',' &&
+        _literal[_position] != '}') {
+      _position++;
+    }
+    final raw = _literal.substring(start, _position).trim();
+    return raw.toUpperCase() == 'NULL' ? null : raw;
+  }
+
+  void _skipWhitespace() {
+    while (!_isAtEnd && _literal[_position].trim().isEmpty) {
+      _position++;
+    }
+  }
+
+  String _peek() {
+    if (_isAtEnd) {
+      throw const FormatException();
+    }
+    return _literal[_position];
+  }
+
+  String _next() {
+    if (_isAtEnd) {
+      throw const FormatException();
+    }
+    return _literal[_position++];
+  }
+
+  bool _consume(String char) {
+    if (_isAtEnd || _literal[_position] != char) {
+      return false;
+    }
+    _position++;
+    return true;
+  }
+
+  void _expect(String char) {
+    if (!_consume(char)) {
+      throw const FormatException();
+    }
+  }
 }
 
 /// Fixes timestamp to be ISO-8601. Swaps the space between the date and time

--- a/packages/supabase_realtime/lib/src/transformers.dart
+++ b/packages/supabase_realtime/lib/src/transformers.dart
@@ -449,11 +449,11 @@ class _ArrayLiteralParser {
     _expect('"');
     final buffer = StringBuffer();
     while (true) {
-      final char = _next();
-      if (char == '"') {
+      final character = _next();
+      if (character == '"') {
         return buffer.toString();
       }
-      buffer.write(char == r'\' ? _next() : char);
+      buffer.write(character == r'\' ? _next() : character);
     }
   }
 
@@ -498,16 +498,16 @@ class _ArrayLiteralParser {
     return _literal[_position++];
   }
 
-  bool _consume(String char) {
-    if (_isAtEnd || _literal[_position] != char) {
+  bool _consume(String character) {
+    if (_isAtEnd || _literal[_position] != character) {
       return false;
     }
     _position++;
     return true;
   }
 
-  void _expect(String char) {
-    if (!_consume(char)) {
+  void _expect(String character) {
+    if (!_consume(character)) {
       throw const FormatException();
     }
   }

--- a/packages/supabase_realtime/test/transformers_test.dart
+++ b/packages/supabase_realtime/test/transformers_test.dart
@@ -259,10 +259,24 @@ void main() {
       );
     });
 
+    test('drops whitespace around the literal itself', () {
+      expect(toArray(' {1,2} ', 'int4'), equals([1, 2]));
+    });
+
     test('returns the raw value when the literal is malformed', () {
       expect(toArray('{"unterminated}', 'text'), equals('{"unterminated}'));
       expect(toArray('{a}{b}', 'text'), equals('{a}{b}'));
       expect(toArray('not an array', 'text'), equals('not an array'));
+    });
+
+    test('returns the raw value for an empty unquoted element', () {
+      expect(toArray('{1,,2}', 'int4'), equals('{1,,2}'));
+      expect(toArray('{1,}', 'int4'), equals('{1,}'));
+      expect(toArray('{,1}', 'int4'), equals('{,1}'));
+    });
+
+    test('returns the raw value for a backslash outside quotes', () {
+      expect(toArray(r'{a\,b}', 'text'), equals(r'{a\,b}'));
     });
   });
 

--- a/packages/supabase_realtime/test/transformers_test.dart
+++ b/packages/supabase_realtime/test/transformers_test.dart
@@ -241,6 +241,24 @@ void main() {
       );
     });
 
+    test('strips explicit dimension decorations', () {
+      expect(toArray('[0:1]={1,2}', 'int4'), equals([1, 2]));
+      expect(
+        toArray('[1:2][11:12]={{1,2},{3,4}}', 'int4'),
+        equals([
+          [1, 2],
+          [3, 4],
+        ]),
+      );
+    });
+
+    test('splits box elements on the semicolon delimiter', () {
+      expect(
+        toArray('{(1,1),(0,0);(10,10),(0,0)}', 'box'),
+        equals(['(1,1),(0,0)', '(10,10),(0,0)']),
+      );
+    });
+
     test('returns the raw value when the literal is malformed', () {
       expect(toArray('{"unterminated}', 'text'), equals('{"unterminated}'));
       expect(toArray('{a}{b}', 'text'), equals('{a}{b}'));

--- a/packages/supabase_realtime/test/transformers_test.dart
+++ b/packages/supabase_realtime/test/transformers_test.dart
@@ -193,6 +193,61 @@ void main() {
     );
   });
 
+  group('transformers toArray with quoting', () {
+    test('keeps commas inside a quoted element', () {
+      expect(toArray('{"a,b",c}', 'text'), equals(['a,b', 'c']));
+    });
+
+    test('unquoted NULL is the null element, quoted NULL is the string', () {
+      expect(toArray('{NULL,a}', 'text'), equals([null, 'a']));
+      expect(toArray('{null,1}', 'int4'), equals([null, 1]));
+      expect(toArray('{"NULL",a}', 'text'), equals(['NULL', 'a']));
+    });
+
+    test('reads an empty string element', () {
+      expect(toArray('{"",a}', 'text'), equals(['', 'a']));
+    });
+
+    test('keeps the shape of a multidimensional array', () {
+      expect(
+        toArray('{{1,2},{3,4}}', 'int4'),
+        equals([
+          [1, 2],
+          [3, 4],
+        ]),
+      );
+    });
+
+    test('unescapes quotes and backslashes inside a quoted element', () {
+      expect(toArray(r'{"a\"b","c\\d"}', 'text'), equals(['a"b', r'c\d']));
+    });
+
+    test('keeps braces that are part of a quoted element', () {
+      expect(
+        toArray(r'{"{not an array}"}', 'text'),
+        equals(['{not an array}']),
+      );
+    });
+
+    test('drops whitespace around unquoted elements but not inside them', () {
+      expect(toArray('{a , b}', 'text'), equals(['a', 'b']));
+      expect(
+        toArray('{hello world,foo}', 'text'),
+        equals(['hello world', 'foo']),
+      );
+      expect(
+        toArray('{"hello world"," foo "}', 'text'),
+        equals(['hello world', ' foo ']),
+      );
+    });
+
+    test('returns the raw value when the literal is malformed', () {
+      expect(toArray('{"unterminated}', 'text'), equals('{"unterminated}'));
+      expect(toArray('{a}{b}', 'text'), equals('{a}{b}'));
+      expect(toArray('not an array', 'text'), equals('not an array'));
+    });
+  });
+
   group('enrich payload', () {
     test('can enrich single tenant realtime payload', () {
       final enrichedPayload = getEnrichedPayload({


### PR DESCRIPTION
## What

`toArray` in `supabase_realtime` decoded a Postgres array literal by trying `json.decode` on the body and, when that threw, splitting the string on every comma. Both paths carried a `TODO` and a `WARNING: splitting on comma does not cover all edge cases`, and the edge cases turn into wrong data in realtime payloads:

| Literal Postgres sends | Before | After |
| --- | --- | --- |
| `{"a,b",c}` | `['"a', ' b"', 'c']` (three elements) | `['a,b', 'c']` |
| `{NULL,a}` on `text[]` | `['NULL', 'a']` | `[null, 'a']` |
| `{"",a}` | `['""', 'a']` | `['', 'a']` |
| `{{1,2},{3,4}}` on `int4[]` | `[null, null, null, null]` | `[[1, 2], [3, 4]]` |

A `text[]` column whose values contain commas is the common case here: subscribers got extra elements with stray quote characters in them, and nothing signalled that the value had been mangled.

This replaces both paths with a parser for the literal itself: comma separated elements, optional double quotes where `\` escapes the next character, whitespace around unquoted elements dropped, an unquoted `NULL` as the null element (a quoted `"NULL"` stays the four character string), and nested arrays keeping their shape. A literal that doesn't parse now returns the raw string instead of data that looks structured but isn't.

`{}`, `{1,2,3}` and quoted ranges like `{"[2021-01-01,2021-12-31)"}` behave exactly as before — the existing tests cover those and are unchanged.

## Note on parity with supabase-js

`realtime-js` still has the same `JSON.parse`-then-split logic (`src/lib/transformers.ts`), including the same TODO and warning comments, so after this change the Dart client parses these literals where the JS client does not. I went with correctness here since the current behaviour silently returns wrong values, but happy to align differently if you'd rather keep the two in lockstep, and I can open the matching issue on `realtime-js`.

## Tests

Added a `toArray with quoting` group in `packages/supabase_realtime/test/transformers_test.dart` covering quoted commas, `NULL` vs `"NULL"`, empty string elements, nested arrays, escaped quotes and backslashes, quoted braces, whitespace handling, and malformed literals.

`dart test -j 1 --exclude-tags integration` in `packages/supabase_realtime` passes (239 tests), and `dart analyze packages/supabase_realtime` is clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PostgreSQL array parsing for quoted values, escaped characters, whitespace, nested arrays, empty strings, and `NULL` values.
  * Added support for explicit dimension prefixes and PostgreSQL `box` array delimiters.
  * Malformed array literals, including invalid unquoted elements, are now safely returned unchanged instead of being incorrectly parsed.

* **Tests**
  * Added coverage for multidimensional arrays, quoting, escaping, whitespace, embedded braces, dimension prefixes, `box` values, and malformed input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->