### PR TITLE
feat(supabase_typegen): emit relation members from foreign key metadata

### DIFF
--- a/packages/supabase_typegen/README.md
+++ b/packages/supabase_typegen/README.md
@@ -13,6 +13,12 @@ For every table the generator emits:
   `PostgrestNullableColumn` so `isNull()` only exists where it can match, and
   range columns typed `PostgrestRange<int>`, `PostgrestRange<num>` or
   `PostgrestRange<DateTime>` so the range operators only exist on them,
+- `PostgrestToOneRelation` and `PostgrestToManyRelation` members for every
+  foreign key between two generated tables of the selected schema, named
+  after the table on the other side and carrying the constraint hint when two
+  keys point at the same table. Keys into another schema and self-referential
+  keys get no member, the latter because PostgREST needs a computed
+  relationship to embed a table into itself,
 - Dart enums for Postgres enums, with wire-name mapping.
 
 ## Usage
@@ -77,5 +83,6 @@ await client.table(Books.table).insert(
 - `timestamptz` values are written back in UTC, naive `timestamp` values as
   local wall time, and `date` values date-only, so calendar dates never
   shift with the client timezone.
-- Foreign key relationship getters and typed functions (rpc) are not
-  generated yet.
+- Foreign keys into another schema get no relation member, since the row type
+  on the other side is not generated. Typed functions (rpc) are not generated
+  yet.

--- a/packages/supabase_typegen/lib/src/dart_generator.dart
+++ b/packages/supabase_typegen/lib/src/dart_generator.dart
@@ -20,7 +20,8 @@ class _Binding {
 ///
 /// The generated code depends only on the library at [importUri], which must
 /// export the typed table access API of `package:postgrest` (`PostgrestTable`,
-/// `PostgrestColumn`, `PostgrestNullableColumn` and `PostgrestRange`).
+/// `PostgrestColumn`, `PostgrestNullableColumn`, `PostgrestRange`,
+/// `PostgrestToOneRelation` and `PostgrestToManyRelation`).
 String generateDartCode(
   SchemaDescription schema, {
   String importUri = 'package:postgrest/postgrest.dart',
@@ -59,9 +60,21 @@ String generateDartCode(
     _writeEnum(buffer, enumDescription, typeName);
   }
 
-  for (final table in schema.tables) {
-    if (table.columns.isEmpty) continue;
-    _writeTable(buffer, table, typeNames, enumTypeNames);
+  final tables = [
+    for (final table in schema.tables)
+      if (table.columns.isNotEmpty) table,
+  ];
+  final tableNames = {
+    for (final table in tables) table.name: _TableNames.claim(table, typeNames),
+  };
+  for (final table in tables) {
+    _writeTable(
+      buffer,
+      table,
+      tableNames[table.name]!,
+      _relationMembers(table, schema, tableNames),
+      enumTypeNames,
+    );
   }
 
   if (usesDateColumns) {
@@ -99,15 +112,11 @@ class _TypeNameRegistry {
     'PostgrestColumn',
     'PostgrestNullableColumn',
     'PostgrestRange',
+    'PostgrestToOneRelation',
+    'PostgrestToManyRelation',
   };
 
-  String claim(String name) {
-    var candidate = name;
-    while (!_used.add(candidate)) {
-      candidate = '$candidate\$';
-    }
-    return candidate;
-  }
+  String claim(String name) => _claimName(_used, name);
 }
 
 void _writeEnum(
@@ -164,21 +173,153 @@ void _writeEnum(
     ..writeln();
 }
 
+/// The generated type names of one table, claimed in a fixed order so a
+/// collision always resolves the same way.
+class _TableNames {
+  const _TableNames({
+    required this.rowType,
+    required this.insertType,
+    required this.updateType,
+    required this.namespaceType,
+  });
+
+  factory _TableNames.claim(
+    TableDescription table,
+    _TypeNameRegistry typeNames,
+  ) {
+    final baseName = pascalCase(table.name);
+    return _TableNames(
+      rowType: typeNames.claim('${baseName}Row'),
+      insertType: table.isInsertable
+          ? typeNames.claim('${baseName}Insert')
+          : null,
+      updateType: table.isUpdatable
+          ? typeNames.claim('${baseName}Update')
+          : null,
+      namespaceType: typeNames.claim(baseName),
+    );
+  }
+
+  final String rowType;
+  final String? insertType;
+  final String? updateType;
+  final String namespaceType;
+}
+
+/// One relation member of a namespace class, before its Dart name is settled
+/// against the table's columns.
+class _RelationMember {
+  const _RelationMember({
+    required this.baseName,
+    required this.disambiguatedName,
+    required this.type,
+    required this.embedName,
+    required this.docLine,
+  });
+
+  /// The name used when nothing else in the namespace claims it.
+  final String baseName;
+
+  /// The name used when [baseName] collides, spelling out the foreign key
+  /// columns.
+  final String disambiguatedName;
+
+  /// `PostgrestToOneRelation<SourceRow, TargetRow>` or the to-many kind.
+  final String type;
+
+  /// The name PostgREST addresses the embed by, with a foreign key hint when
+  /// the plain table name would be ambiguous.
+  final String embedName;
+
+  final String docLine;
+}
+
+/// The relation members of [table]: one to-one member per foreign key it
+/// holds, and one to-many (or to-one, for a unique key) member per foreign
+/// key pointing at it.
+///
+/// A self-referential key produces no member. PostgREST cannot tell the two
+/// directions of such an embed apart and needs a computed relationship, so a
+/// generated member could never be requested.
+List<_RelationMember> _relationMembers(
+  TableDescription table,
+  SchemaDescription schema,
+  Map<String, _TableNames> tableNames,
+) {
+  final members = <_RelationMember>[];
+  for (final relationship in schema.relationships) {
+    final source = tableNames[relationship.sourceTable];
+    final target = tableNames[relationship.targetTable];
+    if (source == null || target == null) continue;
+    if (relationship.sourceTable == relationship.targetTable) continue;
+    final columns = relationship.sourceColumns.join('_');
+    // `By` names the key this table holds, `Via` the key the other table
+    // holds.
+    final byColumns = 'By${pascalCase(columns)}';
+    final viaColumns = 'Via${pascalCase(columns)}';
+
+    if (relationship.sourceTable == table.name) {
+      // Several keys from this table to the same target make the plain
+      // table name ambiguous for PostgREST, so the embed carries the hint.
+      final ambiguous = schema.relationships.any(
+        (other) =>
+            other != relationship &&
+            other.sourceTable == relationship.sourceTable &&
+            other.targetTable == relationship.targetTable,
+      );
+      final targetName = memberIdentifier(relationship.targetTable);
+      members.add(
+        _RelationMember(
+          baseName: ambiguous ? '$targetName$byColumns' : targetName,
+          disambiguatedName: '$targetName$byColumns',
+          type: 'PostgrestToOneRelation<${source.rowType}, ${target.rowType}>',
+          embedName: ambiguous
+              ? '${relationship.targetTable}!${relationship.foreignKeyName}'
+              : relationship.targetTable,
+          docLine:
+              'The `${relationship.targetTable}` row referenced by '
+              '`$columns`.',
+        ),
+      );
+    }
+    if (relationship.targetTable == table.name) {
+      final ambiguous = schema.relationships.any(
+        (other) =>
+            other != relationship &&
+            other.sourceTable == relationship.sourceTable &&
+            other.targetTable == relationship.targetTable,
+      );
+      final sourceName = memberIdentifier(relationship.sourceTable);
+      final kind = relationship.isOneToOne
+          ? 'PostgrestToOneRelation'
+          : 'PostgrestToManyRelation';
+      members.add(
+        _RelationMember(
+          baseName: ambiguous ? '$sourceName$viaColumns' : sourceName,
+          disambiguatedName: '$sourceName$viaColumns',
+          type: '$kind<${target.rowType}, ${source.rowType}>',
+          embedName: ambiguous
+              ? '${relationship.sourceTable}!${relationship.foreignKeyName}'
+              : relationship.sourceTable,
+          docLine:
+              'The `${relationship.sourceTable}` '
+              '${relationship.isOneToOne ? 'row' : 'rows'} referencing this '
+              'row through `$columns`.',
+        ),
+      );
+    }
+  }
+  return members;
+}
+
 void _writeTable(
   StringBuffer buffer,
   TableDescription table,
-  _TypeNameRegistry typeNames,
+  _TableNames names,
+  List<_RelationMember> relations,
   Map<String, String> enumTypeNames,
 ) {
-  final baseName = pascalCase(table.name);
-  final rowType = typeNames.claim('${baseName}Row');
-  final insertType = table.isInsertable
-      ? typeNames.claim('${baseName}Insert')
-      : null;
-  final updateType = table.isUpdatable
-      ? typeNames.claim('${baseName}Update')
-      : null;
-  final namespaceType = typeNames.claim(baseName);
+  final _TableNames(:rowType, :insertType, :updateType, :namespaceType) = names;
 
   final memberNames = _uniqueMemberNames(
     [for (final column in table.columns) column.name],
@@ -221,7 +362,15 @@ void _writeTable(
           'Use the `set…ToNull` methods to write SQL NULL explicitly.',
     );
   }
-  _writeNamespace(buffer, table, namespaceType, rowType, memberNames, bindings);
+  _writeNamespace(
+    buffer,
+    table,
+    namespaceType,
+    rowType,
+    memberNames,
+    bindings,
+    relations,
+  );
 }
 
 void _writeRow(
@@ -329,12 +478,32 @@ void _writeNamespace(
   String rowType,
   Map<String, String> memberNames,
   Map<String, _Binding> bindings,
+  List<_RelationMember> relations,
 ) {
   final columnNames = _uniqueMemberNames(
     [for (final column in table.columns) column.name],
     reserved: {'table', namespaceType},
     existing: memberNames,
   );
+  final used = {'table', namespaceType, ...columnNames.values};
+  final baseNameCounts = <String, int>{};
+  for (final relation in relations) {
+    baseNameCounts.update(
+      relation.baseName,
+      (count) => count + 1,
+      ifAbsent: () => 1,
+    );
+  }
+  final relationNames = [
+    for (final relation in relations)
+      _claimName(
+        used,
+        used.contains(relation.baseName) ||
+                baseNameCounts[relation.baseName]! > 1
+            ? relation.disambiguatedName
+            : relation.baseName,
+      ),
+  ];
 
   buffer
     ..writeln('/// Typed access to the `${table.name}` table.')
@@ -356,6 +525,14 @@ void _writeNamespace(
       '  static const ${columnNames[column.name]} = '
       '$columnType<$rowType, ${binding.dartType}>'
       '(${_stringLiteral(column.name)});',
+    );
+  }
+  for (final (index, relation) in relations.indexed) {
+    buffer.writeln();
+    _writeDocComment(buffer, relation.docLine, indent: '  ');
+    buffer.writeln(
+      '  static const ${relationNames[index]} = '
+      '${relation.type}(${_stringLiteral(relation.embedName)});',
     );
   }
   buffer
@@ -572,15 +749,20 @@ Map<String, String> _uniqueMemberNames(
   Map<String, String>? existing,
 }) {
   final used = {...reserved};
-  final result = <String, String>{};
-  for (final name in names) {
-    var candidate = existing?[name] ?? memberIdentifier(name);
-    while (!used.add(candidate)) {
-      candidate = '$candidate\$';
-    }
-    result[name] = candidate;
+  return {
+    for (final name in names)
+      name: _claimName(used, existing?[name] ?? memberIdentifier(name)),
+  };
+}
+
+/// Adds [candidate] to [used], suffixed with `\$` until no earlier name
+/// matches, and returns the name added.
+String _claimName(Set<String> used, String candidate) {
+  var name = candidate;
+  while (!used.add(name)) {
+    name = '$name\$';
   }
-  return result;
+  return name;
 }
 
 void _writeDocComment(

--- a/packages/supabase_typegen/lib/src/generator_metadata_parser.dart
+++ b/packages/supabase_typegen/lib/src/generator_metadata_parser.dart
@@ -233,6 +233,11 @@ SchemaDescription _parseGeneratorMetadata(
     schemaName: schemaName,
     tables: tables,
     enums: enums,
+    relationships: _relationships(
+      document,
+      schemaName,
+      {for (final table in tables) table.name},
+    ),
   );
 }
 
@@ -245,6 +250,32 @@ Iterable<Map<String, dynamic>> _relationsOf(
 ) => (document[collection] as List<dynamic>? ?? const [])
     .cast<Map<String, dynamic>>()
     .where((relation) => relation['schema'] == schemaName);
+
+/// The foreign keys whose both ends are relations of [schemaName] listed in
+/// [relationNames]; a key into another schema has no generated row type to
+/// point at and is left out.
+List<RelationshipDescription> _relationships(
+  Map<String, dynamic> document,
+  String schemaName,
+  Set<String> relationNames,
+) => [
+  for (final relationship
+      in (document['relationships'] as List<dynamic>? ?? const [])
+          .cast<Map<String, dynamic>>())
+    if (relationship['schema'] == schemaName &&
+        relationship['referenced_schema'] == schemaName &&
+        relationNames.contains(relationship['relation']) &&
+        relationNames.contains(relationship['referenced_relation']))
+      RelationshipDescription(
+        foreignKeyName: relationship['foreign_key_name'] as String,
+        sourceTable: relationship['relation'] as String,
+        sourceColumns: (relationship['columns'] as List<dynamic>).cast(),
+        targetTable: relationship['referenced_relation'] as String,
+        targetColumns: (relationship['referenced_columns'] as List<dynamic>)
+            .cast(),
+        isOneToOne: relationship['is_one_to_one'] as bool? ?? false,
+      ),
+];
 
 /// Maps `(table, column)` pairs of [schemaName] to their foreign key targets,
 /// pairing the source and referenced columns of each relationship by index.

--- a/packages/supabase_typegen/lib/src/schema_description.dart
+++ b/packages/supabase_typegen/lib/src/schema_description.dart
@@ -54,6 +54,7 @@ class SchemaDescription {
     required this.schemaName,
     required this.tables,
     required this.enums,
+    this.relationships = const [],
   });
 
   /// Name of the database schema, for example `public`.
@@ -64,6 +65,40 @@ class SchemaDescription {
 
   /// Postgres enums referenced by the tables, sorted by name.
   final List<EnumDescription> enums;
+
+  /// Foreign keys between tables of the schema, in database order.
+  final List<RelationshipDescription> relationships;
+}
+
+/// A foreign key from [sourceTable] to [targetTable].
+class RelationshipDescription {
+  const RelationshipDescription({
+    required this.foreignKeyName,
+    required this.sourceTable,
+    required this.sourceColumns,
+    required this.targetTable,
+    required this.targetColumns,
+    this.isOneToOne = false,
+  });
+
+  /// The constraint name, which PostgREST accepts as an embed hint.
+  final String foreignKeyName;
+
+  /// The table holding the foreign key columns.
+  final String sourceTable;
+
+  /// The foreign key columns, in constraint order.
+  final List<String> sourceColumns;
+
+  /// The referenced table.
+  final String targetTable;
+
+  /// The referenced columns, paired with [sourceColumns] by index.
+  final List<String> targetColumns;
+
+  /// Whether the foreign key columns are unique, so each target row has at
+  /// most one source row.
+  final bool isOneToOne;
 }
 
 /// Description of a table or view.

--- a/packages/supabase_typegen/test/dart_generator_test.dart
+++ b/packages/supabase_typegen/test/dart_generator_test.dart
@@ -91,6 +91,57 @@ void main() {
     );
   });
 
+  test('emits a relation member for each side of a foreign key', () {
+    final compact = _normalize(generateDartCode(schema)).replaceAll(' ', '');
+
+    expect(
+      compact,
+      contains(
+        "staticconstauthors=PostgrestToOneRelation<BooksRow,AuthorsRow>"
+        "('authors'",
+      ),
+    );
+    expect(
+      compact,
+      contains(
+        "staticconstbooks=PostgrestToManyRelation<AuthorsRow,BooksRow>('books'",
+      ),
+    );
+  });
+
+  test('relation members are disambiguated by hint and column', () {
+    final compact = _normalize(
+      generateDartCode(hostileSchema),
+    ).replaceAll(' ', '');
+
+    // Two keys from postgrest_table to map: both carry the constraint hint,
+    // and `map` itself is renamed like any member that shadows a core name.
+    expect(
+      compact,
+      contains(
+        r"staticconstmap$ByMood=PostgrestToOneRelation<PostgrestTableRow,"
+        "MapRow>('map!postgrest_table_mood_fkey'",
+      ),
+    );
+    expect(
+      compact,
+      contains(
+        "staticconstpostgrestTableViaDays=PostgrestToOneRelation<MapRow,"
+        "PostgrestTableRow>('postgrest_table!postgrest_table_days_fkey'",
+      ),
+    );
+  });
+
+  test('a self-referential key produces no relation member', () {
+    // PostgREST needs a computed relationship to embed a table into itself.
+    final compact = _normalize(
+      generateDartCode(hostileSchema),
+    ).replaceAll(' ', '');
+
+    expect(compact, isNot(contains('<MapRow,MapRow>')));
+    expect(compact, isNot(contains(r'map$ByList')));
+  });
+
   test('respects a custom import', () {
     final code = generateDartCode(
       schema,

--- a/packages/supabase_typegen/test/generated_schema_behavior_test.dart
+++ b/packages/supabase_typegen/test/generated_schema_behavior_test.dart
@@ -74,6 +74,28 @@ void main() {
     expect(book.publishedOn == null, isTrue);
   });
 
+  test('relation members project embedded columns', () async {
+    await client.table(Books.table).select([
+      Books.id,
+      Books.authors(Authors.name),
+    ]);
+
+    expect(
+      httpClient.lastRequest!.url.queryParameters['select'],
+      'id,authors(name)',
+    );
+
+    await client.table(Authors.table).select([
+      Authors.id,
+      Authors.books(Books.id).count(),
+    ]);
+
+    expect(
+      httpClient.lastRequest!.url.queryParameters['select'],
+      'id,books(id.count())',
+    );
+  });
+
   test('enum column tokens filter with the wire name', () async {
     await client.table(Books.table).select().where(Books.mood.eq(Mood.happy));
 

--- a/packages/supabase_typegen/test/generator_metadata_parser_test.dart
+++ b/packages/supabase_typegen/test/generator_metadata_parser_test.dart
@@ -226,6 +226,40 @@ void main() {
     expect(authorId.foreignKey?.column, 'id');
   });
 
+  test('collects the relationships between tables of the schema', () {
+    final books = schema.relationships.singleWhere(
+      (relationship) => relationship.sourceTable == 'books',
+    );
+
+    expect(books.foreignKeyName, 'books_author_id_fkey');
+    expect(books.sourceColumns, ['author_id']);
+    expect(books.targetTable, 'authors');
+    expect(books.targetColumns, ['id']);
+    expect(books.isOneToOne, isFalse);
+  });
+
+  test('leaves out relationships into another schema', () {
+    final parsed = parseGeneratorMetadata({
+      'tables': [
+        {'id': 1, 'schema': 'public', 'name': 'books', 'comment': null},
+      ],
+      'columns': [_column(tableId: 1, table: 'books', name: 'author_id')],
+      'relationships': [
+        {
+          'foreign_key_name': 'books_author_id_fkey',
+          'schema': 'public',
+          'relation': 'books',
+          'columns': ['author_id'],
+          'referenced_schema': 'private',
+          'referenced_relation': 'authors',
+          'referenced_columns': ['id'],
+        },
+      ],
+    });
+
+    expect(parsed.relationships, isEmpty);
+  });
+
   test('derives type kinds from formats', () {
     final books = schema.tables.singleWhere((table) => table.name == 'books');
     ColumnTypeKind kindOf(String name) =>

--- a/packages/supabase_typegen/test/goldens/hostile_fixture.dart
+++ b/packages/supabase_typegen/test/goldens/hostile_fixture.dart
@@ -119,6 +119,32 @@ const SchemaDescription hostileSchema = SchemaDescription(
       ],
     ),
   ],
+  relationships: [
+    // A self reference: PostgREST cannot embed it, so no member is generated.
+    RelationshipDescription(
+      foreignKeyName: 'map_list_fkey',
+      sourceTable: 'map',
+      sourceColumns: ['list'],
+      targetTable: 'map',
+      targetColumns: ['list'],
+    ),
+    // Two keys to the same target: the plain table name is ambiguous.
+    RelationshipDescription(
+      foreignKeyName: 'postgrest_table_mood_fkey',
+      sourceTable: 'postgrest_table',
+      sourceColumns: ['mood'],
+      targetTable: 'map',
+      targetColumns: ['list'],
+    ),
+    RelationshipDescription(
+      foreignKeyName: 'postgrest_table_days_fkey',
+      sourceTable: 'postgrest_table',
+      sourceColumns: ['days'],
+      targetTable: 'map',
+      targetColumns: ['list'],
+      isOneToOne: true,
+    ),
+  ],
   enums: [
     EnumDescription(
       qualifiedName: 'public.string',

--- a/packages/supabase_typegen/test/goldens/hostile_schema.dart
+++ b/packages/supabase_typegen/test/goldens/hostile_schema.dart
@@ -126,6 +126,16 @@ class PostgrestTable$ {
   static const days = PostgrestNullableColumn<PostgrestTableRow, List<String>>(
     'days',
   );
+
+  /// The `map` row referenced by `mood`.
+  static const map$ByMood = PostgrestToOneRelation<PostgrestTableRow, MapRow>(
+    'map!postgrest_table_mood_fkey',
+  );
+
+  /// The `map` row referenced by `days`.
+  static const map$ByDays = PostgrestToOneRelation<PostgrestTableRow, MapRow>(
+    'map!postgrest_table_days_fkey',
+  );
 }
 
 /// A row of the `map` table.
@@ -249,6 +259,18 @@ class Map$ {
   );
   static const during =
       PostgrestNullableColumn<MapRow, PostgrestRange<DateTime>>('during');
+
+  /// The `postgrest_table` rows referencing this row through `mood`.
+  static const postgrestTableViaMood =
+      PostgrestToManyRelation<MapRow, PostgrestTableRow>(
+        'postgrest_table!postgrest_table_mood_fkey',
+      );
+
+  /// The `postgrest_table` row referencing this row through `days`.
+  static const postgrestTableViaDays =
+      PostgrestToOneRelation<MapRow, PostgrestTableRow>(
+        'postgrest_table!postgrest_table_days_fkey',
+      );
 }
 
 String _dateString(DateTime date) =>

--- a/packages/supabase_typegen/test/goldens/supabase_schema.dart
+++ b/packages/supabase_typegen/test/goldens/supabase_schema.dart
@@ -53,6 +53,11 @@ class AuthorStats {
   static const bookCount = PostgrestNullableColumn<AuthorStatsRow, int>(
     'book_count',
   );
+
+  /// The `authors` row referenced by `author_id`.
+  static const authors = PostgrestToOneRelation<AuthorStatsRow, AuthorsRow>(
+    'authors',
+  );
 }
 
 /// A row of the `authors` table.
@@ -89,6 +94,13 @@ class Authors {
 
   static const id = PostgrestColumn<AuthorsRow, int>('id');
   static const name = PostgrestColumn<AuthorsRow, String>('name');
+
+  /// The `books` rows referencing this row through `author_id`.
+  static const books = PostgrestToManyRelation<AuthorsRow, BooksRow>('books');
+
+  /// The `author_stats` rows referencing this row through `author_id`.
+  static const authorStats =
+      PostgrestToManyRelation<AuthorsRow, AuthorStatsRow>('author_stats');
 }
 
 /// A row of the `book_prices` table.
@@ -437,6 +449,11 @@ class Books {
   static const title = PostgrestColumn<BooksRow, String>('title');
   static const updatedAt = PostgrestNullableColumn<BooksRow, DateTime>(
     'updated_at',
+  );
+
+  /// The `authors` row referenced by `author_id`.
+  static const authors = PostgrestToOneRelation<BooksRow, AuthorsRow>(
+    'authors',
   );
 }
 


### PR DESCRIPTION
Stack 9/9 for SDK-1741, implementing SDK-1759. Base: `lukasklingsbo/sdk-1741-8-typed-ranges`.

`PostgrestToOneRelation` and `PostgrestToManyRelation` (8/9, #1799) had to be declared by hand. `supabase_typegen` already parsed the `relationships` array of the `GeneratorMetadata` document but only used it to mark foreign key columns; it now emits the relation members.

For every foreign key whose both ends are tables of the schema, the referencing table's namespace gets a `PostgrestToOneRelation<SourceRow, TargetRow>` named after the referenced table, and the referenced table's namespace gets a `PostgrestToManyRelation<TargetRow, SourceRow>` named after the referencing table, or a to-one relation when the metadata flags the key as one-to-one:

```dart
class Books {
  static const authors = PostgrestToOneRelation<BooksRow, AuthorsRow>('authors');
}
class Authors {
  static const books = PostgrestToManyRelation<AuthorsRow, BooksRow>('books');
}

client.table(Books.table).select([Books.id, Books.authors(Authors.name)]);
// select=id,authors(name)
```

Two rules handle names that would otherwise collide:

- Two keys from the same table to the same target make the plain table name ambiguous for PostgREST (PGRST201), so the embed carries the constraint hint, `map!postgrest_table_mood_fkey`, and the members are told apart by the key they follow: `mapByMood` on the referencing side, `postgrestTableViaMood` on the referenced side.
- A member that collides with a column, another relation or a core member name goes through the same disambiguation. `By` names a key this table holds, `Via` a key the other table holds.
- A self-referential key produces no member: PostgREST cannot tell the two directions of such an embed apart and needs a computed relationship, so a generated member could never be requested.

Keys into another schema get no member, since there is no generated row type to point at. Views take part when the metadata lists a relationship for them, as `author_stats` does in the fixture.

The type names of all tables are now claimed in one pass before any table is written, in the same order as before, so the relation types can reference each other; existing goldens are unchanged apart from the new members.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Dart schema generation now includes typed one-to-one and one-to-many relation members for supported foreign keys.
  - Relation names are disambiguated when multiple keys connect the same tables, including self-referencing relationships.
  - Generated relation members support embedded-column selects and count modifiers.

- **Documentation**
  - Documented generated relation members and clarified limitations for cross-schema relationships and typed functions.

- **Tests**
  - Added coverage for relationship parsing, generation, naming, and embedded select behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->