### PR TITLE
ci: use client-id instead of deprecated app-id for app tokens

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -27,7 +27,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ vars.GH_APP_CLIENT_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
 
       - name: Checkout

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -20,7 +20,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ vars.GH_APP_CLIENT_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
 
       - name: Checkout

--- a/.github/workflows/sync-compliance.yml
+++ b/.github/workflows/sync-compliance.yml
@@ -12,5 +12,5 @@ jobs:
       pull-requests: write
     uses: supabase/sdk/.github/workflows/sync-sdk-compliance.yml@75cf587c486f80c2d2afe57ec909ee2520c098b9 # v1.5.0
     secrets:
-      app-id: ${{ secrets.APP_ID }}
+      client-id: ${{ vars.GH_APP_CLIENT_ID }}
       private-key: ${{ secrets.PRIVATE_KEY }}


### PR DESCRIPTION
## What

Replace the deprecated `app-id` input of `actions/create-github-app-token` with `client-id` in the three workflows that still used it:

- `release-prepare.yml`
- `release-publish.yml`
- `sync-compliance.yml` (forwarded as the `client-id` secret to the reusable workflow, which already accepts it at the pinned `v1.5.0`)

All three now use the existing `vars.GH_APP_CLIENT_ID` repository variable, the same pattern `release-tag.yml` already uses. The `APP_ID` secret is no longer referenced anywhere.

## Why

Every `Generate token` step logged, twice (once for the main step, once for the post step):

```
##[warning]Input 'app-id' has been deprecated with message: Use 'client-id' instead.
```

The action declares `deprecationMessage` on `app-id`, so the warning fires whenever the key is present in `with`. Internally it does `core.getInput("client-id") || core.getInput("app-id")` and passes the result straight through as the JWT issuer, so the two inputs are interchangeable apart from the warning.

## Test plan

- No behaviour change to token generation; `secrets.PRIVATE_KEY` is untouched and `GH_APP_CLIENT_ID` is the client ID of the same app.
- Note that `release-tag.yml` has not had a non-skipped run since it switched to `client-id`, so the first release cycle after this merges is the real exercise of the variable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release preparation, publishing, and compliance synchronization workflows to use the configured GitHub App client identifier.
  * Improved workflow configuration consistency across automated release processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->