### PR TITLE
feat(postgrest): add an isUnknown filter method

### DIFF
--- a/packages/postgrest/lib/src/postgrest_filter_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_filter_builder.dart
@@ -242,8 +242,25 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   ///     .select()
   ///     .isFilter('data', null);
   /// ```
+  ///
+  /// For the SQL `UNKNOWN` state, use [isUnknown] instead.
   PostgrestFilterBuilder<T> isFilter(String column, bool? value) {
     return copyWithUrl(_url.appendSearchParameters(column, 'is.$value'));
+  }
+
+  /// A check for the SQL boolean `UNKNOWN` state.
+  ///
+  /// Only meaningful on boolean columns and expressions. See [isFilter] for
+  /// `null`, `true` and `false`.
+  ///
+  /// ```dart
+  /// await supabase
+  ///     .from('users')
+  ///     .select()
+  ///     .isUnknown('confirmed');
+  /// ```
+  PostgrestFilterBuilder<T> isUnknown(String column) {
+    return copyWithUrl(_url.appendSearchParameters(column, 'is.unknown'));
   }
 
   /// Finds all rows whose value on the stated [column] is found on the

--- a/packages/postgrest/test/filter_test.dart
+++ b/packages/postgrest/test/filter_test.dart
@@ -1,6 +1,7 @@
 import 'package:postgrest/postgrest.dart';
 import 'package:test/test.dart';
 
+import 'custom_http_client.dart';
 import 'reset_helper.dart';
 import 'test_utils.dart';
 
@@ -257,6 +258,29 @@ void main() {
     for (final item in response) {
       expect(item['data'], null);
     }
+  });
+
+  test('is unknown', () async {
+    final customHttpClient = CustomHttpClient();
+    final mockedPostgrest = PostgrestClient(
+      'http://localhost:3000',
+      httpClient: customHttpClient,
+    );
+    try {
+      await mockedPostgrest.from('users').select().isUnknown('confirmed');
+    } catch (_) {}
+    expect(
+      customHttpClient.lastRequest!.url.queryParameters['confirmed'],
+      'is.unknown',
+    );
+
+    // The `todos.is_complete` column is `not null`, so no row is ever
+    // `UNKNOWN`, but the request is still accepted by the server.
+    final response = await postgrest
+        .from('todos')
+        .select('is_complete')
+        .isUnknown('is_complete');
+    expect(response, isEmpty);
   });
 
   test('in', () async {

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -828,6 +828,7 @@ features:
     status: implemented
     symbols:
       - PostgrestFilterBuilder.isFilter
+      - PostgrestFilterBuilder.isUnknown
       - SupabaseStreamFilterBuilder.isFilter
   database.using_filters.is_distinct:
     status: implemented


### PR DESCRIPTION
## What

`PostgrestFilterBuilder.isFilter` takes a `bool?`, so it covers `is.null`, `is.true` and `is.false`, but not PostgREST's fourth `is` value, `unknown`.

Rather than replacing the `bool?` with an enum (a breaking change), this adds a dedicated method for the rarely used state, as suggested in https://github.com/supabase/supabase-flutter/issues/1609#issuecomment-5000621975:

```dart
await supabase.from('users').select().isUnknown('confirmed');
```

## Changes

- `PostgrestFilterBuilder.isUnknown(String column)` appends `is.unknown`, with a cross-reference from the `isFilter` docs.
- Test asserting the generated query parameter is `is.unknown` and that PostgREST accepts the filter.
- Registered the new symbol under `database.using_filters.is` in `sdk-compliance.yaml`.

## Notes

`isUnknown` was deliberately not added to `SupabaseStreamFilterBuilder`. Realtime validates filter values by casting them to the column type server-side, and `unknown` is not castable to boolean, so exposing it there could not be verified to work. On a boolean column `is unknown` is also equivalent to `is null`, which streams already support.

Closes #1609

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an `isUnknown` filter for querying rows where a SQL boolean value is `UNKNOWN`.
  * Updated filter guidance to clarify when to use this option.

* **Documentation**
  * Updated compliance documentation to include the new filter capability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->