### PR TITLE
feat(auth): add MFA recovery codes API

### DIFF
--- a/.github/workflows/sync-compliance.yml
+++ b/.github/workflows/sync-compliance.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: supabase/sdk/.github/workflows/sync-sdk-compliance.yml@a494be6719174adbca0313de1ee187407e2dca95 # capability-matrix-v1.6.0
+    uses: supabase/sdk/.github/workflows/sync-sdk-compliance.yml@ad910cfa7b87ed7dab32b409f5509611d64168c9 # capability-matrix-v1.9.0
     secrets:
       client-id: ${{ vars.GH_APP_CLIENT_ID }}
       private-key: ${{ secrets.PRIVATE_KEY }}

--- a/.github/workflows/validate-capabilities.yml
+++ b/.github/workflows/validate-capabilities.yml
@@ -13,4 +13,4 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    uses: supabase/sdk/.github/workflows/validate-sdk-compliance-dart.yml@a494be6719174adbca0313de1ee187407e2dca95 # capability-matrix-v1.6.0
+    uses: supabase/sdk/.github/workflows/validate-sdk-compliance-dart.yml@ad910cfa7b87ed7dab32b409f5509611d64168c9 # capability-matrix-v1.9.0

--- a/packages/supabase_auth/lib/src/auth_client.dart
+++ b/packages/supabase_auth/lib/src/auth_client.dart
@@ -21,6 +21,7 @@ import 'version.dart';
 
 part 'auth_oauth_api.dart';
 part 'auth_mfa_api.dart';
+part 'auth_mfa_recovery_codes_api.dart';
 part 'auth_passkey_api.dart';
 
 class _SessionState {

--- a/packages/supabase_auth/lib/src/auth_mfa_api.dart
+++ b/packages/supabase_auth/lib/src/auth_mfa_api.dart
@@ -65,7 +65,7 @@ class AuthMFAApi {
 
     final body = <String, dynamic>{
       'friendly_name': friendlyName,
-      'factor_type': factorType.value,
+      'factor_type': factorType.snakeCase,
     };
 
     if (factorType == FactorType.totp) {

--- a/packages/supabase_auth/lib/src/auth_mfa_api.dart
+++ b/packages/supabase_auth/lib/src/auth_mfa_api.dart
@@ -3,11 +3,18 @@ part of 'auth_client.dart';
 /// API namespace for managing the signed-in user's MFA factors, exposed on
 /// `AuthClient.mfa`.
 class AuthMFAApi {
-  const AuthMFAApi({required AuthClient client, required AuthFetch fetch})
+  AuthMFAApi({required AuthClient client, required AuthFetch fetch})
     : _client = client,
-      _fetch = fetch;
+      _fetch = fetch,
+      recoveryCodes = AuthMFARecoveryCodesApi(client: client, fetch: fetch);
   final AuthClient _client;
   final AuthFetch _fetch;
+
+  /// Namespace for the MFA recovery codes API methods.
+  ///
+  /// {@macro auth_mfa_recovery_codes_api}
+  @experimental
+  final AuthMFARecoveryCodesApi recoveryCodes;
 
   /// Unenroll removes a MFA factor.
   ///
@@ -58,7 +65,7 @@ class AuthMFAApi {
 
     final body = <String, dynamic>{
       'friendly_name': friendlyName,
-      'factor_type': factorType.name,
+      'factor_type': factorType.value,
     };
 
     if (factorType == FactorType.totp) {
@@ -208,12 +215,20 @@ class AuthMFAApi {
               factor.status == FactorStatus.verified,
         )
         .toList();
+    final recoveryCode = factors
+        .where(
+          (factor) =>
+              factor.factorType == FactorType.recoveryCode &&
+              factor.status == FactorStatus.verified,
+        )
+        .toList();
 
     return AuthMFAListFactorsResponse(
       all: factors,
       totp: totp,
       phone: phone,
       webauthn: webauthn,
+      recoveryCode: recoveryCode,
     );
   }
 

--- a/packages/supabase_auth/lib/src/auth_mfa_recovery_codes_api.dart
+++ b/packages/supabase_auth/lib/src/auth_mfa_recovery_codes_api.dart
@@ -1,0 +1,171 @@
+part of 'auth_client.dart';
+
+/// {@template auth_mfa_recovery_codes_api}
+/// API namespace for MFA recovery codes, exposed on
+/// `AuthClient.mfa.recoveryCodes`.
+///
+/// Recovery codes are single-use backup codes that let a user reach `aal2`
+/// when they cannot use their other MFA factors, for example after losing an
+/// authenticator app. A user has a single set of recovery codes and the codes
+/// are shown exactly once when generated.
+///
+/// Recovery codes are an experimental feature and must be enabled on the
+/// Supabase Auth server before these methods can be used. They can never be
+/// the user's only factor: generate them after another factor is verified.
+///
+/// ```dart
+/// final generated = await supabase.auth.mfa.recoveryCodes.generate(
+///   friendlyName: 'Backup codes',
+/// );
+/// // Show generated.codes to the user once and ask them to store them safely.
+///
+/// final verified = await supabase.auth.mfa.recoveryCodes.verify(
+///   'K4M9-X7QP-2AB8-HT3Z',
+/// );
+/// ```
+/// {@endtemplate}
+@experimental
+class AuthMFARecoveryCodesApi {
+  const AuthMFARecoveryCodesApi({
+    required AuthClient client,
+    required AuthFetch fetch,
+  }) : _client = client,
+       _fetch = fetch;
+  final AuthClient _client;
+  final AuthFetch _fetch;
+
+  /// Returns the enrollment status of the user's recovery codes: the total
+  /// number of codes in the current set and how many are still unused. Never
+  /// returns the codes themselves.
+  ///
+  /// Works at any authenticator assurance level. Throws an
+  /// [AuthApiException] with [ErrorCode.mfaFactorNotFound] when the user has
+  /// not generated recovery codes yet. When
+  /// [AuthMFARecoveryCodesStatusResponse.remaining] reaches `0`, prompt the
+  /// user to call [regenerate].
+  Future<AuthMFARecoveryCodesStatusResponse> getStatus() async {
+    final data = await _fetch.request(
+      '${_client._url}/factors/recovery-codes',
+      HttpMethod.get,
+      options: AuthRequestOptions(
+        headers: _client._headers,
+        jwt: _client.currentSession?.accessToken,
+      ),
+    );
+
+    return AuthMFARecoveryCodesStatusResponse.fromJson(data);
+  }
+
+  /// Generates the user's set of recovery codes.
+  ///
+  /// The plaintext codes are returned exactly once in
+  /// [AuthMFARecoveryCodesGenerateResponse.codes] and cannot be retrieved
+  /// again, so show them to the user and ask them to store the codes safely.
+  ///
+  /// [friendlyName] is the name of the recovery codes factor as shown in
+  /// [User.factors] and [AuthMFAApi.listFactors]. It must be unique among the
+  /// user's factors. The server defaults it to `Recovery codes` when omitted.
+  ///
+  /// The session must be at `aal2` and the user must already have another
+  /// verified factor. A user can only have one set of recovery codes; use
+  /// [regenerate] to replace an existing set. Throws an [AuthApiException]
+  /// with [ErrorCode.insufficientAal], [ErrorCode.mfaRecoveryCodesSoleFactor],
+  /// [ErrorCode.mfaVerifiedFactorExists] or
+  /// [ErrorCode.mfaRecoveryCodesEnrollDisabled] otherwise.
+  Future<AuthMFARecoveryCodesGenerateResponse> generate({
+    String? friendlyName,
+  }) async {
+    final data = await _fetch.request(
+      '${_client._url}/factors/recovery-codes',
+      HttpMethod.post,
+      options: AuthRequestOptions(
+        headers: _client._headers,
+        body: friendlyName == null ? null : {'friendly_name': friendlyName},
+        jwt: _client.currentSession?.accessToken,
+      ),
+    );
+
+    return AuthMFARecoveryCodesGenerateResponse.fromJson(data);
+  }
+
+  /// Verifies one of the user's recovery codes and upgrades the current
+  /// session to `aal2`. Each code can be used only once.
+  ///
+  /// [code] can be passed exactly as the user typed it: letter case,
+  /// whitespace and `-` separators are ignored by the server.
+  ///
+  /// On success the session is replaced with the upgraded one and
+  /// [AuthChangeEvent.mfaChallengeVerified] is emitted. The user's other
+  /// `aal1` sessions are signed out and the new access token includes
+  /// [AuthenticationMethodReference.mfaRecoveryCode] in its `amr` claim.
+  ///
+  /// A wrong, already used or missing code throws an [AuthApiException] with
+  /// [ErrorCode.mfaVerificationFailed]. After too many failed attempts the
+  /// server locks verification for a period and responds with
+  /// [ErrorCode.mfaRecoveryCodesLocked]. When recovery code verification is
+  /// disabled on the server the code is
+  /// [ErrorCode.mfaRecoveryCodesVerifyDisabled].
+  Future<AuthMFAVerifyResponse> verify(String code) async {
+    final data = await _fetch.request(
+      '${_client._url}/factors/recovery-codes/verify',
+      HttpMethod.post,
+      options: AuthRequestOptions(
+        headers: _client._headers,
+        body: {'code': code},
+        jwt: _client.currentSession?.accessToken,
+      ),
+    );
+
+    final response = AuthMFAVerifyResponse.fromJson(data);
+    _client._saveSession(
+      Session(
+        accessToken: response.accessToken,
+        tokenType: response.tokenType,
+        user: response.user,
+        expiresIn: response.expiresIn.inSeconds,
+        refreshToken: response.refreshToken,
+      ),
+    );
+    _client.notifyAllSubscribers(AuthChangeEvent.mfaChallengeVerified);
+    return response;
+  }
+
+  /// Replaces the user's recovery codes with a brand new set.
+  ///
+  /// All remaining codes from the previous set stop working immediately and
+  /// any verification lockout is cleared. The factor's id and friendly name
+  /// are preserved. The new plaintext codes are returned exactly once.
+  ///
+  /// The session must be at `aal2`. Throws an [AuthApiException] with
+  /// [ErrorCode.mfaFactorNotFound] when the user has no recovery codes to
+  /// regenerate; use [generate] instead.
+  Future<AuthMFARecoveryCodesGenerateResponse> regenerate() async {
+    final data = await _fetch.request(
+      '${_client._url}/factors/recovery-codes/regenerate',
+      HttpMethod.post,
+      options: AuthRequestOptions(
+        headers: _client._headers,
+        jwt: _client.currentSession?.accessToken,
+      ),
+    );
+
+    return AuthMFARecoveryCodesGenerateResponse.fromJson(data);
+  }
+
+  /// Removes the user's recovery codes factor together with all of its codes.
+  ///
+  /// The session must be at `aal2`. Throws an [AuthApiException] with
+  /// [ErrorCode.mfaFactorNotFound] when the user has no recovery codes.
+  Future<AuthMFAUnenrollResponse> unenroll() async {
+    final data = await _fetch.request(
+      '${_client._url}/factors/recovery-codes',
+      HttpMethod.delete,
+      options: AuthRequestOptions(
+        headers: _client._headers,
+        jwt: _client.currentSession?.accessToken,
+      ),
+    );
+
+    return AuthMFAUnenrollResponse.fromJson(data);
+  }
+}

--- a/packages/supabase_auth/lib/src/types/error_code.dart
+++ b/packages/supabase_auth/lib/src/types/error_code.dart
@@ -246,6 +246,22 @@ enum ErrorCode {
   /// Verifying a WebAuthn MFA factor is disabled for this project.
   mfaWebauthnVerifyDisabled('mfa_webauthn_verify_not_enabled'),
 
+  /// Generating MFA recovery codes is disabled for this project.
+  mfaRecoveryCodesEnrollDisabled('mfa_recovery_codes_enroll_not_enabled'),
+
+  /// Verifying MFA recovery codes is disabled for this project.
+  mfaRecoveryCodesVerifyDisabled('mfa_recovery_codes_verify_not_enabled'),
+
+  /// Recovery code verification is temporarily locked after too many failed
+  /// attempts.
+  mfaRecoveryCodesLocked('mfa_recovery_codes_locked'),
+
+  /// Recovery codes cannot be the user's only MFA factor.
+  mfaRecoveryCodesSoleFactor('mfa_recovery_codes_sole_factor'),
+
+  /// The user already has a verified factor of this type.
+  mfaVerifiedFactorExists('mfa_verified_factor_exists'),
+
   /// Passkeys are disabled for this project.
   passkeyDisabled('passkey_disabled'),
 

--- a/packages/supabase_auth/lib/src/types/mfa.dart
+++ b/packages/supabase_auth/lib/src/types/mfa.dart
@@ -12,7 +12,7 @@ class AuthMFAEnrollResponse {
 
   factory AuthMFAEnrollResponse.fromJson(Map<String, dynamic> json) {
     final type = FactorType.values.firstWhere(
-      (e) => e.name == json['type'],
+      (e) => e.value == json['type'],
       orElse: () => FactorType.unknown,
     );
     return AuthMFAEnrollResponse(
@@ -196,6 +196,7 @@ class AuthMFAListFactorsResponse {
     required this.totp,
     required this.phone,
     this.webauthn = const [],
+    this.recoveryCode = const [],
   });
 
   /// Every MFA factor enabled for the user, of any status.
@@ -209,6 +210,90 @@ class AuthMFAListFactorsResponse {
 
   /// The user's verified WebAuthn factors.
   final List<Factor> webauthn;
+
+  /// The user's verified recovery codes factors.
+  ///
+  /// A user has at most one; see [AuthMFARecoveryCodesApi].
+  final List<Factor> recoveryCode;
+}
+
+/// The response of `AuthMFARecoveryCodesApi.getStatus`.
+///
+/// Never contains the codes themselves.
+class AuthMFARecoveryCodesStatusResponse {
+  const AuthMFARecoveryCodesStatusResponse({
+    required this.id,
+    required this.total,
+    required this.remaining,
+  });
+
+  factory AuthMFARecoveryCodesStatusResponse.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    return AuthMFARecoveryCodesStatusResponse(
+      id: json['id'] as String,
+      total: (json['total'] as num).toInt(),
+      remaining: (json['remaining'] as num).toInt(),
+    );
+  }
+
+  /// ID of the recovery codes factor, as it appears in [User.factors].
+  final String id;
+
+  /// Number of codes in the current set.
+  final int total;
+
+  /// Number of codes in the current set that have not been used yet. `0` when
+  /// every code has been consumed.
+  final int remaining;
+}
+
+/// The response of `AuthMFARecoveryCodesApi.generate` and
+/// `AuthMFARecoveryCodesApi.regenerate`.
+///
+/// The [codes] are returned exactly once and cannot be retrieved again.
+class AuthMFARecoveryCodesGenerateResponse {
+  const AuthMFARecoveryCodesGenerateResponse({
+    required this.id,
+    required this.friendlyName,
+    required this.total,
+    required this.codes,
+  });
+
+  factory AuthMFARecoveryCodesGenerateResponse.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    final codes = json['codes'];
+    if (codes is! List) {
+      throw FormatException(
+        'Expected codes to be a list, got ${codes.runtimeType}',
+        json.toString(),
+      );
+    }
+    return AuthMFARecoveryCodesGenerateResponse(
+      id: json['id'] as String,
+      friendlyName: json['friendly_name'] as String?,
+      total: (json['total'] as num).toInt(),
+      codes: codes.cast<String>(),
+    );
+  }
+
+  /// ID of the recovery codes factor.
+  final String id;
+
+  /// Friendly name of the recovery codes factor.
+  final String? friendlyName;
+
+  /// Number of codes in the set.
+  final int total;
+
+  /// The plaintext recovery codes in canonical form: lowercase, without
+  /// separators.
+  ///
+  /// They are returned exactly once and cannot be retrieved again. Show them
+  /// to the user in a copy or download friendly layout and ask them to store
+  /// the codes safely. Avoid logging them to the console.
+  final List<String> codes;
 }
 
 /// The response of `AuthAdminMFAApi.listFactors`.
@@ -262,17 +347,26 @@ enum FactorStatus {
 /// The kind of second factor an MFA [Factor] uses.
 enum FactorType {
   /// A time-based one-time password from an authenticator app.
-  totp,
+  totp('totp'),
 
   /// A one-time password sent by SMS.
-  phone,
+  phone('phone'),
 
   /// A WebAuthn security key or platform authenticator.
-  webauthn,
+  webauthn('webauthn'),
+
+  /// A set of single-use recovery codes, managed through
+  /// [AuthMFARecoveryCodesApi] rather than [AuthMFAApi.enroll].
+  recoveryCode('recovery_code'),
 
   /// Returned when the backend sends an unknown factor type.
   /// This allows forward compatibility with new factor types.
-  unknown,
+  unknown('unknown');
+
+  const FactorType(this.value);
+
+  /// The wire value received from and sent to the server.
+  final String value;
 }
 
 /// An MFA factor enrolled by a user.
@@ -291,7 +385,7 @@ class Factor {
       id: json['id'] as String,
       friendlyName: json['friendly_name'] as String?,
       factorType: FactorType.values.firstWhere(
-        (e) => e.name == json['factor_type'],
+        (e) => e.value == json['factor_type'],
         orElse: () => FactorType.unknown,
       ),
       status: FactorStatus.values.firstWhere(
@@ -310,7 +404,8 @@ class Factor {
   /// factors.
   final String? friendlyName;
 
-  /// Type of factor. Supports `totp`, `phone` and `webauthn`.
+  /// Type of factor. Supports `totp`, `phone`, `webauthn` and
+  /// `recovery_code`.
   final FactorType factorType;
 
   /// Factor's status.
@@ -326,7 +421,7 @@ class Factor {
     return {
       'id': id,
       'friendly_name': friendlyName,
-      'factor_type': factorType.name,
+      'factor_type': factorType.value,
       'status': status.name,
       'created_at': createdAt.toIso8601String(),
       'updated_at': updatedAt.toIso8601String(),
@@ -443,6 +538,9 @@ enum AuthenticationMethodReference {
 
   /// Verified an MFA WebAuthn factor.
   mfaWebauthn('mfa/webauthn'),
+
+  /// Verified an MFA recovery code.
+  mfaRecoveryCode('mfa/recovery_code'),
 
   /// Signed in with a passkey.
   passkey('passkey'),

--- a/packages/supabase_auth/lib/src/types/mfa.dart
+++ b/packages/supabase_auth/lib/src/types/mfa.dart
@@ -12,7 +12,7 @@ class AuthMFAEnrollResponse {
 
   factory AuthMFAEnrollResponse.fromJson(Map<String, dynamic> json) {
     final type = FactorType.values.firstWhere(
-      (e) => e.value == json['type'],
+      (e) => e.snakeCase == json['type'],
       orElse: () => FactorType.unknown,
     );
     return AuthMFAEnrollResponse(
@@ -347,26 +347,21 @@ enum FactorStatus {
 /// The kind of second factor an MFA [Factor] uses.
 enum FactorType {
   /// A time-based one-time password from an authenticator app.
-  totp('totp'),
+  totp,
 
   /// A one-time password sent by SMS.
-  phone('phone'),
+  phone,
 
   /// A WebAuthn security key or platform authenticator.
-  webauthn('webauthn'),
+  webauthn,
 
   /// A set of single-use recovery codes, managed through
   /// [AuthMFARecoveryCodesApi] rather than [AuthMFAApi.enroll].
-  recoveryCode('recovery_code'),
+  recoveryCode,
 
   /// Returned when the backend sends an unknown factor type.
   /// This allows forward compatibility with new factor types.
-  unknown('unknown');
-
-  const FactorType(this.value);
-
-  /// The wire value received from and sent to the server.
-  final String value;
+  unknown,
 }
 
 /// An MFA factor enrolled by a user.
@@ -385,7 +380,7 @@ class Factor {
       id: json['id'] as String,
       friendlyName: json['friendly_name'] as String?,
       factorType: FactorType.values.firstWhere(
-        (e) => e.value == json['factor_type'],
+        (e) => e.snakeCase == json['factor_type'],
         orElse: () => FactorType.unknown,
       ),
       status: FactorStatus.values.firstWhere(
@@ -421,7 +416,7 @@ class Factor {
     return {
       'id': id,
       'friendly_name': friendlyName,
-      'factor_type': factorType.value,
+      'factor_type': factorType.snakeCase,
       'status': status.name,
       'created_at': createdAt.toIso8601String(),
       'updated_at': updatedAt.toIso8601String(),

--- a/packages/supabase_auth/test/mfa_recovery_codes_test.dart
+++ b/packages/supabase_auth/test/mfa_recovery_codes_test.dart
@@ -1,0 +1,279 @@
+import 'dart:convert';
+
+import 'package:supabase_auth/supabase_auth.dart';
+import 'package:test/test.dart';
+
+import 'mocks/mfa_recovery_codes_mock_client.dart';
+import 'utils.dart';
+
+void main() {
+  group('AuthClient.mfa.recoveryCodes with mocked server', () {
+    late MfaRecoveryCodesMockClient mockClient;
+    late AuthClient client;
+
+    setUp(() {
+      mockClient = MfaRecoveryCodesMockClient();
+      client = AuthClient(
+        url: 'http://localhost:9999',
+        httpClient: mockClient,
+        autoRefreshToken: false,
+        asyncStorage: TestAsyncStorage(),
+      );
+    });
+
+    tearDown(() {
+      client.dispose();
+    });
+
+    Future<void> signIn() async {
+      await client.recoverSession(
+        json.encode(MfaRecoveryCodesMockClient.sessionJson()),
+      );
+    }
+
+    Map<String, dynamic> lastBody() =>
+        json.decode(mockClient.lastBody!) as Map<String, dynamic>;
+
+    test('getStatus requests the status with the session token', () async {
+      await signIn();
+      final storedToken = client.currentSession!.accessToken;
+
+      final status = await client.mfa.recoveryCodes.getStatus();
+
+      expect(mockClient.lastMethod, 'GET');
+      expect(mockClient.lastUrl?.path, '/factors/recovery-codes');
+      expect(mockClient.lastHeaders?['Authorization'], 'Bearer $storedToken');
+      expect(status.id, MfaRecoveryCodesMockClient.factorId);
+      expect(status.total, 10);
+      expect(status.remaining, 7);
+    });
+
+    test('generate posts without a friendly name by default', () async {
+      await signIn();
+
+      final generated = await client.mfa.recoveryCodes.generate();
+
+      expect(mockClient.lastMethod, 'POST');
+      expect(mockClient.lastUrl?.path, '/factors/recovery-codes');
+      expect(lastBody().containsKey('friendly_name'), isFalse);
+      expect(generated.id, MfaRecoveryCodesMockClient.factorId);
+      expect(generated.friendlyName, 'Recovery codes');
+      expect(generated.total, 10);
+      expect(generated.codes, MfaRecoveryCodesMockClient.codes);
+      for (final code in generated.codes) {
+        expect(code, matches(RegExp(r'^[a-z2-7]{16}$')));
+      }
+    });
+
+    test('generate forwards the friendly name', () async {
+      await signIn();
+
+      final generated = await client.mfa.recoveryCodes.generate(
+        friendlyName: 'Backup codes',
+      );
+
+      expect(lastBody(), {'friendly_name': 'Backup codes'});
+      expect(generated.friendlyName, 'Backup codes');
+    });
+
+    test(
+      'verify posts the code as typed, upgrades the session and emits '
+      'mfaChallengeVerified',
+      () async {
+        await signIn();
+        final previousToken = client.currentSession!.accessToken;
+        final events = <AuthChangeEvent>[];
+        client.onAuthStateChange.listen((state) => events.add(state.event));
+
+        final response = await client.mfa.recoveryCodes.verify(
+          'K4M6-X7QP 2AB5-ht3z',
+        );
+
+        expect(mockClient.lastMethod, 'POST');
+        expect(mockClient.lastUrl?.path, '/factors/recovery-codes/verify');
+        expect(
+          mockClient.lastHeaders?['Authorization'],
+          'Bearer $previousToken',
+        );
+        expect(lastBody(), {'code': 'K4M6-X7QP 2AB5-ht3z'});
+
+        expect(response.accessToken, isNot(previousToken));
+        expect(client.currentSession?.accessToken, response.accessToken);
+        expect(client.currentSession?.refreshToken, response.refreshToken);
+        expect(client.currentUser?.factors, hasLength(3));
+
+        final assurance = client.mfa.getAuthenticatorAssuranceLevel();
+        expect(assurance.currentLevel, AuthenticatorAssuranceLevel.aal2);
+        expect(
+          assurance.currentAuthenticationMethods.map((entry) => entry.method),
+          contains(AuthenticationMethodReference.mfaRecoveryCode),
+        );
+
+        await Future<void>.delayed(Duration.zero);
+        expect(
+          events.where(
+            (event) => event == AuthChangeEvent.mfaChallengeVerified,
+          ),
+          hasLength(1),
+        );
+        expect(events.last, AuthChangeEvent.mfaChallengeVerified);
+      },
+    );
+
+    test(
+      'verify surfaces server errors without touching the session',
+      () async {
+        await signIn();
+        final storedToken = client.currentSession!.accessToken;
+        final events = <AuthChangeEvent>[];
+        client.onAuthStateChange.listen((state) => events.add(state.event));
+        mockClient.errorResponse = (
+          statusCode: 429,
+          code: 'mfa_recovery_codes_locked',
+        );
+
+        await expectLater(
+          client.mfa.recoveryCodes.verify('wrong'),
+          throwsA(
+            isA<AuthApiException>()
+                .having((e) => e.statusCode, 'statusCode', 429)
+                .having(
+                  (e) => e.errorCode,
+                  'errorCode',
+                  ErrorCode.mfaRecoveryCodesLocked.code,
+                ),
+          ),
+        );
+
+        expect(client.currentSession?.accessToken, storedToken);
+        await Future<void>.delayed(Duration.zero);
+        expect(events, isNot(contains(AuthChangeEvent.mfaChallengeVerified)));
+      },
+    );
+
+    test('regenerate posts to the regenerate endpoint', () async {
+      await signIn();
+
+      final regenerated = await client.mfa.recoveryCodes.regenerate();
+
+      expect(mockClient.lastMethod, 'POST');
+      expect(mockClient.lastUrl?.path, '/factors/recovery-codes/regenerate');
+      expect(lastBody(), isEmpty);
+      expect(regenerated.id, MfaRecoveryCodesMockClient.factorId);
+      expect(
+        regenerated.codes,
+        MfaRecoveryCodesMockClient.codes.reversed.toList(),
+      );
+    });
+
+    test('unenroll deletes the recovery codes factor', () async {
+      await signIn();
+
+      final response = await client.mfa.recoveryCodes.unenroll();
+
+      expect(mockClient.lastMethod, 'DELETE');
+      expect(mockClient.lastUrl?.path, '/factors/recovery-codes');
+      expect(response.id, MfaRecoveryCodesMockClient.factorId);
+    });
+
+    test('server errors are thrown as AuthApiException', () async {
+      await signIn();
+      final calls = <Future<Object> Function()>[
+        client.mfa.recoveryCodes.getStatus,
+        client.mfa.recoveryCodes.generate,
+        () => client.mfa.recoveryCodes.verify('k4m6x7qp2ab5ht3z'),
+        client.mfa.recoveryCodes.regenerate,
+        client.mfa.recoveryCodes.unenroll,
+      ];
+      mockClient.errorResponse = (statusCode: 403, code: 'insufficient_aal');
+
+      for (final call in calls) {
+        await expectLater(
+          call(),
+          throwsA(
+            isA<AuthApiException>()
+                .having((e) => e.statusCode, 'statusCode', 403)
+                .having(
+                  (e) => e.errorCode,
+                  'errorCode',
+                  ErrorCode.insufficientAal.code,
+                ),
+          ),
+        );
+      }
+    });
+
+    test('requests are sent without a bearer token when signed out', () async {
+      mockClient.errorResponse = (statusCode: 401, code: 'no_authorization');
+
+      await expectLater(
+        client.mfa.recoveryCodes.getStatus(),
+        throwsA(
+          isA<AuthApiException>().having(
+            (e) => e.errorCode,
+            'errorCode',
+            ErrorCode.noAuthorization.code,
+          ),
+        ),
+      );
+
+      expect(mockClient.lastHeaders?.containsKey('Authorization'), isFalse);
+    });
+
+    test('listFactors buckets verified recovery code factors', () async {
+      await signIn();
+
+      final factors = await client.mfa.listFactors();
+
+      expect(factors.all, hasLength(3));
+      expect(factors.totp, hasLength(1));
+      expect(factors.phone, isEmpty);
+      expect(factors.webauthn, isEmpty);
+      expect(factors.recoveryCode, hasLength(1));
+      expect(
+        factors.recoveryCode.single.id,
+        MfaRecoveryCodesMockClient.factorId,
+      );
+      expect(factors.recoveryCode.single.factorType, FactorType.recoveryCode);
+      expect(
+        factors.all.where((factor) => factor.factorType == FactorType.unknown),
+        hasLength(1),
+      );
+    });
+
+    test('enroll rejects the recovery code factor type', () async {
+      await signIn();
+
+      await expectLater(
+        client.mfa.enroll(factorType: FactorType.recoveryCode),
+        throwsArgumentError,
+      );
+      expect(mockClient.lastUrl, isNull);
+    });
+  });
+
+  group('recovery codes error codes', () {
+    test('are mapped from their wire values', () {
+      expect(
+        ErrorCode.fromCode('mfa_recovery_codes_enroll_not_enabled'),
+        ErrorCode.mfaRecoveryCodesEnrollDisabled,
+      );
+      expect(
+        ErrorCode.fromCode('mfa_recovery_codes_verify_not_enabled'),
+        ErrorCode.mfaRecoveryCodesVerifyDisabled,
+      );
+      expect(
+        ErrorCode.fromCode('mfa_recovery_codes_locked'),
+        ErrorCode.mfaRecoveryCodesLocked,
+      );
+      expect(
+        ErrorCode.fromCode('mfa_recovery_codes_sole_factor'),
+        ErrorCode.mfaRecoveryCodesSoleFactor,
+      );
+      expect(
+        ErrorCode.fromCode('mfa_verified_factor_exists'),
+        ErrorCode.mfaVerifiedFactorExists,
+      );
+    });
+  });
+}

--- a/packages/supabase_auth/test/mocks/mfa_recovery_codes_mock_client.dart
+++ b/packages/supabase_auth/test/mocks/mfa_recovery_codes_mock_client.dart
@@ -1,0 +1,193 @@
+import 'dart:convert';
+
+import 'package:dart_jsonwebtoken/dart_jsonwebtoken.dart';
+import 'package:http/http.dart';
+
+/// A mock HTTP client that simulates the MFA recovery codes API of the
+/// Supabase Auth server.
+class MfaRecoveryCodesMockClient extends BaseClient {
+  static const userId = 'b13898bb-3b85-4d83-a447-841dc3232ea1';
+  static const factorId = '99999999-8888-7777-6666-555555555555';
+  static const totpFactorId = '744c1f56-7e2f-46a2-b1cf-1c8e77e4b23d';
+  static const codes = [
+    'k4m6x7qp2ab5ht3z',
+    'wze6r5npd4cmq7vt',
+    'nq5v7xk2m6tp4wzs',
+    'h3kqw2m7xt4rpn6b',
+    'p7tz4mq2k6xn5wrb',
+    'b3d6fh2jkm4npq5r',
+    'r5t7vwx2z3a4b6cd',
+    'c6d7efg2h3j4k5mn',
+    'm6n7pq2r3s4t5vwx',
+    'w6x7yz2a3b4c5def',
+  ];
+
+  String? lastMethod;
+  Uri? lastUrl;
+  String? lastBody;
+  Map<String, String>? lastHeaders;
+
+  /// When set, every request is answered with this error instead of the
+  /// regular mock response.
+  ({int statusCode, String code})? errorResponse;
+
+  /// Builds a signed access token carrying [aal] and the given [amr] methods.
+  static String accessToken({
+    String aal = 'aal1',
+    List<String> amr = const ['password'],
+  }) {
+    final issuedAt = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+    return JWT(
+      {
+        'aud': 'authenticated',
+        'role': 'authenticated',
+        'aal': aal,
+        'amr': [
+          for (final method in amr) {'method': method, 'timestamp': issuedAt},
+        ],
+        'exp': issuedAt + 3600,
+      },
+      subject: userId,
+    ).sign(SecretKey('test-secret'));
+  }
+
+  static Map<String, dynamic> sessionJson({
+    String? accessToken,
+    bool withFactors = false,
+  }) {
+    final now = '2026-01-01T00:00:00.000Z';
+    return {
+      'access_token': accessToken ?? MfaRecoveryCodesMockClient.accessToken(),
+      'token_type': 'bearer',
+      'expires_in': 3600,
+      'refresh_token': 'mock-refresh-token',
+      'user': {
+        'id': userId,
+        'aud': 'authenticated',
+        'role': 'authenticated',
+        'email': 'recovery-codes-user@example.com',
+        'created_at': now,
+        'updated_at': now,
+        'app_metadata': {
+          'provider': 'email',
+          'providers': ['email'],
+        },
+        'user_metadata': <String, dynamic>{},
+        'identities': [],
+        if (withFactors)
+          'factors': [
+            {
+              'id': totpFactorId,
+              'friendly_name': 'Authenticator app',
+              'factor_type': 'totp',
+              'status': 'verified',
+              'created_at': now,
+              'updated_at': now,
+            },
+            {
+              'id': factorId,
+              'friendly_name': 'Recovery codes',
+              'factor_type': 'recovery_code',
+              'status': 'verified',
+              'created_at': now,
+              'updated_at': now,
+            },
+            {
+              'id': 'cf5ea60c-d52b-46a6-a306-3a0c4b68dd0f',
+              'friendly_name': 'Future factor',
+              'factor_type': 'future_factor_type',
+              'status': 'verified',
+              'created_at': now,
+              'updated_at': now,
+            },
+          ],
+      },
+    };
+  }
+
+  @override
+  Future<StreamedResponse> send(BaseRequest request) async {
+    lastMethod = request.method;
+    lastUrl = request.url;
+    lastHeaders = request.headers;
+    lastBody = request is Request ? request.body : null;
+
+    final errorResponse = this.errorResponse;
+    if (errorResponse != null) {
+      return _jsonResponse(
+        {'code': errorResponse.code, 'msg': 'mock error'},
+        statusCode: errorResponse.statusCode,
+      );
+    }
+
+    final path = request.url.path;
+    final method = request.method;
+
+    if (path.endsWith('/factors/recovery-codes') && method == 'GET') {
+      return _jsonResponse({
+        'id': factorId,
+        'type': 'recovery_code',
+        'total': 10,
+        'remaining': 7,
+      });
+    }
+
+    if (path.endsWith('/factors/recovery-codes') && method == 'POST') {
+      final body = lastBody == null || lastBody!.isEmpty
+          ? const <String, dynamic>{}
+          : json.decode(lastBody!) as Map<String, dynamic>;
+      return _jsonResponse({
+        'id': factorId,
+        'type': 'recovery_code',
+        'friendly_name': body['friendly_name'] ?? 'Recovery codes',
+        'total': 10,
+        'codes': codes,
+      });
+    }
+
+    if (path.endsWith('/factors/recovery-codes/regenerate') &&
+        method == 'POST') {
+      return _jsonResponse({
+        'id': factorId,
+        'type': 'recovery_code',
+        'friendly_name': 'Recovery codes',
+        'total': 10,
+        'codes': codes.reversed.toList(),
+      });
+    }
+
+    if (path.endsWith('/factors/recovery-codes/verify') && method == 'POST') {
+      return _jsonResponse(
+        sessionJson(
+          accessToken: accessToken(
+            aal: 'aal2',
+            amr: ['password', 'mfa/recovery_code'],
+          ),
+          withFactors: true,
+        ),
+      );
+    }
+
+    if (path.endsWith('/factors/recovery-codes') && method == 'DELETE') {
+      return _jsonResponse({'id': factorId});
+    }
+
+    if (path.endsWith('/token') && method == 'POST') {
+      return _jsonResponse(sessionJson(withFactors: true));
+    }
+
+    return _jsonResponse({'error': 'Unhandled mock request'}, statusCode: 501);
+  }
+
+  StreamedResponse _jsonResponse(Object body, {int statusCode = 200}) {
+    return StreamedResponse(
+      Stream.value(utf8.encode(jsonEncode(body))),
+      statusCode,
+      headers: {
+        'content-type': 'application/json',
+        'x-supabase-api-version': '2024-01-01',
+      },
+      request: null,
+    );
+  }
+}

--- a/packages/supabase_auth/test/src/types/mfa_test.dart
+++ b/packages/supabase_auth/test/src/types/mfa_test.dart
@@ -21,6 +21,13 @@ void main() {
       expect(factor.status, FactorStatus.verified);
     });
 
+    test('fromJson parses recovery_code factor type', () {
+      final factor = Factor.fromJson(factorJson('recovery_code'));
+
+      expect(factor.factorType, FactorType.recoveryCode);
+      expect(factor.toJson()['factor_type'], 'recovery_code');
+    });
+
     test('fromJson falls back to unknown for unrecognized factor types', () {
       final factor = Factor.fromJson(factorJson('something-new'));
 
@@ -29,6 +36,15 @@ void main() {
   });
 
   group('AuthenticationMethodReferenceEntry', () {
+    test('fromJson parses mfa/recovery_code method', () {
+      final entry = AuthenticationMethodReferenceEntry.fromJson({
+        'method': 'mfa/recovery_code',
+        'timestamp': 1735689600,
+      });
+
+      expect(entry.method, AuthenticationMethodReference.mfaRecoveryCode);
+    });
+
     test('fromJson parses passkey method', () {
       final entry = AuthenticationMethodReferenceEntry.fromJson({
         'method': 'passkey',

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -2438,8 +2438,6 @@ supporting_symbols:
   - Factor.updatedAt
   - FactorStatus
   - FactorType
-  - FactorType.FactorType
-  - FactorType.value
   - FlutterAuthClientOptions
   - FlutterAuthClientOptions.FlutterAuthClientOptions
   - FlutterAuthClientOptions.copyWith

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -346,6 +346,7 @@ features:
       - AuthMFAListFactorsResponse.AuthMFAListFactorsResponse
       - AuthMFAListFactorsResponse.all
       - AuthMFAListFactorsResponse.phone
+      - AuthMFAListFactorsResponse.recoveryCode
       - AuthMFAListFactorsResponse.totp
       - AuthMFAListFactorsResponse.webauthn
   auth.mfa.get_authenticator_assurance_level:
@@ -367,6 +368,46 @@ features:
       - AuthMFAGetAuthenticatorAssuranceLevelResponse.currentAuthenticationMethods
       - AuthMFAGetAuthenticatorAssuranceLevelResponse.currentLevel
       - AuthMFAGetAuthenticatorAssuranceLevelResponse.nextLevel
+
+  # auth — MFA recovery codes
+  auth.mfa_recovery_codes.get_status:
+    status: implemented
+    symbols:
+      - AuthMFARecoveryCodesApi.getStatus
+    supporting_symbols:
+      - AuthMFAApi.recoveryCodes
+      - AuthMFARecoveryCodesApi
+      - AuthMFARecoveryCodesApi.AuthMFARecoveryCodesApi
+      - AuthMFARecoveryCodesStatusResponse
+      - AuthMFARecoveryCodesStatusResponse.AuthMFARecoveryCodesStatusResponse
+      - AuthMFARecoveryCodesStatusResponse.fromJson
+      - AuthMFARecoveryCodesStatusResponse.id
+      - AuthMFARecoveryCodesStatusResponse.remaining
+      - AuthMFARecoveryCodesStatusResponse.total
+  auth.mfa_recovery_codes.generate:
+    status: implemented
+    symbols:
+      - AuthMFARecoveryCodesApi.generate
+    supporting_symbols:
+      - AuthMFARecoveryCodesGenerateResponse
+      - AuthMFARecoveryCodesGenerateResponse.AuthMFARecoveryCodesGenerateResponse
+      - AuthMFARecoveryCodesGenerateResponse.codes
+      - AuthMFARecoveryCodesGenerateResponse.friendlyName
+      - AuthMFARecoveryCodesGenerateResponse.fromJson
+      - AuthMFARecoveryCodesGenerateResponse.id
+      - AuthMFARecoveryCodesGenerateResponse.total
+  auth.mfa_recovery_codes.verify:
+    status: implemented
+    symbols:
+      - AuthMFARecoveryCodesApi.verify
+  auth.mfa_recovery_codes.regenerate:
+    status: implemented
+    symbols:
+      - AuthMFARecoveryCodesApi.regenerate
+  auth.mfa_recovery_codes.unenroll:
+    status: implemented
+    symbols:
+      - AuthMFARecoveryCodesApi.unenroll
 
   # auth — passkeys (experimental)
   auth.passkey.register_passkey:
@@ -2397,6 +2438,8 @@ supporting_symbols:
   - Factor.updatedAt
   - FactorStatus
   - FactorType
+  - FactorType.FactorType
+  - FactorType.value
   - FlutterAuthClientOptions
   - FlutterAuthClientOptions.FlutterAuthClientOptions
   - FlutterAuthClientOptions.copyWith


### PR DESCRIPTION
## Summary

Adds the MFA recovery codes API to `supabase_auth`, exposed as `supabase.auth.mfa.recoveryCodes`:

- `getStatus()` returns the factor id, total number of codes and how many remain unused.
- `generate({friendlyName})` creates the user's set of single-use codes. The codes are returned once.
- `verify(code)` upgrades the session to `aal2`, replaces the stored session and emits `AuthChangeEvent.mfaChallengeVerified`, matching `AuthMFAApi.verify`.
- `regenerate()` replaces the set and `unenroll()` removes the factor.

Supporting changes:

- `FactorType.recoveryCode`. The wire name (`recovery_code`) is derived with the shared `snakeCase` getter in `Factor`, `AuthMFAEnrollResponse` and `enroll()` instead of the enum `name`.
- `AuthMFAListFactorsResponse.recoveryCode` bucket in `listFactors()`.
- `AuthenticationMethodReference.mfaRecoveryCode` for the `mfa/recovery_code` AMR claim.
- New `ErrorCode` values: `mfaRecoveryCodesEnrollDisabled`, `mfaRecoveryCodesVerifyDisabled`, `mfaRecoveryCodesLocked`, `mfaRecoveryCodesSoleFactor` and `mfaVerifiedFactorExists`.

The namespace is annotated `@experimental`, following the existing passkey API. supabase-js gates the feature behind a runtime `experimental.recoveryCodes` flag instead, which is a JavaScript idiom the Dart SDK does not use.

## Compliance matrix

- `auth.mfa_recovery_codes.get_status` → implemented
- `auth.mfa_recovery_codes.generate` → implemented
- `auth.mfa_recovery_codes.verify` → implemented
- `auth.mfa_recovery_codes.regenerate` → implemented
- `auth.mfa_recovery_codes.unenroll` → implemented

These IDs were introduced in `supabase/sdk` capability-matrix v1.9.0, so the compliance workflow pins are bumped from v1.6.0 to v1.9.0. The Dart validation workflow is unchanged between those tags.

## Reference

- supabase-js: https://github.com/supabase/supabase-js/pull/2676
- No Linear parity ticket exists for this change yet.

## Testing

- New `test/mfa_recovery_codes_test.dart` with a mock server covering each endpoint, request shape, session replacement, event emission, error propagation and `listFactors` bucketing.
- Full `supabase_auth` suite passes against the local stack (549 tests).
- `check-api-symbols`, `check-drift` and `validate-compliance` pass locally against v1.9.0.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added MFA recovery-code management through the Auth API, including status checks, generation, verification, regeneration, and unenrollment.
  - Added support for recovery-code factors in MFA factor listings and authentication method references.
  - Added new MFA recovery-code error handling and response types.
  - Updated MFA factor serialization to use standardized wire values.

- **Tests**
  - Added coverage for recovery-code workflows, request handling, error mapping, and factor serialization.

- **Chores**
  - Updated SDK compliance workflow references and capability coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->