### PR TITLE
chore: mark concurrent PKCE flows as implemented in the compliance matrix

### DIFF
--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -109,9 +109,6 @@ features:
     status: implemented
     symbols:
       - AuthClient.exchangeCodeForSession
-      - AuthClient.appendPkceFlowIdToRedirects
-      - AuthClientOptions.appendPkceFlowIdToRedirects
-      - OAuthResponse.flowId
   auth.sign_in.resend_confirmation:
     status: implemented
     symbols:
@@ -128,7 +125,12 @@ features:
     status: implemented
     symbols:
       - AuthClient.resetPasswordForEmail
-  auth.sign_in.concurrent_pkce_flows: not_implemented
+  auth.sign_in.concurrent_pkce_flows:
+    status: implemented
+    symbols:
+      - AuthClient.appendPkceFlowIdToRedirects
+      - AuthClientOptions.appendPkceFlowIdToRedirects
+      - OAuthResponse.flowId
 
   # auth — session & user
   auth.session.get_session:


### PR DESCRIPTION
## What

The capability-ID sync in #1786 added `auth.sign_in.concurrent_pkce_flows` to `sdk-compliance.yaml` with the default `not_implemented` status. The capability is already implemented, so this marks it `implemented` and gives it the symbols that describe it.

## Why it is already implemented

The canonical capability asks for each PKCE code verifier to live in its own bounded, per-flow slot keyed by a generated flow id, with the code exchange accepting an optional flow id to select the right verifier. That is what `PKCEVerifierStore` does, landed in #1662 and refactored in #1744:

- Each flow gets its own storage slot, pending ids are tracked in an index entry, and starting another flow past `AuthConstants.pkceMaxConcurrentFlows` (5) evicts the oldest.
- `AuthClient.exchangeCodeForSession` takes an optional `flowId` and validates it before building a storage key.
- `AuthClient.appendPkceFlowIdToRedirects` and `AuthClientOptions.appendPkceFlowIdToRedirects` put the id on the callback URL, and `getOAuthSignInUrl` / `getLinkIdentityUrl` return it as `OAuthResponse.flowId`.

## Changes

`AuthClient.appendPkceFlowIdToRedirects`, `AuthClientOptions.appendPkceFlowIdToRedirects` and `OAuthResponse.flowId` move from `auth.sign_in.exchange_code_for_session` to the new capability, which is where they belong now that it exists. `exchange_code_for_session` keeps `AuthClient.exchangeCodeForSession`.

No note is added, since the implementation matches expected parity.

## Verification

The supabase/sdk compliance tooling was run locally against this branch:

```
validate-compliance  OK — compliance file is valid.
check-api-symbols    All new public API symbols are covered in the capability matrix.
check-drift          No capability matrix drift detected.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for handling multiple concurrent PKCE authentication flows.
* **Bug Fixes**
  * Updated sign-in capability reporting to accurately associate PKCE flow support with concurrent authentication flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->