### PR TITLE
ci: drop --order-dependents from the release publish trigger

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -45,8 +45,14 @@ jobs:
           tag: true
           token: ${{ steps.app-token.outputs.token }}
       - name: Trigger publish workflows
+        # --order-dependents cannot be used here: melos builds its ordering
+        # graph from dev_dependencies as well, and supabase_testing depends on
+        # supabase while the client packages dev-depend on supabase_testing, so
+        # the graph is cyclic and melos exec refuses to run. The dispatch order
+        # does not matter, since every tag points at the same release commit and
+        # melos publish resolves each package against the workspace.
         run: |
-          melos exec -c 1 --no-published --no-private --order-dependents -- \
+          melos exec -c 1 --no-published --no-private -- \
           gh workflow run release-publish.yml \
           --ref \$MELOS_PACKAGE_NAME-v\$MELOS_PACKAGE_VERSION
         env:


### PR DESCRIPTION
## What kind of change does this PR introduce?

CI fix. The `Create Release Tags` workflow failed on the v3.0.0-dev.2 release ([run 33512894194](https://github.com/supabase/supabase-flutter/actions/runs/33512894194/job/99872665110)): the tags were created and pushed, but the `Trigger publish workflows` step exited before dispatching anything, so nothing reached pub.dev.

## What is the current behavior?

```
🚨 1 cycles in dependencies found:
[ postgrest -> supabase_testing -> supabase ]
```

`melos exec --order-dependents` builds its ordering graph from `dev_dependencies` as well as `dependencies`. Since #1747, `supabase_testing` depends on `supabase`, and nine packages dev-depend on `supabase_testing`, which closes a cycle through `postgrest`. Melos checks for cycles across the whole workspace before running anything and exits 1 when it finds one, so the flag cannot be combined with this dependency graph. Filtering the cycle away with `--ignore` does not help either, because the check runs over all packages rather than the filtered set.

This is the first run of the workflow since `supabase_testing` landed. The previous release commit was titled `chore: publish packages as 3.0.0-dev.1`, which does not match the workflow's `chore(release):` condition, so the job was skipped; the last run before that was on 2026-08-05, before the package existed.

## What is the new behavior?

The flag is dropped, with a comment recording why it cannot come back. Dispatch order does not affect the outcome: every tag points at the same release commit, each dispatched `Publish Packages` run publishes whatever is unpublished at that commit, and `melos publish` itself runs unordered at concurrency 1 and resolves each package against the workspace rather than against pub.dev.

Verified locally against `main`: the command as it stands reproduces the cycle error, and without the flag it enumerates all 12 unpublished non-private packages with the expected tag refs.

## Additional context

This does not retrigger the stuck release. `Create Release Tags` runs on push to `main`, and the tags for `3.0.0-dev.2` already exist, so publishing that release still needs a manual `Publish Packages` dispatch on one of those tags.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the release process to reliably trigger package publishing when the project contains cyclic dependencies.
  - Publishing now proceeds without requiring dependency-based execution order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->