### PR TITLE
docs: document capability-matrix flow for adding a new public API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -216,3 +216,25 @@ await Supabase.initialize(
   in the same pull request, under the major version it will ship in
 - Line length limit is 80 characters
 - Use `dart format` for consistent formatting
+
+### Adding a new public API
+
+Every exported public symbol must be declared in `sdk-compliance.yaml` at the
+repo root, or the "SDK Compliance" CI check fails. If the capability already
+exists in the [SDK capability matrix](https://github.com/supabase/sdk)
+(`capabilities/<area>.yaml` there), just register your symbols. If it doesn't
+exist yet, open a PR on that repo first to declare it; once it's merged and
+released, bump the pinned SHA in
+[`.github/workflows/validate-capabilities.yml`](.github/workflows/validate-capabilities.yml)
+to the new `capability-matrix-vX.Y.Z` tag, then register the symbols here,
+entry points under `symbols`, everything else (params, response types, etc.)
+under `supporting_symbols`:
+
+```yaml
+auth.mfa_recovery_codes.generate:
+  status: implemented
+  symbols:
+    - AuthClient.generateMfaRecoveryCodes
+  supporting_symbols:
+    - MFARecoveryCodesGenerateResponse
+```


### PR DESCRIPTION
## Summary
- Adds an "Adding a new public API" section to `AGENTS.md`'s Contributing Guidelines, explaining that new public Dart symbols must be registered in `sdk-compliance.yaml`, and how to add a new canonical capability upstream in `supabase/sdk` first when one doesn't already exist.
- Mirrors [supabase-js#2677](https://github.com/supabase/supabase-js/pull/2677), which added the equivalent section to its `CONTRIBUTING.md`. This repo has no `CONTRIBUTING.md`, so the section was added to `AGENTS.md` instead, adapted to this repo's actual mechanism (`symbols`/`supporting_symbols` keys, pinned SHA in `.github/workflows/validate-capabilities.yml`).

Documentation only, no behavioral or API change.

SDK-1742

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added contributor guidance for registering new public API symbols in the SDK capability configuration.
  - Documented how to handle existing and new SDK capabilities, including required validation updates.
  - Added guidance and an example for categorizing entry points and supporting symbols in YAML.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->