### PR TITLE
feat(postgrest): add aggregate functions as select-only expressions

### DIFF
--- a/packages/postgrest/lib/src/postgrest_column_expression.dart
+++ b/packages/postgrest/lib/src/postgrest_column_expression.dart
@@ -60,8 +60,63 @@ sealed class PostgrestColumnExpression<Row, Value extends Object> {
   /// chain [jsonText] or [cast] to reach a scalar.
   PostgrestColumnExpression<Row, Value> jsonObject(String path);
 
+  /// The sum of this expression across the group, typed [double] whatever
+  /// the column's type. Past 2^53 the value rounds silently.
+  ///
+  /// {@template postgrest_aggregate}
+  /// Select position only: PostgREST has no `HAVING` and rejects an aggregate
+  /// in `order`. Selecting a plain column alongside an aggregate groups by
+  /// it. Needs PostgREST's `db-aggregates-enabled` setting, which is on for
+  /// hosted Supabase. The response is keyed by the function name alone, so
+  /// two aggregates of the same function in one `select` collide. `sum`,
+  /// `avg`, `min` and `max` are `null` when no row matches; the type
+  /// parameter describes a present value.
+  /// {@endtemplate}
+  PostgrestDerivedExpression<Row, double> sum() =>
+      _derive(_AggregateFunction.sum.suffix);
+
+  /// The mean of this expression across the group.
+  ///
+  /// {@macro postgrest_aggregate}
+  PostgrestDerivedExpression<Row, double> avg() =>
+      _derive(_AggregateFunction.avg.suffix);
+
+  /// The smallest value of this expression in the group, keeping the
+  /// expression's own type.
+  ///
+  /// {@macro postgrest_aggregate}
+  PostgrestDerivedExpression<Row, Value> min() =>
+      _derive(_AggregateFunction.min.suffix);
+
+  /// The largest value of this expression in the group, keeping the
+  /// expression's own type.
+  ///
+  /// {@macro postgrest_aggregate}
+  PostgrestDerivedExpression<Row, Value> max() =>
+      _derive(_AggregateFunction.max.suffix);
+
+  /// How many non-null values of this expression are in the group.
+  ///
+  /// Use [PostgrestDerivedExpression.countAll] to count rows instead.
+  ///
+  /// {@macro postgrest_aggregate}
+  PostgrestDerivedExpression<Row, int> count() =>
+      _derive(_AggregateFunction.count.suffix);
+
   @override
   String toString() => expression;
+}
+
+/// The aggregate functions PostgREST applies to a `select` list entry.
+enum _AggregateFunction {
+  sum,
+  avg,
+  min,
+  max,
+  count;
+
+  /// The call appended to the expression, `.sum()`.
+  String get suffix => '.$name()';
 }
 
 /// A column expression that can also sit on the left of a filter operator.

--- a/packages/postgrest/lib/src/postgrest_derived_expression.dart
+++ b/packages/postgrest/lib/src/postgrest_derived_expression.dart
@@ -28,8 +28,8 @@ final class PostgrestCastTarget<Value extends Object> {
   final String sqlType;
 }
 
-/// A cast or an aggregate applied to another expression: select position
-/// only, whatever it was applied to.
+/// A cast or an aggregate applied to another expression, or [countAll]:
+/// select position only, whatever it was applied to.
 ///
 /// PostgREST drops a cast from a filter, has no `HAVING` for an aggregate and
 /// rejects both in `order`. A JSON path chained onto one stays select-only,
@@ -47,6 +47,18 @@ final class PostgrestDerivedExpression<Row, Value extends Object>
 
   final String? _embed;
   final String _inner;
+
+  /// `count()`, which counts rows rather than the values of a column.
+  ///
+  /// ```dart
+  /// final rows = await client
+  ///     .table(Orders.table)
+  ///     .select([PostgrestDerivedExpression.countAll()]); // select=count()
+  /// ```
+  ///
+  /// {@macro postgrest_aggregate}
+  static PostgrestDerivedExpression<Row, int> countAll<Row>() =>
+      const PostgrestDerivedExpression._(embed: null, inner: 'count()');
 
   @override
   String get expression => switch (_embed) {

--- a/packages/postgrest/test/postgrest_aggregate_test.dart
+++ b/packages/postgrest/test/postgrest_aggregate_test.dart
@@ -1,0 +1,67 @@
+import 'package:postgrest/postgrest.dart';
+import 'package:test/test.dart';
+
+extension type const Order(Map<String, dynamic> _json)
+    implements Map<String, dynamic> {}
+
+class Orders {
+  static const amount = PostgrestColumn<Order, double>('amount');
+  static const quantity = PostgrestColumn<Order, int>('quantity');
+}
+
+void main() {
+  test('aggregates render their function suffix', () {
+    expect(Orders.amount.sum().expression, 'amount.sum()');
+    expect(Orders.amount.avg().expression, 'amount.avg()');
+    expect(Orders.amount.min().expression, 'amount.min()');
+    expect(Orders.amount.max().expression, 'amount.max()');
+    expect(Orders.amount.count().expression, 'amount.count()');
+  });
+
+  test('aggregates carry the right result type', () {
+    // sum and avg widen to double whatever the column's type, min and max
+    // keep it, and count is always an int.
+    expect(
+      Orders.quantity.sum(),
+      isA<PostgrestDerivedExpression<Order, double>>(),
+    );
+    expect(
+      Orders.quantity.avg(),
+      isA<PostgrestDerivedExpression<Order, double>>(),
+    );
+    expect(
+      Orders.quantity.min(),
+      isA<PostgrestDerivedExpression<Order, int>>(),
+    );
+    expect(
+      Orders.quantity.max(),
+      isA<PostgrestDerivedExpression<Order, int>>(),
+    );
+    expect(
+      Orders.quantity.count(),
+      isA<PostgrestDerivedExpression<Order, int>>(),
+    );
+  });
+
+  test('countAll renders with no column', () {
+    expect(PostgrestDerivedExpression.countAll<Order>().expression, 'count()');
+  });
+
+  test('an aggregate is selectable and nothing else', () {
+    // Neither `Orders.amount.sum().gt(100)` nor `Orders.amount.sum().desc()`
+    // compiles: PostgREST has no HAVING and cannot order by an aggregate.
+    final Object sum = Orders.amount.sum();
+
+    expect(sum, isA<PostgrestColumnExpression<Order, double>>());
+    expect(sum, isNot(isA<PostgrestFilterableExpression<Order, double>>()));
+    expect(sum, isNot(isA<PostgrestOrderableExpression<Order, double>>()));
+    expect(sum, isNot(isA<PostgrestNullableExpression<Order, double>>()));
+  });
+
+  test('a cast on an aggregate lands after the function', () {
+    expect(
+      Orders.amount.sum().cast(PostgrestCastTarget.text).expression,
+      'amount.sum()::text',
+    );
+  });
+}

--- a/packages/postgrest/test/typed_query_test.dart
+++ b/packages/postgrest/test/typed_query_test.dart
@@ -104,6 +104,17 @@ void main() {
       expect(requestParameters()['select'], 'id,title::text,metadata->>isbn');
     });
 
+    test('selects aggregates', () async {
+      httpClient.responseBody = '[{"count":2,"max":"b"}]';
+
+      await client.table(Books.table).select([
+        PostgrestDerivedExpression.countAll(),
+        Books.title.max(),
+      ]);
+
+      expect(requestParameters()['select'], 'count(),title.max()');
+    });
+
     test('an empty column list throws', () {
       expect(() => client.table(Books.table).select([]), throwsArgumentError);
     });

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -809,7 +809,13 @@ features:
       - PostgrestCastTarget.integer
       - PostgrestCastTarget.doublePrecision
       - PostgrestCastTarget.boolean
+      - PostgrestColumnExpression.sum
+      - PostgrestColumnExpression.avg
+      - PostgrestColumnExpression.min
+      - PostgrestColumnExpression.max
+      - PostgrestColumnExpression.count
       - PostgrestDerivedExpression
+      - PostgrestDerivedExpression.countAll
       - PostgrestDerivedExpression.expression
       - PostgrestDerivedExpression.jsonText
       - PostgrestDerivedExpression.jsonObject


### PR DESCRIPTION
Stack 6/7 for SDK-1741. Base: `lukasklingsbo/sdk-1741-5-casts-json-paths`.

`sum()`, `avg()`, `min()`, `max()`, `count()` and `PostgrestDerivedExpression.countAll()` render `amount.sum()` and `count()` in a `select` list.

An aggregate is a `PostgrestDerivedExpression`, select position only, because PostgREST has no `HAVING`: filtering on an aggregate is not a request it can serve, and `order=children(amount.sum()).desc` is a PGRST100. So `Orders.amount.sum().gt(100)` does not compile.

`min()`/`max()` keep the column's type while `sum()`/`avg()` are `double`: a min of an `int` column is an `int`, but a sum can overflow it and an average is rarely integral.

Aggregates need `db-aggregates-enabled`, which is on for hosted Supabase and off by default in self-hosted PostgREST.

Two limitations are documented rather than solved here. PostgREST keys the response by the function name alone, so `[Orders.amount.sum(), Orders.quantity.sum()]` produces two `sum` keys and needs aliasing, tracked as SDK-1757. And `sum`, `avg`, `min` and `max` are `null` in the response when no row matches, which the `Value` type parameter of a select-only expression does not express; it describes a present value, and nothing decodes through it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added aggregate expressions for sums, averages, minimums, maximums, and counts in select queries.
  - Added support for counting all records without specifying a column.
  - Aggregate results preserve appropriate numeric and column value types.
  - Added support for casting aggregate results in queries.
  - Aggregate expressions can be selected but aren’t available for filtering or ordering.

- **Documentation**
  - Updated query capability documentation to include aggregate expressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->