### PR TITLE
feat(postgrest): add the remaining filter operators

### DIFF
--- a/packages/postgrest/lib/src/postgrest_column_expression.dart
+++ b/packages/postgrest/lib/src/postgrest_column_expression.dart
@@ -91,6 +91,120 @@ base mixin PostgrestFilterableExpression<Row, Value extends Object>
   /// beneath `|` or [PostgrestFilter.not] unless it is valid inside `or=(…)`.
   PostgrestFilter<Row> raw(String operand) =>
       PostgrestFilter._raw(expression, operand);
+
+  /// Only rows where this expression equals one of [values].
+  ///
+  /// There is no `notIn`; negate instead: `Books.id.inFilter([1, 2]).not()`
+  /// renders `id=not.in.(1,2)`.
+  ///
+  /// An empty [values] matches no rows.
+  PostgrestFilter<Row> inFilter(List<Value> values) =>
+      PostgrestFilter._comparison(
+        this,
+        PostgrestFilterOperator.inFilter,
+        values,
+      );
+
+  /// Only rows whose range value contains [range].
+  ///
+  /// [range] is a Postgres range literal, for example `[2,3)`.
+  PostgrestFilter<Row> containsRange(String range) =>
+      PostgrestFilter._comparison(
+        this,
+        PostgrestFilterOperator.contains,
+        range,
+      );
+
+  /// Only rows whose range value is contained by [range].
+  PostgrestFilter<Row> containedByRange(String range) =>
+      PostgrestFilter._comparison(
+        this,
+        PostgrestFilterOperator.containedBy,
+        range,
+      );
+
+  /// Only rows whose range value overlaps [range].
+  PostgrestFilter<Row> overlapsRange(String range) =>
+      PostgrestFilter._comparison(
+        this,
+        PostgrestFilterOperator.overlaps,
+        range,
+      );
+
+  /// Only rows whose range value is strictly to the left of [range].
+  ///
+  /// [range] is a Postgres range literal, for example
+  /// `[2024-01-01,2024-02-01)`.
+  PostgrestFilter<Row> rangeLt(String range) => PostgrestFilter._comparison(
+    this,
+    PostgrestFilterOperator.rangeLt,
+    range,
+  );
+
+  /// Only rows whose range value is strictly to the right of [range].
+  PostgrestFilter<Row> rangeGt(String range) => PostgrestFilter._comparison(
+    this,
+    PostgrestFilterOperator.rangeGt,
+    range,
+  );
+
+  /// Only rows whose range value does not extend to the left of [range].
+  PostgrestFilter<Row> rangeGte(String range) => PostgrestFilter._comparison(
+    this,
+    PostgrestFilterOperator.rangeGte,
+    range,
+  );
+
+  /// Only rows whose range value does not extend to the right of [range].
+  PostgrestFilter<Row> rangeLte(String range) => PostgrestFilter._comparison(
+    this,
+    PostgrestFilterOperator.rangeLte,
+    range,
+  );
+
+  /// Only rows whose range value is adjacent to [range].
+  PostgrestFilter<Row> rangeAdjacent(String range) =>
+      PostgrestFilter._comparison(
+        this,
+        PostgrestFilterOperator.rangeAdjacent,
+        range,
+      );
+
+  /// Only rows whose `json`/`jsonb` value contains [value].
+  ///
+  /// [value] is the decoded JSON to look for, for example `{'a': 1}` or
+  /// `null`, and is encoded before it is sent.
+  PostgrestFilter<Row> containsJson(Object? value) =>
+      PostgrestFilter._comparison(
+        this,
+        PostgrestFilterOperator.contains,
+        json.encode(value),
+      );
+
+  /// Only rows whose `json`/`jsonb` value is contained by [value].
+  PostgrestFilter<Row> containedByJson(Object? value) =>
+      PostgrestFilter._comparison(
+        this,
+        PostgrestFilterOperator.containedBy,
+        json.encode(value),
+      );
+
+  /// Only rows whose `text` or `tsvector` value matches the full text search
+  /// [query].
+  ///
+  /// [config] is the text search configuration, for example `english`;
+  /// omitted, the database default applies. [type] chooses how [query] is
+  /// turned into a `tsquery`; omitted, `to_tsquery` is used.
+  PostgrestFilter<Row> textSearch(
+    String query, {
+    String? config,
+    TextSearchType? type,
+  }) => PostgrestFilter._textSearch(
+    this,
+    query,
+    config: config,
+    type: type,
+  );
 }
 
 /// A column expression that can be used as an `order` key.

--- a/packages/postgrest/lib/src/postgrest_filter.dart
+++ b/packages/postgrest/lib/src/postgrest_filter.dart
@@ -25,7 +25,62 @@ enum PostgrestFilterOperator {
   isDistinct('isdistinct'),
 
   /// The `IS` check for `null`, `true` and `false`, `is`.
-  isFilter('is');
+  isFilter('is'),
+
+  /// One of a list of values, `in`.
+  inFilter('in'),
+
+  /// Case-sensitive `LIKE`, `like`.
+  like('like'),
+
+  /// Case-insensitive `LIKE`, `ilike`.
+  ilike('ilike'),
+
+  /// Case-sensitive POSIX regular expression, `match`.
+  matchRegex('match'),
+
+  /// Case-insensitive POSIX regular expression, `imatch`.
+  imatchRegex('imatch'),
+
+  /// Case-sensitive `LIKE ALL`, `like(all)`.
+  likeAllOf('like(all)'),
+
+  /// Case-sensitive `LIKE ANY`, `like(any)`.
+  likeAnyOf('like(any)'),
+
+  /// Case-insensitive `LIKE ALL`, `ilike(all)`.
+  ilikeAllOf('ilike(all)'),
+
+  /// Case-insensitive `LIKE ANY`, `ilike(any)`.
+  ilikeAnyOf('ilike(any)'),
+
+  /// Contains, `cs`.
+  contains('cs'),
+
+  /// Contained by, `cd`.
+  containedBy('cd'),
+
+  /// Overlaps, `ov`.
+  overlaps('ov'),
+
+  /// Range strictly left of, `sl`.
+  rangeLt('sl'),
+
+  /// Range strictly right of, `sr`.
+  rangeGt('sr'),
+
+  /// Range does not extend to the left of, `nxl`.
+  rangeGte('nxl'),
+
+  /// Range does not extend to the right of, `nxr`.
+  rangeLte('nxr'),
+
+  /// Range adjacent to, `adj`.
+  rangeAdjacent('adj'),
+
+  /// Full text search, `fts`, prefixed by the query type and suffixed by the
+  /// configuration when given.
+  textSearch('fts');
 
   const PostgrestFilterOperator(this.token);
 
@@ -59,6 +114,13 @@ final class PostgrestFilter<Row> {
     PostgrestFilterOperator operator,
     Object? value,
   ) : _node = _Comparison(column, operator, value);
+
+  PostgrestFilter._textSearch(
+    PostgrestFilterableExpression<Row, Object> column,
+    String query, {
+    required String? config,
+    required TextSearchType? type,
+  }) : _node = _TextSearch(column, query, config: config, type: type);
 
   PostgrestFilter._raw(String column, String operand)
     : _node = _Raw(column, operand);
@@ -137,13 +199,46 @@ base class _Comparison<Row> extends _FilterNode<Row> {
 
   /// The operand as sent at top level.
   String get operand {
+    if (operator == PostgrestFilterOperator.inFilter) {
+      final members = (value! as List<Object?>).map(
+        (member) => _escapeFilterValue(_renderFilterValue(member)),
+      );
+      return '(${members.join(',')})';
+    }
     return _renderFilterValue(value);
   }
 
   /// The operand as sent inside a group, escaped. The parentheses of an `in`
   /// list stay literal there; its members are escaped already.
   String get groupOperand {
+    if (operator == PostgrestFilterOperator.inFilter) return operand;
     return _escapeFilterValue(operand);
+  }
+}
+
+/// A full text search, whose operator token carries the query type and the
+/// configuration: `wfts(english)`.
+final class _TextSearch<Row> extends _Comparison<Row> {
+  const _TextSearch(
+    PostgrestFilterableExpression<Row, Object> column,
+    String query, {
+    required this.config,
+    required this.type,
+  }) : super(column, PostgrestFilterOperator.textSearch, query);
+
+  final String? config;
+  final TextSearchType? type;
+
+  @override
+  String get operatorToken {
+    final prefix = switch (type) {
+      TextSearchType.plain => 'pl',
+      TextSearchType.phrase => 'ph',
+      TextSearchType.websearch => 'w',
+      null => '',
+    };
+    final suffix = config == null ? '' : '($config)';
+    return '$prefix${operator.token}$suffix';
   }
 }
 

--- a/packages/postgrest/lib/src/postgrest_filter_operators.dart
+++ b/packages/postgrest/lib/src/postgrest_filter_operators.dart
@@ -1,0 +1,116 @@
+part of 'postgrest_typed_builder.dart';
+
+/// Filters that only apply to text columns.
+@experimental
+extension PostgrestTextFilters<Row>
+    on PostgrestFilterableExpression<Row, String> {
+  /// Only rows matching the `LIKE` [pattern] case-sensitively.
+  ///
+  /// `%` matches any run of characters, `_` matches exactly one.
+  PostgrestFilter<Row> like(String pattern) => PostgrestFilter._comparison(
+    this,
+    PostgrestFilterOperator.like,
+    pattern,
+  );
+
+  /// Only rows matching the `LIKE` [pattern] case-insensitively.
+  PostgrestFilter<Row> ilike(String pattern) => PostgrestFilter._comparison(
+    this,
+    PostgrestFilterOperator.ilike,
+    pattern,
+  );
+
+  /// Only rows matching the POSIX regular expression [pattern]
+  /// case-sensitively.
+  PostgrestFilter<Row> matchRegex(String pattern) =>
+      PostgrestFilter._comparison(
+        this,
+        PostgrestFilterOperator.matchRegex,
+        pattern,
+      );
+
+  /// Only rows matching the POSIX regular expression [pattern]
+  /// case-insensitively.
+  PostgrestFilter<Row> imatchRegex(String pattern) =>
+      PostgrestFilter._comparison(
+        this,
+        PostgrestFilterOperator.imatchRegex,
+        pattern,
+      );
+
+  /// Only rows matching every one of [patterns] case-sensitively.
+  ///
+  /// An empty [patterns] matches every row, `NULL` rows included.
+  PostgrestFilter<Row> likeAllOf(List<String> patterns) =>
+      PostgrestFilter._comparison(
+        this,
+        PostgrestFilterOperator.likeAllOf,
+        patterns,
+      );
+
+  /// Only rows matching at least one of [patterns] case-sensitively.
+  ///
+  /// An empty [patterns] matches no rows.
+  PostgrestFilter<Row> likeAnyOf(List<String> patterns) =>
+      PostgrestFilter._comparison(
+        this,
+        PostgrestFilterOperator.likeAnyOf,
+        patterns,
+      );
+
+  /// Only rows matching every one of [patterns] case-insensitively.
+  ///
+  /// An empty [patterns] matches every row, as with [likeAllOf].
+  PostgrestFilter<Row> ilikeAllOf(List<String> patterns) =>
+      PostgrestFilter._comparison(
+        this,
+        PostgrestFilterOperator.ilikeAllOf,
+        patterns,
+      );
+
+  /// Only rows matching at least one of [patterns] case-insensitively.
+  ///
+  /// An empty [patterns] matches no rows.
+  PostgrestFilter<Row> ilikeAnyOf(List<String> patterns) =>
+      PostgrestFilter._comparison(
+        this,
+        PostgrestFilterOperator.ilikeAnyOf,
+        patterns,
+      );
+}
+
+/// Filters that only apply to array columns.
+///
+/// The range and JSON forms of the same operators live on every
+/// [PostgrestFilterableExpression], as
+/// [PostgrestFilterableExpression.containsRange] and
+/// [PostgrestFilterableExpression.containsJson].
+@experimental
+extension PostgrestArrayFilters<Row, Element>
+    on PostgrestFilterableExpression<Row, List<Element>> {
+  /// Only rows whose array contains every element of [values].
+  ///
+  /// An empty [values] matches every row whose column is non-null.
+  PostgrestFilter<Row> contains(List<Element?> values) =>
+      PostgrestFilter._comparison(
+        this,
+        PostgrestFilterOperator.contains,
+        values,
+      );
+
+  /// Only rows whose array elements are all contained in [values].
+  PostgrestFilter<Row> containedBy(List<Element?> values) =>
+      PostgrestFilter._comparison(
+        this,
+        PostgrestFilterOperator.containedBy,
+        values,
+      );
+
+  /// Only rows whose array shares at least one element with [values].
+  PostgrestFilter<Row> overlaps(List<Element?> values) =>
+      PostgrestFilter._comparison(
+        this,
+        PostgrestFilterOperator.overlaps,
+        values,
+      );
+}

--- a/packages/postgrest/lib/src/postgrest_typed_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_typed_builder.dart
@@ -6,6 +6,7 @@ import 'package:postgrest/postgrest.dart';
 
 part 'postgrest_column_expression.dart';
 part 'postgrest_filter.dart';
+part 'postgrest_filter_operators.dart';
 part 'postgrest_table.dart';
 part 'postgrest_typed_query_builder.dart';
 part 'postgrest_typed_transform_builder.dart';

--- a/packages/postgrest/test/postgrest_filter_operators_test.dart
+++ b/packages/postgrest/test/postgrest_filter_operators_test.dart
@@ -1,0 +1,233 @@
+import 'package:postgrest/postgrest.dart';
+import 'package:test/test.dart';
+
+extension type const Post(Map<String, dynamic> _json)
+    implements Map<String, dynamic> {}
+
+class Posts {
+  static const id = PostgrestColumn<Post, int>('id');
+  static const tags = PostgrestColumn<Post, List<String>>('tags');
+  static const labels = PostgrestColumn<Post, List<String?>>('labels');
+  static const scheduled = PostgrestColumn<Post, String>('scheduled');
+  static const content = PostgrestColumn<Post, String>('content');
+  static const metadata = PostgrestColumn<Post, Map<String, Object?>>(
+    'metadata',
+  );
+  static const search = PostgrestColumn<Post, Object>('search');
+}
+
+String rendered(PostgrestFilter<Post> filter) => [
+  for (final parameter in filter.queryParameters)
+    '${parameter.key}=${parameter.value}',
+].join('&');
+
+void main() {
+  group('in', () {
+    test('renders a parenthesised list', () {
+      expect(rendered(Posts.id.inFilter([1, 2])), 'id=in.(1,2)');
+      expect(rendered(Posts.content.inFilter(['a', 'b'])), 'content=in.(a,b)');
+    });
+
+    test('quotes members only when the list grammar needs it', () {
+      // The filter escaper, not the array one: `name=in.(p(q),Ada)` answers
+      // 200 with zero rows unquoted, while a brace needs no quoting here.
+      expect(
+        rendered(Posts.content.inFilter(['p(q)', 'a,b', 'a{b', 'x'])),
+        'content=in.("p(q)","a,b",a{b,x)',
+      );
+    });
+
+    test('negates as not.in', () {
+      // There is no notIn; negation is the tree's job.
+      expect(rendered(Posts.id.inFilter([1, 2]).not()), 'id=not.in.(1,2)');
+    });
+
+    test('keeps its own parentheses literal inside a group', () {
+      // Escaping them gives `or=(id.in."(2,3)",…)`, a PGRST100.
+      expect(
+        rendered(Posts.id.inFilter([2, 3]) | Posts.id.eq(1)),
+        'or=(id.in.(2,3),id.eq.1)',
+      );
+      expect(
+        rendered(Posts.content.inFilter(['a,b']).not() | Posts.id.eq(1)),
+        'or=(content.not.in.("a,b"),id.eq.1)',
+      );
+    });
+
+    test('an empty list renders an empty pair of parentheses', () {
+      expect(rendered(Posts.id.inFilter([])), 'id=in.()');
+    });
+  });
+
+  group('pattern operators', () {
+    test('render their wire operator', () {
+      expect(rendered(Posts.content.like('%a%')), 'content=like.%a%');
+      expect(rendered(Posts.content.ilike('%a%')), 'content=ilike.%a%');
+      expect(rendered(Posts.content.matchRegex('^a')), 'content=match.^a');
+      expect(rendered(Posts.content.imatchRegex('^a')), 'content=imatch.^a');
+    });
+
+    test('the quantified forms take an array literal', () {
+      expect(
+        rendered(Posts.content.likeAllOf(['%a%', '%b%'])),
+        'content=like(all).{%a%,%b%}',
+      );
+      expect(
+        rendered(Posts.content.likeAnyOf(['%a%', '%b%'])),
+        'content=like(any).{%a%,%b%}',
+      );
+      expect(
+        rendered(Posts.content.ilikeAllOf(['%a%', '%b%'])),
+        'content=ilike(all).{%a%,%b%}',
+      );
+      expect(
+        rendered(Posts.content.ilikeAnyOf(['%a%', '%b%'])),
+        'content=ilike(any).{%a%,%b%}',
+      );
+    });
+
+    test('quantified members are escaped as array elements', () {
+      expect(
+        rendered(Posts.content.likeAnyOf(['a,b', 'c'])),
+        'content=like(any).{"a,b",c}',
+      );
+    });
+  });
+
+  group('array operators', () {
+    test('render a braced array', () {
+      expect(rendered(Posts.tags.contains(['dart'])), 'tags=cs.{dart}');
+      expect(
+        rendered(Posts.tags.containedBy(['dart', 'flutter'])),
+        'tags=cd.{dart,flutter}',
+      );
+      expect(rendered(Posts.tags.overlaps(['dart'])), 'tags=ov.{dart}');
+    });
+
+    test('members are escaped', () {
+      // A member containing a literal brace is what tells the two escapers
+      // apart: the array escaper quotes it, the filter escaper would let it
+      // through and corrupt the literal's delimiters.
+      expect(rendered(Posts.tags.contains(['a{b'])), 'tags=cs.{"a{b"}');
+      expect(rendered(Posts.tags.containedBy(['a,b'])), 'tags=cd.{"a,b"}');
+    });
+
+    test('a null member is SQL NULL', () {
+      expect(rendered(Posts.tags.contains(['a', null])), 'tags=cs.{a,NULL}');
+    });
+
+    test('a nullable element type is accepted', () {
+      expect(
+        rendered(Posts.labels.contains(['a', null])),
+        'labels=cs.{a,NULL}',
+      );
+      expect(rendered(Posts.labels.overlaps([null])), 'labels=ov.{NULL}');
+    });
+
+    test('an empty array renders empty braces', () {
+      // `tags=cs.{}` matches every row whose column is non-null.
+      expect(rendered(Posts.tags.contains([])), 'tags=cs.{}');
+    });
+  });
+
+  group('range operators', () {
+    test('render their abbreviation', () {
+      const range = '[2024-01-01,2024-02-01)';
+      expect(rendered(Posts.scheduled.rangeLt(range)), 'scheduled=sl.$range');
+      expect(rendered(Posts.scheduled.rangeGt(range)), 'scheduled=sr.$range');
+      expect(rendered(Posts.scheduled.rangeGte(range)), 'scheduled=nxl.$range');
+      expect(rendered(Posts.scheduled.rangeLte(range)), 'scheduled=nxr.$range');
+      expect(
+        rendered(Posts.scheduled.rangeAdjacent(range)),
+        'scheduled=adj.$range',
+      );
+    });
+
+    test('containment takes a range literal', () {
+      // Same wire operators as the array trio, but taking a range literal.
+      // Crossing the two shapes (`span=ov.{1,20}`) is a 400.
+      expect(
+        rendered(Posts.scheduled.containsRange('[21,22)')),
+        'scheduled=cs.[21,22)',
+      );
+      expect(
+        rendered(Posts.scheduled.containedByRange('[21,22)')),
+        'scheduled=cd.[21,22)',
+      );
+      expect(
+        rendered(Posts.scheduled.overlapsRange('[25,35)')),
+        'scheduled=ov.[25,35)',
+      );
+    });
+
+    test('a range operand is escaped inside a group', () {
+      // Bare, the `)` in `or=(span.ov.[25,35),id.eq.3)` closes the logic
+      // group early and 400s, so a range must not take the raw path `in`
+      // takes.
+      expect(
+        rendered(Posts.scheduled.overlapsRange('[25,35)') | Posts.id.eq(3)),
+        'or=(scheduled.ov."[25,35)",id.eq.3)',
+      );
+    });
+  });
+
+  group('json operators', () {
+    test('containment encodes the decoded json', () {
+      expect(
+        rendered(Posts.metadata.containsJson({'a': 1})),
+        'metadata=cs.{"a":1}',
+      );
+      expect(
+        rendered(Posts.metadata.containedByJson({'a': 1})),
+        'metadata=cd.{"a":1}',
+      );
+    });
+
+    test('json null is an operand', () {
+      expect(rendered(Posts.metadata.containsJson(null)), 'metadata=cs.null');
+      expect(
+        rendered(Posts.metadata.containedByJson(null)),
+        'metadata=cd.null',
+      );
+    });
+
+    test('a json operand is quoted inside a group', () {
+      expect(
+        rendered(Posts.metadata.containsJson({'a': 1}) | Posts.id.eq(1)),
+        r'or=(metadata.cs."{\"a\":1}",id.eq.1)',
+      );
+    });
+  });
+
+  group('text search', () {
+    test('renders config and type', () {
+      expect(rendered(Posts.content.textSearch('dart')), 'content=fts.dart');
+      expect(
+        rendered(Posts.content.textSearch('dart', config: 'english')),
+        'content=fts(english).dart',
+      );
+      expect(
+        rendered(
+          Posts.content.textSearch(
+            'dart',
+            config: 'english',
+            type: TextSearchType.websearch,
+          ),
+        ),
+        'content=wfts(english).dart',
+      );
+      expect(
+        rendered(Posts.content.textSearch('dart', type: TextSearchType.plain)),
+        'content=plfts.dart',
+      );
+      expect(
+        rendered(Posts.content.textSearch('dart', type: TextSearchType.phrase)),
+        'content=phfts.dart',
+      );
+    });
+
+    test('is available on a tsvector column typed as Object', () {
+      expect(rendered(Posts.search.textSearch('dart')), 'search=fts.dart');
+    });
+  });
+}

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -917,6 +917,8 @@ features:
       - SupabaseStreamFilterBuilder.like
       - TextTableColumnFilters
       - TextTableColumnFilters.like
+      - PostgrestTextFilters
+      - PostgrestTextFilters.like
       - PatternFilter
       - PatternFilter.column
       - PatternFilter.pattern
@@ -928,6 +930,7 @@ features:
     symbols:
       - PostgrestFilterBuilder.likeAllOf
       - TextTableColumnFilters.likeAllOf
+      - PostgrestTextFilters.likeAllOf
       - PatternListFilter
       - PatternListFilter.column
       - PatternListFilter.patterns
@@ -939,6 +942,7 @@ features:
     symbols:
       - PostgrestFilterBuilder.likeAnyOf
       - TextTableColumnFilters.likeAnyOf
+      - PostgrestTextFilters.likeAnyOf
       - LikeAnyOfFilter
       - LikeAnyOfFilter.operator
   database.using_filters.ilike:
@@ -947,6 +951,7 @@ features:
       - PostgrestFilterBuilder.ilike
       - SupabaseStreamFilterBuilder.ilike
       - TextTableColumnFilters.ilike
+      - PostgrestTextFilters.ilike
       - IlikeFilter
       - IlikeFilter.operator
   database.using_filters.ilike_all:
@@ -954,6 +959,7 @@ features:
     symbols:
       - PostgrestFilterBuilder.ilikeAllOf
       - TextTableColumnFilters.ilikeAllOf
+      - PostgrestTextFilters.ilikeAllOf
       - IlikeAllOfFilter
       - IlikeAllOfFilter.operator
   database.using_filters.ilike_any:
@@ -961,6 +967,7 @@ features:
     symbols:
       - PostgrestFilterBuilder.ilikeAnyOf
       - TextTableColumnFilters.ilikeAnyOf
+      - PostgrestTextFilters.ilikeAnyOf
       - IlikeAnyOfFilter
       - IlikeAnyOfFilter.operator
   database.using_filters.is:
@@ -996,6 +1003,7 @@ features:
       - PostgrestFilterBuilder.inFilter
       - SupabaseStreamFilterBuilder.inFilter
       - TableColumn.inFilter
+      - PostgrestFilterableExpression.inFilter
       - InListFilter
       - InListFilter.column
       - InListFilter.operator
@@ -1003,14 +1011,20 @@ features:
       - InListFilter.values
   database.using_filters.not_in:
     status: implemented
+    note: "The column-expression surface has no dedicated notIn: negation is `not()` on the filter tree, so `Books.id.inFilter([1, 2]).not()` renders `id=not.in.(1,2)`."
     symbols:
       - PostgrestFilterBuilder.notInFilter
       - PostgrestFilterBuilder.not
   database.using_filters.contains:
     status: implemented
+    note: "The operand literal is chosen by the column's Postgres type, not by the operator: `cs.{a,b}` for an array, `cs.[1,3)` for a range, `cs.{\"a\":1}` for jsonb. The column-expression surface spells the three as separate methods so each takes the operand shape it needs; the string builder takes one list, string or map argument."
     symbols:
       - PostgrestFilterBuilder.contains
       - TableColumn.contains
+      - PostgrestArrayFilters
+      - PostgrestArrayFilters.contains
+      - PostgrestFilterableExpression.containsRange
+      - PostgrestFilterableExpression.containsJson
       - ContainmentFilter
       - ContainmentFilter.column
       - ContainmentFilter.value
@@ -1021,6 +1035,9 @@ features:
     symbols:
       - PostgrestFilterBuilder.containedBy
       - TableColumn.containedBy
+      - PostgrestArrayFilters.containedBy
+      - PostgrestFilterableExpression.containedByRange
+      - PostgrestFilterableExpression.containedByJson
       - ContainedByFilter
       - ContainedByFilter.operator
   database.using_filters.overlaps:
@@ -1028,6 +1045,8 @@ features:
     symbols:
       - PostgrestFilterBuilder.overlaps
       - TableColumn.overlaps
+      - PostgrestArrayFilters.overlaps
+      - PostgrestFilterableExpression.overlapsRange
       - OverlapsFilter
       - OverlapsFilter.operator
   database.using_filters.match:
@@ -1057,6 +1076,7 @@ features:
     symbols:
       - PostgrestFilterBuilder.rangeGt
       - TableColumn.rangeGt
+      - PostgrestFilterableExpression.rangeGt
       - RangeFilter
       - RangeFilter.column
       - RangeFilter.range
@@ -1068,6 +1088,7 @@ features:
     symbols:
       - PostgrestFilterBuilder.rangeGte
       - TableColumn.rangeGte
+      - PostgrestFilterableExpression.rangeGte
       - RangeGteFilter
       - RangeGteFilter.operator
   database.using_filters.range_lt:
@@ -1075,6 +1096,7 @@ features:
     symbols:
       - PostgrestFilterBuilder.rangeLt
       - TableColumn.rangeLt
+      - PostgrestFilterableExpression.rangeLt
       - RangeLtFilter
       - RangeLtFilter.operator
   database.using_filters.range_lte:
@@ -1082,6 +1104,7 @@ features:
     symbols:
       - PostgrestFilterBuilder.rangeLte
       - TableColumn.rangeLte
+      - PostgrestFilterableExpression.rangeLte
       - RangeLteFilter
       - RangeLteFilter.operator
   database.using_filters.range_adjacent:
@@ -1089,6 +1112,7 @@ features:
     symbols:
       - PostgrestFilterBuilder.rangeAdjacent
       - TableColumn.rangeAdjacent
+      - PostgrestFilterableExpression.rangeAdjacent
       - RangeAdjacentFilter
       - RangeAdjacentFilter.operator
   database.using_filters.text_search:
@@ -1096,6 +1120,7 @@ features:
     symbols:
       - PostgrestFilterBuilder.textSearch
       - TextTableColumnFilters.textSearch
+      - PostgrestFilterableExpression.textSearch
       - TextSearchFilter
       - TextSearchFilter.column
       - TextSearchFilter.config
@@ -1111,6 +1136,7 @@ features:
       - PostgrestFilterBuilder.matchRegex
       - SupabaseStreamFilterBuilder.matchRegex
       - TextTableColumnFilters.matchRegex
+      - PostgrestTextFilters.matchRegex
       - MatchRegexFilter
       - MatchRegexFilter.operator
   database.using_filters.regex_icase:
@@ -1119,6 +1145,7 @@ features:
       - PostgrestFilterBuilder.imatchRegex
       - SupabaseStreamFilterBuilder.imatchRegex
       - TextTableColumnFilters.imatchRegex
+      - PostgrestTextFilters.imatchRegex
       - ImatchRegexFilter
       - ImatchRegexFilter.operator
   database.using_filters.raw:


### PR DESCRIPTION
Stack 2/7 for SDK-1741. Base: `lukasklingsbo/sdk-1741-1-column-expressions`.

Pattern, list, array, range, JSON and text search operators, completing the operator surface.

- `contains`/`containedBy`/`overlaps` come in three forms because the operand literal is chosen by the column's Postgres type, not by the operator: `{a,b}` for an array, `[1,3)` for a range, `{"a":1}` for `jsonb`. The array form is an extension on `PostgrestFilterableExpression<Row, List<E>>`, so it only exists on array columns; the range and JSON forms (`containsRange`, `containsJson`, …) have no Dart type to constrain on and live on every filterable expression. `containsJson` takes decoded JSON and encodes it, matching the string builder's `contains`.
- `inFilter` is its own node: its `in.(…)` parentheses must reach the server literal, so a group leaves them alone while still escaping the members. Named `inFilter` like the string builder and the realtime stream, since `in` is a keyword. There is no `notIn`; `.not()` covers it.
- `textSearch` lives on every filterable expression rather than on text columns only, because `supabase_typegen` maps `tsvector` to `Object`.
- `matchRegex`/`imatchRegex` keep the string builder's names.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added typed filtering for `IN`, pattern matching, regular expressions, arrays, ranges, JSON containment, and full-text search.
  - Added support for configurable full-text search modes.
  - Added handling for list values, nulls, and special characters in filter expressions.

- **Tests**
  - Added coverage for new filter operators, escaping behavior, grouped filters, and text-search variants.

- **Documentation**
  - Updated the SDK compliance matrix with the new filtering capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->