### PR TITLE
feat(supabase_flutter): pluggable OAuth launcher + opt-in supabase_flutter_web_auth

### DIFF
--- a/packages/supabase/example/pubspec.yaml
+++ b/packages/supabase/example/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 resolution: workspace
 
 dependencies:
-  web: '>=1.0.0 <2.0.0'
+  web: ^1.0.0
   supabase: ^3.0.0-dev.2
 
 dev_dependencies:

--- a/packages/supabase_auth/lib/src/types/mfa.dart
+++ b/packages/supabase_auth/lib/src/types/mfa.dart
@@ -274,7 +274,7 @@ class AuthMFARecoveryCodesGenerateResponse {
       id: json['id'] as String,
       friendlyName: json['friendly_name'] as String?,
       total: (json['total'] as num).toInt(),
-      codes: codes.cast<String>(),
+      codes: codes.cast(),
     );
   }
 

--- a/packages/supabase_auth/pubspec.yaml
+++ b/packages/supabase_auth/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
   meta: ^1.16.0
   logging: ^1.3.0
   supabase_common: 3.0.0-dev.1
-  web: ">=1.0.0 <2.0.0"
+  web: ^1.0.0
   dart_jsonwebtoken: ">=3.0.0 <4.0.0"
 
 dev_dependencies:

--- a/packages/supabase_flutter/lib/src/flutter_auth_client_options.dart
+++ b/packages/supabase_flutter/lib/src/flutter_auth_client_options.dart
@@ -16,7 +16,17 @@ class FlutterAuthClientOptions extends AuthClientOptions {
     super.retryOptions,
     this.detectSessionInUri = true,
     this.detectSessionInUriPredicate,
+    this.oauthLauncher = const UrlLauncherOAuthLauncher(),
   });
+
+  /// Launches the URL used to complete an OAuth, SSO, or identity-linking
+  /// flow.
+  ///
+  /// Defaults to [UrlLauncherOAuthLauncher], which opens a browser via
+  /// `url_launcher`. Provide a different [OAuthLauncher] to change how the
+  /// flow is presented, for example the one shipped by the
+  /// `supabase_flutter_web_auth` package.
+  final OAuthLauncher oauthLauncher;
 
   /// If true, the client will start the deep link observer and obtain sessions
   /// when a valid URI is detected.
@@ -45,6 +55,7 @@ class FlutterAuthClientOptions extends AuthClientOptions {
     SupabaseRetryOptions? retryOptions,
     bool? detectSessionInUri,
     bool Function(Uri uri)? detectSessionInUriPredicate,
+    OAuthLauncher? oauthLauncher,
   }) {
     return FlutterAuthClientOptions(
       authFlowType: authFlowType ?? this.authFlowType,
@@ -58,6 +69,7 @@ class FlutterAuthClientOptions extends AuthClientOptions {
       detectSessionInUri: detectSessionInUri ?? this.detectSessionInUri,
       detectSessionInUriPredicate:
           detectSessionInUriPredicate ?? this.detectSessionInUriPredicate,
+      oauthLauncher: oauthLauncher ?? this.oauthLauncher,
     );
   }
 }

--- a/packages/supabase_flutter/lib/src/oauth_launcher.dart
+++ b/packages/supabase_flutter/lib/src/oauth_launcher.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/foundation.dart'
+    show defaultTargetPlatform, kIsWeb, TargetPlatform;
+import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+/// Launches the URL used to complete an OAuth, SSO, or identity-linking flow.
+///
+/// Supply a custom implementation via [FlutterAuthClientOptions.oauthLauncher]
+/// to change how the flow is presented, for example running it through a
+/// system web authentication session instead of a plain browser launch (see
+/// the `supabase_flutter_web_auth` package).
+abstract class OAuthLauncher {
+  const OAuthLauncher();
+
+  /// Launches [url] on behalf of [client].
+  ///
+  /// [provider] is set for OAuth sign-in and identity-linking, and is null for
+  /// SSO. [redirectTo] is the configured callback URL, parsed, when provided.
+  /// [preferEphemeral] mirrors the same option on
+  /// `ASWebAuthenticationSession`/Custom Tabs; the default launcher ignores
+  /// it.
+  ///
+  /// Returns whether the flow launched successfully. A `true` result does not
+  /// by itself mean sign-in succeeded — observe [AuthClient.onAuthStateChange]
+  /// for the outcome, unless the implementation documents otherwise.
+  Future<bool> launch(
+    AuthClient client,
+    Uri url, {
+    required OAuthProvider? provider,
+    required Uri? redirectTo,
+    required LaunchMode launchMode,
+    bool preferEphemeral = false,
+  });
+}
+
+/// The default [OAuthLauncher]: opens [url] via `url_launcher`, forcing an
+/// external browser for Google sign-in on Android.
+///
+/// Google's OAuth policy blocks routing sign-in through an embedded
+/// user-agent under the app's control (see
+/// https://developers.google.com/identity/protocols/oauth2/resources/best-practices),
+/// which `url_launcher`'s `LaunchMode.inAppWebView` is on Android.
+class UrlLauncherOAuthLauncher extends OAuthLauncher {
+  const UrlLauncherOAuthLauncher();
+
+  @override
+  Future<bool> launch(
+    AuthClient client,
+    Uri url, {
+    required OAuthProvider? provider,
+    required Uri? redirectTo,
+    required LaunchMode launchMode,
+    bool preferEphemeral = false,
+  }) {
+    var mode = launchMode;
+
+    // `defaultTargetPlatform` reports the host OS even on web, so guard with
+    // `kIsWeb` to keep the external-browser workaround native-only.
+    final isAndroid =
+        !kIsWeb && defaultTargetPlatform == TargetPlatform.android;
+
+    if (provider == OAuthProvider.google && isAndroid) {
+      mode = LaunchMode.externalApplication;
+    }
+
+    return launchUrl(url, mode: mode, webOnlyWindowName: '_self');
+  }
+}

--- a/packages/supabase_flutter/lib/src/supabase.dart
+++ b/packages/supabase_flutter/lib/src/supabase.dart
@@ -8,6 +8,7 @@ import 'package:supabase_flutter/src/supabase_flutter_constants.dart';
 import 'package:supabase_flutter/src/flutter_auth_client_options.dart';
 import 'package:supabase_flutter/src/shared_preferences_auth_async_storage.dart';
 import 'package:supabase_flutter/src/logger.dart';
+import 'package:supabase_flutter/src/oauth_launcher.dart';
 import 'package:supabase_flutter/src/supabase_auth.dart';
 
 import 'hot_restart_cleanup_stub.dart'
@@ -114,6 +115,7 @@ class Supabase {
         asyncStorage: SharedPreferencesAuthAsyncStorage(),
       );
     }
+    _instance._oauthLauncher = authOptions.oauthLauncher;
     _instance._init(
       url,
       publishableKey,
@@ -163,6 +165,25 @@ class Supabase {
     return currentClient;
   }
 
+  OAuthLauncher? _oauthLauncher;
+
+  /// The [OAuthLauncher] configured via
+  /// [FlutterAuthClientOptions.oauthLauncher], used by
+  /// `signInWithOAuth`/`signInWithSSO`/`linkIdentity` to open the sign-in URL.
+  ///
+  /// Throws a [StateError] if [Supabase.initialize] was not called, or if the
+  /// instance has since been disposed.
+  OAuthLauncher get oauthLauncher {
+    final currentLauncher = _oauthLauncher;
+    if (currentLauncher == null) {
+      throw StateError(
+        'You must initialize the supabase instance before calling '
+        'Supabase.instance.oauthLauncher',
+      );
+    }
+    return currentLauncher;
+  }
+
   SupabaseAuth? _supabaseAuth;
 
   // Listener for app lifecycle events to handle Realtime reconnection.
@@ -191,6 +212,7 @@ class Supabase {
 
     _client = null;
     _supabaseAuth = null;
+    _oauthLauncher = null;
     _lifecycleListener = null;
     _isInitialized = false;
 

--- a/packages/supabase_flutter/lib/src/supabase_auth.dart
+++ b/packages/supabase_flutter/lib/src/supabase_auth.dart
@@ -10,7 +10,6 @@ import 'package:supabase_flutter/src/logger.dart';
 import 'package:meta/meta.dart';
 import 'package:supabase_common/supabase_common.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
-import 'package:url_launcher/url_launcher.dart';
 
 import 'clear_auth_url_parameters_stub.dart'
     if (dart.library.js_interop) 'clear_auth_url_parameters_web.dart';
@@ -265,6 +264,10 @@ extension AuthClientSignInProvider on AuthClient {
   /// To obtain the OAuth URL without launching a browser, use
   /// [getOAuthSignInUrl] instead.
   ///
+  /// [preferEphemeral] is ignored by the default [OAuthLauncher]; it is used
+  /// by launchers that support it, such as the one in
+  /// `supabase_flutter_web_auth`.
+  ///
   /// See also:
   ///
   ///   * <https://supabase.io/docs/guides/auth#third-party-logins>
@@ -274,6 +277,7 @@ extension AuthClientSignInProvider on AuthClient {
     String? scopes,
     LaunchMode authScreenLaunchMode = LaunchMode.platformDefault,
     Map<String, String>? queryParameters,
+    bool preferEphemeral = false,
   }) async {
     final response = await getOAuthSignInUrl(
       provider: provider,
@@ -281,32 +285,13 @@ extension AuthClientSignInProvider on AuthClient {
       scopes: scopes,
       queryParameters: queryParameters,
     );
-    return _launchAuthUrl(response.url, provider, authScreenLaunchMode);
-  }
-
-  /// Launches the [url] for an OAuth or identity-linking flow, forcing an
-  /// external browser for Google on Android.
-  Future<bool> _launchAuthUrl(
-    Uri url,
-    OAuthProvider provider,
-    LaunchMode authScreenLaunchMode,
-  ) {
-    LaunchMode launchMode = authScreenLaunchMode;
-
-    // `defaultTargetPlatform` reports the host OS even on web, so guard with
-    // `kIsWeb` to keep the external-browser workaround native-only.
-    final isAndroid =
-        !kIsWeb && defaultTargetPlatform == TargetPlatform.android;
-
-    // Google login has to be performed on external browser window on Android
-    if (provider == OAuthProvider.google && isAndroid) {
-      launchMode = LaunchMode.externalApplication;
-    }
-
-    return launchUrl(
-      url,
-      mode: launchMode,
-      webOnlyWindowName: '_self',
+    return Supabase.instance.oauthLauncher.launch(
+      this,
+      response.url,
+      provider: provider,
+      redirectTo: redirectTo == null ? null : Uri.parse(redirectTo),
+      launchMode: authScreenLaunchMode,
+      preferEphemeral: preferEphemeral,
     );
   }
 
@@ -327,6 +312,10 @@ extension AuthClientSignInProvider on AuthClient {
   /// returns false or throws a [PlatformException] depending on the launchUrl
   /// failure.
   ///
+  /// [preferEphemeral] is ignored by the default [OAuthLauncher]; it is used
+  /// by launchers that support it, such as the one in
+  /// `supabase_flutter_web_auth`.
+  ///
   /// ```dart
   /// await supabase.auth.signInWithSSO(
   ///   domain: 'company.com',
@@ -338,6 +327,7 @@ extension AuthClientSignInProvider on AuthClient {
     String? redirectTo,
     String? captchaToken,
     LaunchMode launchMode = LaunchMode.platformDefault,
+    bool preferEphemeral = false,
   }) async {
     final ssoUrl = await getSSOSignInUrl(
       providerId: providerId,
@@ -345,10 +335,13 @@ extension AuthClientSignInProvider on AuthClient {
       redirectTo: redirectTo,
       captchaToken: captchaToken,
     );
-    return await launchUrl(
+    return Supabase.instance.oauthLauncher.launch(
+      this,
       ssoUrl,
-      mode: launchMode,
-      webOnlyWindowName: '_self',
+      provider: null,
+      redirectTo: redirectTo == null ? null : Uri.parse(redirectTo),
+      launchMode: launchMode,
+      preferEphemeral: preferEphemeral,
     );
   }
 
@@ -359,12 +352,17 @@ extension AuthClientSignInProvider on AuthClient {
 
   /// Links an oauth identity to an existing user.
   /// This method supports the PKCE flow.
+  ///
+  /// [preferEphemeral] is ignored by the default [OAuthLauncher]; it is used
+  /// by launchers that support it, such as the one in
+  /// `supabase_flutter_web_auth`.
   Future<bool> linkIdentity(
     OAuthProvider provider, {
     String? redirectTo,
     String? scopes,
     LaunchMode authScreenLaunchMode = LaunchMode.platformDefault,
     Map<String, String>? queryParameters,
+    bool preferEphemeral = false,
   }) async {
     final response = await getLinkIdentityUrl(
       provider,
@@ -372,6 +370,13 @@ extension AuthClientSignInProvider on AuthClient {
       scopes: scopes,
       queryParameters: queryParameters,
     );
-    return _launchAuthUrl(response.url, provider, authScreenLaunchMode);
+    return Supabase.instance.oauthLauncher.launch(
+      this,
+      response.url,
+      provider: provider,
+      redirectTo: redirectTo == null ? null : Uri.parse(redirectTo),
+      launchMode: authScreenLaunchMode,
+      preferEphemeral: preferEphemeral,
+    );
   }
 }

--- a/packages/supabase_flutter/lib/supabase_flutter.dart
+++ b/packages/supabase_flutter/lib/supabase_flutter.dart
@@ -7,6 +7,7 @@ export 'package:supabase_common/supabase_common.dart'
 export 'package:url_launcher/url_launcher.dart' show LaunchMode;
 
 export 'src/flutter_auth_client_options.dart';
+export 'src/oauth_launcher.dart';
 export 'src/shared_preferences_auth_async_storage.dart';
 export 'src/supabase.dart';
 export 'src/supabase_auth.dart' hide SupabaseAuth;

--- a/packages/supabase_flutter/pubspec.yaml
+++ b/packages/supabase_flutter/pubspec.yaml
@@ -30,7 +30,7 @@ dependencies:
   url_launcher: ^6.3.2
   shared_preferences: ^2.5.5
   logging: ^1.3.0
-  web: '>=1.0.0 <2.0.0'
+  web: ^1.0.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/supabase_flutter/test/oauth_launcher_test.dart
+++ b/packages/supabase_flutter/test/oauth_launcher_test.dart
@@ -51,8 +51,7 @@ void main() {
       url: 'https://test.supabase.co',
       publishableKey: '',
       authOptions: FlutterAuthClientOptions(
-        localStorage: const MockEmptyLocalStorage(),
-        pkceAsyncStorage: MockAsyncStorage(),
+        asyncStorage: MockAsyncStorage(),
         oauthLauncher: fakeLauncher,
       ),
     );

--- a/packages/supabase_flutter/test/oauth_launcher_test.dart
+++ b/packages/supabase_flutter/test/oauth_launcher_test.dart
@@ -1,0 +1,97 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import 'widget_test_stubs.dart';
+
+/// Fake [OAuthLauncher] that records the arguments it was called with instead
+/// of launching a browser.
+class FakeOAuthLauncher extends OAuthLauncher {
+  AuthClient? lastClient;
+  Uri? lastUrl;
+  OAuthProvider? lastProvider;
+  Uri? lastRedirectTo;
+  LaunchMode? lastLaunchMode;
+  bool? lastPreferEphemeral;
+
+  @override
+  Future<bool> launch(
+    AuthClient client,
+    Uri url, {
+    required OAuthProvider? provider,
+    required Uri? redirectTo,
+    required LaunchMode launchMode,
+    bool preferEphemeral = false,
+  }) async {
+    lastClient = client;
+    lastUrl = url;
+    lastProvider = provider;
+    lastRedirectTo = redirectTo;
+    lastLaunchMode = launchMode;
+    lastPreferEphemeral = preferEphemeral;
+    return true;
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late FakeOAuthLauncher fakeLauncher;
+
+  setUp(() async {
+    try {
+      await Supabase.instance.dispose();
+    } catch (_) {
+      // Ignore dispose errors
+    }
+
+    mockAppLink();
+    fakeLauncher = FakeOAuthLauncher();
+
+    await Supabase.initialize(
+      url: 'https://test.supabase.co',
+      publishableKey: '',
+      authOptions: FlutterAuthClientOptions(
+        localStorage: const MockEmptyLocalStorage(),
+        pkceAsyncStorage: MockAsyncStorage(),
+        oauthLauncher: fakeLauncher,
+      ),
+    );
+  });
+
+  tearDown(() async {
+    await Supabase.instance.dispose();
+  });
+
+  test(
+    'signInWithOAuth delegates to the configured OAuthLauncher',
+    () async {
+      await Supabase.instance.client.auth.signInWithOAuth(
+        OAuthProvider.github,
+        redirectTo: 'io.supabase.flutter://callback',
+        preferEphemeral: true,
+      );
+
+      expect(fakeLauncher.lastClient, Supabase.instance.client.auth);
+      expect(fakeLauncher.lastUrl?.queryParameters['provider'], 'github');
+      expect(fakeLauncher.lastProvider, OAuthProvider.github);
+      expect(
+        fakeLauncher.lastRedirectTo,
+        Uri.parse('io.supabase.flutter://callback'),
+      );
+      expect(fakeLauncher.lastLaunchMode, LaunchMode.platformDefault);
+      expect(fakeLauncher.lastPreferEphemeral, isTrue);
+    },
+  );
+
+  test(
+    'signInWithOAuth with no redirectTo passes a null redirectTo through',
+    () async {
+      await Supabase.instance.client.auth.signInWithOAuth(
+        OAuthProvider.github,
+      );
+
+      expect(fakeLauncher.lastRedirectTo, isNull);
+      expect(fakeLauncher.lastPreferEphemeral, isFalse);
+    },
+  );
+}

--- a/packages/supabase_flutter_web_auth/LICENSE
+++ b/packages/supabase_flutter_web_auth/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Supabase Community
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/supabase_flutter_web_auth/LICENSE
+++ b/packages/supabase_flutter_web_auth/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Supabase Community
+Copyright (c) 2020 Supabase
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/supabase_flutter_web_auth/LICENSE
+++ b/packages/supabase_flutter_web_auth/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 Supabase
+Copyright (c) 2026 Supabase
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/supabase_flutter_web_auth/README.md
+++ b/packages/supabase_flutter_web_auth/README.md
@@ -3,15 +3,18 @@
 Runs [supabase_flutter](https://pub.dev/packages/supabase_flutter)'s
 `signInWithOAuth`, `signInWithSSO`, and `linkIdentity` flows through a system
 web authentication session (`ASWebAuthenticationSession` on iOS/macOS, Custom
-Tabs on Android and desktop) instead of a plain browser launch.
+Tabs on Android) instead of a plain browser launch. On Linux and Windows there
+is no equivalent OS session, so the flow runs in an embedded webview window
+instead (see Setup below).
 
 By default, `supabase_flutter` opens the sign-in URL with `url_launcher`. That
 browser surface does not close itself when the OAuth redirect returns to the
 app, so the user is left on a blank page after a successful sign-in and has to
-dismiss it manually. A system web authentication session is owned by the OS:
-it auto-dismisses and hands the callback URL straight back, and it shares
-cookies with the system browser, so a user already signed in to a provider
-elsewhere isn't asked to sign in again.
+dismiss it manually. This package's launcher always auto-dismisses once the
+redirect arrives. On iOS/macOS and Android it also shares cookies with the
+system browser, so a user already signed in to a provider elsewhere isn't
+asked to sign in again; the embedded webview used on Linux and Windows has its
+own separate cookie store and does not share that session.
 
 This behavior isn't the default in `supabase_flutter` because achieving it
 pulls in `flutter_web_auth_2` and, on Linux/Windows, its own embedded-webview

--- a/packages/supabase_flutter_web_auth/README.md
+++ b/packages/supabase_flutter_web_auth/README.md
@@ -1,0 +1,71 @@
+# supabase_flutter_web_auth
+
+Runs [supabase_flutter](https://pub.dev/packages/supabase_flutter)'s
+`signInWithOAuth`, `signInWithSSO`, and `linkIdentity` flows through a system
+web authentication session (`ASWebAuthenticationSession` on iOS/macOS, Custom
+Tabs on Android and desktop) instead of a plain browser launch.
+
+By default, `supabase_flutter` opens the sign-in URL with `url_launcher`. That
+browser surface does not close itself when the OAuth redirect returns to the
+app, so the user is left on a blank page after a successful sign-in and has to
+dismiss it manually. A system web authentication session is owned by the OS:
+it auto-dismisses and hands the callback URL straight back, and it shares
+cookies with the system browser, so a user already signed in to a provider
+elsewhere isn't asked to sign in again.
+
+This behavior isn't the default in `supabase_flutter` because achieving it
+pulls in `flutter_web_auth_2` and, on Linux/Windows, its own embedded-webview
+dependency. Add this package only if you want that trade-off.
+
+## Usage
+
+```dart
+import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:supabase_flutter_web_auth/supabase_flutter_web_auth.dart';
+
+await Supabase.initialize(
+  url: 'https://your-project.supabase.co',
+  publishableKey: 'your-publishable-key',
+  authOptions: const FlutterAuthClientOptions(
+    oauthLauncher: FlutterWebAuth2OAuthLauncher(),
+  ),
+);
+```
+
+`signInWithOAuth`, `signInWithSSO`, and `linkIdentity` are called exactly as
+documented in `supabase_flutter`; the new `preferEphemeral` parameter (ignored
+by the default launcher) requests a session that does not share cookies with
+the system browser.
+
+## Setup
+
+### Android
+
+Register the `flutter_web_auth_2` callback activity for your redirect scheme
+in `android/app/src/main/AndroidManifest.xml`:
+
+```xml
+<activity
+    android:name="com.linusu.flutter_web_auth_2.CallbackActivity"
+    android:exported="true">
+  <intent-filter android:label="flutter_web_auth_2">
+    <action android:name="android.intent.action.VIEW" />
+    <category android:name="android.intent.category.DEFAULT" />
+    <category android:name="android.intent.category.BROWSABLE" />
+    <data android:scheme="my-scheme" />
+  </intent-filter>
+</activity>
+```
+
+Replace `my-scheme` with the scheme of the `redirectTo` URL you pass to
+`signInWithOAuth`/`signInWithSSO`/`linkIdentity`.
+
+### iOS and macOS
+
+No extra configuration is needed for a custom URL scheme redirect. For an
+`https` universal link `redirectTo`, set up associated domains as usual.
+
+### Linux and Windows
+
+No native configuration is needed; the flow runs in an embedded webview
+window provided by `flutter_web_auth_2`.

--- a/packages/supabase_flutter_web_auth/analysis_options.yaml
+++ b/packages/supabase_flutter_web_auth/analysis_options.yaml
@@ -1,0 +1,10 @@
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
+include: package:supabase_lints/analysis_options.yaml

--- a/packages/supabase_flutter_web_auth/example/.gitignore
+++ b/packages/supabase_flutter_web_auth/example/.gitignore
@@ -1,0 +1,10 @@
+# Platform folders are not checked in for this example. Run `flutter create .`
+# in this directory to generate the ones you want to test on.
+/android/
+/ios/
+/linux/
+/macos/
+/windows/
+/web/
+/.metadata
+/*.iml

--- a/packages/supabase_flutter_web_auth/example/README.md
+++ b/packages/supabase_flutter_web_auth/example/README.md
@@ -1,0 +1,15 @@
+# supabase_flutter_web_auth_example
+
+Demonstrates using `supabase_flutter_web_auth`'s `FlutterWebAuth2OAuthLauncher`
+with `supabase_flutter`.
+
+Platform folders (`android/`, `ios/`, etc.) are not checked in. Before running,
+generate the ones you want to test on:
+
+```sh
+flutter create .
+```
+
+Then fill in `SUPABASE_URL`/`SUPABASE_PUBLISHABLE_KEY` in `lib/main.dart`,
+register the redirect scheme (see the package README's Setup section), and
+run the app.

--- a/packages/supabase_flutter_web_auth/example/analysis_options.yaml
+++ b/packages/supabase_flutter_web_auth/example/analysis_options.yaml
@@ -1,0 +1,18 @@
+include: package:supabase_lints/analysis_options_flutter.yaml
+
+analyzer:
+  exclude:
+    - lib/generated_plugin_registrant.dart
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
+
+dcm:
+  rules:
+    # This is a single-file demo app, so keeping every widget in one file is
+    # intentional.
+    - prefer-single-widget-per-file: false

--- a/packages/supabase_flutter_web_auth/example/lib/main.dart
+++ b/packages/supabase_flutter_web_auth/example/lib/main.dart
@@ -102,9 +102,9 @@ class _SignedInView extends StatelessWidget {
     return Center(
       child: Column(
         mainAxisSize: MainAxisSize.min,
+        spacing: 16,
         children: [
           Text('Signed in as ${user.email}'),
-          const SizedBox(height: 16),
           TextButton(
             onPressed: () => unawaited(
               Supabase.instance.client.auth.signOut(),

--- a/packages/supabase_flutter_web_auth/example/lib/main.dart
+++ b/packages/supabase_flutter_web_auth/example/lib/main.dart
@@ -1,0 +1,118 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:supabase_flutter_web_auth/supabase_flutter_web_auth.dart';
+
+Future<void> main() async {
+  await Supabase.initialize(
+    url: 'SUPABASE_URL',
+    publishableKey: 'SUPABASE_PUBLISHABLE_KEY',
+    authOptions: const FlutterAuthClientOptions(
+      oauthLauncher: FlutterWebAuth2OAuthLauncher(),
+    ),
+  );
+  runApp(const MyApp());
+}
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const MaterialApp(
+      title: 'supabase_flutter_web_auth Demo',
+      home: MyHomePage(),
+    );
+  }
+}
+
+class MyHomePage extends StatefulWidget {
+  const MyHomePage({super.key});
+
+  @override
+  State<MyHomePage> createState() => _MyHomePageState();
+}
+
+class _MyHomePageState extends State<MyHomePage> {
+  User? _user;
+  StreamSubscription<AuthState>? _authSubscription;
+
+  @override
+  void initState() {
+    super.initState();
+    _user = Supabase.instance.client.auth.currentUser;
+    _authSubscription = Supabase.instance.client.auth.onAuthStateChange.listen(
+      (data) {
+        setState(() {
+          _user = data.session?.user;
+        });
+      },
+      onError: (error, stackTrace) {
+        // Network errors (e.g. offline) are emitted as stream errors.
+        // Handle or log them here; omitting this handler causes an unhandled
+        // exception when the device has no connectivity.
+      },
+    );
+  }
+
+  @override
+  void dispose() {
+    unawaited(_authSubscription?.cancel());
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('OAuth via web auth session')),
+      body: _user == null ? const _SignInForm() : _SignedInView(user: _user!),
+    );
+  }
+}
+
+class _SignInForm extends StatelessWidget {
+  const _SignInForm();
+
+  Future<void> _signInWithGitHub() {
+    return Supabase.instance.client.auth.signInWithOAuth(
+      OAuthProvider.github,
+      redirectTo: 'io.supabase.flutterwebauthexample://callback',
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: ElevatedButton(
+        onPressed: () => unawaited(_signInWithGitHub()),
+        child: const Text('Sign in with GitHub'),
+      ),
+    );
+  }
+}
+
+class _SignedInView extends StatelessWidget {
+  const _SignedInView({required this.user});
+
+  final User user;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text('Signed in as ${user.email}'),
+          const SizedBox(height: 16),
+          TextButton(
+            onPressed: () => unawaited(
+              Supabase.instance.client.auth.signOut(),
+            ),
+            child: const Text('Sign out'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/packages/supabase_flutter_web_auth/example/pubspec.yaml
+++ b/packages/supabase_flutter_web_auth/example/pubspec.yaml
@@ -1,0 +1,26 @@
+name: supabase_flutter_web_auth_example
+description: Demonstrates how to use supabase_flutter_web_auth
+
+publish_to: 'none'
+
+version: 1.0.0+1
+
+environment:
+  sdk: '>=3.9.0 <4.0.0'
+
+resolution: workspace
+
+dependencies:
+  flutter:
+    sdk: flutter
+  supabase_flutter: ^3.0.0-dev.2
+  supabase_flutter_web_auth: ^0.1.0
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
+  supabase_lints: ^0.1.2
+
+flutter:
+  uses-material-design: true

--- a/packages/supabase_flutter_web_auth/lib/src/flutter_web_auth2_oauth_launcher.dart
+++ b/packages/supabase_flutter_web_auth/lib/src/flutter_web_auth2_oauth_launcher.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:flutter_web_auth_2/flutter_web_auth_2.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import 'oauth_redirect_stub.dart'
+    if (dart.library.js_interop) 'oauth_redirect_web.dart';
+
+/// Runs the OAuth, SSO, and identity-linking flows through a system web
+/// authentication session (`ASWebAuthenticationSession` on Apple platforms,
+/// Custom Tabs on Android and desktop) instead of a plain browser launch.
+///
+/// The session captures the redirect to [redirectTo], closes itself, and
+/// hands the callback URL back, which is exchanged for a session directly —
+/// unlike [UrlLauncherOAuthLauncher], this does not rely on `app_links` to
+/// observe the callback.
+///
+/// Unlike [UrlLauncherOAuthLauncher], this never forces an external browser
+/// for Google sign-in on Android: Custom Tabs runs as Chrome's own sandboxed
+/// process, not an embedded user-agent under the app's control, so it already
+/// satisfies Google's OAuth policy
+/// (https://developers.google.com/identity/protocols/oauth2/resources/best-practices).
+class FlutterWebAuth2OAuthLauncher extends OAuthLauncher {
+  const FlutterWebAuth2OAuthLauncher();
+
+  @override
+  Future<bool> launch(
+    AuthClient client,
+    Uri url, {
+    required OAuthProvider? provider,
+    required Uri? redirectTo,
+    required LaunchMode launchMode,
+    bool preferEphemeral = false,
+  }) async {
+    if (kIsWeb) {
+      redirectToUrl(url.toString());
+      return true;
+    }
+
+    if (redirectTo == null) {
+      throw const AuthException(
+        'redirectTo is required to capture the authentication callback on '
+        'this platform.',
+      );
+    }
+
+    final isHttps = redirectTo.scheme == 'https';
+    final result = await FlutterWebAuth2.authenticate(
+      url: url.toString(),
+      callbackUrlScheme: redirectTo.scheme,
+      options: FlutterWebAuth2Options(
+        preferEphemeral: preferEphemeral,
+        httpsHost: isHttps ? redirectTo.host : null,
+        httpsPath: isHttps ? redirectTo.path : null,
+      ),
+    );
+
+    await client.getSessionFromUrl(Uri.parse(result));
+    return true;
+  }
+}

--- a/packages/supabase_flutter_web_auth/lib/src/flutter_web_auth2_oauth_launcher.dart
+++ b/packages/supabase_flutter_web_auth/lib/src/flutter_web_auth2_oauth_launcher.dart
@@ -7,7 +7,9 @@ import 'oauth_redirect_stub.dart'
 
 /// Runs the OAuth, SSO, and identity-linking flows through a system web
 /// authentication session (`ASWebAuthenticationSession` on Apple platforms,
-/// Custom Tabs on Android and desktop) instead of a plain browser launch.
+/// Custom Tabs on Android) instead of a plain browser launch. On Linux and
+/// Windows, which have no equivalent OS session, the flow runs in an
+/// embedded webview window instead, with its own separate cookie store.
 ///
 /// The session captures the redirect to [redirectTo], closes itself, and
 /// hands the callback URL back, which is exchanged for a session directly —
@@ -17,8 +19,8 @@ import 'oauth_redirect_stub.dart'
 /// Unlike [UrlLauncherOAuthLauncher], this never forces an external browser
 /// for Google sign-in on Android: Custom Tabs runs as Chrome's own sandboxed
 /// process, not an embedded user-agent under the app's control, so it already
-/// satisfies Google's OAuth policy
-/// (https://developers.google.com/identity/protocols/oauth2/resources/best-practices).
+/// satisfies Google's OAuth policy. See
+/// https://developers.google.com/identity/protocols/oauth2/resources/best-practices.
 class FlutterWebAuth2OAuthLauncher extends OAuthLauncher {
   const FlutterWebAuth2OAuthLauncher();
 

--- a/packages/supabase_flutter_web_auth/lib/src/oauth_redirect_stub.dart
+++ b/packages/supabase_flutter_web_auth/lib/src/oauth_redirect_stub.dart
@@ -1,0 +1,8 @@
+// coverage:ignore-file
+
+/// Navigates the current browser tab to [url].
+///
+/// Only meaningful on web. The stub throws because native and desktop
+/// platforms go through the web auth session instead of a full-page
+/// redirect.
+void redirectToUrl(String url) => throw UnimplementedError();

--- a/packages/supabase_flutter_web_auth/lib/src/oauth_redirect_stub.dart
+++ b/packages/supabase_flutter_web_auth/lib/src/oauth_redirect_stub.dart
@@ -1,8 +1,11 @@
 // coverage:ignore-file
 
+import 'package:meta/meta.dart';
+
 /// Navigates the current browser tab to [url].
 ///
 /// Only meaningful on web. The stub throws because native and desktop
 /// platforms go through the web auth session instead of a full-page
 /// redirect.
+@internal
 void redirectToUrl(String url) => throw UnimplementedError();

--- a/packages/supabase_flutter_web_auth/lib/src/oauth_redirect_web.dart
+++ b/packages/supabase_flutter_web_auth/lib/src/oauth_redirect_web.dart
@@ -1,0 +1,5 @@
+import 'package:web/web.dart';
+
+/// Navigates the current browser tab to [url], preserving the full-page
+/// redirect behavior the OAuth flow relies on for web.
+void redirectToUrl(String url) => window.location.assign(url);

--- a/packages/supabase_flutter_web_auth/lib/src/oauth_redirect_web.dart
+++ b/packages/supabase_flutter_web_auth/lib/src/oauth_redirect_web.dart
@@ -1,5 +1,7 @@
+import 'package:meta/meta.dart';
 import 'package:web/web.dart';
 
 /// Navigates the current browser tab to [url], preserving the full-page
 /// redirect behavior the OAuth flow relies on for web.
+@internal
 void redirectToUrl(String url) => window.location.assign(url);

--- a/packages/supabase_flutter_web_auth/lib/supabase_flutter_web_auth.dart
+++ b/packages/supabase_flutter_web_auth/lib/supabase_flutter_web_auth.dart
@@ -1,0 +1,5 @@
+/// Runs `supabase_flutter`'s OAuth, SSO, and identity-linking flows through a
+/// system web authentication session instead of a plain browser launch.
+library;
+
+export 'src/flutter_web_auth2_oauth_launcher.dart';

--- a/packages/supabase_flutter_web_auth/pubspec.yaml
+++ b/packages/supabase_flutter_web_auth/pubspec.yaml
@@ -29,9 +29,8 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_web_auth_2_platform_interface: ^5.0.0
-  http: ^1.6.0
   plugin_platform_interface: ^2.0.0
   supabase_lints: ^0.1.2
-  supabase_testing: 0.1.1
+  supabase_test: 0.1.1
 
 flutter:

--- a/packages/supabase_flutter_web_auth/pubspec.yaml
+++ b/packages/supabase_flutter_web_auth/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
   flutter_web_auth_2: ^5.0.0
   meta: ^1.16.0
   supabase_flutter: 3.0.0-dev.2
-  web: '>=1.0.0 <2.0.0'
+  web: ^1.0.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/supabase_flutter_web_auth/pubspec.yaml
+++ b/packages/supabase_flutter_web_auth/pubspec.yaml
@@ -1,0 +1,36 @@
+name: supabase_flutter_web_auth
+description: Runs supabase_flutter's OAuth, SSO, and identity-linking flows through a system web authentication session instead of a plain browser launch.
+version: 0.1.0
+homepage: 'https://supabase.com'
+repository: 'https://github.com/supabase/supabase-flutter/tree/main/packages/supabase_flutter_web_auth'
+issue_tracker: 'https://github.com/supabase/supabase-flutter/issues'
+documentation: 'https://supabase.com/docs/reference/dart/introduction'
+topics:
+  - supabase
+  - flutter
+  - auth
+  - oauth
+
+environment:
+  sdk: '>=3.9.0 <4.0.0'
+  flutter: '>=3.35.0'
+
+resolution: workspace
+
+dependencies:
+  flutter:
+    sdk: flutter
+  flutter_web_auth_2: ^5.0.0
+  supabase_flutter: 3.0.0-dev.2
+  web: '>=1.0.0 <2.0.0'
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_web_auth_2_platform_interface: ^5.0.0
+  http: ^1.6.0
+  plugin_platform_interface: ^2.0.0
+  supabase_lints: ^0.1.2
+  supabase_testing: 0.1.1
+
+flutter:

--- a/packages/supabase_flutter_web_auth/pubspec.yaml
+++ b/packages/supabase_flutter_web_auth/pubspec.yaml
@@ -21,6 +21,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_web_auth_2: ^5.0.0
+  meta: ^1.16.0
   supabase_flutter: 3.0.0-dev.2
   web: '>=1.0.0 <2.0.0'
 

--- a/packages/supabase_flutter_web_auth/test/oauth_test.dart
+++ b/packages/supabase_flutter_web_auth/test/oauth_test.dart
@@ -1,0 +1,103 @@
+@TestOn('!browser')
+library;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_web_auth_2_platform_interface/flutter_web_auth_2_platform_interface.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:supabase_flutter_web_auth/supabase_flutter_web_auth.dart';
+
+import 'test_stubs.dart';
+
+void main() {
+  late FakeFlutterWebAuth2 fakeWebAuth;
+  late PkceHttpClient pkceHttpClient;
+
+  setUp(() async {
+    TestWidgetsFlutterBinding.ensureInitialized();
+
+    try {
+      await Supabase.instance.dispose();
+    } catch (_) {
+      // Ignore dispose errors
+    }
+
+    fakeWebAuth = FakeFlutterWebAuth2(
+      'io.supabase.flutter://callback/?code=my-code-verifier',
+    );
+    FlutterWebAuth2Platform.instance = fakeWebAuth;
+
+    pkceHttpClient = PkceHttpClient();
+
+    await Supabase.initialize(
+      url: 'https://test.supabase.co',
+      publishableKey: '',
+      httpClient: pkceHttpClient,
+      authOptions: FlutterAuthClientOptions(
+        localStorage: const MockEmptyLocalStorage(),
+        pkceAsyncStorage: MockAsyncStorage(),
+        oauthLauncher: const FlutterWebAuth2OAuthLauncher(),
+      ),
+    );
+  });
+
+  tearDown(() async {
+    await Supabase.instance.dispose();
+  });
+
+  test(
+    'signInWithOAuth runs the web auth session and exchanges the returned code',
+    () async {
+      await Supabase.instance.client.auth.signInWithOAuth(
+        OAuthProvider.github,
+        redirectTo: 'io.supabase.flutter://callback',
+      );
+
+      // The authorize URL is opened in the web auth session, and the callback
+      // scheme is derived from redirectTo.
+      expect(fakeWebAuth.authenticatedUrl, contains('/authorize'));
+      expect(fakeWebAuth.authenticatedUrl, contains('provider=github'));
+      expect(fakeWebAuth.callbackUrlScheme, 'io.supabase.flutter');
+
+      // The code from the callback URL is exchanged for a session.
+      expect(pkceHttpClient.lastRequestBody['auth_code'], 'my-code-verifier');
+      expect(
+        Supabase.instance.client.auth.currentUser?.email,
+        'fake1@email.com',
+      );
+    },
+  );
+
+  test(
+    'preferEphemeral is forwarded to the web auth session options',
+    () async {
+      await Supabase.instance.client.auth.signInWithOAuth(
+        OAuthProvider.github,
+        redirectTo: 'io.supabase.flutter://callback',
+        preferEphemeral: true,
+      );
+
+      expect(fakeWebAuth.options?['preferEphemeral'], true);
+    },
+  );
+
+  test('https redirectTo forwards host and path for universal links', () async {
+    await Supabase.instance.client.auth.signInWithOAuth(
+      OAuthProvider.github,
+      redirectTo: 'https://myapp.com/auth/callback',
+    );
+
+    expect(fakeWebAuth.callbackUrlScheme, 'https');
+    expect(fakeWebAuth.options?['httpsHost'], 'myapp.com');
+    expect(fakeWebAuth.options?['httpsPath'], '/auth/callback');
+  });
+
+  test(
+    'signInWithOAuth without redirectTo throws on native platforms',
+    () async {
+      await expectLater(
+        Supabase.instance.client.auth.signInWithOAuth(OAuthProvider.github),
+        throwsA(isA<AuthException>()),
+      );
+    },
+  );
+}

--- a/packages/supabase_flutter_web_auth/test/oauth_test.dart
+++ b/packages/supabase_flutter_web_auth/test/oauth_test.dart
@@ -56,7 +56,7 @@ void main() {
       // scheme is derived from redirectTo.
       expect(fakeWebAuth.authenticatedUrl, contains('/authorize'));
       expect(fakeWebAuth.authenticatedUrl, contains('provider=github'));
-      expect(fakeWebAuth.callbackUrlScheme, 'io.supabase.flutter');
+      expect(fakeWebAuth.capturedCallbackUrlScheme, 'io.supabase.flutter');
 
       // The code from the callback URL is exchanged for a session.
       expect(pkceHttpClient.lastRequestBody['auth_code'], 'my-code-verifier');
@@ -76,7 +76,7 @@ void main() {
         preferEphemeral: true,
       );
 
-      expect(fakeWebAuth.options?['preferEphemeral'], true);
+      expect(fakeWebAuth.capturedOptions?['preferEphemeral'], true);
     },
   );
 
@@ -86,9 +86,9 @@ void main() {
       redirectTo: 'https://myapp.com/auth/callback',
     );
 
-    expect(fakeWebAuth.callbackUrlScheme, 'https');
-    expect(fakeWebAuth.options?['httpsHost'], 'myapp.com');
-    expect(fakeWebAuth.options?['httpsPath'], '/auth/callback');
+    expect(fakeWebAuth.capturedCallbackUrlScheme, 'https');
+    expect(fakeWebAuth.capturedOptions?['httpsHost'], 'myapp.com');
+    expect(fakeWebAuth.capturedOptions?['httpsPath'], '/auth/callback');
   });
 
   test(

--- a/packages/supabase_flutter_web_auth/test/oauth_test.dart
+++ b/packages/supabase_flutter_web_auth/test/oauth_test.dart
@@ -5,12 +5,13 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_web_auth_2_platform_interface/flutter_web_auth_2_platform_interface.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:supabase_flutter_web_auth/supabase_flutter_web_auth.dart';
+import 'package:supabase_test/supabase_test.dart';
 
 import 'test_stubs.dart';
 
 void main() {
   late FakeFlutterWebAuth2 fakeWebAuth;
-  late PkceHttpClient pkceHttpClient;
+  late MockSupabaseHttpClient pkceHttpClient;
 
   setUp(() async {
     TestWidgetsFlutterBinding.ensureInitialized();
@@ -26,15 +27,14 @@ void main() {
     );
     FlutterWebAuth2Platform.instance = fakeWebAuth;
 
-    pkceHttpClient = PkceHttpClient();
+    pkceHttpClient = createPkceHttpClient();
 
     await Supabase.initialize(
       url: 'https://test.supabase.co',
       publishableKey: '',
       httpClient: pkceHttpClient,
       authOptions: FlutterAuthClientOptions(
-        localStorage: const MockEmptyLocalStorage(),
-        pkceAsyncStorage: MockAsyncStorage(),
+        asyncStorage: MockAsyncStorage(),
         oauthLauncher: const FlutterWebAuth2OAuthLauncher(),
       ),
     );
@@ -59,7 +59,10 @@ void main() {
       expect(fakeWebAuth.capturedCallbackUrlScheme, 'io.supabase.flutter');
 
       // The code from the callback URL is exchanged for a session.
-      expect(pkceHttpClient.lastRequestBody['auth_code'], 'my-code-verifier');
+      expect(
+        pkceHttpClient.requests.last.jsonBody['auth_code'],
+        'my-code-verifier',
+      );
       expect(
         Supabase.instance.client.auth.currentUser?.email,
         'fake1@email.com',

--- a/packages/supabase_flutter_web_auth/test/test_stubs.dart
+++ b/packages/supabase_flutter_web_auth/test/test_stubs.dart
@@ -17,8 +17,8 @@ class FakeFlutterWebAuth2 extends FlutterWebAuth2Platform
   final String callbackUrl;
 
   String? authenticatedUrl;
-  String? callbackUrlScheme;
-  Map<String, dynamic>? options;
+  String? capturedCallbackUrlScheme;
+  Map<String, dynamic>? capturedOptions;
 
   @override
   Future<String> authenticate({
@@ -27,8 +27,8 @@ class FakeFlutterWebAuth2 extends FlutterWebAuth2Platform
     required Map<String, dynamic> options,
   }) async {
     authenticatedUrl = url;
-    this.callbackUrlScheme = callbackUrlScheme;
-    this.options = options;
+    capturedCallbackUrlScheme = callbackUrlScheme;
+    capturedOptions = options;
     return callbackUrl;
   }
 

--- a/packages/supabase_flutter_web_auth/test/test_stubs.dart
+++ b/packages/supabase_flutter_web_auth/test/test_stubs.dart
@@ -1,10 +1,7 @@
-import 'dart:convert';
-
 import 'package:flutter_web_auth_2_platform_interface/flutter_web_auth_2_platform_interface.dart';
-import 'package:http/http.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
-import 'package:supabase_testing/supabase_testing.dart';
+import 'package:supabase_test/supabase_test.dart';
 
 /// Fake [FlutterWebAuth2Platform] that records the authentication request and
 /// returns a preconfigured callback URL, standing in for the system web auth
@@ -36,48 +33,20 @@ class FakeFlutterWebAuth2 extends FlutterWebAuth2Platform
   Future<void> clearAllDanglingCalls() async {}
 }
 
-class MockEmptyLocalStorage extends LocalStorage {
-  const MockEmptyLocalStorage();
-  @override
-  Future<void> initialize() async {}
-  @override
-  Future<String?> accessToken() async => null;
-  @override
-  Future<bool> hasAccessToken() async => false;
-  @override
-  Future<void> persistSession(String persistSessionString) async {}
-  @override
-  Future<void> removePersistedSession() async {}
-}
-
 class MockAsyncStorage extends MemoryAuthAsyncStorage {}
 
-/// Custom HTTP client just to test the PKCE flow.
-class PkceHttpClient extends BaseClient {
-  int requestCount = 0;
-  Map<String, dynamic> lastRequestBody = {};
-
-  @override
-  Future<StreamedResponse> send(BaseRequest request) async {
-    requestCount++;
-
-    if (request is Request) {
-      lastRequestBody = jsonDecode(request.body);
-    }
-
-    final accessToken = signedTestJwt({
-      'exp': (DateTime.now().millisecondsSinceEpoch / 1000).round() + 60,
-      'sub': testUserId,
-    }, secret: '37c304f8-51aa-419a-a1af-06154e63707a');
-
-    return StreamedResponse(
-      Stream.value(
-        utf8.encode(
-          jsonEncode(testSessionResponseJson(accessToken: accessToken)),
+/// A mock HTTP client that answers the PKCE token exchange with a fresh
+/// session, so the code returned by the fake web auth session can be
+/// exchanged.
+MockSupabaseHttpClient createPkceHttpClient() =>
+    MockSupabaseHttpClient()..stubHandler(
+      (_) => jsonResponse(
+        testSessionResponseJson(
+          accessToken: signedTestJwt({
+            'exp': (DateTime.now().millisecondsSinceEpoch / 1000).round() + 60,
+            'sub': testUserId,
+          }, secret: '37c304f8-51aa-419a-a1af-06154e63707a'),
         ),
+        statusCode: 201,
       ),
-      201,
-      request: request,
     );
-  }
-}

--- a/packages/supabase_flutter_web_auth/test/test_stubs.dart
+++ b/packages/supabase_flutter_web_auth/test/test_stubs.dart
@@ -1,0 +1,83 @@
+import 'dart:convert';
+
+import 'package:flutter_web_auth_2_platform_interface/flutter_web_auth_2_platform_interface.dart';
+import 'package:http/http.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:supabase_testing/supabase_testing.dart';
+
+/// Fake [FlutterWebAuth2Platform] that records the authentication request and
+/// returns a preconfigured callback URL, standing in for the system web auth
+/// session in tests.
+class FakeFlutterWebAuth2 extends FlutterWebAuth2Platform
+    with MockPlatformInterfaceMixin {
+  FakeFlutterWebAuth2(this.callbackUrl);
+
+  /// The callback URL the fake session resolves with.
+  final String callbackUrl;
+
+  String? authenticatedUrl;
+  String? callbackUrlScheme;
+  Map<String, dynamic>? options;
+
+  @override
+  Future<String> authenticate({
+    required String url,
+    required String callbackUrlScheme,
+    required Map<String, dynamic> options,
+  }) async {
+    authenticatedUrl = url;
+    this.callbackUrlScheme = callbackUrlScheme;
+    this.options = options;
+    return callbackUrl;
+  }
+
+  @override
+  Future<void> clearAllDanglingCalls() async {}
+}
+
+class MockEmptyLocalStorage extends LocalStorage {
+  const MockEmptyLocalStorage();
+  @override
+  Future<void> initialize() async {}
+  @override
+  Future<String?> accessToken() async => null;
+  @override
+  Future<bool> hasAccessToken() async => false;
+  @override
+  Future<void> persistSession(String persistSessionString) async {}
+  @override
+  Future<void> removePersistedSession() async {}
+}
+
+class MockAsyncStorage extends MemoryAuthAsyncStorage {}
+
+/// Custom HTTP client just to test the PKCE flow.
+class PkceHttpClient extends BaseClient {
+  int requestCount = 0;
+  Map<String, dynamic> lastRequestBody = {};
+
+  @override
+  Future<StreamedResponse> send(BaseRequest request) async {
+    requestCount++;
+
+    if (request is Request) {
+      lastRequestBody = jsonDecode(request.body);
+    }
+
+    final accessToken = signedTestJwt({
+      'exp': (DateTime.now().millisecondsSinceEpoch / 1000).round() + 60,
+      'sub': testUserId,
+    }, secret: '37c304f8-51aa-419a-a1af-06154e63707a');
+
+    return StreamedResponse(
+      Stream.value(
+        utf8.encode(
+          jsonEncode(testSessionResponseJson(accessToken: accessToken)),
+        ),
+      ),
+      201,
+      request: request,
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -225,6 +225,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.2"
+  code_assets:
+    dependency: transitive
+    description:
+      name: code_assets
+      sha256: cfd4f5f575a49c5f10ca856e9846073f1e6c3ee94912377eea5f6cefc5272941
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
   collection:
     dependency: transitive
     description:
@@ -289,6 +297,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.8"
+  desktop_webview_window:
+    dependency: transitive
+    description:
+      name: desktop_webview_window
+      sha256: b6fdae2cbf9571879b1761c12f27facaf82e22d0bdc74d049907c2a09a432957
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.0"
   device_info_plus:
     dependency: transitive
     description:
@@ -368,6 +384,22 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_web_auth_2:
+    dependency: transitive
+    description:
+      name: flutter_web_auth_2
+      sha256: a7655829251ee63aae64a748f8512f36670d8eba4657b0055cdf5ef304a9d164
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.1.0"
+  flutter_web_auth_2_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_web_auth_2_platform_interface
+      sha256: ba0fbba55bffb47242025f96852ad1ffba34bc451568f56ef36e613612baffab
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.0"
   flutter_web_plugins:
     dependency: transitive
     description: flutter
@@ -410,6 +442,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  hooks:
+    dependency: transitive
+    description:
+      name: hooks
+      sha256: eaac480a35ec0814146c2c48d96aaa829e0e44a7662c88ae84c9edf4bc35651f
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.0"
   http:
     dependency: transitive
     description:
@@ -447,6 +487,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
+  jni:
+    dependency: transitive
+    description:
+      name: jni
+      sha256: f038e58b4dc2c9037f50e233175086337e0b305e356d28211bf55f21c504cbd3
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.3"
+  jni_flutter:
+    dependency: transitive
+    description:
+      name: jni_flutter
+      sha256: b2310cdd4c18c65c081ab141a41efa94aa26c65431803703ece51996f174f351
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.3"
+  jni_util:
+    dependency: transitive
+    description:
+      name: jni_util
+      sha256: "1ba86da04a5f2bf18fde2edb235587e70c5b0fc5bd4ba955f46b00942c3fc35f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   json_annotation:
     dependency: transitive
     description:
@@ -567,6 +631,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.2"
+  objective_c:
+    dependency: transitive
+    description:
+      name: objective_c
+      sha256: ad56fd53a78ff6b1472fa59ff2a4e8b8ccabafc586fc263a1dfad0b99b5553e3
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.6.0"
   otp:
     dependency: transitive
     description:
@@ -663,6 +735,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  path_provider:
+    dependency: transitive
+    description:
+      name: path_provider
+      sha256: a7f4874f987173da295a61c181b8ee71dab59b332a486b391babf26a1b884825
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.6"
+  path_provider_android:
+    dependency: transitive
+    description:
+      name: path_provider_android
+      sha256: "69cbd515a62b94d32a7944f086b2f82b4ac40a1d45bebfc00813a430ab2dabcd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.1"
+  path_provider_foundation:
+    dependency: transitive
+    description:
+      name: path_provider_foundation
+      sha256: "2a376b7d6392d80cd3705782d2caa734ca4727776db0b6ec36ef3f1855197699"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.6.0"
   path_provider_linux:
     dependency: transitive
     description:
@@ -791,6 +887,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.0"
+  record_use:
+    dependency: transitive
+    description:
+      name: record_use
+      sha256: "1cb8564af8d43b464294411db9217f5ec04891c6f22ee2c32d73ae05e88a6bd2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
   scratch_space:
     dependency: transitive
     description:
@@ -1164,6 +1268,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
+  window_to_front:
+    dependency: transitive
+    description:
+      name: window_to_front
+      sha256: "14fad8984db4415e2eeb30b04bb77140b180e260d6cb66b26de126a8657a9241"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.4"
   xdg_directories:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,6 +16,8 @@ workspace:
   - packages/supabase/example
   - packages/supabase_flutter
   - packages/supabase_flutter/example
+  - packages/supabase_flutter_web_auth
+  - packages/supabase_flutter_web_auth/example
   - packages/supabase_common
   - packages/supabase_lints
   - packages/supabase_test

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -46,6 +46,13 @@ features:
       - OAuthProvider
       - OAuthProvider.OAuthProvider
     supporting_symbols:
+      - FlutterAuthClientOptions.oauthLauncher
+      - FlutterWebAuth2OAuthLauncher
+      - FlutterWebAuth2OAuthLauncher.FlutterWebAuth2OAuthLauncher
+      - FlutterWebAuth2OAuthLauncher.launch
+      - OAuthLauncher
+      - OAuthLauncher.OAuthLauncher
+      - OAuthLauncher.launch
       - OAuthProvider.==
       - OAuthProvider.apple
       - OAuthProvider.azure
@@ -77,6 +84,10 @@ features:
       - OAuthResponse.OAuthResponse
       - OAuthResponse.provider
       - OAuthResponse.url
+      - Supabase.oauthLauncher
+      - UrlLauncherOAuthLauncher
+      - UrlLauncherOAuthLauncher.UrlLauncherOAuthLauncher
+      - UrlLauncherOAuthLauncher.launch
   auth.sign_in.sign_in_with_id_token:
     status: implemented
     symbols:


### PR DESCRIPTION
## What

Makes how `signInWithOAuth`/`signInWithSSO`/`linkIdentity` open their sign-in
URL pluggable, and ships the improved behavior as a new, separate, opt-in
package instead of a breaking change to `supabase_flutter` itself.

- Add an `OAuthLauncher` extension point
  (`FlutterAuthClientOptions.oauthLauncher`), defaulting to
  `UrlLauncherOAuthLauncher`, which preserves today's `url_launcher`-based
  behavior byte-for-byte (same launch modes, same Google-on-Android
  external-browser workaround). No breaking change, no new dependency.
- Add a new package, `supabase_flutter_web_auth`, providing
  `FlutterWebAuth2OAuthLauncher`: runs OAuth/SSO/identity-linking through a
  system web authentication session (`ASWebAuthenticationSession` on
  iOS/macOS, Custom Tabs on Android/desktop) via `flutter_web_auth_2`.

## Why

`url_launcher`'s in-app browser never dismisses itself after an OAuth
redirect returns to the app, leaving the user on a blank page after a
successful sign-in (#1174). A system web authentication session fixes this
and shares cookies with the system browser for SSO, but pulling
`flutter_web_auth_2` (and, on Linux/Windows, its own embedded-webview
dependency) into `supabase_flutter` directly would force every app to carry
that dependency weight and would be a breaking change (drops
`authScreenLaunchMode`/`launchMode`, requires Android manifest changes).

Making the launcher pluggable gets the fix to apps that want it without
touching the dependency graph or the public API of apps that don't.

## Notes

- `supabase_flutter_web_auth`'s launcher drops the hardcoded
  "force external browser for Google on Android" workaround. Verified
  against Google's OAuth policy
  (https://developers.google.com/identity/protocols/oauth2/resources/best-practices):
  it bans routing through an embedded user-agent under the app's control,
  and Custom Tabs (the only mode `flutter_web_auth_2` uses on Android) runs
  as Chrome's own sandboxed process, so it already satisfies the policy.
- Verified the dependency isolation actually holds in this pub workspace
  (shared `pubspec.lock`): `packages/supabase_flutter/example`'s own
  `.flutter-plugins-dependencies` only lists `app_links`/
  `shared_preferences`/`url_launcher` after `pub get`, while
  `packages/supabase_flutter_web_auth/example` correctly picks up
  `flutter_web_auth_2`, `desktop_webview_window`, `jni`, etc.
- The new package's example app does not check in native platform folders;
  run `flutter create .` inside it to add the ones you want to test on.

## Test plan

- [x] `flutter test` in `packages/supabase_flutter` — all existing
      OAuth/SSO/link-identity behavior unchanged (82 pre-existing tests
      pass), plus new coverage for the `OAuthLauncher` extension point.
- [x] `flutter test` in `packages/supabase_flutter_web_auth` — new coverage
      for `FlutterWebAuth2OAuthLauncher` against a fake
      `FlutterWebAuth2Platform`.
- [x] `flutter analyze` clean in both packages.
- [ ] Manual on-device verification of the native flow (not done — no
      platform folders are checked in for the new example; see Notes).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable launchers for OAuth, SSO, and identity-linking flows.
  - Added support for ephemeral authentication sessions and custom launch behavior.
  - Added the `supabase_flutter_web_auth` package for system authentication sessions, shared browser cookies, and automatic session dismissal.
  - Added platform-specific redirect handling for web, mobile, desktop, and universal links.

- **Documentation**
  - Added setup instructions, usage guidance, licensing information, and an example application.

- **Tests**
  - Added coverage for launcher delegation, redirects, ephemeral sessions, and authentication flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->