### PR TITLE
ci: move the test stack off the ephemeral port range

### DIFF
--- a/.github/workflows/example-integration-tests.yml
+++ b/.github/workflows/example-integration-tests.yml
@@ -41,7 +41,13 @@ jobs:
           version: ${{ env.SUPABASE_CLI_VERSION }}
 
       - name: Start Supabase
-        run: supabase start --workdir examples
+        run: |
+          # This stack keeps the CLI default ports, which sit in the ephemeral
+          # port range, so a bind conflict is possible; retry once.
+          supabase start --workdir examples || {
+            supabase stop --no-backup --workdir examples || true
+            supabase start --workdir examples
+          }
 
       - name: Install cloudflared
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -172,7 +172,13 @@ jobs:
 
       - name: Start Supabase
         if: ${{ matrix.package.backend }}
-        run: supabase start
+        run: |
+          # A container can still lose a host port to a transient conflict, and
+          # the CLI tears the stack down when that happens, so retry once.
+          supabase start || {
+            supabase stop --no-backup || true
+            supabase start
+          }
 
       - name: Save Supabase Docker images to cache
         if: ${{ matrix.package.backend && steps.supabase-images.outputs.cache-hit != 'true' }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,7 +69,7 @@ dart test -j 1
 supabase stop
 ```
 
-The single `supabase/` config at the repository root serves every package: its migrations and `seed.sql` create the schemas, functions, and test data all four packages rely on. The ports are offset from the CLI defaults (gateway on `http://127.0.0.1:54421`, database on `127.0.0.1:54422`) so this test stack can run alongside another local Supabase project.
+The single `supabase/` config at the repository root serves every package: its migrations and `seed.sql` create the schemas, functions, and test data all four packages rely on. The stack binds ports 14420 to 14429 (gateway on `http://127.0.0.1:14421`, database on `127.0.0.1:14422`), off the CLI defaults so it can run alongside another local Supabase project and below Linux's default ephemeral port range so an outgoing connection cannot claim a port the stack still needs to bind.
 
 The `-j 1` flag runs tests sequentially (not concurrently), which is required since tests share the same backend.
 

--- a/packages/supabase_common/lib/src/testing/local_stack.dart
+++ b/packages/supabase_common/lib/src/testing/local_stack.dart
@@ -6,7 +6,7 @@ const localStackHost = '127.0.0.1';
 
 /// Port of the API gateway of the local Supabase CLI stack.
 @visibleForTesting
-const localStackPort = 54421;
+const localStackPort = 14421;
 
 /// Base URL of the API gateway, which every service is exposed through.
 @visibleForTesting
@@ -33,7 +33,7 @@ const localStackRealtimeUrl =
 /// mails the auth service would have sent. The `[inbucket]` section of
 /// `supabase/config.toml` exposes it.
 @visibleForTesting
-const localStackMailPort = 54424;
+const localStackMailPort = 14424;
 
 /// Base URL of the mail server web interface of the local stack.
 @visibleForTesting
@@ -41,7 +41,7 @@ const localStackMailUrl = 'http://$localStackHost:$localStackMailPort';
 
 /// Port Postgres itself is exposed on, for tests that need to run SQL.
 @visibleForTesting
-const localStackDatabasePort = 54422;
+const localStackDatabasePort = 14422;
 
 /// Database of the local stack.
 @visibleForTesting

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -6,9 +6,12 @@ project_id = "supabase-flutter"
 
 [api]
 enabled = true
-# Port to use for the API URL. Offset from the CLI defaults (54321+) so this test stack can run
-# alongside another local Supabase project (for example the supabase_flutter example app).
-port = 54421
+# Port to use for the API URL. Moved off the CLI defaults (54321+) so this test stack can run
+# alongside another local Supabase project (for example the supabase_flutter example app). The whole
+# stack sits in 14420 to 14429, deliberately below Linux's default ephemeral port range
+# (32768 to 60999): a port in that range can be handed out as the local port of an outgoing
+# connection while the stack starts, and the container then fails to bind it.
+port = 14421
 # Schemas to expose in your API. Tables, views and stored procedures in this schema will get API
 # endpoints. `public` and `graphql_public` schemas are included by default. `personal` is exposed
 # for the postgrest_client schema-switching tests.
@@ -36,9 +39,9 @@ enabled = false
 
 [db]
 # Port to use for the local database URL.
-port = 54422
+port = 14422
 # Port used by db diff command to initialize the shadow database.
-shadow_port = 54420
+shadow_port = 14420
 # Maximum amount of time to wait for health check when starting the local database.
 health_timeout = "2m"
 # The database major version to use. This has to be the same as your remote database's. Run `SHOW
@@ -48,7 +51,7 @@ major_version = 17
 [db.pooler]
 enabled = false
 # Port to use for the local connection pooler.
-port = 54429
+port = 14429
 # Specifies when a server connection can be reused by other clients.
 # Configure one of the supported pooler modes: `transaction`, `session`.
 pool_mode = "transaction"
@@ -98,7 +101,7 @@ enabled = true
 [studio]
 enabled = false
 # Port to use for Supabase Studio.
-port = 54423
+port = 14423
 # External URL of the API server that frontend connects to.
 api_url = "http://127.0.0.1"
 # OpenAI API Key to use for Supabase AI in the Supabase Studio.
@@ -109,10 +112,10 @@ openai_api_key = "env(OPENAI_API_KEY)"
 [inbucket]
 enabled = true
 # Port to use for the email testing server web interface.
-port = 54424
+port = 14424
 # Uncomment to expose additional ports for testing user applications that send emails.
-# smtp_port = 54325
-# pop3_port = 54326
+# smtp_port = 14425
+# pop3_port = 14426
 # admin_email = "admin@email.com"
 # sender_name = "Admin"
 
@@ -417,7 +420,7 @@ deno_version = 2
 
 [analytics]
 enabled = false
-port = 54427
+port = 14427
 # Configure one of the supported backends: `postgres`, `bigquery`.
 backend = "postgres"
 


### PR DESCRIPTION
Fixes SDK-1764.

## Problem

The backend test jobs (`postgrest`, `supabase_auth`, `supabase_realtime`, `supabase_storage`) failed intermittently on pull requests that touched none of those packages. The job never reached the tests, `Start Supabase` failed:

```
failed to start docker container "supabase_inbucket_supabase-flutter": Error response from daemon:
failed to set up container networking: driver failed programming external connectivity on endpoint
supabase_inbucket_supabase-flutter (…): failed to bind host port for 0.0.0.0:54424:172.18.0.5:8025/tcp:
address already in use
```

Nothing in the workflow binds that port. The stack used 54420 to 54429, and all of those sit inside Linux's default ephemeral port range, 32768 to 60999. Any outgoing connection the runner opens while the stack is starting (Docker layer pulls, `pub get`, the Flutter tool) can be assigned one of them as its local port, and the container then loses the race to bind it. That makes the failure random and independent of the code under test, which is what was observed.

## Change

The stack now binds 14420 to 14429, below the ephemeral range, so no outgoing connection can claim a port it still needs. The block is still off the CLI defaults (54321+), so the test stack keeps running alongside another local Supabase project such as the example app.

| Service | Before | After |
| --- | --- | --- |
| `api` | 54421 | 14421 |
| `db` | 54422 | 14422 |
| `db.shadow_port` | 54420 | 14420 |
| `studio` | 54423 | 14423 |
| `inbucket` | 54424 | 14424 |
| `analytics` | 54427 | 14427 |
| `db.pooler` | 54429 | 14429 |

The commented-out `inbucket` SMTP and POP3 ports moved into the same block for consistency; they were left on the CLI defaults before.

`localStackPort`, `localStackDatabasePort`, and `localStackMailPort` in `supabase_common`'s testing helpers follow, and `AGENTS.md` documents the new block and why it sits where it does. Those three constants are the only place the packages read the ports from, so no test needed touching.

Both workflows also retry `supabase start` once. A bind conflict is transient and the CLI tears the stack down when a container fails, so a single retry costs nothing on the happy path. The examples stack (`supabase start --workdir examples`) deliberately keeps the CLI default ports because the example READMEs document them, so the retry is the mitigation there rather than a port move.

## Verification

Restarted the stack locally on the new ports and confirmed the containers bind them:

```
supabase_kong_supabase-flutter      0.0.0.0:14421->8000/tcp
supabase_db_supabase-flutter        0.0.0.0:14422->5432/tcp
supabase_inbucket_supabase-flutter  0.0.0.0:14424->8025/tcp
```

Then ran the four backend suites against it:

- `supabase_auth`: 549 passed
- `postgrest`: 232 passed
- `supabase_realtime`: 265 passed
- `supabase_storage`: 272 passed, 1 failed

The storage failure is unrelated to this change and does not reproduce in CI. `client_test.dart` "cannot upload to a signed url twice" expects `errorCode: Duplicate`, and the locally installed CLI (2.116.0) pulls a storage-api image that returns `KeyAlreadyExists`. CI pins CLI 2.109.1, which still returns `Duplicate`. Worth its own look when the pin is bumped.

The `supabase/config.toml` hash is part of the Docker image cache key, so the first run on each branch repopulates that cache.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved local Supabase stack startup reliability by retrying once after an unsuccessful start.

- **Development Experience**
  - Updated local Supabase services to use ports 14420–14429, including the API, database, mail, Studio, and analytics services.
  - Local test stacks can now coexist more reliably with other projects and outgoing connections.

- **Documentation**
  - Updated local testing documentation with the new port assignments and range details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->