### PR TITLE
fix(supabase_test): match stub paths behind URL prefixes and widen the auth shorthands

### DIFF
--- a/packages/supabase_test/README.md
+++ b/packages/supabase_test/README.md
@@ -63,7 +63,9 @@ final httpClient = MockSupabaseHttpClient()
 ```
 
 Anything else, storage endpoints for example, is stubbed through the general
-`stub`, which matches on method and URL path:
+`stub`, which matches on method and URL path. A path matches a request whose
+path is the same or ends in it, so stubs written for `/rest/v1/todos` keep
+working for a project served under a path prefix:
 
 ```dart
 httpClient.stub(
@@ -165,16 +167,20 @@ registered stubs and the recorded requests.
 ## Asserting on requests
 
 The client records every request it answered in `requests`, with the body
-already read:
+already read, and `requestsTo` narrows them down by path and method:
 
 ```dart
+await supabase.from('todos').select().eq('status', true);
 await supabase.from('todos').insert({'task': 'Write tests'});
 
-final request = httpClient.requests.single;
-expect(request.method, 'POST');
-expect(request.url.path, '/rest/v1/todos');
-expect(request.jsonBody, {'task': 'Write tests'});
+final select = httpClient.requestsTo('/rest/v1/todos', method: 'GET').single;
+expect(select.queryParameters['status'], 'eq.true');
+
+final insert = httpClient.requestsTo('/rest/v1/todos', method: 'POST').single;
+expect(insert.jsonBody, {'task': 'Write tests'});
 ```
+
+Headers are looked up case-insensitively, as on the request itself.
 
 ## Testing auth
 
@@ -208,6 +214,10 @@ await supabase.auth.signInWithPassword(
   password: 'password',
 );
 ```
+
+`stubSignUp`, `stubSignOut` and `stubUser` cover the sign-up, logout and user
+endpoints the same way, so `signUp`, `signOut`, `getUser` and `updateUser`
+run against stubs too.
 
 For code that inspects tokens, `unsignedTestJwt` and `signedTestJwt` craft
 JWTs carrying exactly the claims you pass, with no auto-injected `iat` and no

--- a/packages/supabase_test/lib/src/mock_supabase_http_client.dart
+++ b/packages/supabase_test/lib/src/mock_supabase_http_client.dart
@@ -3,6 +3,7 @@
 // ignore_for_file: invalid_use_of_visible_for_testing_member
 
 import 'dart:async';
+import 'dart:collection';
 import 'dart:convert';
 import 'dart:typed_data';
 
@@ -21,8 +22,14 @@ class RecordedRequest {
 
   final String method;
   final Uri url;
+
+  /// The request headers, looked up case-insensitively like the headers of
+  /// the request itself.
   final Map<String, String> headers;
   final Uint8List bodyBytes;
+
+  /// The query parameters of [url].
+  Map<String, String> get queryParameters => url.queryParameters;
 
   /// The request body decoded as UTF-8.
   String get body => utf8.decode(bodyBytes);
@@ -64,7 +71,7 @@ class _Stub {
         method!.toUpperCase() != request.method.toUpperCase()) {
       return false;
     }
-    if (path != null && path != request.url.path) {
+    if (path != null && !_pathMatches(request.url.path, path!)) {
       return false;
     }
     return true;
@@ -72,6 +79,20 @@ class _Stub {
 
   @override
   String toString() => '${method ?? '(any method)'} ${path ?? '(any path)'}';
+}
+
+/// Whether [requestPath] is [stubPath], or ends in [stubPath] at a segment
+/// boundary, so that a stub written for `/rest/v1/todos` also answers a
+/// project hosted under a path prefix, `/supabase/rest/v1/todos` for example.
+bool _pathMatches(String requestPath, String stubPath) {
+  if (requestPath == stubPath) {
+    return true;
+  }
+  if (!requestPath.endsWith(stubPath)) {
+    return false;
+  }
+  final boundary = requestPath.length - stubPath.length;
+  return stubPath.startsWith('/') || requestPath[boundary - 1] == '/';
 }
 
 const _singleObjectAccept = 'application/vnd.pgrst.object+json';
@@ -107,6 +128,24 @@ class MockSupabaseHttpClient extends BaseClient {
   /// Every request this client has answered, oldest first.
   final requests = <RecordedRequest>[];
 
+  /// The answered requests whose URL path ends in [path], optionally
+  /// narrowed to [method], oldest first.
+  ///
+  /// ```dart
+  /// final inserts = httpClient.requestsTo('/rest/v1/todos', method: 'POST');
+  /// expect(inserts.single.jsonBody, {'task': 'Write tests'});
+  /// ```
+  List<RecordedRequest> requestsTo(String path, {String? method}) {
+    return requests
+        .where(
+          (request) =>
+              _pathMatches(request.url.path, path) &&
+              (method == null ||
+                  method.toUpperCase() == request.method.toUpperCase()),
+        )
+        .toList();
+  }
+
   /// Forgets every registered stub and every recorded request, so a client
   /// shared between tests starts each of them clean.
   void reset() {
@@ -117,8 +156,10 @@ class MockSupabaseHttpClient extends BaseClient {
   /// Answers requests matching [method] and [path] with [body] under
   /// [statusCode].
   ///
-  /// A null [method] or [path] matches any method or path; [path] is compared
-  /// against the path of the request URL, ignoring the query. A [Uint8List]
+  /// A null [method] or [path] matches any method or path. [path] matches a
+  /// request whose URL path is [path] or ends in it, ignoring the query, so a
+  /// stub for `/rest/v1/todos` also answers a project served under a path
+  /// prefix. A [Uint8List]
   /// body is sent as is with the content type `application/octet-stream`, any
   /// other body is encoded as JSON, and a null [body] produces an empty
   /// response body. [headers] are added to the response, and override the
@@ -272,6 +313,51 @@ class MockSupabaseHttpClient extends BaseClient {
     DateTime? expiresAt,
     int? times,
   }) {
+    stub(
+      _sessionJson(user: user, expiresAt: expiresAt),
+      method: 'POST',
+      path: '/auth/v1/token',
+      times: times,
+    );
+  }
+
+  /// Answers the sign-up endpoint the way an auto-confirming project does:
+  /// `signUp` succeeds with a session for [user], which defaults to
+  /// [testUserJson], built as [stubSignIn] builds it.
+  void stubSignUp({
+    Map<String, dynamic>? user,
+    DateTime? expiresAt,
+    int? times,
+  }) {
+    stub(
+      _sessionJson(user: user, expiresAt: expiresAt),
+      method: 'POST',
+      path: '/auth/v1/signup',
+      times: times,
+    );
+  }
+
+  /// Answers the logout endpoint, so `signOut` completes.
+  void stubSignOut({int? times}) {
+    stub(
+      null,
+      method: 'POST',
+      path: '/auth/v1/logout',
+      statusCode: 204,
+      times: times,
+    );
+  }
+
+  /// Answers the user endpoint with [user], which defaults to [testUserJson],
+  /// so `getUser` and `updateUser` succeed.
+  void stubUser({Map<String, dynamic>? user, int? times}) {
+    stub(user ?? testUserJson(), path: '/auth/v1/user', times: times);
+  }
+
+  Map<String, dynamic> _sessionJson({
+    Map<String, dynamic>? user,
+    DateTime? expiresAt,
+  }) {
     final userJson = user ?? testUserJson();
     final expiry = expiresAt ?? DateTime.now().add(const Duration(hours: 1));
     final accessToken = unsignedTestJwt({
@@ -279,12 +365,7 @@ class MockSupabaseHttpClient extends BaseClient {
       'sub': userJson['id'],
       'role': 'authenticated',
     });
-    stub(
-      testSessionResponseJson(accessToken: accessToken, user: userJson),
-      method: 'POST',
-      path: '/auth/v1/token',
-      times: times,
-    );
+    return testSessionResponseJson(accessToken: accessToken, user: userJson);
   }
 
   void _stubPostgrest(
@@ -402,10 +483,14 @@ class MockSupabaseHttpClient extends BaseClient {
 
   @override
   Future<StreamedResponse> send(BaseRequest request) async {
+    final headers = LinkedHashMap<String, String>(
+      equals: (a, b) => a.toLowerCase() == b.toLowerCase(),
+      hashCode: (key) => key.toLowerCase().hashCode,
+    )..addAll(request.headers);
     final recorded = RecordedRequest._(
       request.method,
       request.url,
-      Map.of(request.headers),
+      UnmodifiableMapView(headers),
       await request.finalize().toBytes(),
     );
     requests.add(recorded);

--- a/packages/supabase_test/test/mock_supabase_http_client_test.dart
+++ b/packages/supabase_test/test/mock_supabase_http_client_test.dart
@@ -472,4 +472,105 @@ void main() {
       );
     });
   });
+
+  group('path matching', () {
+    test('a stub answers a project served under a path prefix', () async {
+      final prefixed = testSupabaseClient(
+        httpClient: httpClient,
+        url: 'http://localhost:54321/supabase',
+      );
+      addTearDown(prefixed.dispose);
+      httpClient.stubTable(
+        'todos',
+        rows: [
+          {'id': 1},
+        ],
+      );
+
+      final todos = await prefixed.from('todos').select();
+
+      expect(todos, hasLength(1));
+      expect(httpClient.requests.single.url.path, '/supabase/rest/v1/todos');
+    });
+
+    test('a suffix only matches at a segment boundary', () {
+      httpClient.stubTable('todos', rows: []);
+
+      expect(
+        () => httpClient.get(
+          Uri.parse('http://localhost:54321/rest/v1/my_todos'),
+        ),
+        throwsA(isA<StateError>()),
+      );
+    });
+  });
+
+  group('recorded requests', () {
+    test('headers are looked up case-insensitively', () async {
+      httpClient.stubTable('todos', rows: []);
+      final session = await signInTestUser(supabase.auth);
+
+      await supabase.from('todos').select();
+
+      final request = httpClient.requests.single;
+      expect(request.headers['authorization'], 'Bearer ${session.accessToken}');
+      expect(request.headers['AUTHORIZATION'], 'Bearer ${session.accessToken}');
+    });
+
+    test('requestsTo narrows by path and method', () async {
+      httpClient.stubTable('todos', rows: []);
+      httpClient.stubTable('profiles', rows: []);
+
+      await supabase.from('todos').select();
+      await supabase.from('profiles').select();
+      await supabase.from('todos').insert({'task': 'Write tests'});
+
+      expect(httpClient.requestsTo('/rest/v1/todos'), hasLength(2));
+      final inserts = httpClient.requestsTo('/rest/v1/todos', method: 'POST');
+      expect(inserts.single.jsonBody, {'task': 'Write tests'});
+    });
+
+    test('queryParameters exposes the query of the request', () async {
+      httpClient.stubTable('todos', rows: []);
+
+      await supabase.from('todos').select('id').eq('status', true);
+
+      final query = httpClient.requests.single.queryParameters;
+      expect(query, {'select': 'id', 'status': 'eq.true'});
+    });
+  });
+
+  group('auth shorthands', () {
+    test('stubSignUp lets a sign-up produce a session', () async {
+      httpClient.stubSignUp(user: testUserJson(id: 'new-user'));
+
+      final response = await supabase.auth.signUp(
+        email: 'new@example.com',
+        password: 'password',
+      );
+
+      expect(response.session, isNotNull);
+      expect(supabase.auth.currentUser?.id, 'new-user');
+    });
+
+    test('stubSignOut lets a signed-in client sign out', () async {
+      httpClient.stubSignOut();
+      await signInTestUser(supabase.auth);
+
+      await supabase.auth.signOut();
+
+      expect(supabase.auth.currentSession, isNull);
+      final request = httpClient.requestsTo('/auth/v1/logout').single;
+      expect(request.method, 'POST');
+    });
+
+    test('stubUser answers getUser', () async {
+      httpClient.stubUser(user: testUserJson(email: 'fresh@example.com'));
+      await signInTestUser(supabase.auth);
+
+      final response = await supabase.auth.getUser();
+
+      expect(response.user?.email, 'fresh@example.com');
+    });
+  });
 }


### PR DESCRIPTION
Stacked on #1813; the diff shown here is only this change once that merges.

## What kind of change does this PR introduce?

Bug fix, with two small additions to the request assertion surface. Closes SDK-1771.

## What is the current behavior?

- Stub paths are compared exactly against the request path. A project URL with a path prefix (self-hosted behind a reverse proxy, `https://example.com/supabase`) produces `/supabase/rest/v1/todos`, so `stubTable` and every other shorthand miss and the test throws "no stub matches".
- `RecordedRequest.headers` is a plain map, while `package:http` request headers are case-insensitive. `request.headers['authorization']` is null.
- `stubSignIn` only answers the token endpoint. `signUp`, `signOut`, `getUser` and `updateUser` all hit endpoints no shorthand covers.

## What is the new behavior?

- A stub path matches a request whose path is the same or ends in it at a segment boundary, so `/rest/v1/todos` answers `/supabase/rest/v1/todos` but not `/rest/v1/my_todos`.
- Recorded headers are looked up case-insensitively.
- `stubSignUp` answers `/auth/v1/signup` with a session the way an auto-confirming project does, `stubSignOut` answers `/auth/v1/logout`, and `stubUser` answers `/auth/v1/user`.
- `requestsTo(path, method:)` narrows the recorded requests, and `RecordedRequest.queryParameters` exposes the query, so assertions stop repeating URL plumbing.

## Additional context

All new behavior is covered in `packages/supabase_test/test/mock_supabase_http_client_test.dart`; the suite runs 43 tests and passes. `dart analyze packages/` is clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for stubbing authentication flows, including sign-up, sign-out, user retrieval, and updates.
  * Added tools for filtering recorded requests by path and method, inspecting query parameters, and handling headers without case sensitivity.
  * Improved stub matching for applications using URL path prefixes.

* **Documentation**
  * Expanded testing documentation with request inspection examples and authentication stub guidance.

* **Tests**
  * Added coverage for path matching, request inspection, and authentication scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->