### PR TITLE
feat(postgrest): add embedded relations to the column namespace

### DIFF
--- a/packages/postgrest/lib/src/postgrest_embedded_relation.dart
+++ b/packages/postgrest/lib/src/postgrest_embedded_relation.dart
@@ -1,0 +1,114 @@
+part of 'postgrest_typed_builder.dart';
+
+/// A to-one embedded relation (many-to-one or one-to-one) of the table whose
+/// rows are [Row], pointing at the table whose rows are [Target].
+///
+/// Calling it with a column of the target projects that column into the
+/// parent's `select` list:
+///
+/// ```dart
+/// class Orders {
+///   static const todo = PostgrestToOneRelation<Order, Todo>('todo');
+/// }
+///
+/// Orders.todo(Todos.title).expression // todo(title)
+/// ```
+///
+/// Projections of a to-one embed can be ordered by, unlike those of a
+/// [PostgrestToManyRelation].
+@experimental
+final class PostgrestToOneRelation<Row, Target> {
+  /// Creates a relation PostgREST addresses as [name], including any
+  /// disambiguating foreign key hint such as `authors!books_author_id_fkey`.
+  const PostgrestToOneRelation(this.name);
+
+  /// The name PostgREST addresses the embed by.
+  final String name;
+
+  /// Projects [column] of the embedded table into the parent's frame.
+  PostgrestToOneColumn<Row, Value> call<Value extends Object>(
+    PostgrestColumnExpression<Target, Value> column,
+  ) => PostgrestToOneColumn._(name, column.expression);
+}
+
+/// A to-many embedded relation (one-to-many or many-to-many) of the table
+/// whose rows are [Row], pointing at the table whose rows are [Target].
+///
+/// Its projections are select position only: PostgREST answers
+/// `order=children(amount).desc` with PGRST118.
+@experimental
+final class PostgrestToManyRelation<Row, Target> {
+  /// Creates a relation PostgREST addresses as [name], including any
+  /// disambiguating foreign key hint.
+  const PostgrestToManyRelation(this.name);
+
+  /// The name PostgREST addresses the embed by.
+  final String name;
+
+  /// Projects [column] of the embedded table into the parent's frame.
+  PostgrestToManyColumn<Row, Value> call<Value extends Object>(
+    PostgrestColumnExpression<Target, Value> column,
+  ) => PostgrestToManyColumn._(name, column.expression);
+}
+
+/// A column of an embedded relation, seen from the parent.
+sealed class _EmbeddedColumn<Row, Value extends Object>
+    extends PostgrestColumnExpression<Row, Value> {
+  const _EmbeddedColumn(this._embed, this._inner) : super._();
+
+  final String _embed;
+  final String _inner;
+
+  /// The `select` list form, `parent(title)`.
+  @override
+  String get expression => '$_embed($_inner)';
+
+  /// The filter form, `parent.title`.
+  String get embeddedFilterName => '$_embed.$_inner';
+
+  /// Places the derivation inside the embed's parentheses, where PostgREST
+  /// applies it.
+  @override
+  PostgrestDerivedExpression<Row, Derived> _derive<Derived extends Object>(
+    String derivation,
+  ) => PostgrestDerivedExpression._(
+    embed: _embed,
+    inner: '$_inner$derivation',
+  );
+}
+
+/// A column of a to-one embedded relation, seen from the parent.
+///
+/// Selectable and orderable; filtering inside an embed is not supported.
+@experimental
+final class PostgrestToOneColumn<Row, Value extends Object>
+    extends _EmbeddedColumn<Row, Value>
+    with PostgrestOrderableExpression<Row, Value> {
+  const PostgrestToOneColumn._(super.embed, super.inner);
+
+  @override
+  PostgrestToOneColumn<Row, String> jsonText(String path) =>
+      PostgrestToOneColumn._(_embed, '$_inner->>$path');
+
+  @override
+  PostgrestToOneColumn<Row, Value> jsonObject(String path) =>
+      PostgrestToOneColumn._(_embed, '$_inner->$path');
+}
+
+/// A column of a to-many embedded relation, seen from the parent.
+///
+/// Select position only: PostgREST rejects a to-many embed in `order`, and
+/// filtering inside an embed is not supported.
+@experimental
+final class PostgrestToManyColumn<Row, Value extends Object>
+    extends _EmbeddedColumn<Row, Value> {
+  const PostgrestToManyColumn._(super.embed, super.inner);
+
+  @override
+  PostgrestToManyColumn<Row, String> jsonText(String path) =>
+      PostgrestToManyColumn._(_embed, '$_inner->>$path');
+
+  @override
+  PostgrestToManyColumn<Row, Value> jsonObject(String path) =>
+      PostgrestToManyColumn._(_embed, '$_inner->$path');
+}

--- a/packages/postgrest/lib/src/postgrest_typed_builder.dart
+++ b/packages/postgrest/lib/src/postgrest_typed_builder.dart
@@ -7,6 +7,7 @@ import 'package:supabase_common/supabase_common.dart' show SortDirection;
 
 part 'postgrest_column_expression.dart';
 part 'postgrest_derived_expression.dart';
+part 'postgrest_embedded_relation.dart';
 part 'postgrest_filter.dart';
 part 'postgrest_filter_operators.dart';
 part 'postgrest_ordering.dart';

--- a/packages/postgrest/test/postgrest_embedded_relation_test.dart
+++ b/packages/postgrest/test/postgrest_embedded_relation_test.dart
@@ -1,0 +1,134 @@
+import 'package:postgrest/postgrest.dart';
+import 'package:test/test.dart';
+
+extension type const Order(Map<String, dynamic> _json)
+    implements Map<String, dynamic> {}
+
+extension type const Todo(Map<String, dynamic> _json)
+    implements Map<String, dynamic> {}
+
+class Orders {
+  static const id = PostgrestColumn<Order, int>('id');
+  static const amount = PostgrestColumn<Order, double>('amount');
+  static const shippedAt = PostgrestNullableColumn<Order, DateTime>(
+    'shipped_at',
+  );
+  static const todo = PostgrestToOneRelation<Order, Todo>('todo');
+}
+
+class Todos {
+  static const id = PostgrestColumn<Todo, int>('id');
+  static const title = PostgrestColumn<Todo, String>('title');
+  static const amount = PostgrestColumn<Todo, double>('amount');
+  static const orders = PostgrestToManyRelation<Todo, Order>('orders');
+}
+
+void main() {
+  test('a projected column wraps in the embed name', () {
+    expect(Todos.orders(Orders.amount).expression, 'orders(amount)');
+    expect(Orders.todo(Todos.title).expression, 'todo(title)');
+    expect(Orders.todo.name, 'todo');
+  });
+
+  test('a projected column keeps its value type', () {
+    expect(
+      Todos.orders(Orders.amount),
+      isA<PostgrestColumnExpression<Todo, double>>(),
+    );
+    expect(
+      Todos.orders(Orders.amount).sum(),
+      isA<PostgrestDerivedExpression<Todo, double>>(),
+    );
+    expect(
+      Todos.orders(Orders.shippedAt),
+      isA<PostgrestColumnExpression<Todo, DateTime>>(),
+    );
+  });
+
+  test('an aggregate over an embed renders inside the parentheses', () {
+    // `orders(amount).sum()` is a 200 with the `.sum()` silently ignored.
+    expect(
+      Todos.orders(Orders.amount).sum().expression,
+      'orders(amount.sum())',
+    );
+    expect(Todos.orders(Orders.id).count().expression, 'orders(id.count())');
+    expect(
+      Todos.orders(Orders.amount).avg().expression,
+      'orders(amount.avg())',
+    );
+    expect(Todos.orders(Orders.id).min().expression, 'orders(id.min())');
+    expect(Todos.orders(Orders.id).max().expression, 'orders(id.max())');
+    expect(Orders.todo(Todos.id).sum().expression, 'todo(id.sum())');
+  });
+
+  test('a cast over an embed renders inside the parentheses', () {
+    expect(
+      Todos.orders(Orders.amount).cast(PostgrestCastTarget.text).expression,
+      'orders(amount::text)',
+    );
+    expect(
+      Orders.todo(Todos.id).cast(PostgrestCastTarget.text).expression,
+      'todo(id::text)',
+    );
+  });
+
+  test('a JSON path over an embed renders inside the parentheses', () {
+    expect(
+      Todos.orders(Orders.amount).jsonText('k').expression,
+      'orders(amount->>k)',
+    );
+    expect(
+      Todos.orders(Orders.amount).jsonObject('k').expression,
+      'orders(amount->k)',
+    );
+    expect(Orders.todo(Todos.id).jsonText('k').expression, 'todo(id->>k)');
+    expect(Orders.todo(Todos.id).jsonObject('k').expression, 'todo(id->k)');
+  });
+
+  test('a derivation chained onto a derivation stays inside the embed', () {
+    expect(
+      Orders.todo(Todos.amount).sum().cast(PostgrestCastTarget.text).expression,
+      'todo(amount.sum()::text)',
+    );
+  });
+
+  test('the filter form is dotted and separate', () {
+    final Object projected = Todos.orders(Orders.id);
+
+    expect(Todos.orders(Orders.id).embeddedFilterName, 'orders.id');
+    expect(Orders.todo(Todos.title).embeddedFilterName, 'todo.title');
+    final Object toOne = Orders.todo(Todos.title);
+
+    expect(projected, isNot(isA<PostgrestFilterableExpression<Todo, int>>()));
+    expect(toOne, isNot(isA<PostgrestFilterableExpression<Order, String>>()));
+  });
+
+  test('a to-one projection is orderable but a to-many projection is not', () {
+    // `order=children(amount).desc` is PGRST118 on the server.
+    final Object toMany = Todos.orders(Orders.amount);
+
+    expect(Orders.todo(Todos.title).asc().orderKey, 'todo(title).asc');
+    expect(Orders.todo(Todos.title).desc().orderKey, 'todo(title).desc');
+    expect(Orders.todo(Todos.title).orderKey, 'todo(title)');
+    expect(toMany, isNot(isA<PostgrestOrderableExpression<Todo, double>>()));
+  });
+
+  test('a to-one cast is not orderable but a to-one JSON path is', () {
+    final Object cast = Orders.todo(Todos.id).cast(PostgrestCastTarget.text);
+    final Object sum = Orders.todo(Todos.id).sum();
+
+    expect(cast, isNot(isA<PostgrestOrderableExpression<Order, String>>()));
+    expect(sum, isNot(isA<PostgrestOrderableExpression<Order, double>>()));
+    expect(
+      Orders.todo(Todos.id).jsonText('k').asc().orderKey,
+      'todo(id->>k).asc',
+    );
+  });
+
+  test('embeds nest', () {
+    expect(
+      Orders.todo(Todos.orders(Orders.amount)).expression,
+      'todo(orders(amount))',
+    );
+  });
+}

--- a/packages/postgrest/test/typed_query_test.dart
+++ b/packages/postgrest/test/typed_query_test.dart
@@ -27,11 +27,22 @@ class Books {
   static const publishedOn = PostgrestNullableColumn<Book, DateTime>(
     'published_on',
   );
+  static const author = PostgrestToOneRelation<Book, Author>('author');
 }
 
 class Authors {
   static const table = PostgrestTable('authors', Author.new);
   static const id = PostgrestColumn<Author, int>('id');
+  static const name = PostgrestColumn<Author, String>('name');
+  static const books = PostgrestToManyRelation<Author, Book>('books');
+}
+
+class BookClass {
+  const BookClass();
+}
+
+class AuthorClass {
+  const AuthorClass();
 }
 
 class MockHttpClient extends BaseClient {
@@ -113,6 +124,25 @@ void main() {
       ]);
 
       expect(requestParameters()['select'], 'count(),title.max()');
+    });
+
+    test('selects and orders by embedded columns', () async {
+      httpClient.responseBody = '[{"id":1,"author":{"name":"a"}}]';
+
+      await client
+          .table(Books.table)
+          .select([Books.id, Books.author(Authors.name)])
+          .order(Books.author(Authors.name).desc());
+
+      expect(requestParameters()['select'], 'id,author(name)');
+      expect(requestParameters()['order'], 'author(name).desc');
+
+      await client.table(Authors.table).select([
+        Authors.id,
+        Authors.books(Books.id).count(),
+      ]);
+
+      expect(requestParameters()['select'], 'id,books(id.count())');
     });
 
     test('an empty column list throws', () {
@@ -313,11 +343,13 @@ void main() {
     });
 
     test('a filter carries the row type of its table', () {
-      // `client.table(Books.table).select().where(Authors.id.eq(1))` is a
-      // compile error: the filter is a PostgrestFilter<Author>. The static
-      // types are what the check rests on.
-      expect(Books.id.eq(1), isA<PostgrestFilter<Book>>());
-      expect(Authors.id.eq(1), isA<PostgrestFilter<Author>>());
+      // Book and Author are extension types and erased at runtime, so the
+      // check uses class row types.
+      const id = PostgrestColumn<BookClass, int>('id');
+      final Object filter = id.eq(1);
+
+      expect(filter, isA<PostgrestFilter<BookClass>>());
+      expect(filter, isNot(isA<PostgrestFilter<AuthorClass>>()));
     });
   });
 

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -1123,8 +1123,24 @@ features:
       - PostgrestTransformBuilder.geojson
   database.using_modifiers.relationship_embed:
     status: implemented
+    note: "Two spellings. The string builder takes query-string syntax in select(), for example `author(*)`. The column-expression surface declares a relation once on the table's namespace class as a PostgrestToOneRelation or PostgrestToManyRelation and projects a column through it, `Books.author(Authors.name)`, which is compile-time checked in select position and, for the to-one direction only, in order position (a to-many order key is PGRST118 on the server). Filtering inside an embed is not on the typed surface; embeddedFilterName is the form it will use."
     symbols:
       - PostgrestTransformBuilder.select
+      - PostgrestToOneRelation.call
+      - PostgrestToManyRelation.call
+    supporting_symbols:
+      - PostgrestToOneRelation
+      - PostgrestToOneRelation.PostgrestToOneRelation
+      - PostgrestToOneRelation.name
+      - PostgrestToManyRelation
+      - PostgrestToManyRelation.PostgrestToManyRelation
+      - PostgrestToManyRelation.name
+      - PostgrestToOneColumn
+      - PostgrestToOneColumn.jsonText
+      - PostgrestToOneColumn.jsonObject
+      - PostgrestToManyColumn
+      - PostgrestToManyColumn.jsonText
+      - PostgrestToManyColumn.jsonObject
   database.using_modifiers.explain:
     status: implemented
     symbols:


### PR DESCRIPTION
Stack 7/7 for SDK-1741. Base: `lukasklingsbo/sdk-1741-6-aggregates`.

`PostgrestToOneRelation`/`PostgrestToManyRelation` sit on a table's namespace class and project a column of the related table through the embed: `Books.author(Authors.name)` renders `author(name)` in a `select` list. The relation is declared once, by hand for now; teaching `supabase_typegen` to emit them from the foreign key metadata it already parses is a follow-up, as it was for the Swift generator.

Cardinality reaches the type system because the server distinguishes it: `order=author(name).asc` is fine, while the to-many direction is PGRST118, so a `PostgrestToOneColumn` is orderable and a `PostgrestToManyColumn` is not. Neither is filterable; filtering inside an embed is out of scope, and `embeddedFilterName` (`author.name`) is what it will read.

An embedded projection renders `author(name)`, so a cast, JSON path or aggregate on one lands inside those parentheses through the `_derive` hook from 5/7: `Authors.books(Books.id).count()` renders `books(id.count())`, where `books(id).count()` would be a 200 with the `.count()` silently dropped. A JSON path on an embedded column stays an embedded column, keeping its position.

Projections compose, so `Orders.todo(Todos.orders(Orders.amount))` renders `todo(orders(amount))`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added typed embedded-relation support for selecting columns from related records.
  * Supports to-one and to-many relationships, including nested embeds.
  * Embedded selections support aggregates, casts, JSON paths, and chained derivations.
  * To-one embedded columns can be ordered; to-many embedded columns remain non-orderable.

* **Documentation**
  * Updated SDK capability documentation with typed relationship embedding syntax.

* **Tests**
  * Added coverage for embedded projections, nesting, filtering, ordering, and derived expressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->