### PR TITLE
feat(postgrest): route where, order and select through column expressions

### DIFF
--- a/packages/postgrest/lib/src/postgrest.dart
+++ b/packages/postgrest/lib/src/postgrest.dart
@@ -125,7 +125,7 @@ class PostgrestClient {
   ///
   /// Unlike [from], results are converted into the row type of [table]
   /// instead of raw `Map<String, dynamic>` data, and filters are built from
-  /// [TableColumn]s, which makes them compile-time checked.
+  /// [PostgrestColumn]s, which makes them compile-time checked.
   ///
   /// ```dart
   /// final List<Book> books = await client

--- a/packages/postgrest/lib/src/postgrest_column_expression.dart
+++ b/packages/postgrest/lib/src/postgrest_column_expression.dart
@@ -209,11 +209,32 @@ base mixin PostgrestFilterableExpression<Row, Value extends Object>
 
 /// A column expression that can be used as an `order` key.
 ///
-/// Stored columns mix this in. Expression kinds PostgREST rejects in `order`
-/// do not, so ordering by one is a compile error.
+/// On its own it is a [PostgrestOrdering] with no direction, so
+/// `order(Books.title)` sends `order=title`. Chain [asc], [desc],
+/// [nullsFirst] or [nullsLast] to say more.
 @experimental
 base mixin PostgrestOrderableExpression<Row, Value extends Object>
-    on PostgrestColumnExpression<Row, Value> {}
+    on PostgrestColumnExpression<Row, Value>
+    implements PostgrestOrdering<Row> {
+  @override
+  String get orderKey => expression;
+
+  @override
+  PostgrestOrdering<Row> asc() =>
+      _Ordering(expression, direction: SortDirection.ascending);
+
+  @override
+  PostgrestOrdering<Row> desc() =>
+      _Ordering(expression, direction: SortDirection.descending);
+
+  @override
+  PostgrestOrdering<Row> nullsFirst() =>
+      _Ordering(expression, nulls: _NullPlacement.first);
+
+  @override
+  PostgrestOrdering<Row> nullsLast() =>
+      _Ordering(expression, nulls: _NullPlacement.last);
+}
 
 /// A filterable expression whose value the database allows to be `NULL`,
 /// which is what makes [isNull] available.

--- a/packages/postgrest/lib/src/postgrest_filter_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_filter_builder.dart
@@ -8,6 +8,11 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   PostgrestFilterBuilder<T> copyWithUrl(Uri url) =>
       PostgrestFilterBuilder(_copyWith(url: url));
 
+  /// Appends [value] as another value of the query parameter [key].
+  @internal
+  PostgrestFilterBuilder<T> appendSearchParameter(String key, String value) =>
+      copyWithUrl(_url.appendSearchParameters(key, value));
+
   /// Finds all rows which doesn't satisfy the filter.
   ///
   /// ```dart

--- a/packages/postgrest/lib/src/postgrest_ordering.dart
+++ b/packages/postgrest/lib/src/postgrest_ordering.dart
@@ -1,0 +1,92 @@
+part of 'postgrest_typed_builder.dart';
+
+/// One sort key for [PostgrestTypedTransformBuilder.order]: a column
+/// expression, optionally with a direction and a null placement.
+///
+/// ```dart
+/// .order(Books.priority.desc())
+/// .order(Books.id) // breaks ties in the first; direction left to PostgREST
+/// ```
+///
+/// Only what was asked for is sent: `order(Books.id)` renders `order=id`,
+/// and `Books.title.nullsFirst()` renders `title.nullsfirst`.
+///
+/// [Row] is the row type of the table the key belongs to, so an ordering on
+/// one table cannot be applied to a query on another.
+@experimental
+sealed class PostgrestOrdering<Row> {
+  const PostgrestOrdering._();
+
+  /// The rendered key as it appears in the `order` parameter, for example
+  /// `title.desc.nullslast`.
+  String get orderKey;
+
+  /// Sorts smallest first.
+  PostgrestOrdering<Row> asc();
+
+  /// Sorts largest first.
+  PostgrestOrdering<Row> desc();
+
+  /// Places `NULL`s before non-null values.
+  PostgrestOrdering<Row> nullsFirst();
+
+  /// Places `NULL`s after non-null values.
+  PostgrestOrdering<Row> nullsLast();
+}
+
+/// Where `NULL`s sort relative to other values.
+enum _NullPlacement {
+  first('nullsfirst'),
+  last('nullslast');
+
+  const _NullPlacement(this.token);
+
+  final String token;
+}
+
+final class _Ordering<Row> extends PostgrestOrdering<Row> {
+  const _Ordering(
+    this._expression, {
+    SortDirection? direction,
+    _NullPlacement? nulls,
+  }) : _direction = direction,
+       _nulls = nulls,
+       super._();
+
+  final String _expression;
+
+  /// `null` sends no direction, so PostgREST's default applies.
+  final SortDirection? _direction;
+
+  /// `null` sends no placement, so the database default applies.
+  final _NullPlacement? _nulls;
+
+  @override
+  String get orderKey {
+    final direction = _direction == null ? '' : '.${_direction.value}';
+    final placement = _nulls == null ? '' : '.${_nulls.token}';
+    return '$_expression$direction$placement';
+  }
+
+  @override
+  PostgrestOrdering<Row> asc() =>
+      _Ordering(_expression, direction: SortDirection.ascending, nulls: _nulls);
+
+  @override
+  PostgrestOrdering<Row> desc() => _Ordering(
+    _expression,
+    direction: SortDirection.descending,
+    nulls: _nulls,
+  );
+
+  @override
+  PostgrestOrdering<Row> nullsFirst() => _Ordering(
+    _expression,
+    direction: _direction,
+    nulls: _NullPlacement.first,
+  );
+
+  @override
+  PostgrestOrdering<Row> nullsLast() =>
+      _Ordering(_expression, direction: _direction, nulls: _NullPlacement.last);
+}

--- a/packages/postgrest/lib/src/postgrest_table.dart
+++ b/packages/postgrest/lib/src/postgrest_table.dart
@@ -18,14 +18,15 @@ typedef RowConverter<Row> = Row Function(Map<String, dynamic> json);
 ///
 /// class Books {
 ///   static const table = PostgrestTable('books', Book.new);
-///   static const id = TableColumn<int>('id');
-///   static const title = TableColumn<String>('title');
+///   static const id = PostgrestColumn<Book, int>('id');
+///   static const title = PostgrestColumn<Book, String>('title');
 /// }
 ///
 /// final List<Book> books = await client
 ///     .table(Books.table)
 ///     .select()
-///     .where(Books.title.like('%Dart%'));
+///     .where(Books.title.like('%Dart%'))
+///     .order(Books.id.desc());
 /// ```
 ///
 /// Extension types over the decoded JSON map (as above) are the recommended
@@ -191,10 +192,6 @@ sealed class ColumnFilter {
   /// The value the filter compares against.
   Object? get value;
 
-  PostgrestFilterBuilder<dynamic> _apply(
-    PostgrestFilterBuilder<dynamic> builder,
-  );
-
   /// Negates this filter.
   ///
   /// Throws a [StateError] when this filter is already negated, including the
@@ -229,11 +226,6 @@ final class EqFilter extends ComparisonFilter {
 
   @override
   String get operator => 'eq';
-
-  @override
-  PostgrestFilterBuilder<dynamic> _apply(
-    PostgrestFilterBuilder<dynamic> builder,
-  ) => builder.eq(column, value);
 }
 
 /// Only rows where the column does not equal [value]; created by
@@ -244,11 +236,6 @@ final class NeqFilter extends ComparisonFilter {
 
   @override
   String get operator => 'neq';
-
-  @override
-  PostgrestFilterBuilder<dynamic> _apply(
-    PostgrestFilterBuilder<dynamic> builder,
-  ) => builder.neq(column, value);
 }
 
 /// Only rows where the column is greater than [value]; created by
@@ -259,11 +246,6 @@ final class GtFilter extends ComparisonFilter {
 
   @override
   String get operator => 'gt';
-
-  @override
-  PostgrestFilterBuilder<dynamic> _apply(
-    PostgrestFilterBuilder<dynamic> builder,
-  ) => builder.gt(column, value);
 }
 
 /// Only rows where the column is greater than or equal to [value]; created
@@ -274,11 +256,6 @@ final class GteFilter extends ComparisonFilter {
 
   @override
   String get operator => 'gte';
-
-  @override
-  PostgrestFilterBuilder<dynamic> _apply(
-    PostgrestFilterBuilder<dynamic> builder,
-  ) => builder.gte(column, value);
 }
 
 /// Only rows where the column is less than [value]; created by
@@ -289,11 +266,6 @@ final class LtFilter extends ComparisonFilter {
 
   @override
   String get operator => 'lt';
-
-  @override
-  PostgrestFilterBuilder<dynamic> _apply(
-    PostgrestFilterBuilder<dynamic> builder,
-  ) => builder.lt(column, value);
 }
 
 /// Only rows where the column is less than or equal to [value]; created by
@@ -304,11 +276,6 @@ final class LteFilter extends ComparisonFilter {
 
   @override
   String get operator => 'lte';
-
-  @override
-  PostgrestFilterBuilder<dynamic> _apply(
-    PostgrestFilterBuilder<dynamic> builder,
-  ) => builder.lte(column, value);
 }
 
 /// A filter matching rows whose column value equals one of [values]; created
@@ -333,11 +300,6 @@ final class InListFilter extends ColumnFilter {
   // The generic accessor intentionally aliases the semantic field.
   // ignore: match-getter-setter-field-names
   Object get value => values;
-
-  @override
-  PostgrestFilterBuilder<dynamic> _apply(
-    PostgrestFilterBuilder<dynamic> builder,
-  ) => builder.inFilter(column, values);
 }
 
 /// A filter matching rows whose column value is `null`; created by
@@ -354,11 +316,6 @@ final class IsNullFilter extends ColumnFilter {
 
   @override
   Object? get value => null;
-
-  @override
-  PostgrestFilterBuilder<dynamic> _apply(
-    PostgrestFilterBuilder<dynamic> builder,
-  ) => builder.isFilter(column, null);
 }
 
 /// A filter matching rows whose column value is distinct from [value],
@@ -376,11 +333,6 @@ final class IsDistinctFilter extends ColumnFilter {
 
   @override
   String get operator => 'isdistinct';
-
-  @override
-  PostgrestFilterBuilder<dynamic> _apply(
-    PostgrestFilterBuilder<dynamic> builder,
-  ) => builder.isDistinct(column, value);
 }
 
 /// A containment or overlap filter on a json, array, or range column.
@@ -402,11 +354,6 @@ final class ContainsFilter extends ContainmentFilter {
 
   @override
   String get operator => 'cs';
-
-  @override
-  PostgrestFilterBuilder<dynamic> _apply(
-    PostgrestFilterBuilder<dynamic> builder,
-  ) => builder.contains(column, value);
 }
 
 /// Only rows whose value is contained by [value]; created by
@@ -417,11 +364,6 @@ final class ContainedByFilter extends ContainmentFilter {
 
   @override
   String get operator => 'cd';
-
-  @override
-  PostgrestFilterBuilder<dynamic> _apply(
-    PostgrestFilterBuilder<dynamic> builder,
-  ) => builder.containedBy(column, value);
 }
 
 /// Only rows whose value overlaps with [value]; created by
@@ -432,11 +374,6 @@ final class OverlapsFilter extends ContainmentFilter {
 
   @override
   String get operator => 'ov';
-
-  @override
-  PostgrestFilterBuilder<dynamic> _apply(
-    PostgrestFilterBuilder<dynamic> builder,
-  ) => builder.overlaps(column, value);
 }
 
 /// A filter comparing a range column against the range literal [range].
@@ -464,11 +401,6 @@ final class RangeLtFilter extends RangeFilter {
 
   @override
   String get operator => 'sl';
-
-  @override
-  PostgrestFilterBuilder<dynamic> _apply(
-    PostgrestFilterBuilder<dynamic> builder,
-  ) => builder.rangeLt(column, range);
 }
 
 /// Only rows whose range is strictly to the right of [range]; created by
@@ -479,11 +411,6 @@ final class RangeGtFilter extends RangeFilter {
 
   @override
   String get operator => 'sr';
-
-  @override
-  PostgrestFilterBuilder<dynamic> _apply(
-    PostgrestFilterBuilder<dynamic> builder,
-  ) => builder.rangeGt(column, range);
 }
 
 /// Only rows whose range does not extend to the left of [range]; created by
@@ -494,11 +421,6 @@ final class RangeGteFilter extends RangeFilter {
 
   @override
   String get operator => 'nxl';
-
-  @override
-  PostgrestFilterBuilder<dynamic> _apply(
-    PostgrestFilterBuilder<dynamic> builder,
-  ) => builder.rangeGte(column, range);
 }
 
 /// Only rows whose range does not extend to the right of [range]; created by
@@ -509,11 +431,6 @@ final class RangeLteFilter extends RangeFilter {
 
   @override
   String get operator => 'nxr';
-
-  @override
-  PostgrestFilterBuilder<dynamic> _apply(
-    PostgrestFilterBuilder<dynamic> builder,
-  ) => builder.rangeLte(column, range);
 }
 
 /// Only rows whose range is adjacent to [range]; created by
@@ -524,11 +441,6 @@ final class RangeAdjacentFilter extends RangeFilter {
 
   @override
   String get operator => 'adj';
-
-  @override
-  PostgrestFilterBuilder<dynamic> _apply(
-    PostgrestFilterBuilder<dynamic> builder,
-  ) => builder.rangeAdjacent(column, range);
 }
 
 /// A filter matching a text column against a single [pattern].
@@ -556,11 +468,6 @@ final class LikeFilter extends PatternFilter {
 
   @override
   String get operator => 'like';
-
-  @override
-  PostgrestFilterBuilder<dynamic> _apply(
-    PostgrestFilterBuilder<dynamic> builder,
-  ) => builder.like(column, pattern);
 }
 
 /// Only rows matching [pattern] case-insensitively; created by
@@ -571,11 +478,6 @@ final class IlikeFilter extends PatternFilter {
 
   @override
   String get operator => 'ilike';
-
-  @override
-  PostgrestFilterBuilder<dynamic> _apply(
-    PostgrestFilterBuilder<dynamic> builder,
-  ) => builder.ilike(column, pattern);
 }
 
 /// Only rows matching the regular expression [pattern] case-sensitively;
@@ -586,11 +488,6 @@ final class MatchRegexFilter extends PatternFilter {
 
   @override
   String get operator => 'match';
-
-  @override
-  PostgrestFilterBuilder<dynamic> _apply(
-    PostgrestFilterBuilder<dynamic> builder,
-  ) => builder.matchRegex(column, pattern);
 }
 
 /// Only rows matching the regular expression [pattern] case-insensitively;
@@ -601,11 +498,6 @@ final class ImatchRegexFilter extends PatternFilter {
 
   @override
   String get operator => 'imatch';
-
-  @override
-  PostgrestFilterBuilder<dynamic> _apply(
-    PostgrestFilterBuilder<dynamic> builder,
-  ) => builder.imatchRegex(column, pattern);
 }
 
 /// A filter matching a text column against several [patterns] at once.
@@ -633,11 +525,6 @@ final class LikeAllOfFilter extends PatternListFilter {
 
   @override
   String get operator => 'like(all)';
-
-  @override
-  PostgrestFilterBuilder<dynamic> _apply(
-    PostgrestFilterBuilder<dynamic> builder,
-  ) => builder.likeAllOf(column, patterns);
 }
 
 /// Only rows matching any of [patterns] case-sensitively; created by
@@ -648,11 +535,6 @@ final class LikeAnyOfFilter extends PatternListFilter {
 
   @override
   String get operator => 'like(any)';
-
-  @override
-  PostgrestFilterBuilder<dynamic> _apply(
-    PostgrestFilterBuilder<dynamic> builder,
-  ) => builder.likeAnyOf(column, patterns);
 }
 
 /// Only rows matching all of [patterns] case-insensitively; created by
@@ -663,11 +545,6 @@ final class IlikeAllOfFilter extends PatternListFilter {
 
   @override
   String get operator => 'ilike(all)';
-
-  @override
-  PostgrestFilterBuilder<dynamic> _apply(
-    PostgrestFilterBuilder<dynamic> builder,
-  ) => builder.ilikeAllOf(column, patterns);
 }
 
 /// Only rows matching any of [patterns] case-insensitively; created by
@@ -678,11 +555,6 @@ final class IlikeAnyOfFilter extends PatternListFilter {
 
   @override
   String get operator => 'ilike(any)';
-
-  @override
-  PostgrestFilterBuilder<dynamic> _apply(
-    PostgrestFilterBuilder<dynamic> builder,
-  ) => builder.ilikeAnyOf(column, patterns);
 }
 
 /// A full text search filter on a text or tsvector column; created by
@@ -720,11 +592,6 @@ final class TextSearchFilter extends ColumnFilter {
   // The generic accessor intentionally aliases the semantic field.
   // ignore: match-getter-setter-field-names
   Object get value => query;
-
-  @override
-  PostgrestFilterBuilder<dynamic> _apply(
-    PostgrestFilterBuilder<dynamic> builder,
-  ) => builder.textSearch(column, query, config: config, type: type);
 }
 
 /// The negation of another [ColumnFilter], created through
@@ -748,18 +615,4 @@ final class NegatedFilter extends ColumnFilter {
   @override
   NegatedFilter not() =>
       throw StateError('The filter on "$column" is already negated.');
-
-  @override
-  PostgrestFilterBuilder<dynamic> _apply(
-    PostgrestFilterBuilder<dynamic> builder,
-  ) {
-    // The untyped `not` stringifies map values with `Map.toString`, unlike
-    // the json-encoding positive paths such as `contains`, so encode here.
-    final innerValue = inner.value;
-    return builder.not(
-      column,
-      inner.operator,
-      innerValue is Map ? json.encode(innerValue) : innerValue,
-    );
-  }
 }

--- a/packages/postgrest/lib/src/postgrest_transform_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_transform_builder.dart
@@ -122,6 +122,17 @@ class PostgrestTransformBuilder<T> extends RawPostgrestBuilder<T, T, T> {
     return PostgrestTransformBuilder(copyWithUrl(url));
   }
 
+  /// Merges the rendered sort key [key] into the `order` parameter, which
+  /// PostgREST reads once, adding nothing to [key].
+  @internal
+  PostgrestTransformBuilder<T> appendOrderKey(String key) {
+    final existingOrder = _url.queryParameters['order'];
+    final value = existingOrder == null ? key : '$existingOrder,$key';
+    return PostgrestTransformBuilder(
+      copyWithUrl(_url.overrideSearchParameters('order', value)),
+    );
+  }
+
   /// Limits the result with the specified [count].
   ///
   /// ```dart

--- a/packages/postgrest/lib/src/postgrest_typed_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_typed_builder.dart
@@ -3,10 +3,12 @@ import 'dart:convert';
 
 import 'package:meta/meta.dart';
 import 'package:postgrest/postgrest.dart';
+import 'package:supabase_common/supabase_common.dart' show SortDirection;
 
 part 'postgrest_column_expression.dart';
 part 'postgrest_filter.dart';
 part 'postgrest_filter_operators.dart';
+part 'postgrest_ordering.dart';
 part 'postgrest_table.dart';
 part 'postgrest_typed_query_builder.dart';
 part 'postgrest_typed_transform_builder.dart';
@@ -24,6 +26,19 @@ Row? _maybeRowFromJson<Row>(PostgrestTable<Row> table, dynamic data) =>
     data == null ? null : table.rowFromJson(data as Map<String, dynamic>);
 
 void _toVoid(dynamic data) {}
+
+/// The `select` parameter for [columns], or `*` when none are given.
+String _selectList<Row>(List<PostgrestColumnExpression<Row, Object>>? columns) {
+  if (columns == null) return '*';
+  if (columns.isEmpty) {
+    throw ArgumentError.value(
+      columns,
+      'columns',
+      'select needs at least one column',
+    );
+  }
+  return columns.map((column) => column.expression).join(',');
+}
 
 /// A typed PostgREST request that can be awaited.
 ///

--- a/packages/postgrest/lib/src/postgrest_typed_filter_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_typed_filter_builder.dart
@@ -2,8 +2,8 @@ part of 'postgrest_typed_builder.dart';
 
 /// The typed counterpart of [PostgrestFilterBuilder].
 ///
-/// Filters are built from [TableColumn]s and applied with [where], which
-/// checks the value type of each filter against its column at compile time.
+/// Filters are built from [PostgrestColumn]s and applied with [where]; the
+/// value type and the table of each filter are checked at compile time.
 @experimental
 class PostgrestTypedFilterBuilder<Row, T>
     extends PostgrestTypedTransformBuilder<Row, T> {
@@ -18,21 +18,34 @@ class PostgrestTypedFilterBuilder<Row, T>
 
   /// Only rows satisfying [filter].
   ///
-  /// Chain multiple [where] calls to combine filters with logical AND.
+  /// Operators are methods on a column, composed with `&`, `|` and
+  /// [PostgrestFilter.not]:
   ///
   /// ```dart
   /// final List<Book> books = await client
   ///     .table(Books.table)
   ///     .select()
-  ///     .where(Books.id.gt(10))
-  ///     .where(Books.title.like('%Dart%'));
+  ///     .where(
+  ///       (Books.isDone.eq(false) & Books.priority.gt(3)) | Books.id.eq(7),
+  ///     );
   /// ```
-  PostgrestTypedFilterBuilder<Row, T> where(ColumnFilter filter) =>
-      PostgrestTypedFilterBuilder._(
-        filter._apply(_filterBuilder),
-        _table,
-        _convert,
-      );
+  ///
+  /// A filter is a value, so it can be assembled conditionally:
+  ///
+  /// ```dart
+  /// var filter = Books.isDone.eq(false);
+  /// if (priority != null) filter = filter & Books.priority.gte(priority);
+  /// client.table(Books.table).select().where(filter);
+  /// ```
+  ///
+  /// Repeated [where] calls combine with logical AND.
+  PostgrestTypedFilterBuilder<Row, T> where(PostgrestFilter<Row> filter) {
+    var builder = _filterBuilder;
+    for (final parameter in filter.queryParameters) {
+      builder = builder.appendSearchParameter(parameter.key, parameter.value);
+    }
+    return PostgrestTypedFilterBuilder._(builder, _table, _convert);
+  }
 
   /// Only rows satisfying at least one of the [filters].
   ///

--- a/packages/postgrest/lib/src/postgrest_typed_query_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_typed_query_builder.dart
@@ -22,15 +22,29 @@ class PostgrestTypedQueryBuilder<Row> {
 
   /// Perform a SELECT query on the table or view.
   ///
+  /// Without [columns] every column is selected:
+  ///
   /// ```dart
   /// final List<Book> books = await client.table(Books.table).select();
   /// ```
-  PostgrestTypedFilterBuilder<Row, List<Row>> select([String columns = '*']) =>
-      PostgrestTypedFilterBuilder._(
-        _queryBuilder.select(columns),
-        table,
-        (data) => _rowsFromJson(table, data),
-      );
+  ///
+  /// With [columns], only those are, and each has to belong to this table:
+  ///
+  /// ```dart
+  /// final List<Book> books = await client
+  ///     .table(Books.table)
+  ///     .select([Books.id, Books.title]);
+  /// ```
+  ///
+  /// Rows are still converted into [Row], whose getters for the columns left
+  /// out have nothing to read.
+  PostgrestTypedFilterBuilder<Row, List<Row>> select([
+    List<PostgrestColumnExpression<Row, Object>>? columns,
+  ]) => PostgrestTypedFilterBuilder._(
+    _queryBuilder.select(_selectList(columns)),
+    table,
+    (data) => _rowsFromJson(table, data),
+  );
 
   /// Perform an INSERT into the table or view.
   ///

--- a/packages/postgrest/lib/src/postgrest_typed_transform_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_typed_transform_builder.dart
@@ -25,30 +25,32 @@ class PostgrestTypedTransformBuilder<Row, T> extends PostgrestTypedBuilder<T> {
   /// final List<Book> books =
   ///     await client.table(Books.table).insert({'title': 'foo'}).select();
   /// ```
+  ///
+  /// See [PostgrestTypedQueryBuilder.select] for [columns].
   PostgrestTypedTransformBuilder<Row, List<Row>> select([
-    String columns = '*',
+    List<PostgrestColumnExpression<Row, Object>>? columns,
   ]) => PostgrestTypedTransformBuilder._(
-    _transformBuilder.select(columns),
+    _transformBuilder.select(_selectList(columns)),
     _table,
     (data) => _rowsFromJson(_table, data),
   );
 
-  /// Orders the result with the specified [column].
+  /// Sorts the result by [ordering].
   ///
-  /// See [PostgrestTransformBuilder.order] for [ascending], [nullsFirst] and
-  /// [referencedTable].
+  /// The direction is spelled on the column, the same way an operator is, and
+  /// only what was asked for is sent:
+  ///
+  /// ```dart
+  /// .order(Books.title)                       // order=title
+  /// .order(Books.priority.desc())             // order=priority.desc
+  /// .order(Books.dueDate.asc().nullsFirst())  // order=due_date.asc.nullsfirst
+  /// ```
+  ///
+  /// Repeated calls append, so the second key breaks ties in the first.
   PostgrestTypedTransformBuilder<Row, T> order(
-    TableColumn<Object> column, {
-    bool ascending = true,
-    bool nullsFirst = false,
-    String? referencedTable,
-  }) => PostgrestTypedTransformBuilder._(
-    _transformBuilder.order(
-      column.name,
-      ascending: ascending,
-      nullsFirst: nullsFirst,
-      referencedTable: referencedTable,
-    ),
+    PostgrestOrdering<Row> ordering,
+  ) => PostgrestTypedTransformBuilder._(
+    _transformBuilder.appendOrderKey(ordering.orderKey),
     _table,
     _convert,
   );

--- a/packages/postgrest/test/typed_query_test.dart
+++ b/packages/postgrest/test/typed_query_test.dart
@@ -10,15 +10,28 @@ extension type const Book(Map<String, dynamic> _json)
   String get title => _json['title'] as String;
 }
 
+extension type const Author(Map<String, dynamic> _json)
+    implements Map<String, dynamic> {}
+
 const bookRows = '[{"id":1,"title":"a"},{"id":2,"title":"b"}]';
 
 class Books {
   static const table = PostgrestTable('books', Book.new);
-  static const id = TableColumn<int>('id');
-  static const title = TableColumn<String>('title');
-  static const tags = TableColumn<List<String>>('tags');
-  static const ageRange = TableColumn<String>('age_range');
-  static const metadata = TableColumn<Map<String, dynamic>>('metadata');
+  static const id = PostgrestColumn<Book, int>('id');
+  static const title = PostgrestColumn<Book, String>('title');
+  static const tags = PostgrestColumn<Book, List<String>>('tags');
+  static const ageRange = PostgrestColumn<Book, String>('age_range');
+  static const metadata = PostgrestColumn<Book, Map<String, dynamic>>(
+    'metadata',
+  );
+  static const publishedOn = PostgrestNullableColumn<Book, DateTime>(
+    'published_on',
+  );
+}
+
+class Authors {
+  static const table = PostgrestTable('authors', Author.new);
+  static const id = PostgrestColumn<Author, int>('id');
 }
 
 class MockHttpClient extends BaseClient {
@@ -69,6 +82,18 @@ void main() {
       expect(httpClient.lastRequest!.url.path, '/rest/v1/books');
       expect(requestParameters()['select'], '*');
       expect(books.map((book) => book.title), ['a', 'b']);
+    });
+
+    test('selects the given columns', () async {
+      httpClient.responseBody = bookRows;
+
+      await client.table(Books.table).select([Books.id, Books.title]);
+
+      expect(requestParameters()['select'], 'id,title');
+    });
+
+    test('an empty column list throws', () {
+      expect(() => client.table(Books.table).select([]), throwsArgumentError);
     });
 
     test('single returns one row converted into the table row type', () async {
@@ -148,6 +173,52 @@ void main() {
       expect(requestParameters()['title'], 'like.%a%');
     });
 
+    test('a top-level AND renders as separate parameters', () async {
+      await client
+          .table(Books.table)
+          .select()
+          .where(Books.id.gt(1) & Books.title.like('%a%'));
+
+      expect(requestParameters()['id'], 'gt.1');
+      expect(requestParameters()['title'], 'like.%a%');
+    });
+
+    test('an OR renders as one or parameter', () async {
+      await client
+          .table(Books.table)
+          .select()
+          .where(Books.id.eq(1) | Books.title.eq('foo'));
+
+      expect(requestParameters()['or'], '(id.eq.1,title.eq.foo)');
+    });
+
+    test('a nested tree renders groups and escapes group operands', () async {
+      await client
+          .table(Books.table)
+          .select()
+          .where(
+            (Books.id.eq(1) & Books.title.eq('foo,bar')) |
+                Books.id.inFilter([2, 3]).not(),
+          );
+
+      expect(
+        requestParameters()['or'],
+        '(and(id.eq.1,title.eq."foo,bar"),id.not.in.(2,3))',
+      );
+    });
+
+    test('the same column filtered twice keeps both parameters', () async {
+      await client
+          .table(Books.table)
+          .select()
+          .where(Books.id.gt(1) & Books.id.lt(10));
+
+      expect(httpClient.lastRequest!.url.queryParametersAll['id'], [
+        'gt.1',
+        'lt.10',
+      ]);
+    });
+
     test('builds the same URLs as the untyped filters', () async {
       final filters = {
         Books.id.eq(1): ('id', 'eq.1'),
@@ -157,13 +228,13 @@ void main() {
         Books.id.lt(1): ('id', 'lt.1'),
         Books.id.lte(1): ('id', 'lte.1'),
         Books.id.eq(1).not(): ('id', 'not.eq.1'),
-        Books.title.isNull(): ('title', 'is.null'),
-        Books.title.isNotNull(): ('title', 'not.is.null'),
+        Books.publishedOn.isNull(): ('published_on', 'is.null'),
+        Books.publishedOn.isNull().not(): ('published_on', 'not.is.null'),
         Books.id.inFilter([1, 2]): ('id', 'in.(1,2)'),
-        Books.id.isDistinctFrom(5): ('id', 'isdistinct.5'),
-        Books.tags.contains(['a', 'b']): ('tags', 'cs.{"a","b"}'),
-        Books.tags.containedBy(['a', 'b']): ('tags', 'cd.{"a","b"}'),
-        Books.ageRange.overlaps('[2,25)'): ('age_range', 'ov.[2,25)'),
+        Books.id.isDistinct(5): ('id', 'isdistinct.5'),
+        Books.tags.contains(['a', 'b']): ('tags', 'cs.{a,b}'),
+        Books.tags.containedBy(['a', 'b']): ('tags', 'cd.{a,b}'),
+        Books.ageRange.overlapsRange('[2,25)'): ('age_range', 'ov.[2,25)'),
         Books.ageRange.rangeLt('[2,25)'): ('age_range', 'sl.[2,25)'),
         Books.ageRange.rangeGt('[2,25)'): ('age_range', 'sr.[2,25)'),
         Books.ageRange.rangeGte('[2,25)'): ('age_range', 'nxl.[2,25)'),
@@ -182,16 +253,18 @@ void main() {
         ),
         Books.title.matchRegex('^a'): ('title', 'match.^a'),
         Books.title.imatchRegex('^a'): ('title', 'imatch.^a'),
-        Books.title.textSearch(
-          "'fat' & 'cat'",
-          config: 'english',
-        ): (
+        Books.title.textSearch("'fat' & 'cat'", config: 'english'): (
           'title',
           "fts(english).'fat' & 'cat'",
         ),
         Books.title.textSearch('fat cat', type: TextSearchType.websearch): (
           'title',
           'wfts.fat cat',
+        ),
+        Books.metadata.containsJson({'a': 1}): ('metadata', 'cs.{"a":1}'),
+        Books.metadata.containsJson({'a': 1}).not(): (
+          'metadata',
+          'not.cs.{"a":1}',
         ),
       };
 
@@ -207,54 +280,21 @@ void main() {
       }
     });
 
-    test('whereAny combines filters with logical OR', () async {
-      await client.table(Books.table).select().whereAny([
-        Books.id.eq(1),
-        Books.title.eq('foo'),
-      ]);
-
-      expect(requestParameters()['or'], '(id.eq.1,title.eq."foo")');
-    });
-
-    test('whereAny quotes values with reserved characters', () async {
-      await client.table(Books.table).select().whereAny([
-        Books.title.eq('foo,bar'),
-        Books.id.inFilter([1, 2]),
-      ]);
-
-      expect(requestParameters()['or'], '(title.eq."foo,bar",id.in.(1,2))');
-    });
-
-    test('negating a filter twice throws', () {
-      expect(() => Books.id.eq(1).not().not(), throwsStateError);
-    });
-
-    test('negated json containment encodes the value as json', () async {
+    test('a raw filter reaches the request untouched', () async {
       await client
           .table(Books.table)
           .select()
-          .where(Books.metadata.contains({'a': 1}).not());
+          .where(PostgrestFilter.raw('cost::text', 'eq.10'));
 
-      expect(requestParameters()['metadata'], 'not.cs.{"a":1}');
+      expect(requestParameters()['cost::text'], 'eq.10');
     });
 
-    test('whereAny encodes json containment values', () async {
-      await client.table(Books.table).select().whereAny([
-        Books.metadata.contains({'a': 1}),
-        Books.id.eq(1),
-      ]);
-
-      expect(
-        requestParameters()['or'],
-        r'(metadata.cs."{\"a\":1}",id.eq.1)',
-      );
-    });
-
-    test('whereAny without filters throws', () {
-      expect(
-        () => client.table(Books.table).select().whereAny([]),
-        throwsArgumentError,
-      );
+    test('a filter carries the row type of its table', () {
+      // `client.table(Books.table).select().where(Authors.id.eq(1))` is a
+      // compile error: the filter is a PostgrestFilter<Author>. The static
+      // types are what the check rests on.
+      expect(Books.id.eq(1), isA<PostgrestFilter<Book>>());
+      expect(Authors.id.eq(1), isA<PostgrestFilter<Author>>());
     });
   });
 
@@ -279,6 +319,44 @@ void main() {
       httpClient.responseBody = bookRows;
     });
 
+    test('order sends only what was asked for', () async {
+      await client.table(Books.table).select().order(Books.title);
+      expect(
+        requestParameters()['order'],
+        'title',
+        reason: 'a bare column leaves the direction to PostgREST',
+      );
+
+      await client.table(Books.table).select().order(Books.title.desc());
+      expect(requestParameters()['order'], 'title.desc');
+
+      await client
+          .table(Books.table)
+          .select()
+          .order(Books.publishedOn.asc().nullsFirst());
+      expect(requestParameters()['order'], 'published_on.asc.nullsfirst');
+
+      await client
+          .table(Books.table)
+          .select()
+          .order(Books.publishedOn.nullsLast());
+      expect(requestParameters()['order'], 'published_on.nullslast');
+    });
+
+    test('repeated order calls merge into one parameter', () async {
+      // PostgREST honours only the first `order` parameter it sees.
+      await client
+          .table(Books.table)
+          .select()
+          .order(Books.title.desc())
+          .order(Books.id);
+
+      expect(requestParameters()['order'], 'title.desc,id');
+      expect(httpClient.lastRequest!.url.queryParametersAll['order'], [
+        'title.desc,id',
+      ]);
+    });
+
     test('order, limit and range keep the row type', () async {
       final List<Book> books = await client
           .table(Books.table)
@@ -287,11 +365,6 @@ void main() {
           .order(Books.title)
           .limit(2);
 
-      expect(
-        requestParameters()['order'],
-        'title.asc.nullslast',
-        reason: 'order defaults to ascending like the untyped builder',
-      );
       expect(requestParameters()['limit'], '2');
       expect(books, hasLength(2));
 
@@ -327,6 +400,16 @@ void main() {
         contains('return=representation'),
       );
       expect(book.id, 3);
+    });
+
+    test('a trailing select takes columns', () async {
+      httpClient.responseBody = '[{"id":3}]';
+
+      await client.table(Books.table).insert({'title': 'foo'}).select([
+        Books.id,
+      ]);
+
+      expect(requestParameters()['select'], 'id');
     });
 
     test('upsert sets the resolution header', () async {

--- a/packages/supabase/lib/src/supabase_client.dart
+++ b/packages/supabase/lib/src/supabase_client.dart
@@ -247,7 +247,7 @@ class SupabaseClient {
   ///
   /// Unlike [from], results are converted into the row type of [table]
   /// instead of raw `Map<String, dynamic>` data, and filters are built from
-  /// [TableColumn]s, which makes them compile-time checked.
+  /// [PostgrestColumn]s, which makes them compile-time checked.
   ///
   /// ```dart
   /// final List<Book> books = await supabase

--- a/packages/supabase_typegen/README.md
+++ b/packages/supabase_typegen/README.md
@@ -8,8 +8,9 @@ For every table the generator emits:
 - a zero-cost row extension type over the decoded JSON map with typed getters,
 - `Insert` and `Update` value types that enforce required columns at the
   construction site,
-- a `PostgrestTable` definition and `TableColumn` tokens for compile-time
-  checked filters,
+- a `PostgrestTable` definition and `PostgrestColumn` tokens for compile-time
+  checked filters and orderings, with nullable columns as
+  `PostgrestNullableColumn` so `isNull()` only exists where it can match,
 - Dart enums for Postgres enums, with wire-name mapping.
 
 ## Usage
@@ -40,7 +41,7 @@ generate from whatever that database currently contains.
 
 Use `--schema` to generate for a schema other than `public`, and `--import`
 to change which library the generated file imports `PostgrestTable` and
-`TableColumn` from.
+`PostgrestColumn` from.
 
 The metadata comes from the database catalog, so nullability, database
 defaults, and identity columns are exact: a `NOT NULL` column with a default
@@ -52,8 +53,8 @@ columns appear in the row type but not in the insert and update types.
 ```dart
 final books = await client.table(Books.table)
     .select()
-    .where(Books.mood.eq(Mood.happy))
-    .order(Books.createdAt, ascending: false); // List<BooksRow>
+    .where(Books.mood.eq(Mood.happy) & Books.publishedOn.isNull().not())
+    .order(Books.createdAt.desc()); // List<BooksRow>
 
 await client.table(Books.table).insert(
   BooksInsert(title: 'A typed row', tags: ['dart']),

--- a/packages/supabase_typegen/bin/supabase_typegen.dart
+++ b/packages/supabase_typegen/bin/supabase_typegen.dart
@@ -21,7 +21,7 @@ final _argParser = ArgParser()
     defaultsTo: 'package:postgrest/postgrest.dart',
     help:
         'The import the generated file uses for PostgrestTable and '
-        'TableColumn.',
+        'PostgrestColumn.',
   )
   ..addFlag('help', abbr: 'h', negatable: false, help: 'Show this usage.');
 

--- a/packages/supabase_typegen/lib/src/dart_generator.dart
+++ b/packages/supabase_typegen/lib/src/dart_generator.dart
@@ -16,8 +16,8 @@ class _Binding {
 /// [schema].
 ///
 /// The generated code depends only on the library at [importUri], which must
-/// export the typed table access API of `package:postgrest` (`PostgrestTable`
-/// and `TableColumn`).
+/// export the typed table access API of `package:postgrest` (`PostgrestTable`,
+/// `PostgrestColumn` and `PostgrestNullableColumn`).
 String generateDartCode(
   SchemaDescription schema, {
   String importUri = 'package:postgrest/postgrest.dart',
@@ -90,7 +90,8 @@ class _TypeNameRegistry {
     'num',
     'bool',
     'PostgrestTable',
-    'TableColumn',
+    'PostgrestColumn',
+    'PostgrestNullableColumn',
   };
 
   String claim(String name) {
@@ -341,9 +342,13 @@ void _writeNamespace(
     ..writeln();
   for (final column in table.columns) {
     final binding = bindings[column.name]!;
+    final columnType = column.isNullable
+        ? 'PostgrestNullableColumn'
+        : 'PostgrestColumn';
     buffer.writeln(
       '  static const ${columnNames[column.name]} = '
-      'TableColumn<${binding.dartType}>(${_stringLiteral(column.name)});',
+      '$columnType<$rowType, ${binding.dartType}>'
+      '(${_stringLiteral(column.name)});',
     );
   }
   buffer

--- a/packages/supabase_typegen/test/dart_generator_test.dart
+++ b/packages/supabase_typegen/test/dart_generator_test.dart
@@ -89,7 +89,7 @@ void main() {
 
     expect(code, contains('AuthorsInsert({required String name})'));
     expect(code, contains('AuthorsUpdate({String? name})'));
-    expect(code, contains("TableColumn<int>('id')"));
+    expect(code, contains("PostgrestColumn<AuthorsRow, int>('id')"));
   });
 
   test('read-only views and materialized views generate no insert or '
@@ -114,7 +114,12 @@ void main() {
     final code = generateDartCode(schema);
 
     expect(code, contains('num? get discountedPrice'));
-    expect(code, contains("TableColumn<num>('discounted_price')"));
+    expect(
+      _normalize(code),
+      contains(
+        "PostgrestNullableColumn<BookPricesRow, num>( 'discounted_price', )",
+      ),
+    );
     expect(
       code,
       contains('BookPricesInsert({int? id, num? price, String? title})'),

--- a/packages/supabase_typegen/test/goldens/hostile_schema.dart
+++ b/packages/supabase_typegen/test/goldens/hostile_schema.dart
@@ -114,10 +114,18 @@ class PostgrestTable$ {
   /// Table definition for [PostgrestClient.table].
   static const table = PostgrestTable('postgrest_table', PostgrestTableRow.new);
 
-  static const quoteNameTail = TableColumn<String>('quote\'name\u{2029}tail');
-  static const mood = TableColumn<String$>('mood');
-  static const samples = TableColumn<List<double>>('samples');
-  static const days = TableColumn<List<String>>('days');
+  static const quoteNameTail = PostgrestColumn<PostgrestTableRow, String>(
+    'quote\'name\u{2029}tail',
+  );
+  static const mood = PostgrestNullableColumn<PostgrestTableRow, String$>(
+    'mood',
+  );
+  static const samples = PostgrestColumn<PostgrestTableRow, List<double>>(
+    'samples',
+  );
+  static const days = PostgrestNullableColumn<PostgrestTableRow, List<String>>(
+    'days',
+  );
 }
 
 /// A row of the `map` table.
@@ -168,6 +176,8 @@ class Map$ {
   /// Table definition for [PostgrestClient.table].
   static const table = PostgrestTable('map', MapRow.new);
 
-  static const list = TableColumn<int>('list');
-  static const dateTime = TableColumn<DateTime>('date_time');
+  static const list = PostgrestColumn<MapRow, int>('list');
+  static const dateTime = PostgrestNullableColumn<MapRow, DateTime>(
+    'date_time',
+  );
 }

--- a/packages/supabase_typegen/test/goldens/supabase_schema.dart
+++ b/packages/supabase_typegen/test/goldens/supabase_schema.dart
@@ -47,8 +47,12 @@ class AuthorStats {
   /// Table definition for [PostgrestClient.table].
   static const table = PostgrestTable('author_stats', AuthorStatsRow.new);
 
-  static const authorId = TableColumn<int>('author_id');
-  static const bookCount = TableColumn<int>('book_count');
+  static const authorId = PostgrestNullableColumn<AuthorStatsRow, int>(
+    'author_id',
+  );
+  static const bookCount = PostgrestNullableColumn<AuthorStatsRow, int>(
+    'book_count',
+  );
 }
 
 /// A row of the `authors` table.
@@ -83,8 +87,8 @@ class Authors {
   /// Table definition for [PostgrestClient.table].
   static const table = PostgrestTable('authors', AuthorsRow.new);
 
-  static const id = TableColumn<int>('id');
-  static const name = TableColumn<String>('name');
+  static const id = PostgrestColumn<AuthorsRow, int>('id');
+  static const name = PostgrestColumn<AuthorsRow, String>('name');
 }
 
 /// A row of the `book_prices` table.
@@ -150,10 +154,12 @@ class BookPrices {
   /// Table definition for [PostgrestClient.table].
   static const table = PostgrestTable('book_prices', BookPricesRow.new);
 
-  static const discountedPrice = TableColumn<num>('discounted_price');
-  static const id = TableColumn<int>('id');
-  static const price = TableColumn<num>('price');
-  static const title = TableColumn<String>('title');
+  static const discountedPrice = PostgrestNullableColumn<BookPricesRow, num>(
+    'discounted_price',
+  );
+  static const id = PostgrestNullableColumn<BookPricesRow, int>('id');
+  static const price = PostgrestNullableColumn<BookPricesRow, num>('price');
+  static const title = PostgrestNullableColumn<BookPricesRow, String>('title');
 }
 
 /// A row of the `book_submissions` table.
@@ -173,8 +179,12 @@ class BookSubmissions {
     BookSubmissionsRow.new,
   );
 
-  static const authorName = TableColumn<String>('author_name');
-  static const title = TableColumn<String>('title');
+  static const authorName = PostgrestNullableColumn<BookSubmissionsRow, String>(
+    'author_name',
+  );
+  static const title = PostgrestNullableColumn<BookSubmissionsRow, String>(
+    'title',
+  );
 }
 
 /// A row of the `book_summaries` table.
@@ -193,9 +203,13 @@ class BookSummaries {
   /// Table definition for [PostgrestClient.table].
   static const table = PostgrestTable('book_summaries', BookSummariesRow.new);
 
-  static const authorName = TableColumn<String>('author_name');
-  static const id = TableColumn<int>('id');
-  static const title = TableColumn<String>('title');
+  static const authorName = PostgrestNullableColumn<BookSummariesRow, String>(
+    'author_name',
+  );
+  static const id = PostgrestNullableColumn<BookSummariesRow, int>('id');
+  static const title = PostgrestNullableColumn<BookSummariesRow, String>(
+    'title',
+  );
 }
 
 /// A row of the `books` table.
@@ -402,20 +416,28 @@ class Books {
   /// Table definition for [PostgrestClient.table].
   static const table = PostgrestTable('books', BooksRow.new);
 
-  static const authorId = TableColumn<int>('author_id');
-  static const coverUuid = TableColumn<String>('cover_uuid');
-  static const createdAt = TableColumn<DateTime>('created_at');
-  static const id = TableColumn<int>('id');
-  static const inPrint = TableColumn<bool>('in_print');
-  static const metadata = TableColumn<Object>('metadata');
-  static const mood = TableColumn<Mood>('mood');
-  static const pageCounts = TableColumn<List<int>>('page_counts');
-  static const price = TableColumn<num>('price');
-  static const publishedOn = TableColumn<DateTime>('published_on');
-  static const rating = TableColumn<double>('rating');
-  static const tags = TableColumn<List<String>>('tags');
-  static const title = TableColumn<String>('title');
-  static const updatedAt = TableColumn<DateTime>('updated_at');
+  static const authorId = PostgrestColumn<BooksRow, int>('author_id');
+  static const coverUuid = PostgrestNullableColumn<BooksRow, String>(
+    'cover_uuid',
+  );
+  static const createdAt = PostgrestColumn<BooksRow, DateTime>('created_at');
+  static const id = PostgrestColumn<BooksRow, int>('id');
+  static const inPrint = PostgrestColumn<BooksRow, bool>('in_print');
+  static const metadata = PostgrestNullableColumn<BooksRow, Object>('metadata');
+  static const mood = PostgrestNullableColumn<BooksRow, Mood>('mood');
+  static const pageCounts = PostgrestNullableColumn<BooksRow, List<int>>(
+    'page_counts',
+  );
+  static const price = PostgrestNullableColumn<BooksRow, num>('price');
+  static const publishedOn = PostgrestNullableColumn<BooksRow, DateTime>(
+    'published_on',
+  );
+  static const rating = PostgrestNullableColumn<BooksRow, double>('rating');
+  static const tags = PostgrestNullableColumn<BooksRow, List<String>>('tags');
+  static const title = PostgrestColumn<BooksRow, String>('title');
+  static const updatedAt = PostgrestNullableColumn<BooksRow, DateTime>(
+    'updated_at',
+  );
 }
 
 String _dateString(DateTime date) =>

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -1174,6 +1174,18 @@ features:
       - SupabaseStreamBuilder.order
       - PostgrestTypedTransformBuilder.order
       - SupabaseTypedStreamBuilder.order
+      - PostgrestOrderableExpression.asc
+      - PostgrestOrderableExpression.desc
+      - PostgrestOrderableExpression.nullsFirst
+      - PostgrestOrderableExpression.nullsLast
+      - PostgrestOrderableExpression.orderKey
+    supporting_symbols:
+      - PostgrestOrdering
+      - PostgrestOrdering.orderKey
+      - PostgrestOrdering.asc
+      - PostgrestOrdering.desc
+      - PostgrestOrdering.nullsFirst
+      - PostgrestOrdering.nullsLast
   database.using_modifiers.limit:
     status: implemented
     symbols:


### PR DESCRIPTION
Stack 3/7 for SDK-1741. Base: `lukasklingsbo/sdk-1741-2-filter-operators`.

```dart
final books = await client
    .table(Books.table)
    .select([Books.id, Books.title])
    .where((Books.isDone.eq(false) & Books.priority.gt(3)) | Books.id.eq(7))
    .order(Books.dueDate.desc().nullsFirst());
```

`where` takes a `PostgrestFilter<Row>`, so a whole boolean expression is one call instead of a chain of per-operator methods, and a filter that depends on runtime state is assembled as a value. `order` takes a `PostgrestOrdering<Row>`; a bare orderable expression is one with no direction, so `order(Books.title)` sends `order=title` and lets PostgREST apply its default, `.asc()`/`.desc()` are for when it matters and chain into `.nullsFirst()`/`.nullsLast()`. Repeated `order` calls merge into the single `order` parameter PostgREST reads. `select` takes a list of column expressions instead of a string, since the typed surface is about not spelling columns as strings; `select()` still means `*`.

A `PostgrestOrdering` holds a `SortDirection` and a null placement enum, so the `asc`/`desc`/`nullsfirst`/`nullslast` tokens appear only where the key is rendered.

Two `@internal` hooks on the string builders carry a rendered filter and a rendered order key to the request without going through methods that would re-render them.

`supabase_typegen` emits `PostgrestColumn<BooksRow, int>` for a `NOT NULL` column and `PostgrestNullableColumn` for a nullable one, so `isNull()` exists exactly where it can match. The generator and `where` move together because the generated code has to compile against whichever `where` exists.

`TableColumn` and the `ColumnFilter` hierarchy still exist for the realtime stream; they go in 4/7.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added strongly typed column selection for queries and transformations.
  - Added composable filtering with typed expressions, including nested AND/OR logic.
  - Added fluent ordering with ascending/descending direction and null placement controls.
  - Generated Dart clients now use typed, nullability-aware column definitions.

- **Documentation**
  - Updated examples and API guidance for typed selection, filtering, and ordering.
  - Clarified nullable-column behavior and updated generated-code usage instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->