### PR TITLE
feat(supabase_test): shape PostgREST responses and answer requests from handlers

### DIFF
--- a/packages/supabase_test/README.md
+++ b/packages/supabase_test/README.md
@@ -101,6 +101,67 @@ httpClient.stubTable(
 // supabase.from('todos').select() now throws a PostgrestApiException.
 ```
 
+### Single rows and counts
+
+`stubTable` and `stubRpc` shape their rows the way PostgREST would for the
+query that arrives. A query ending in `single()` receives the only row of a
+one-row list, and the `PGRST116` error when the list holds any other number
+of rows, so the same stub serves both a list query and a single-row query:
+
+```dart
+httpClient.stubTable('todos', rows: [
+  {'id': 1, 'task': 'Ship it'},
+]);
+
+final todos = await supabase.from('todos').select();
+final todo = await supabase.from('todos').select().eq('id', 1).single();
+```
+
+A query asking for a count receives the number of stubbed rows, or the
+`count` you pass when the stub represents one page of a larger table:
+
+```dart
+httpClient.stubTable('todos', rows: [{'id': 1}], count: 42);
+
+final page = await supabase
+    .from('todos')
+    .select()
+    .limit(1)
+    .count(CountOption.exact);
+// page.data has one row, page.count is 42.
+```
+
+### Responses that depend on the request
+
+When a fixed body is not enough, `stubHandler` builds the response from the
+request it receives, with the body already read. `jsonResponse` wraps a JSON
+body with the right content type:
+
+```dart
+httpClient.stubHandler(
+  (request) {
+    final params = request.jsonBody as Map<String, dynamic>;
+    return jsonResponse(params['a'] + params['b']);
+  },
+  path: '/rest/v1/rpc/add_them',
+);
+
+httpClient.stubHandler(
+  (request) => request.url.queryParameters['city'] == null
+      ? jsonResponse({'message': 'city is required'}, statusCode: 400)
+      : jsonResponse({'weather': 'sunny'}),
+  path: '/functions/v1/weather',
+);
+```
+
+The handler may be asynchronous and may return any `http.Response`, so a
+plain text or binary edge function response is a `Response.bytes` away. A
+`Uint8List` passed as the body of `stub` or `stubEdgeFunction` is sent as
+bytes with the content type `application/octet-stream`.
+
+A client shared between tests is wiped with `reset`, which forgets the
+registered stubs and the recorded requests.
+
 ## Asserting on requests
 
 The client records every request it answered in `requests`, with the body
@@ -186,6 +247,24 @@ Mocks are for fast unit tests. For integration coverage, run your tests
 against a local Supabase stack started with the
 [Supabase CLI](https://supabase.com/docs/guides/local-development) and point
 your client at the URL and keys `supabase start` prints.
+
+## Migrating from mock_supabase_http_client
+
+The community package `mock_supabase_http_client` kept an in-memory database
+and interpreted every filter, order and limit of a query. `supabase_test`
+takes the other approach and answers each endpoint with what you stub, which
+keeps a test independent of the query it runs and keeps the mock free of
+subtle differences to PostgREST. The pieces map as follows:
+
+- Rows that used to be inserted through the client are passed to `stubTable`
+  as `rows`. The filters of a query are not applied, so stub the rows the
+  query is expected to return.
+- `registerRpcFunction` and `registerEdgeFunction` become `stubRpc` and
+  `stubEdgeFunction` for fixed responses, or `stubHandler` when the response
+  depends on the parameters.
+- `postgrestExceptionTrigger` becomes a stub with an error `statusCode`, or a
+  `stubHandler` that chooses the status per request.
+- `reset` keeps its name.
 
 ## A note on scope
 

--- a/packages/supabase_test/lib/src/mock_http_clients.dart
+++ b/packages/supabase_test/lib/src/mock_http_clients.dart
@@ -23,6 +23,21 @@ StreamedResponse jsonStreamedResponse(
   );
 }
 
+/// A [Response] with [body] encoded as UTF-8 JSON and a matching content
+/// type, for a `MockSupabaseHttpClient` handler to return.
+@visibleForTesting
+Response jsonResponse(
+  Object? body, {
+  int statusCode = 200,
+  Map<String, String> headers = const {},
+}) {
+  return Response.bytes(
+    utf8.encode(jsonEncode(body)),
+    statusCode,
+    headers: {'content-type': 'application/json; charset=utf-8', ...headers},
+  );
+}
+
 /// A mock HTTP client that answers every request with the same JSON body.
 @visibleForTesting
 class JsonResponseMockClient extends BaseClient {

--- a/packages/supabase_test/lib/src/mock_supabase_http_client.dart
+++ b/packages/supabase_test/lib/src/mock_supabase_http_client.dart
@@ -34,6 +34,11 @@ class RecordedRequest {
   String toString() => '$method $url';
 }
 
+/// Builds the response a [MockSupabaseHttpClient] answers a matched request
+/// with, from the request it received.
+@visibleForTesting
+typedef StubHandler = FutureOr<Response> Function(RecordedRequest request);
+
 class _Stub {
   _Stub({
     required this.method,
@@ -44,7 +49,11 @@ class _Stub {
 
   final String? method;
   final String? path;
-  final StreamedResponse Function(BaseRequest request) respond;
+  final FutureOr<StreamedResponse> Function(
+    BaseRequest request,
+    RecordedRequest recorded,
+  )
+  respond;
   int? remaining;
 
   bool matches(BaseRequest request) {
@@ -64,6 +73,8 @@ class _Stub {
   @override
   String toString() => '${method ?? '(any method)'} ${path ?? '(any path)'}';
 }
+
+const _singleObjectAccept = 'application/vnd.pgrst.object+json';
 
 /// A mock HTTP client that answers Supabase requests from stubs registered
 /// per endpoint, and records every request it answered in [requests].
@@ -86,6 +97,9 @@ class _Stub {
 /// registered inside a test overrides one registered in `setUp`. A request no
 /// stub matches throws a [StateError] naming the request and the registered
 /// stubs.
+///
+/// A response that depends on the request, on the parameters of an `rpc` call
+/// for example, is registered with [stubHandler].
 @visibleForTesting
 class MockSupabaseHttpClient extends BaseClient {
   final _stubs = <_Stub>[];
@@ -93,14 +107,24 @@ class MockSupabaseHttpClient extends BaseClient {
   /// Every request this client has answered, oldest first.
   final requests = <RecordedRequest>[];
 
-  /// Answers requests matching [method] and [path] with [body] encoded as
-  /// JSON under [statusCode].
+  /// Forgets every registered stub and every recorded request, so a client
+  /// shared between tests starts each of them clean.
+  void reset() {
+    _stubs.clear();
+    requests.clear();
+  }
+
+  /// Answers requests matching [method] and [path] with [body] under
+  /// [statusCode].
   ///
   /// A null [method] or [path] matches any method or path; [path] is compared
-  /// against the path of the request URL, ignoring the query. A null [body]
-  /// produces an empty response body. [times] limits how many requests the
-  /// stub answers before it stops matching, so consecutive stubs of the same
-  /// endpoint can model state that changes between calls.
+  /// against the path of the request URL, ignoring the query. A [Uint8List]
+  /// body is sent as is with the content type `application/octet-stream`, any
+  /// other body is encoded as JSON, and a null [body] produces an empty
+  /// response body. [headers] are added to the response, and override the
+  /// content type. [times] limits how many requests the stub answers before
+  /// it stops matching, so consecutive stubs of the same endpoint can model
+  /// state that changes between calls.
   void stub(
     Object? body, {
     String? method,
@@ -114,19 +138,57 @@ class MockSupabaseHttpClient extends BaseClient {
         method: method,
         path: path,
         remaining: times,
-        respond: (request) => body == null
-            ? StreamedResponse(
-                const Stream.empty(),
-                statusCode,
-                request: request,
-                headers: headers,
-              )
-            : jsonStreamedResponse(
-                body,
-                statusCode: statusCode,
-                request: request,
-                headers: headers,
-              ),
+        respond: (request, _) => _response(
+          body,
+          request: request,
+          statusCode: statusCode,
+          headers: headers,
+        ),
+      ),
+    );
+  }
+
+  /// Answers requests matching [method] and [path] with the response
+  /// [handler] builds from the request.
+  ///
+  /// Use it when the response depends on what was sent, on the body of an
+  /// `rpc` call for example. The handler receives the request with its body
+  /// already read, and returns a [Response]; [jsonResponse] builds one from a
+  /// JSON body:
+  ///
+  /// ```dart
+  /// httpClient.stubHandler(
+  ///   (request) {
+  ///     final params = request.jsonBody as Map<String, dynamic>;
+  ///     return jsonResponse(params['a'] + params['b']);
+  ///   },
+  ///   path: '/rest/v1/rpc/add_them',
+  /// );
+  /// ```
+  ///
+  /// [method], [path] and [times] match as they do for [stub].
+  void stubHandler(
+    StubHandler handler, {
+    String? method,
+    String? path,
+    int? times,
+  }) {
+    _stubs.add(
+      _Stub(
+        method: method,
+        path: path,
+        remaining: times,
+        respond: (request, recorded) async {
+          final response = await handler(recorded);
+          return StreamedResponse(
+            Stream.value(response.bodyBytes),
+            response.statusCode,
+            request: request,
+            headers: response.headers,
+            contentLength: response.bodyBytes.length,
+            reasonPhrase: response.reasonPhrase,
+          );
+        },
       ),
     );
   }
@@ -137,39 +199,54 @@ class MockSupabaseHttpClient extends BaseClient {
   /// `update`, `upsert` and `delete` are served through. A null [method]
   /// matches all of them; pass `'GET'` or `'POST'` to answer reads and writes
   /// differently.
+  ///
+  /// The response is shaped the way PostgREST shapes it for the request: a
+  /// query ending in `single()` receives the only row of a one-row list, or
+  /// the `PGRST116` error when the list holds any other number of rows, and a
+  /// query asking for a count receives [count] in the `content-range` header,
+  /// which defaults to the number of rows.
   void stubTable(
     String table, {
     Object? rows,
     String? method,
     int statusCode = 200,
+    int? count,
     int? times,
   }) {
-    stub(
+    _stubPostgrest(
       rows,
       method: method,
       path: '/rest/v1/$table',
       statusCode: statusCode,
+      count: count,
       times: times,
     );
   }
 
   /// Answers calls of the Postgres function [function] made through `rpc`
   /// with [body].
+  ///
+  /// The response is shaped for `single()` and counts the way [stubTable]
+  /// shapes it.
   void stubRpc(
     String function, {
     Object? body,
     int statusCode = 200,
+    int? count,
     int? times,
   }) {
-    stub(
+    _stubPostgrest(
       body,
       path: '/rest/v1/rpc/$function',
       statusCode: statusCode,
+      count: count,
       times: times,
     );
   }
 
   /// Answers invocations of the edge function [function] with [body].
+  ///
+  /// A [Uint8List] body reaches the caller as bytes, any other body as JSON.
   void stubEdgeFunction(
     String function, {
     Object? body,
@@ -210,23 +287,135 @@ class MockSupabaseHttpClient extends BaseClient {
     );
   }
 
-  @override
-  Future<StreamedResponse> send(BaseRequest request) async {
-    requests.add(
-      RecordedRequest._(
-        request.method,
-        request.url,
-        Map.of(request.headers),
-        await request.finalize().toBytes(),
+  void _stubPostgrest(
+    Object? body, {
+    required String path,
+    required int statusCode,
+    String? method,
+    int? count,
+    int? times,
+  }) {
+    _stubs.add(
+      _Stub(
+        method: method,
+        path: path,
+        remaining: times,
+        respond: (request, _) => _postgrestResponse(
+          body,
+          request: request,
+          statusCode: statusCode,
+          count: count,
+        ),
       ),
     );
+  }
+
+  /// Shapes [body] the way PostgREST would for [request]: counts go into the
+  /// `content-range` header, a `HEAD` request carries no body, and a request
+  /// for a single object receives the only row or the `PGRST116` error.
+  StreamedResponse _postgrestResponse(
+    Object? body, {
+    required BaseRequest request,
+    required int statusCode,
+    int? count,
+  }) {
+    final headers = <String, String>{};
+    final prefer = request.headers['Prefer'] ?? '';
+    final rowCount =
+        count ??
+        switch (body) {
+          List<Object?> rows => rows.length,
+          Map() => 1,
+          _ => null,
+        };
+    if (prefer.contains('count=') && rowCount != null) {
+      final range = body is List && body.isNotEmpty
+          ? '0-${body.length - 1}'
+          : '*';
+      headers['content-range'] = '$range/$rowCount';
+    }
+    if (request.method.toUpperCase() == 'HEAD') {
+      return _response(
+        null,
+        request: request,
+        statusCode: statusCode,
+        headers: headers,
+      );
+    }
+    final isSuccess = statusCode >= 200 && statusCode <= 299;
+    final wantsSingleObject =
+        request.headers['Accept']?.startsWith(_singleObjectAccept) ?? false;
+    if (isSuccess && wantsSingleObject && body is List) {
+      if (body.length != 1) {
+        return _response(
+          {
+            'code': 'PGRST116',
+            'details':
+                'Results contain ${body.length} rows, '
+                '$_singleObjectAccept requires 1 row',
+            'hint': null,
+            'message': 'JSON object requested, multiple (or no) rows returned',
+          },
+          request: request,
+          statusCode: 406,
+          headers: headers,
+        );
+      }
+      body = body.single;
+    }
+    return _response(
+      body,
+      request: request,
+      statusCode: statusCode,
+      headers: headers,
+    );
+  }
+
+  StreamedResponse _response(
+    Object? body, {
+    required BaseRequest request,
+    required int statusCode,
+    required Map<String, String> headers,
+  }) {
+    return switch (body) {
+      null => StreamedResponse(
+        const Stream.empty(),
+        statusCode,
+        request: request,
+        headers: headers,
+      ),
+      Uint8List bytes => StreamedResponse(
+        Stream.value(bytes),
+        statusCode,
+        request: request,
+        contentLength: bytes.length,
+        headers: {'content-type': 'application/octet-stream', ...headers},
+      ),
+      _ => jsonStreamedResponse(
+        body,
+        statusCode: statusCode,
+        request: request,
+        headers: headers,
+      ),
+    };
+  }
+
+  @override
+  Future<StreamedResponse> send(BaseRequest request) async {
+    final recorded = RecordedRequest._(
+      request.method,
+      request.url,
+      Map.of(request.headers),
+      await request.finalize().toBytes(),
+    );
+    requests.add(recorded);
     for (final registered in _stubs.reversed) {
       if (registered.matches(request)) {
         final remaining = registered.remaining;
         if (remaining != null) {
           registered.remaining = remaining - 1;
         }
-        return registered.respond(request);
+        return registered.respond(request, recorded);
       }
     }
     final stubs = _stubs.isEmpty

--- a/packages/supabase_test/test/mock_supabase_http_client_test.dart
+++ b/packages/supabase_test/test/mock_supabase_http_client_test.dart
@@ -1,3 +1,6 @@
+import 'dart:typed_data';
+
+import 'package:http/http.dart' as http;
 import 'package:supabase/supabase.dart';
 import 'package:supabase_test/supabase_test.dart';
 import 'package:test/test.dart';
@@ -157,6 +160,316 @@ void main() {
       );
 
       expect(supabase.auth.currentUser?.id, 'custom-id');
+    });
+  });
+
+  group('PostgREST shaping', () {
+    test('single returns the only row of a one-row list', () async {
+      httpClient.stubTable(
+        'todos',
+        rows: [
+          {'id': 1, 'task': 'Ship it'},
+        ],
+      );
+
+      final todo = await supabase.from('todos').select().eq('id', 1).single();
+
+      expect(todo, {'id': 1, 'task': 'Ship it'});
+    });
+
+    test('single passes a stubbed object through untouched', () async {
+      httpClient.stubTable('todos', rows: {'id': 1, 'task': 'Ship it'});
+
+      final todo = await supabase.from('todos').select().single();
+
+      expect(todo, {'id': 1, 'task': 'Ship it'});
+    });
+
+    test('single fails with PGRST116 when no row matches', () async {
+      httpClient.stubTable('todos', rows: []);
+
+      await expectLater(
+        () => supabase.from('todos').select().single(),
+        throwsA(
+          isA<PostgrestApiException>()
+              .having(
+                (exception) => exception.errorCode,
+                'errorCode',
+                'PGRST116',
+              )
+              .having((exception) => exception.statusCode, 'statusCode', 406),
+        ),
+      );
+    });
+
+    test('single fails with PGRST116 when several rows match', () async {
+      httpClient.stubTable(
+        'todos',
+        rows: [
+          {'id': 1},
+          {'id': 2},
+        ],
+      );
+
+      await expectLater(
+        () => supabase.from('todos').select().single(),
+        throwsA(
+          isA<PostgrestApiException>().having(
+            (exception) => exception.errorCode,
+            'errorCode',
+            'PGRST116',
+          ),
+        ),
+      );
+    });
+
+    test('single after an insert returns the inserted row', () async {
+      httpClient.stubTable(
+        'todos',
+        method: 'POST',
+        statusCode: 201,
+        rows: [
+          {'id': 1, 'task': 'Write tests'},
+        ],
+      );
+
+      final todo = await supabase
+          .from('todos')
+          .insert({'task': 'Write tests'})
+          .select()
+          .single();
+
+      expect(todo, {'id': 1, 'task': 'Write tests'});
+    });
+
+    test('maybeSingle resolves to null for no rows', () async {
+      httpClient.stubTable('todos', rows: []);
+
+      final todo = await supabase.from('todos').select().maybeSingle();
+
+      expect(todo, isNull);
+    });
+
+    test('an error body is not shaped for single', () async {
+      httpClient.stubTable(
+        'todos',
+        rows: {'message': 'permission denied', 'code': '42501'},
+        statusCode: 403,
+      );
+
+      await expectLater(
+        () => supabase.from('todos').select().single(),
+        throwsA(
+          isA<PostgrestApiException>().having(
+            (exception) => exception.errorCode,
+            'errorCode',
+            '42501',
+          ),
+        ),
+      );
+    });
+
+    test('count defaults to the number of stubbed rows', () async {
+      httpClient.stubTable(
+        'todos',
+        rows: [
+          {'id': 1},
+          {'id': 2},
+        ],
+      );
+
+      final response = await supabase
+          .from('todos')
+          .select()
+          .count(CountOption.exact);
+
+      expect(response.data, hasLength(2));
+      expect(response.count, 2);
+    });
+
+    test('an explicit count overrides the number of rows', () async {
+      httpClient.stubTable(
+        'todos',
+        rows: [
+          {'id': 1},
+        ],
+        count: 42,
+      );
+
+      final response = await supabase
+          .from('todos')
+          .select()
+          .limit(1)
+          .count(CountOption.exact);
+
+      expect(response.data, hasLength(1));
+      expect(response.count, 42);
+    });
+
+    test('a head count carries no body', () async {
+      httpClient.stubTable('todos', rows: [], count: 7);
+
+      final count = await supabase.from('todos').count();
+
+      expect(count, 7);
+      expect(httpClient.requests.single.method, 'HEAD');
+    });
+
+    test('single combined with count', () async {
+      httpClient.stubTable(
+        'todos',
+        rows: [
+          {'id': 1},
+        ],
+      );
+
+      final response = await supabase
+          .from('todos')
+          .select()
+          .single()
+          .count(CountOption.exact);
+
+      expect(response.data, {'id': 1});
+      expect(response.count, 1);
+    });
+
+    test('no content-range is sent unless a count was asked for', () async {
+      httpClient.stubTable(
+        'todos',
+        rows: [
+          {'id': 1},
+        ],
+      );
+
+      final response = await httpClient.get(
+        Uri.parse('http://localhost:54321/rest/v1/todos'),
+      );
+
+      expect(response.headers, isNot(contains('content-range')));
+    });
+
+    test('stubRpc shapes a single result', () async {
+      httpClient.stubRpc(
+        'current_profile',
+        body: [
+          {'id': 'user-1'},
+        ],
+      );
+
+      final profile = await supabase.rpc('current_profile').select().single();
+
+      expect(profile, {'id': 'user-1'});
+    });
+  });
+
+  group('stubHandler', () {
+    test('builds the response from the request body', () async {
+      httpClient.stubHandler((request) {
+        final params = request.jsonBody as Map<String, dynamic>;
+        return jsonResponse(params['a'] + params['b']);
+      }, path: '/rest/v1/rpc/add_them');
+
+      final result = await supabase.rpc('add_them', params: {'a': 1, 'b': 2});
+
+      expect(result, 3);
+    });
+
+    test('sees the method and query of an edge function invocation', () async {
+      httpClient.stubHandler((request) {
+        return jsonResponse({
+          'method': request.method,
+          'city': request.url.queryParameters['city'],
+        });
+      }, path: '/functions/v1/where');
+
+      final response = await supabase.functions.invoke(
+        'where',
+        method: HttpMethod.patch,
+        queryParameters: {'city': 'Springfield'},
+      );
+
+      expect(response.data, {'method': 'PATCH', 'city': 'Springfield'});
+    });
+
+    test('chooses the status code per request', () async {
+      httpClient.stubHandler(
+        (request) {
+          final row = request.jsonBody as Map<String, dynamic>;
+          if (row['email'] == 'taken@example.com') {
+            return jsonResponse(
+              {'message': 'duplicate key value', 'code': '23505'},
+              statusCode: 409,
+            );
+          }
+          return jsonResponse([row], statusCode: 201);
+        },
+        method: 'POST',
+        path: '/rest/v1/users',
+      );
+
+      await supabase.from('users').insert({'email': 'free@example.com'});
+
+      await expectLater(
+        () => supabase.from('users').insert({'email': 'taken@example.com'}),
+        throwsA(
+          isA<PostgrestApiException>().having(
+            (exception) => exception.errorCode,
+            'errorCode',
+            '23505',
+          ),
+        ),
+      );
+    });
+
+    test('may answer asynchronously with any response', () async {
+      httpClient.stubHandler(
+        (request) async => http.Response('plain text', 200),
+        path: '/functions/v1/text',
+      );
+
+      final response = await supabase.functions.invoke('text');
+
+      expect(response.data, 'plain text');
+    });
+
+    test('encodes non-ASCII JSON as UTF-8', () async {
+      httpClient.stubHandler(
+        (request) => jsonResponse({'greeting': 'こんにちは 👋'}),
+        path: '/functions/v1/hello',
+      );
+
+      final response = await supabase.functions.invoke('hello');
+
+      expect(response.data, {'greeting': 'こんにちは 👋'});
+    });
+  });
+
+  group('binary bodies', () {
+    test('a Uint8List body reaches the caller as bytes', () async {
+      httpClient.stubEdgeFunction(
+        'binary',
+        body: Uint8List.fromList([1, 2, 3]),
+      );
+
+      final response = await supabase.functions.invoke('binary');
+
+      expect(response.data, isA<Uint8List>());
+      expect(response.data, [1, 2, 3]);
+    });
+  });
+
+  group('reset', () {
+    test('forgets the stubs and the recorded requests', () async {
+      httpClient.stubTable('todos', rows: []);
+      await supabase.from('todos').select();
+
+      httpClient.reset();
+
+      expect(httpClient.requests, isEmpty);
+      await expectLater(
+        () => supabase.from('todos').select(),
+        throwsA(isA<StateError>()),
+      );
     });
   });
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature. Ports the behaviors of the community [mock_supabase_http_client](https://github.com/supabase-community/mock_supabase_http_client) package that fit the stub-based design of `supabase_test`, which that package now points people at.

## What is the current behavior?

- A stub registered with `stubTable` always returns the list it was given, so a query ending in `.single()` fails with a type error instead of receiving the single object PostgREST would send, and there is no way to produce the `PGRST116` error.
- `.count()` fails with a null check because no stub sets the `content-range` header.
- Every stub is a fixed body, so an `rpc` or edge function whose result depends on its parameters cannot be modelled without a second stub per call.
- A `Uint8List` body is JSON-encoded, so binary edge function responses reach the caller as `List<int>`.
- A client shared between tests cannot be wiped.

## What is the new behavior?

- `stubTable` and `stubRpc` shape their rows the way PostgREST does for the request: `.single()` receives the only row of a one-row list, or a 406 `PGRST116` error for any other row count. Error bodies and stubbed objects pass through untouched.
- A request that asks for a count receives it in `content-range`, defaulting to the number of stubbed rows, with a `count` parameter for stubbing one page of a larger table. `HEAD` requests carry no body.
- `stubHandler` answers a matched request with the `Response` a handler builds from the recorded request. `jsonResponse` builds a UTF-8 encoded JSON response for it.
- A `Uint8List` body is sent as bytes with `application/octet-stream`.
- `reset()` forgets the registered stubs and recorded requests.
- The README documents all of this and has a short section mapping the community package's API onto `supabase_test`.

Deliberately not ported: the in-memory database, filter parsing and referenced-table handling. Those interpret the query, which is the design `supabase_test` avoids so that the mock does not drift from PostgREST.

## Additional context

All new behavior is covered by tests in `packages/supabase_test/test/mock_supabase_http_client_test.dart`; the suite runs 35 tests and passes. `dart analyze packages/` is clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added request-aware response handlers for custom mock HTTP responses.
  * Added JSON response helpers with configurable status codes and headers.
  * Added support for PostgREST-style row shaping, counts, content-range headers, and single-row responses.
  * Added the ability to reset configured stubs and recorded requests.
  * Added support for binary response bodies.

* **Documentation**
  * Expanded testing documentation with guidance for single rows, counts, request-dependent responses, and migration from the previous mocking API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->