### PR TITLE
ci: bump supabase/sdk reusable workflows to v1.5.0

### DIFF
--- a/.github/workflows/sync-compliance.yml
+++ b/.github/workflows/sync-compliance.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: supabase/sdk/.github/workflows/sync-sdk-compliance.yml@4d74492587bde35691e8a85470c0a7ebd7badb3e # v1.3.0
+    uses: supabase/sdk/.github/workflows/sync-sdk-compliance.yml@7ea18703f9148439941454238f2ee03012bae24b # v1.4.0
     secrets:
       app-id: ${{ secrets.APP_ID }}
       private-key: ${{ secrets.PRIVATE_KEY }}

--- a/.github/workflows/sync-compliance.yml
+++ b/.github/workflows/sync-compliance.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: supabase/sdk/.github/workflows/sync-sdk-compliance.yml@7ea18703f9148439941454238f2ee03012bae24b # v1.4.0
+    uses: supabase/sdk/.github/workflows/sync-sdk-compliance.yml@75cf587c486f80c2d2afe57ec909ee2520c098b9 # v1.5.0
     secrets:
       app-id: ${{ secrets.APP_ID }}
       private-key: ${{ secrets.PRIVATE_KEY }}

--- a/.github/workflows/validate-capabilities.yml
+++ b/.github/workflows/validate-capabilities.yml
@@ -13,4 +13,4 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    uses: supabase/sdk/.github/workflows/validate-sdk-compliance-dart.yml@7ea18703f9148439941454238f2ee03012bae24b # v1.4.0
+    uses: supabase/sdk/.github/workflows/validate-sdk-compliance-dart.yml@75cf587c486f80c2d2afe57ec909ee2520c098b9 # v1.5.0

--- a/.github/workflows/validate-capabilities.yml
+++ b/.github/workflows/validate-capabilities.yml
@@ -13,4 +13,4 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    uses: supabase/sdk/.github/workflows/validate-sdk-compliance-dart.yml@4d74492587bde35691e8a85470c0a7ebd7badb3e # v1.3.0
+    uses: supabase/sdk/.github/workflows/validate-sdk-compliance-dart.yml@7ea18703f9148439941454238f2ee03012bae24b # v1.4.0


### PR DESCRIPTION
Bumps the pinned supabase/sdk reusable workflows from v1.3.0 to v1.5.0 (`75cf587c486f80c2d2afe57ec909ee2520c098b9`).

v1.4.0 (supabase/sdk#107) resolves the compliance tooling, composite actions, and capability spec from the single supabase/sdk commit this pin points at (`job.workflow_sha`), instead of referencing the actions remotely at `@main` while the workflow itself is SHA-pinned. This removes the tooling/spec version skew that broke supabase-go CI after the `packages/` restructure in supabase/sdk, and makes the SHA pin here fully effective: the action code executed can no longer drift from the pinned workflow.

v1.5.0 additionally includes supabase/sdk#109, which fixes an unquoted colon that made the compliance composite action manifests invalid YAML, so this is the first release where the workflow-SHA resolution from #107 actually runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated SDK compliance checks to the latest workflow version.
  * Applied the update across compliance synchronization and capability validation workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
