### PR TITLE
feat(postgrest): add column expressions and the filter tree

### DIFF
--- a/packages/postgrest/lib/src/postgrest_column_expression.dart
+++ b/packages/postgrest/lib/src/postgrest_column_expression.dart
@@ -1,0 +1,183 @@
+part of 'postgrest_typed_builder.dart';
+
+/// Anything that can appear in a `select` list: a stored column, or an
+/// expression derived from one.
+///
+/// [Row] is the row type of the table the expression belongs to. Every
+/// filter and ordering built from the expression carries it, so using a
+/// column of one table against a query on another is a compile error rather
+/// than a PostgREST 400.
+///
+/// [Value] is the Dart type the expression produces. Operators require a
+/// matching operand, so `.eq('seven')` on an `int` column does not compile.
+///
+/// Stored columns are declared as [PostgrestColumn] or
+/// [PostgrestNullableColumn].
+@experimental
+sealed class PostgrestColumnExpression<Row, Value extends Object> {
+  const PostgrestColumnExpression._();
+
+  /// The text PostgREST expects, in a `select` list or on the left of an
+  /// operator.
+  String get expression;
+
+  @override
+  String toString() => expression;
+}
+
+/// A column expression that can also sit on the left of a filter operator.
+///
+/// Each PostgREST operator is a method here, returning a [PostgrestFilter]
+/// that [PostgrestTypedFilterBuilder.where] applies and that composes with
+/// `&`, `|` and [PostgrestFilter.not].
+///
+/// Expression kinds PostgREST cannot filter on do not mix this in.
+@experimental
+base mixin PostgrestFilterableExpression<Row, Value extends Object>
+    on PostgrestColumnExpression<Row, Value> {
+  /// Only rows where this expression equals [value].
+  ///
+  /// `null` is not accepted; use [PostgrestNullableExpression.isNull] to
+  /// test for SQL `NULL`.
+  PostgrestFilter<Row> eq(Value value) =>
+      PostgrestFilter._comparison(this, PostgrestFilterOperator.eq, value);
+
+  /// Only rows where this expression does not equal [value].
+  PostgrestFilter<Row> neq(Value value) => PostgrestFilter._comparison(
+    this,
+    PostgrestFilterOperator.neq,
+    value,
+  );
+
+  /// Only rows where this expression is greater than [value].
+  PostgrestFilter<Row> gt(Value value) =>
+      PostgrestFilter._comparison(this, PostgrestFilterOperator.gt, value);
+
+  /// Only rows where this expression is greater than or equal to [value].
+  PostgrestFilter<Row> gte(Value value) => PostgrestFilter._comparison(
+    this,
+    PostgrestFilterOperator.gte,
+    value,
+  );
+
+  /// Only rows where this expression is less than [value].
+  PostgrestFilter<Row> lt(Value value) =>
+      PostgrestFilter._comparison(this, PostgrestFilterOperator.lt, value);
+
+  /// Only rows where this expression is less than or equal to [value].
+  PostgrestFilter<Row> lte(Value value) => PostgrestFilter._comparison(
+    this,
+    PostgrestFilterOperator.lte,
+    value,
+  );
+
+  /// Only rows where this expression is distinct from [value].
+  ///
+  /// Unlike [neq], a `NULL` row matches any operand.
+  PostgrestFilter<Row> isDistinct(Value value) => PostgrestFilter._comparison(
+    this,
+    PostgrestFilterOperator.isDistinct,
+    value,
+  );
+
+  /// Applies an operator this package has no method for, keeping the column
+  /// compile-time checked.
+  ///
+  /// ```dart
+  /// .where(Books.tags.raw('someop.value')) // tags=someop.value
+  /// ```
+  ///
+  /// The operand is sent unescaped, so keep the filter out of any subtree
+  /// beneath `|` or [PostgrestFilter.not] unless it is valid inside `or=(…)`.
+  PostgrestFilter<Row> raw(String operand) =>
+      PostgrestFilter._raw(expression, operand);
+}
+
+/// A column expression that can be used as an `order` key.
+///
+/// Stored columns mix this in. Expression kinds PostgREST rejects in `order`
+/// do not, so ordering by one is a compile error.
+@experimental
+base mixin PostgrestOrderableExpression<Row, Value extends Object>
+    on PostgrestColumnExpression<Row, Value> {}
+
+/// A filterable expression whose value the database allows to be `NULL`,
+/// which is what makes [isNull] available.
+@experimental
+base mixin PostgrestNullableExpression<Row, Value extends Object>
+    on PostgrestFilterableExpression<Row, Value> {
+  /// Only rows where this expression is SQL `NULL`.
+  ///
+  /// There is no `isNotNull`; negate instead: `Books.dueDate.isNull().not()`
+  /// renders `due_date=not.is.null`.
+  PostgrestFilter<Row> isNull() =>
+      PostgrestFilter._comparison(this, PostgrestFilterOperator.isFilter, null);
+}
+
+/// `IS` checks that only apply to boolean columns.
+@experimental
+extension PostgrestBooleanFilters<Row>
+    on PostgrestFilterableExpression<Row, bool> {
+  /// Only rows where this boolean expression `IS TRUE`.
+  ///
+  /// On a nullable column this differs from `eq(true)`: `eq.true` is unknown
+  /// for a `NULL` row, `is.true` is false.
+  PostgrestFilter<Row> isTrue() =>
+      PostgrestFilter._comparison(this, PostgrestFilterOperator.isFilter, true);
+
+  /// Only rows where this boolean expression `IS FALSE`.
+  PostgrestFilter<Row> isFalse() => PostgrestFilter._comparison(
+    this,
+    PostgrestFilterOperator.isFilter,
+    false,
+  );
+}
+
+/// A stored `NOT NULL` column of the table whose rows are [Row].
+///
+/// Declared once per column, normally by `supabase_typegen`, as a static
+/// member of the table's namespace class:
+///
+/// ```dart
+/// class Books {
+///   static const table = PostgrestTable('books', BooksRow.new);
+///   static const id = PostgrestColumn<BooksRow, int>('id');
+///   static const title = PostgrestColumn<BooksRow, String>('title');
+///   static const dueDate = PostgrestNullableColumn<BooksRow, DateTime>(
+///     'due_date',
+///   );
+/// }
+/// ```
+///
+/// [Value] is the column's non-nullable Dart type; a column that allows
+/// `NULL` is a [PostgrestNullableColumn].
+@experimental
+final class PostgrestColumn<Row, Value extends Object>
+    extends PostgrestColumnExpression<Row, Value>
+    with
+        PostgrestFilterableExpression<Row, Value>,
+        PostgrestOrderableExpression<Row, Value> {
+  /// Creates a reference to the column called [name] in the database.
+  const PostgrestColumn(this.name) : super._();
+
+  /// Name of the column in the database.
+  final String name;
+
+  @override
+  // ignore: match-getter-setter-field-names
+  String get expression => name;
+}
+
+/// A stored column the database allows to be `NULL`.
+///
+/// [Value] stays the non-nullable type, `PostgrestNullableColumn<Row, String>`
+/// for a nullable `text` column; `NULL` is tested with
+/// [PostgrestNullableExpression.isNull].
+@experimental
+final class PostgrestNullableColumn<Row, Value extends Object>
+    extends PostgrestColumn<Row, Value>
+    with PostgrestNullableExpression<Row, Value> {
+  /// Creates a reference to the nullable column called [name] in the
+  /// database.
+  const PostgrestNullableColumn(super.name);
+}

--- a/packages/postgrest/lib/src/postgrest_filter.dart
+++ b/packages/postgrest/lib/src/postgrest_filter.dart
@@ -1,0 +1,295 @@
+part of 'postgrest_typed_builder.dart';
+
+/// A PostgREST filter operator and the token it is sent as.
+@experimental
+enum PostgrestFilterOperator {
+  /// Equals, `eq`.
+  eq('eq'),
+
+  /// Does not equal, `neq`.
+  neq('neq'),
+
+  /// Greater than, `gt`.
+  gt('gt'),
+
+  /// Greater than or equal to, `gte`.
+  gte('gte'),
+
+  /// Less than, `lt`.
+  lt('lt'),
+
+  /// Less than or equal to, `lte`.
+  lte('lte'),
+
+  /// Is distinct from, `isdistinct`.
+  isDistinct('isdistinct'),
+
+  /// The `IS` check for `null`, `true` and `false`, `is`.
+  isFilter('is');
+
+  const PostgrestFilterOperator(this.token);
+
+  /// The operator as it appears after the column in a query parameter.
+  final String token;
+}
+
+/// A filter on the rows of a table, built from the operator methods on a
+/// [PostgrestFilterableExpression] and composed with `&`, `|` and [not]:
+///
+/// ```dart
+/// final List<Book> books = await client
+///     .table(Books.table)
+///     .select()
+///     .where(
+///       (Books.isDone.eq(false) & Books.priority.gt(3)) | Books.id.eq(7),
+///     );
+/// ```
+///
+/// A top-level `&` renders as separate query parameters, `|` as one
+/// `or=(…)`, and an `&` nested inside a `|` as `and(…)`.
+///
+/// [Row] is the row type of the table the filter belongs to, so a filter on
+/// one table cannot be applied to a query on another.
+@experimental
+final class PostgrestFilter<Row> {
+  const PostgrestFilter._(this._node);
+
+  PostgrestFilter._comparison(
+    PostgrestFilterableExpression<Row, Object> column,
+    PostgrestFilterOperator operator,
+    Object? value,
+  ) : _node = _Comparison(column, operator, value);
+
+  PostgrestFilter._raw(String column, String operand)
+    : _node = _Raw(column, operand);
+
+  final _FilterNode<Row> _node;
+
+  /// A filter written entirely in PostgREST syntax, for an expression no
+  /// column can name.
+  ///
+  /// Nothing here is checked. Prefer [PostgrestFilterableExpression.raw],
+  /// which keeps the column compile-time checked and takes only the operand
+  /// as a string.
+  ///
+  /// ```dart
+  /// .where(
+  ///   Books.isDone.eq(false) & PostgrestFilter.raw('cost::text', 'eq.10'),
+  /// )
+  /// ```
+  ///
+  /// The filter is sent as written, so keep it out of any subtree beneath `|`
+  /// or [not] unless it is valid inside `or=(…)`; a `::` in the column name,
+  /// for example, parses at top level only.
+  ///
+  /// [column] is the query parameter name, for example `cost::text`, and
+  /// [operand] everything after the `=`, for example `eq.10`.
+  static PostgrestFilter<Row> raw<Row>(String column, String operand) =>
+      PostgrestFilter._raw(column, operand);
+
+  /// Only rows satisfying both this filter and [other].
+  PostgrestFilter<Row> operator &(PostgrestFilter<Row> other) =>
+      PostgrestFilter._(_And([..._andParts(_node), ..._andParts(other._node)]));
+
+  /// Only rows satisfying this filter, [other], or both.
+  PostgrestFilter<Row> operator |(PostgrestFilter<Row> other) =>
+      PostgrestFilter._(_Or([..._orParts(_node), ..._orParts(other._node)]));
+
+  /// Only rows that do not satisfy this filter.
+  PostgrestFilter<Row> not() => PostgrestFilter._(_Not(_node));
+
+  /// The query parameters this filter contributes to a request.
+  @internal
+  List<({String key, String value})> get queryParameters =>
+      _queryParameters(_node);
+
+  /// Absorbs a child `&` so `a & b & c` renders flat rather than nested.
+  static List<_FilterNode<Row>> _andParts<Row>(_FilterNode<Row> node) =>
+      switch (node) {
+        _And(:final children) => children,
+        _Comparison() || _Raw() || _Or() || _Not() => [node],
+      };
+
+  /// Absorbs a child `|` so `a | b | c` renders `or=(a,b,c)` rather than
+  /// `or=(or(a,b),c)`.
+  static List<_FilterNode<Row>> _orParts<Row>(_FilterNode<Row> node) =>
+      switch (node) {
+        _Or(:final children) => children,
+        _Comparison() || _Raw() || _And() || _Not() => [node],
+      };
+}
+
+sealed class _FilterNode<Row> {
+  const _FilterNode();
+}
+
+/// One operator applied to one column.
+base class _Comparison<Row> extends _FilterNode<Row> {
+  const _Comparison(this.column, this.operator, this.value);
+
+  final PostgrestFilterableExpression<Row, Object> column;
+  final PostgrestFilterOperator operator;
+
+  /// The operand as given, rendered when the request is built.
+  final Object? value;
+
+  String get operatorToken => operator.token;
+
+  /// The operand as sent at top level.
+  String get operand {
+    return _renderFilterValue(value);
+  }
+
+  /// The operand as sent inside a group, escaped. The parentheses of an `in`
+  /// list stay literal there; its members are escaped already.
+  String get groupOperand {
+    return _escapeFilterValue(operand);
+  }
+}
+
+/// Everything after the `=` as one string, sent as written in every position.
+final class _Raw<Row> extends _FilterNode<Row> {
+  const _Raw(this.column, this.operand);
+
+  final String column;
+  final String operand;
+}
+
+final class _And<Row> extends _FilterNode<Row> {
+  const _And(this.children);
+
+  final List<_FilterNode<Row>> children;
+}
+
+final class _Or<Row> extends _FilterNode<Row> {
+  const _Or(this.children);
+
+  final List<_FilterNode<Row>> children;
+}
+
+final class _Not<Row> extends _FilterNode<Row> {
+  const _Not(this.inner);
+
+  final _FilterNode<Row> inner;
+}
+
+List<({String key, String value})> _queryParameters<Row>(
+  _FilterNode<Row> node,
+) => switch (node) {
+  _Comparison(:final column, :final operatorToken, :final operand) => [
+    (key: column.expression, value: '$operatorToken.$operand'),
+  ],
+  _Raw(:final column, :final operand) => [(key: column, value: operand)],
+  _And(:final children) => [
+    for (final child in children) ..._queryParameters(child),
+  ],
+  _Or(:final children) => [(key: 'or', value: _groupList(children))],
+  _Not(inner: _And(:final children)) => [
+    (key: 'not.and', value: _groupList(children)),
+  ],
+  _Not(inner: _Or(:final children)) => [
+    (key: 'not.or', value: _groupList(children)),
+  ],
+  _Not(
+    inner: _Comparison(:final column, :final operatorToken, :final operand),
+  ) =>
+    [
+      (key: column.expression, value: 'not.$operatorToken.$operand'),
+    ],
+  _Not(inner: _Raw(:final column, :final operand)) => [
+    (key: column, value: 'not.$operand'),
+  ],
+  _Not(inner: _Not(:final inner)) => _queryParameters(inner),
+};
+
+String _groupList<Row>(List<_FilterNode<Row>> children) =>
+    '(${children.map(_group).join(',')})';
+
+/// A node in the comma-separated form used inside `or=(…)`: an AND is spelled
+/// `and(…)`, operands are escaped, a negated leaf puts `not.` after the
+/// column (`id.not.eq.2`) while a negated group keeps it in front
+/// (`not.and(…)`), and double negation collapses.
+String _group<Row>(_FilterNode<Row> node) => switch (node) {
+  _Comparison(:final column, :final operatorToken, :final groupOperand) =>
+    '${column.expression}.$operatorToken.$groupOperand',
+  _Raw(:final column, :final operand) => '$column.$operand',
+  _And(:final children) => 'and${_groupList(children)}',
+  _Or(:final children) => 'or${_groupList(children)}',
+  _Not(inner: _Not(:final inner)) => _group(inner),
+  _Not(inner: final inner && (_And() || _Or())) => 'not.${_group(inner)}',
+  _Not(
+    inner: _Comparison(
+      :final column,
+      :final operatorToken,
+      :final groupOperand,
+    ),
+  ) =>
+    '${column.expression}.not.$operatorToken.$groupOperand',
+  _Not(inner: _Raw(:final column, :final operand)) => '$column.not.$operand',
+};
+
+/// Renders an operand the way PostgREST expects it after the operator.
+///
+/// - `null` is `NULL`, for the `is` check.
+/// - A [String] is sent as is.
+/// - A [DateTime] is sent in ISO 8601, so a UTC instant carries its `Z`.
+/// - A [List] becomes a Postgres array literal, `{a,b}`, with each element
+///   escaped as the literal requires.
+/// - A [Map] is encoded as JSON, for `json`/`jsonb` columns.
+/// - Anything else uses its [Object.toString], which for a Dart enum
+///   generated by `supabase_typegen` is the database wire name.
+String _renderFilterValue(Object? value) => switch (value) {
+  null => 'null',
+  String() => value,
+  DateTime() => value.toIso8601String(),
+  List() => _renderArrayLiteral(value),
+  Map() => json.encode(value),
+  _ => value.toString(),
+};
+
+/// `{a,b}`, the array literal the array operators and an array-typed
+/// comparison take. A nested list is a nested literal, and `null` is SQL
+/// `NULL`.
+String _renderArrayLiteral(List<Object?> values) {
+  final elements = values.map(
+    (element) => switch (element) {
+      null => 'NULL',
+      List() => _renderArrayLiteral(element),
+      _ => _escapeArrayElement(_renderFilterValue(element)),
+    },
+  );
+  return '{${elements.join(',')}}';
+}
+
+/// Characters that carry structural meaning in a PostgREST filter value list,
+/// such as `in.(a,b)` or `or=(…)`, and therefore require quoting.
+const _filterReservedCharacters = [',', '(', ')', '"', r'\'];
+
+/// Characters that carry structural meaning inside a Postgres array literal,
+/// such as `cs.{a,b}`, and therefore require quoting.
+const _arrayReservedCharacters = [',', '{', '}', '"', r'\'];
+
+/// Quotes [raw] when it is empty, contains a filter-reserved character or has
+/// surrounding whitespace, escaping `\` and `"` inside the quotes.
+String _escapeFilterValue(String raw) {
+  final needsQuoting =
+      raw.isEmpty ||
+      _filterReservedCharacters.any(raw.contains) ||
+      raw != raw.trim();
+  return needsQuoting ? _quote(raw) : raw;
+}
+
+/// Quotes [raw] when it is empty, spells `NULL`, contains an array-reserved
+/// character or has surrounding whitespace, escaping `\` and `"` inside the
+/// quotes.
+String _escapeArrayElement(String raw) {
+  final needsQuoting =
+      raw.isEmpty ||
+      raw.toUpperCase() == 'NULL' ||
+      _arrayReservedCharacters.any(raw.contains) ||
+      raw != raw.trim();
+  return needsQuoting ? _quote(raw) : raw;
+}
+
+String _quote(String raw) =>
+    '"${raw.replaceAll(r'\', r'\\').replaceAll('"', r'\"')}"';

--- a/packages/postgrest/lib/src/postgrest_typed_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_typed_builder.dart
@@ -4,6 +4,8 @@ import 'dart:convert';
 import 'package:meta/meta.dart';
 import 'package:postgrest/postgrest.dart';
 
+part 'postgrest_column_expression.dart';
+part 'postgrest_filter.dart';
 part 'postgrest_table.dart';
 part 'postgrest_typed_query_builder.dart';
 part 'postgrest_typed_transform_builder.dart';

--- a/packages/postgrest/test/postgrest_column_expression_test.dart
+++ b/packages/postgrest/test/postgrest_column_expression_test.dart
@@ -1,0 +1,137 @@
+import 'package:postgrest/postgrest.dart';
+import 'package:test/test.dart';
+
+extension type const Todo(Map<String, dynamic> _json)
+    implements Map<String, dynamic> {}
+
+enum Mood {
+  happy('happy'),
+  veryHappy('very happy');
+
+  const Mood(this.wireName);
+
+  final String wireName;
+
+  @override
+  String toString() => wireName;
+}
+
+class Todos {
+  static const id = PostgrestColumn<Todo, int>('id');
+  static const title = PostgrestColumn<Todo, String>('title');
+  static const isDone = PostgrestColumn<Todo, bool>('is_done');
+  static const cost = PostgrestColumn<Todo, double>('cost');
+  static const tags = PostgrestColumn<Todo, List<String>>('tags');
+  static const data = PostgrestColumn<Todo, Map<String, Object?>>('data');
+  static const mood = PostgrestColumn<Todo, Mood>('mood');
+  static const dueDate = PostgrestNullableColumn<Todo, DateTime>('due_date');
+  static const isUrgent = PostgrestNullableColumn<Todo, bool>('is_urgent');
+}
+
+String rendered(PostgrestFilter<Todo> filter) => [
+  for (final parameter in filter.queryParameters)
+    '${parameter.key}=${parameter.value}',
+].join('&');
+
+void main() {
+  group('PostgrestColumn', () {
+    test('renders its name as the expression', () {
+      expect(Todos.id.name, 'id');
+      expect(Todos.id.expression, 'id');
+      expect('${Todos.id}', 'id');
+    });
+
+    test('a nullable column is a column', () {
+      // A nullable column keeps every operator of a column and adds isNull.
+      expect(Todos.dueDate, isA<PostgrestColumn<Todo, DateTime>>());
+      expect(rendered(Todos.dueDate.isNull()), 'due_date=is.null');
+      expect(rendered(Todos.dueDate.isNull().not()), 'due_date=not.is.null');
+    });
+
+    test('only a nullable column is a nullable expression', () {
+      // Checked on erased values, since a positive `is` on the concrete type
+      // would be a compile-time truism.
+      const Object notNull = Todos.id;
+      const Object nullable = Todos.dueDate;
+
+      expect(notNull, isNot(isA<PostgrestNullableExpression<Todo, int>>()));
+      expect(nullable, isA<PostgrestNullableExpression<Todo, DateTime>>());
+    });
+
+    test('a column filters and orders', () {
+      const Object column = Todos.id;
+
+      expect(column, isA<PostgrestFilterableExpression<Todo, int>>());
+      expect(column, isA<PostgrestOrderableExpression<Todo, int>>());
+    });
+  });
+
+  group('comparison operators', () {
+    test('render their wire operator', () {
+      expect(rendered(Todos.id.eq(1)), 'id=eq.1');
+      expect(rendered(Todos.id.neq(1)), 'id=neq.1');
+      expect(rendered(Todos.id.gt(1)), 'id=gt.1');
+      expect(rendered(Todos.id.gte(1)), 'id=gte.1');
+      expect(rendered(Todos.id.lt(1)), 'id=lt.1');
+      expect(rendered(Todos.id.lte(1)), 'id=lte.1');
+      expect(rendered(Todos.id.isDistinct(1)), 'id=isdistinct.1');
+    });
+
+    test('boolean IS checks are only available on boolean columns', () {
+      expect(rendered(Todos.isDone.isTrue()), 'is_done=is.true');
+      expect(rendered(Todos.isDone.isFalse()), 'is_done=is.false');
+      expect(rendered(Todos.isUrgent.isTrue()), 'is_urgent=is.true');
+      expect(rendered(Todos.isUrgent.isNull()), 'is_urgent=is.null');
+    });
+
+    test('raw keeps the column and passes the operand through', () {
+      expect(rendered(Todos.tags.raw('someop.value')), 'tags=someop.value');
+      expect(rendered(Todos.tags.raw('someop.v').not()), 'tags=not.someop.v');
+    });
+  });
+
+  group('value rendering', () {
+    test('strings, numbers and booleans render as themselves', () {
+      expect(rendered(Todos.title.eq('a b')), 'title=eq.a b');
+      expect(rendered(Todos.cost.gt(1.5)), 'cost=gt.1.5');
+      expect(rendered(Todos.isDone.eq(true)), 'is_done=eq.true');
+    });
+
+    test('a DateTime renders in ISO 8601', () {
+      expect(
+        rendered(Todos.dueDate.gt(DateTime.utc(2024, 1, 15, 12))),
+        'due_date=gt.2024-01-15T12:00:00.000Z',
+      );
+    });
+
+    test('an enum renders through toString', () {
+      // The enums supabase_typegen generates return the wire name there.
+      expect(rendered(Todos.mood.eq(Mood.veryHappy)), 'mood=eq.very happy');
+    });
+
+    test('a list renders as an array literal', () {
+      expect(rendered(Todos.tags.eq(['a', 'b'])), 'tags=eq.{a,b}');
+    });
+
+    test('array members are quoted only when the literal needs it', () {
+      expect(rendered(Todos.tags.eq(['a{b', 'c,d'])), 'tags=eq.{"a{b","c,d"}');
+      expect(rendered(Todos.tags.eq(['', 'null'])), 'tags=eq.{"","null"}');
+      expect(rendered(Todos.tags.eq([' a'])), 'tags=eq.{" a"}');
+      expect(rendered(Todos.tags.eq([r'a"b\'])), r'tags=eq.{"a\"b\\"}');
+    });
+
+    test('a map renders as json', () {
+      expect(
+        rendered(Todos.data.eq({'a': 1, 'b': 'x'})),
+        'data=eq.{"a":1,"b":"x"}',
+      );
+    });
+
+    test('a map inside a group is quoted as a filter value', () {
+      expect(
+        rendered(Todos.data.eq({'a': 1}) | Todos.id.eq(1)),
+        r'or=(data.eq."{\"a\":1}",id.eq.1)',
+      );
+    });
+  });
+}

--- a/packages/postgrest/test/postgrest_filter_test.dart
+++ b/packages/postgrest/test/postgrest_filter_test.dart
@@ -1,0 +1,187 @@
+import 'package:postgrest/postgrest.dart';
+import 'package:test/test.dart';
+
+extension type const Todo(Map<String, dynamic> _json)
+    implements Map<String, dynamic> {}
+
+class Todos {
+  static const a = PostgrestColumn<Todo, int>('a');
+  static const b = PostgrestColumn<Todo, int>('b');
+  static const c = PostgrestColumn<Todo, int>('c');
+  static const id = PostgrestColumn<Todo, int>('id');
+  static const name = PostgrestColumn<Todo, String>('name');
+}
+
+List<String> rendered(PostgrestFilter<Todo> filter) => [
+  for (final parameter in filter.queryParameters)
+    '${parameter.key}=${parameter.value}',
+];
+
+void main() {
+  group('rendering', () {
+    test('a top-level AND flattens to separate query parameters', () {
+      // PostgREST ANDs separate query parameters implicitly.
+      expect(rendered(Todos.a.eq(1) & Todos.b.gt(2)), ['a=eq.1', 'b=gt.2']);
+    });
+
+    test('an OR renders as a single parenthesised parameter', () {
+      expect(rendered(Todos.a.eq(1) | Todos.b.gt(2)), ['or=(a.eq.1,b.gt.2)']);
+    });
+
+    test('an AND nested inside an OR renders as a group', () {
+      final filter = (Todos.a.eq(1) & Todos.b.gt(2)) | Todos.c.eq(3);
+
+      expect(rendered(filter), ['or=(and(a.eq.1,b.gt.2),c.eq.3)']);
+    });
+
+    test('a repeated OR flattens', () {
+      // Without associative flattening this renders `or=(or(a,b),c)`, which
+      // PostgREST accepts but is not what was written.
+      final filter = Todos.a.eq(1) | Todos.b.eq(2) | Todos.c.eq(3);
+
+      expect(rendered(filter), ['or=(a.eq.1,b.eq.2,c.eq.3)']);
+    });
+
+    test('a repeated AND flattens', () {
+      final filter = Todos.a.eq(1) & Todos.b.eq(2) & Todos.c.eq(3);
+
+      expect(rendered(filter), ['a=eq.1', 'b=eq.2', 'c=eq.3']);
+    });
+
+    test('negation prefixes the group operator', () {
+      expect(rendered((Todos.a.eq(1) & Todos.b.gt(2)).not()), [
+        'not.and=(a.eq.1,b.gt.2)',
+      ]);
+      expect(rendered((Todos.a.eq(1) | Todos.b.gt(2)).not()), [
+        'not.or=(a.eq.1,b.gt.2)',
+      ]);
+    });
+
+    test('negating a single comparison prefixes the operator', () {
+      expect(rendered(Todos.a.eq(1).not()), ['a=not.eq.1']);
+    });
+
+    test('filters reduce into one flat group', () {
+      final ids = [1, 2, 3];
+      final filter = ids
+          .skip(1)
+          .fold(
+            Todos.id.eq(ids.first),
+            (accumulated, id) => accumulated | Todos.id.eq(id),
+          );
+
+      expect(rendered(filter), ['or=(id.eq.1,id.eq.2,id.eq.3)']);
+    });
+
+    test('raw passes an operand through untouched', () {
+      expect(rendered(PostgrestFilter.raw('cost::text', 'eq.10')), [
+        'cost::text=eq.10',
+      ]);
+      expect(rendered(PostgrestFilter.raw<Todo>('x', 'eq.1').not()), [
+        'x=not.eq.1',
+      ]);
+      expect(rendered(Todos.id.eq(1) | PostgrestFilter.raw('x', 'eq.2')), [
+        'or=(id.eq.1,x.eq.2)',
+      ]);
+    });
+
+    test('group operands are escaped and top-level ones are not', () {
+      // Unescaped, `or=(name.eq.p(q),id.eq.3)` answers 200 with zero rows.
+      // Top level must not be quoted: `name=eq.a,b` is already correct there.
+      expect(rendered(Todos.name.eq('a,b')), ['name=eq.a,b']);
+      expect(rendered(Todos.name.eq('a,b') | Todos.id.eq(3)), [
+        'or=(name.eq."a,b",id.eq.3)',
+      ]);
+      expect(rendered(Todos.name.eq('p(q)') | Todos.id.eq(3)), [
+        'or=(name.eq."p(q)",id.eq.3)',
+      ]);
+    });
+
+    test('group operands with surrounding whitespace are quoted', () {
+      expect(rendered(Todos.name.eq(' a') | Todos.id.eq(3)), [
+        'or=(name.eq." a",id.eq.3)',
+      ]);
+    });
+
+    test('quoted group operands escape backslashes and quotes', () {
+      expect(rendered(Todos.name.eq(r'a"b\c,') | Todos.id.eq(3)), [
+        r'or=(name.eq."a\"b\\c,",id.eq.3)',
+      ]);
+    });
+
+    test('double negation collapses in both positions', () {
+      // `group` must collapse too, or `a.not().not() | b` renders `not.not.`
+      // and 400s.
+      expect(rendered(Todos.id.eq(2).not().not()), ['id=eq.2']);
+      expect(rendered(Todos.id.eq(2).not().not() | Todos.id.eq(3)), [
+        'or=(id.eq.2,id.eq.3)',
+      ]);
+    });
+
+    test('a negated leaf inside a group moves not next to the operator', () {
+      // `or=(not.id.eq.2,…)` is a PGRST100; `or=(id.not.eq.2,…)` is the
+      // accepted form. The escaping is pinned here too, since a negated leaf
+      // takes a different branch than a plain one.
+      expect(rendered(Todos.a.eq(1).not() | Todos.b.eq(2)), [
+        'or=(a.not.eq.1,b.eq.2)',
+      ]);
+      expect(rendered(Todos.name.eq('p(q)').not() | Todos.id.eq(3)), [
+        'or=(name.not.eq."p(q)",id.eq.3)',
+      ]);
+      expect(rendered(Todos.name.eq('a,b').not() | Todos.id.eq(3)), [
+        'or=(name.not.eq."a,b",id.eq.3)',
+      ]);
+    });
+
+    test('a negated leaf inside a nested AND renders in place', () {
+      final filter = (Todos.a.eq(1) & Todos.b.eq(2).not()) | Todos.c.eq(3);
+
+      expect(rendered(filter), ['or=(and(a.eq.1,b.not.eq.2),c.eq.3)']);
+    });
+
+    test(
+      'a raw leaf under an AND nested in an OR reaches the group grammar',
+      () {
+        // The group grammar reaches a raw node by ancestry, not by its
+        // immediate
+        // combinator, so a `::` in the column still 400s here.
+        final filter =
+            (Todos.id.eq(1) & PostgrestFilter.raw('cost::text', 'eq.10')) |
+            Todos.id.eq(3);
+
+        expect(rendered(filter), [
+          'or=(and(id.eq.1,cost::text.eq.10),id.eq.3)',
+        ]);
+      },
+    );
+
+    test(
+      'a raw leaf under an AND nested in a NOT reaches the group grammar',
+      () {
+        final filter =
+            (Todos.id.eq(1) & PostgrestFilter.raw('cost::text', 'eq.10')).not();
+
+        expect(rendered(filter), ['not.and=(id.eq.1,cost::text.eq.10)']);
+      },
+    );
+
+    test('a negated raw leaf inside a group moves not next to the operand', () {
+      final filter =
+          Todos.id.eq(1) | PostgrestFilter.raw<Todo>('x', 'eq.2').not();
+
+      expect(rendered(filter), ['or=(id.eq.1,x.not.eq.2)']);
+    });
+
+    test('negating a nested group still prefixes the group operator', () {
+      final filter = (Todos.a.eq(1) & Todos.b.eq(2)).not() | Todos.c.eq(3);
+
+      expect(rendered(filter), ['or=(not.and(a.eq.1,b.eq.2),c.eq.3)']);
+    });
+
+    test('group escaping applies two levels deep', () {
+      final filter = (Todos.a.eq(1) & Todos.name.eq('p(q)')) | Todos.id.eq(3);
+
+      expect(rendered(filter), ['or=(and(a.eq.1,name.eq."p(q)"),id.eq.3)']);
+    });
+  });
+}

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -769,6 +769,18 @@ features:
       - TableColumn.TableColumn
       - TableColumn.name
       - TableColumn.toString
+      - PostgrestColumnExpression
+      - PostgrestColumnExpression.expression
+      - PostgrestColumnExpression.toString
+      - PostgrestFilterableExpression
+      - PostgrestOrderableExpression
+      - PostgrestNullableExpression
+      - PostgrestColumn
+      - PostgrestColumn.PostgrestColumn
+      - PostgrestColumn.name
+      - PostgrestColumn.expression
+      - PostgrestNullableColumn
+      - PostgrestNullableColumn.PostgrestNullableColumn
       - PostgrestTypedQueryBuilder
       - PostgrestTypedQueryBuilder.PostgrestTypedQueryBuilder
       - PostgrestTypedQueryBuilder.table
@@ -847,6 +859,7 @@ features:
       - PostgrestFilterBuilder.eq
       - SupabaseStreamFilterBuilder.eq
       - TableColumn.eq
+      - PostgrestFilterableExpression.eq
       - ComparisonFilter
       - ComparisonFilter.column
       - ComparisonFilter.value
@@ -858,6 +871,7 @@ features:
       - PostgrestFilterBuilder.neq
       - SupabaseStreamFilterBuilder.neq
       - TableColumn.neq
+      - PostgrestFilterableExpression.neq
       - NeqFilter
       - NeqFilter.operator
   database.using_filters.gt:
@@ -866,6 +880,7 @@ features:
       - PostgrestFilterBuilder.gt
       - SupabaseStreamFilterBuilder.gt
       - TableColumn.gt
+      - PostgrestFilterableExpression.gt
       - GtFilter
       - GtFilter.operator
   database.using_filters.gte:
@@ -874,6 +889,7 @@ features:
       - PostgrestFilterBuilder.gte
       - SupabaseStreamFilterBuilder.gte
       - TableColumn.gte
+      - PostgrestFilterableExpression.gte
       - GteFilter
       - GteFilter.operator
   database.using_filters.lt:
@@ -882,6 +898,7 @@ features:
       - PostgrestFilterBuilder.lt
       - SupabaseStreamFilterBuilder.lt
       - TableColumn.lt
+      - PostgrestFilterableExpression.lt
       - LtFilter
       - LtFilter.operator
   database.using_filters.lte:
@@ -890,6 +907,7 @@ features:
       - PostgrestFilterBuilder.lte
       - SupabaseStreamFilterBuilder.lte
       - TableColumn.lte
+      - PostgrestFilterableExpression.lte
       - LteFilter
       - LteFilter.operator
   database.using_filters.like:
@@ -953,6 +971,10 @@ features:
       - SupabaseStreamFilterBuilder.isFilter
       - TableColumn.isNull
       - TableColumn.isNotNull
+      - PostgrestBooleanFilters
+      - PostgrestBooleanFilters.isTrue
+      - PostgrestBooleanFilters.isFalse
+      - PostgrestNullableExpression.isNull
       - IsNullFilter
       - IsNullFilter.column
       - IsNullFilter.operator
@@ -963,6 +985,7 @@ features:
       - PostgrestFilterBuilder.isDistinct
       - SupabaseStreamFilterBuilder.isDistinct
       - TableColumn.isDistinctFrom
+      - PostgrestFilterableExpression.isDistinct
       - IsDistinctFilter
       - IsDistinctFilter.column
       - IsDistinctFilter.operator
@@ -1016,6 +1039,7 @@ features:
     symbols:
       - PostgrestFilterBuilder.not
       - ColumnFilter.not
+      - PostgrestFilter.not
       - NegatedFilter
       - NegatedFilter.column
       - NegatedFilter.inner
@@ -1027,6 +1051,7 @@ features:
     symbols:
       - PostgrestFilterBuilder.or
       - PostgrestTypedFilterBuilder.whereAny
+      - PostgrestFilter.|
   database.using_filters.range_gt:
     status: implemented
     symbols:
@@ -1106,6 +1131,13 @@ features:
       - ColumnFilter.column
       - ColumnFilter.operator
       - ColumnFilter.value
+      - PostgrestFilter
+      - PostgrestFilter.raw
+      - PostgrestFilter.&
+      - PostgrestFilterableExpression.raw
+      - PostgrestFilterOperator
+      - PostgrestFilterOperator.token
+      - PostgrestFilterOperator.PostgrestFilterOperator
 
   # database — modifiers
   database.using_modifiers.order:


### PR DESCRIPTION
Stack 1/7 for SDK-1741, the Dart port of the supabase-swift SDK-1624 stack (supabase/supabase-swift#1288). Base: `main`.

Adds the vocabulary for a typed PostgREST surface where casts, JSON paths, aggregates and embedded relations are all expressible and compile-time checked. Nothing consumes it yet; `where` and `order` move onto it in 3/7.

**`PostgrestColumnExpression<Row, Value>`** is anything valid in a `select` list, with two independent refinements: `PostgrestFilterableExpression` (left of an operator) and `PostgrestOrderableExpression` (an `order` key), because PostgREST accepts a different expression set in each position. `Row` is the table's row type, so a filter built from one table's column is a `PostgrestFilter<ThatRow>` and cannot be passed to a query on another table; `Value` makes `.eq('seven')` on an `int` column a compile error. `PostgrestNullableExpression` is where `isNull()` lives, so a `NOT NULL` column does not get a filter that can never match.

**`PostgrestColumn`** and **`PostgrestNullableColumn`** are the stored column kinds. They stay static members of the table's namespace class (`Books.title`), where the generator already puts them: Dart has no `$0` shorthand for a closure over a columns value, and the row type parameter gives the relation check the Swift `Root` associated type gives.

**`PostgrestFilter<Row>`** is the tree, composed with `&`, `|` and `not()` (Dart cannot overload `&&`, `||` or `!`), rendered to query parameters. Rendering is position-dependent, following what the Swift stack verified against PostgREST 16.1:

- a top-level operand goes unescaped, the same operand inside `or=(…)` must be escaped;
- a negated leaf in a group is `id.not.eq.2`; `not.id.eq.2` is a PGRST100 parse error;
- double negation collapses in both positions.

Values render through one function: `DateTime` in ISO 8601, a `List` as a `{a,b}` array literal with element escaping, a `Map` as JSON, everything else through `toString`, which for the enums `supabase_typegen` generates is the wire name. Quoting is applied only where a value needs it, unlike the string builder's `in`, which quotes every string.

Nothing is stringly typed until the request is rendered: the operator is a `PostgrestFilterOperator` enum that carries its wire token, an `IS` check carries `bool?` (`null`, `true`, `false`) rather than the words, and an operand is kept as the value the caller passed until it is rendered.

Comparison, boolean `IS`, `isNull` and `raw` operators come with it. The remaining operators are 2/7.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added typed PostgREST column expressions for filtering and ordering.
  - Added comparison, nullability, boolean, raw, and composable filters.
  - Added support for combining, grouping, and negating filters.
  - Added rendering for strings, numbers, booleans, dates, enums, lists, and maps.
- **Documentation**
  - Updated SDK capability coverage for the new typed query and filter APIs.
- **Tests**
  - Added comprehensive coverage for column expressions, filter composition, escaping, and serialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->