### PR TITLE
feat(postgrest): add casts and JSON paths as column expressions

### DIFF
--- a/packages/postgrest/lib/src/postgrest_column_expression.dart
+++ b/packages/postgrest/lib/src/postgrest_column_expression.dart
@@ -21,6 +21,45 @@ sealed class PostgrestColumnExpression<Row, Value extends Object> {
   /// operator.
   String get expression;
 
+  /// Applies [derivation] where PostgREST expects it: appended, or inside an
+  /// embedded projection's parentheses.
+  PostgrestDerivedExpression<Row, Derived> _derive<Derived extends Object>(
+    String derivation,
+  ) => PostgrestDerivedExpression._(
+    embed: null,
+    inner: '$expression$derivation',
+  );
+
+  /// Casts this expression to another Postgres type, `cost::text`.
+  ///
+  /// Select position only: PostgREST drops a cast from a filter, so
+  /// `cost::text=eq.10` compares the uncast column, and rejects one in
+  /// `order`. Make it the last step in a chain, since PostgREST applies only
+  /// the first of two casts and rejects a JSON path on a cast.
+  PostgrestDerivedExpression<Row, Target> cast<Target extends Object>(
+    PostgrestCastTarget<Target> target,
+  ) => _derive('::${target.sqlType}');
+
+  /// Reads a `json`/`jsonb` path as text, with `->>`.
+  ///
+  /// ```dart
+  /// .where(Items.data.jsonText('name').eq('Ada')) // data->>name=eq.Ada
+  /// ```
+  ///
+  /// Comparison is textual, so `data->>n=gt.2` excludes a row where `n` is
+  /// `10`; use [jsonObject] for numeric comparison. The result keeps the
+  /// positions of what it was applied to.
+  PostgrestColumnExpression<Row, String> jsonText(String path);
+
+  /// Reads a `json`/`jsonb` path as JSON, with `->`.
+  ///
+  /// Comparison is numeric for numbers, so `data->n=gt.2` includes a row
+  /// where `n` is `10`.
+  ///
+  /// The result keeps this expression's [Value], but `->` returns `jsonb`;
+  /// chain [jsonText] or [cast] to reach a scalar.
+  PostgrestColumnExpression<Row, Value> jsonObject(String path);
+
   @override
   String toString() => expression;
 }
@@ -301,6 +340,14 @@ final class PostgrestColumn<Row, Value extends Object>
   @override
   // ignore: match-getter-setter-field-names
   String get expression => name;
+
+  @override
+  PostgrestJsonPath<Row, String> jsonText(String path) =>
+      PostgrestJsonPath._('$name->>$path');
+
+  @override
+  PostgrestJsonPath<Row, Value> jsonObject(String path) =>
+      PostgrestJsonPath._('$name->$path');
 }
 
 /// A stored column the database allows to be `NULL`.

--- a/packages/postgrest/lib/src/postgrest_derived_expression.dart
+++ b/packages/postgrest/lib/src/postgrest_derived_expression.dart
@@ -1,0 +1,99 @@
+part of 'postgrest_typed_builder.dart';
+
+/// A Postgres type to cast to, paired with the Dart type that cast produces so
+/// the two cannot disagree.
+///
+/// A type with no shipped target is still reachable:
+/// `PostgrestCastTarget<String>('citext')`.
+@experimental
+// ignore: avoid-unused-generics
+final class PostgrestCastTarget<Value extends Object> {
+  /// Creates a target for the Postgres type called [sqlType], as it appears
+  /// after `::`.
+  const PostgrestCastTarget(this.sqlType);
+
+  /// `::text`
+  static const text = PostgrestCastTarget<String>('text');
+
+  /// `::int`
+  static const integer = PostgrestCastTarget<int>('int');
+
+  /// `::float8`
+  static const doublePrecision = PostgrestCastTarget<double>('float8');
+
+  /// `::boolean`
+  static const boolean = PostgrestCastTarget<bool>('boolean');
+
+  /// The Postgres type name, as it appears after `::`.
+  final String sqlType;
+}
+
+/// A cast or an aggregate applied to another expression: select position
+/// only, whatever it was applied to.
+///
+/// PostgREST drops a cast from a filter, has no `HAVING` for an aggregate and
+/// rejects both in `order`. A JSON path chained onto one stays select-only,
+/// and a derivation of an embedded column stays inside the embed's
+/// parentheses, `todo(amount::text)`.
+@experimental
+final class PostgrestDerivedExpression<Row, Value extends Object>
+    extends PostgrestColumnExpression<Row, Value> {
+  const PostgrestDerivedExpression._({
+    required String? embed,
+    required String inner,
+  }) : _embed = embed,
+       _inner = inner,
+       super._();
+
+  final String? _embed;
+  final String _inner;
+
+  @override
+  String get expression => switch (_embed) {
+    null => _inner,
+    final embed => '$embed($_inner)',
+  };
+
+  /// Keeps the embed, so a chained derivation stays inside the parentheses.
+  @override
+  PostgrestDerivedExpression<Row, Derived> _derive<Derived extends Object>(
+    String derivation,
+  ) => PostgrestDerivedExpression._(
+    embed: _embed,
+    inner: '$_inner$derivation',
+  );
+
+  @override
+  PostgrestDerivedExpression<Row, String> jsonText(String path) =>
+      _derive('->>$path');
+
+  @override
+  PostgrestDerivedExpression<Row, Value> jsonObject(String path) =>
+      _derive('->$path');
+}
+
+/// A JSON path read from a stored column, at every position the column is.
+///
+/// Filters and orders like the column it was read from, and is null-testable
+/// whatever the column's own nullability: `data->>name` is `NULL` when the
+/// key is absent, even on a `NOT NULL` `jsonb` column.
+@experimental
+final class PostgrestJsonPath<Row, Value extends Object>
+    extends PostgrestColumnExpression<Row, Value>
+    with
+        PostgrestFilterableExpression<Row, Value>,
+        PostgrestOrderableExpression<Row, Value>,
+        PostgrestNullableExpression<Row, Value> {
+  const PostgrestJsonPath._(this.expression) : super._();
+
+  @override
+  final String expression;
+
+  @override
+  PostgrestJsonPath<Row, String> jsonText(String path) =>
+      PostgrestJsonPath._('$expression->>$path');
+
+  @override
+  PostgrestJsonPath<Row, Value> jsonObject(String path) =>
+      PostgrestJsonPath._('$expression->$path');
+}

--- a/packages/postgrest/lib/src/postgrest_typed_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_typed_builder.dart
@@ -6,6 +6,7 @@ import 'package:postgrest/postgrest.dart';
 import 'package:supabase_common/supabase_common.dart' show SortDirection;
 
 part 'postgrest_column_expression.dart';
+part 'postgrest_derived_expression.dart';
 part 'postgrest_filter.dart';
 part 'postgrest_filter_operators.dart';
 part 'postgrest_ordering.dart';

--- a/packages/postgrest/test/postgrest_derived_expression_test.dart
+++ b/packages/postgrest/test/postgrest_derived_expression_test.dart
@@ -1,0 +1,146 @@
+import 'package:postgrest/postgrest.dart';
+import 'package:test/test.dart';
+
+extension type const Item(Map<String, dynamic> _json)
+    implements Map<String, dynamic> {}
+
+class Items {
+  static const cost = PostgrestColumn<Item, double>('cost');
+  static const data = PostgrestColumn<Item, Map<String, Object?>>('data');
+}
+
+String rendered(PostgrestFilter<Item> filter) => [
+  for (final parameter in filter.queryParameters)
+    '${parameter.key}=${parameter.value}',
+].join('&');
+
+void main() {
+  group('cast', () {
+    test('renders the double colon form', () {
+      expect(
+        Items.cost.cast(PostgrestCastTarget.text).expression,
+        'cost::text',
+      );
+      expect(
+        Items.cost.cast(PostgrestCastTarget.integer).expression,
+        'cost::int',
+      );
+      expect(
+        Items.cost.cast(PostgrestCastTarget.doublePrecision).expression,
+        'cost::float8',
+      );
+      expect(
+        Items.cost.cast(PostgrestCastTarget.boolean).expression,
+        'cost::boolean',
+      );
+    });
+
+    test('is selectable and nothing else', () {
+      // Neither `Items.cost.cast(PostgrestCastTarget.text).eq('10')` nor
+      // `.asc()` compiles, and both misbehave on the wire: the filter answers
+      // 200 with the cast dropped, the order is a 400.
+      const Object costText = PostgrestCastTarget.text;
+      final Object cast = Items.cost.cast(PostgrestCastTarget.text);
+
+      expect(costText, isA<PostgrestCastTarget<String>>());
+      expect(cast, isA<PostgrestColumnExpression<Item, String>>());
+      expect(cast, isNot(isA<PostgrestFilterableExpression<Item, String>>()));
+      expect(cast, isNot(isA<PostgrestOrderableExpression<Item, String>>()));
+    });
+
+    test(
+      'a JSON path chained onto a cast inherits its select-only position',
+      () {
+        // PostgREST rejects `cost::text->>k` in every position, so select-only
+        // is as tight as the type system gets without forbidding the chain.
+        final Object composed = Items.cost
+            .cast(PostgrestCastTarget.text)
+            .jsonText('k');
+
+        expect(
+          Items.cost.cast(PostgrestCastTarget.text).jsonText('k').expression,
+          'cost::text->>k',
+        );
+        expect(
+          composed,
+          isNot(isA<PostgrestFilterableExpression<Item, String>>()),
+        );
+        expect(
+          composed,
+          isNot(isA<PostgrestOrderableExpression<Item, String>>()),
+        );
+      },
+    );
+
+    test('a custom target names its own Dart type', () {
+      const citext = PostgrestCastTarget<String>('citext');
+
+      expect(Items.data.cast(citext).expression, 'data::citext');
+      expect(
+        Items.data.cast(citext),
+        isA<PostgrestColumnExpression<Item, String>>(),
+      );
+    });
+  });
+
+  group('JSON paths', () {
+    test('render their arrows', () {
+      expect(Items.data.jsonText('name').expression, 'data->>name');
+      expect(Items.data.jsonObject('meta').expression, 'data->meta');
+      expect(
+        Items.data.jsonObject('meta').jsonText('name').expression,
+        'data->meta->>name',
+      );
+    });
+
+    test('compose with every operator', () {
+      final name = Items.data.jsonText('name');
+
+      expect(rendered(name.eq('Ada')), 'data->>name=eq.Ada');
+      expect(rendered(name.like('A%')), 'data->>name=like.A%');
+      expect(
+        rendered(name.inFilter(['Ada', 'Bob'])),
+        'data->>name=in.(Ada,Bob)',
+      );
+      expect(name.asc().orderKey, 'data->>name.asc');
+    });
+
+    test('are null-testable on a NOT NULL column', () {
+      // `data` is a NOT NULL column here and `data->>name` is still NULL when
+      // the key is absent.
+      expect(
+        rendered(Items.data.jsonText('name').isNull()),
+        'data->>name=is.null',
+      );
+      expect(
+        rendered(Items.data.jsonText('name').isNull().not()),
+        'data->>name=not.is.null',
+      );
+    });
+
+    test('only a filterable derivation is null-testable', () {
+      final Object path = Items.data.jsonText('name');
+      final Object cast = Items.cost.cast(PostgrestCastTarget.text);
+      const Object column = Items.cost;
+
+      expect(path, isA<PostgrestNullableExpression<Item, String>>());
+      expect(cast, isNot(isA<PostgrestNullableExpression<Item, String>>()));
+      expect(column, isNot(isA<PostgrestNullableExpression<Item, double>>()));
+    });
+
+    test('work inside a group', () {
+      // `cost` is a double column, so `.eq(2)` renders `cost.eq.2.0`, which is
+      // what the SDK sends.
+      final filter = Items.data.jsonText('name').eq('Ada') | Items.cost.eq(2);
+
+      expect(rendered(filter), 'or=(data->>name.eq.Ada,cost.eq.2.0)');
+    });
+
+    test('keep the value type through jsonObject', () {
+      expect(
+        Items.data.jsonObject('meta'),
+        isA<PostgrestColumnExpression<Item, Map<String, Object?>>>(),
+      );
+    });
+  });
+}

--- a/packages/postgrest/test/typed_query_test.dart
+++ b/packages/postgrest/test/typed_query_test.dart
@@ -92,6 +92,18 @@ void main() {
       expect(requestParameters()['select'], 'id,title');
     });
 
+    test('selects casts and JSON paths', () async {
+      httpClient.responseBody = bookRows;
+
+      await client.table(Books.table).select([
+        Books.id,
+        Books.title.cast(PostgrestCastTarget.text),
+        Books.metadata.jsonText('isbn'),
+      ]);
+
+      expect(requestParameters()['select'], 'id,title::text,metadata->>isbn');
+    });
+
     test('an empty column list throws', () {
       expect(() => client.table(Books.table).select([]), throwsArgumentError);
     });
@@ -341,6 +353,15 @@ void main() {
           .select()
           .order(Books.publishedOn.nullsLast());
       expect(requestParameters()['order'], 'published_on.nullslast');
+    });
+
+    test('order accepts a JSON path', () async {
+      await client
+          .table(Books.table)
+          .select()
+          .order(Books.metadata.jsonText('isbn').asc());
+
+      expect(requestParameters()['order'], 'metadata->>isbn.asc');
     });
 
     test('repeated order calls merge into one parameter', () async {

--- a/packages/supabase/test/mock_test.dart
+++ b/packages/supabase/test/mock_test.dart
@@ -913,6 +913,16 @@ void main() {
       );
     });
 
+    test('a JSON path filter throws', () {
+      unawaited(handleRequests(mockServer));
+      final stream = supabase.table(Todos.table).stream(primaryKey: [Todos.id]);
+
+      expect(
+        () => stream.filter(Todos.task.jsonText('k').eq('x')),
+        throwsArgumentError,
+      );
+    });
+
     test('a composed filter throws', () {
       unawaited(handleRequests(mockServer));
       final stream = supabase.table(Todos.table).stream(primaryKey: [Todos.id]);

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -796,6 +796,27 @@ features:
       - PostgrestTypedQueryBuilder.count
       - PostgrestTypedTransformBuilder
       - PostgrestTypedTransformBuilder.count
+    supporting_symbols:
+      - PostgrestColumnExpression.cast
+      - PostgrestColumnExpression.jsonText
+      - PostgrestColumnExpression.jsonObject
+      - PostgrestColumn.jsonText
+      - PostgrestColumn.jsonObject
+      - PostgrestCastTarget
+      - PostgrestCastTarget.PostgrestCastTarget
+      - PostgrestCastTarget.sqlType
+      - PostgrestCastTarget.text
+      - PostgrestCastTarget.integer
+      - PostgrestCastTarget.doublePrecision
+      - PostgrestCastTarget.boolean
+      - PostgrestDerivedExpression
+      - PostgrestDerivedExpression.expression
+      - PostgrestDerivedExpression.jsonText
+      - PostgrestDerivedExpression.jsonObject
+      - PostgrestJsonPath
+      - PostgrestJsonPath.expression
+      - PostgrestJsonPath.jsonText
+      - PostgrestJsonPath.jsonObject
   database.query.rpc:
     status: implemented
     note: "head and count are applied via type-safe chaining (.head()/.count()) rather than inline call options, which is the idiomatic Dart builder pattern; inline options cannot preserve the distinct return types."


### PR DESCRIPTION
Stack 5/7 for SDK-1741. Base: `lukasklingsbo/sdk-1741-4-remove-table-column`.

`cast(PostgrestCastTarget.text)` renders `cost::text`; `jsonText('name')` renders `data->>name` and `jsonObject('n')` renders `data->n`. All three are declared on `PostgrestColumnExpression`, so they chain.

A cast is a `PostgrestDerivedExpression`, which is select position only: PostgREST 16.1 answers `cost::text=eq.10` with 200 and drops the cast from the SQL, so the filter silently compares the uncast column, and `order=cost::text.desc` is a 400. Both are therefore compile errors. `PostgrestCastTarget<T>` pairs the Postgres type with the Dart type the cast produces; `text`, `integer`, `doublePrecision` (spelled `float8`, since a type name with a space does not belong in a query string) and `boolean` ship, and any other type is reachable through the constructor.

A JSON path keeps the positions of what it was read from. On a stored column it is a `PostgrestJsonPath`, which filters, orders and is null-testable whatever the column's own nullability, since `data->>name` is `NULL` when the key is absent. On a cast it stays select-only, so filtering `cost::text->>k`, a 400, does not compile.

`jsonText` versus `jsonObject` is the `->>` / `->` distinction and it changes results: `->>` yields text, so `data->>n=eq.10` misses the row where `n` is the number `10`.

A single `_derive` hook on the base class places a derivation where PostgREST expects it, so the embedded columns in 7/7 can put a cast inside the embed's parentheses without redeclaring the accessors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added typed PostgreSQL column casts for text, integer, double-precision, and Boolean values.
  * Added JSON text and object path expressions that can be chained, filtered, sorted, and checked for null values.
  * Enabled casts and JSON paths in typed selections and ordering.
  * Preserved JSON value types when composing object-path expressions.

* **Bug Fixes**
  * Prevented unsupported JSON path filters on typed realtime streams by reporting an argument error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->