### PR TITLE
chore(supabase_test): move the internal suite fixtures to an internal library and add an example

### DIFF
--- a/packages/postgrest/test/json_codec_test.dart
+++ b/packages/postgrest/test/json_codec_test.dart
@@ -2,7 +2,7 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:postgrest/postgrest.dart';
-import 'package:supabase_test/supabase_test.dart';
+import 'package:supabase_test/internal.dart';
 import 'package:test/test.dart';
 
 void main() {

--- a/packages/postgrest/test/retry_test.dart
+++ b/packages/postgrest/test/retry_test.dart
@@ -4,7 +4,7 @@ import 'dart:typed_data';
 
 import 'package:http/http.dart';
 import 'package:postgrest/postgrest.dart';
-import 'package:supabase_test/supabase_test.dart';
+import 'package:supabase_test/internal.dart';
 import 'package:test/test.dart';
 
 typedef _ResponseFactory = Future<StreamedResponse> Function(BaseRequest);

--- a/packages/postgrest/test/test_utils.dart
+++ b/packages/postgrest/test/test_utils.dart
@@ -10,6 +10,7 @@ library;
 import 'package:supabase_common/testing.dart';
 
 export 'package:supabase_common/testing.dart';
+export 'package:supabase_test/internal.dart';
 export 'package:supabase_test/supabase_test.dart';
 
 const apiHeaders = {

--- a/packages/supabase/test/mock_test.dart
+++ b/packages/supabase/test/mock_test.dart
@@ -6,6 +6,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:supabase/supabase.dart';
+import 'package:supabase_test/internal.dart';
 import 'package:supabase_test/supabase_test.dart';
 import 'package:test/test.dart';
 

--- a/packages/supabase/test/postgrest_options_test.dart
+++ b/packages/supabase/test/postgrest_options_test.dart
@@ -4,7 +4,7 @@ import 'dart:typed_data';
 
 import 'package:http/http.dart';
 import 'package:supabase/supabase.dart';
-import 'package:supabase_test/supabase_test.dart';
+import 'package:supabase_test/internal.dart';
 import 'package:test/test.dart';
 
 abstract class _CountingClient extends BaseClient {

--- a/packages/supabase/test/utils.dart
+++ b/packages/supabase/test/utils.dart
@@ -1,6 +1,7 @@
 import 'package:supabase/supabase.dart';
 
 export 'package:supabase_common/testing.dart';
+export 'package:supabase_test/internal.dart';
 export 'package:supabase_test/supabase_test.dart';
 
 class TestAsyncStorage extends MemoryAuthAsyncStorage {}

--- a/packages/supabase_auth/test/utils.dart
+++ b/packages/supabase_auth/test/utils.dart
@@ -3,6 +3,7 @@ import 'package:supabase_auth/supabase_auth.dart';
 import 'package:supabase_common/testing.dart';
 
 export 'package:supabase_common/testing.dart';
+export 'package:supabase_test/internal.dart';
 export 'package:supabase_test/supabase_test.dart';
 
 /// Email of a user with unverified factor

--- a/packages/supabase_flutter/test/utils.dart
+++ b/packages/supabase_flutter/test/utils.dart
@@ -3,6 +3,7 @@ import 'package:shared_preferences_platform_interface/in_memory_shared_preferenc
 import 'package:shared_preferences_platform_interface/shared_preferences_async_platform_interface.dart';
 
 export 'package:supabase_common/testing.dart';
+export 'package:supabase_test/internal.dart';
 export 'package:supabase_test/supabase_test.dart';
 
 /// Replaces both shared_preferences APIs with empty in-memory stores.

--- a/packages/supabase_functions/test/custom_http_client.dart
+++ b/packages/supabase_functions/test/custom_http_client.dart
@@ -1,7 +1,7 @@
 import 'dart:convert';
 
 import 'package:http/http.dart';
-import 'package:supabase_test/supabase_test.dart';
+import 'package:supabase_test/internal.dart';
 
 class CustomHttpClient extends BaseClient {
   /// List of received requests by the client.

--- a/packages/supabase_realtime/test/mock_test.dart
+++ b/packages/supabase_realtime/test/mock_test.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:supabase_test/internal.dart';
 import 'package:supabase_test/supabase_test.dart';
 import 'package:supabase_realtime/supabase_realtime.dart';
 import 'package:test/test.dart';

--- a/packages/supabase_storage/test/custom_http_client.dart
+++ b/packages/supabase_storage/test/custom_http_client.dart
@@ -3,7 +3,7 @@ import 'dart:typed_data';
 
 import 'package:http/http.dart';
 
-export 'package:supabase_test/supabase_test.dart' show FailingHttpClient;
+export 'package:supabase_test/internal.dart' show FailingHttpClient;
 
 /// Client that fails for few times when attempting to upload file
 class RetryHttpClient extends BaseClient {

--- a/packages/supabase_test/README.md
+++ b/packages/supabase_test/README.md
@@ -222,8 +222,8 @@ run against stubs too.
 For code that inspects tokens, `unsignedTestJwt` and `signedTestJwt` craft
 JWTs carrying exactly the claims you pass, with no auto-injected `iat` and no
 claim overrides, and `decodeTestJwtClaims` reads them back for assertions.
-The fixtures `testUserJson`, `testSessionResponseJson` and `getSessionData`
-produce the JSON shapes the auth server would return.
+The fixtures `testUserJson` and `testSessionResponseJson` produce the JSON
+shapes the auth server would return.
 
 ## Testing realtime
 

--- a/packages/supabase_test/example/supabase_test_example.dart
+++ b/packages/supabase_test/example/supabase_test_example.dart
@@ -8,7 +8,7 @@ import 'package:test/test.dart';
 
 /// The code under test: a repository that reads and writes todos.
 class TodoRepository {
-  TodoRepository(this.supabase);
+  const TodoRepository(this.supabase);
 
   final SupabaseClient supabase;
 

--- a/packages/supabase_test/example/supabase_test_example.dart
+++ b/packages/supabase_test/example/supabase_test_example.dart
@@ -1,0 +1,87 @@
+// This example is a test file; the helpers are meant for test code, so the
+// analyzer warning about using them outside of a test directory is expected.
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
+import 'package:supabase/supabase.dart';
+import 'package:supabase_test/supabase_test.dart';
+import 'package:test/test.dart';
+
+/// The code under test: a repository that reads and writes todos.
+class TodoRepository {
+  TodoRepository(this.supabase);
+
+  final SupabaseClient supabase;
+
+  Future<List<String>> openTasks() async {
+    final rows = await supabase
+        .from('todos')
+        .select('task')
+        .eq('status', false);
+    return rows.map((row) => row['task'] as String).toList();
+  }
+
+  Future<void> add(String task) {
+    return supabase.from('todos').insert({'task': task, 'status': false});
+  }
+}
+
+void main() {
+  late MockSupabaseHttpClient httpClient;
+  late SupabaseClient supabase;
+  late TodoRepository repository;
+
+  setUp(() {
+    httpClient = MockSupabaseHttpClient();
+    supabase = testSupabaseClient(httpClient: httpClient);
+    addTearDown(supabase.dispose);
+    repository = TodoRepository(supabase);
+  });
+
+  test('lists the open tasks', () async {
+    httpClient.stubTable(
+      'todos',
+      rows: [
+        {'task': 'Ship it'},
+        {'task': 'Write tests'},
+      ],
+    );
+
+    final tasks = await repository.openTasks();
+
+    expect(tasks, ['Ship it', 'Write tests']);
+    final request = httpClient.requestsTo('/rest/v1/todos').single;
+    expect(request.queryParameters['status'], 'eq.false');
+  });
+
+  test('sends the new todo to the table', () async {
+    httpClient.stubTable('todos', method: 'POST', statusCode: 201);
+
+    await repository.add('Release');
+
+    final insert = httpClient.requestsTo('/rest/v1/todos', method: 'POST');
+    expect(insert.single.jsonBody, {'task': 'Release', 'status': false});
+  });
+
+  test('surfaces a database error', () async {
+    httpClient.stubTable(
+      'todos',
+      rows: {'message': 'permission denied', 'code': '42501'},
+      statusCode: 403,
+    );
+
+    await expectLater(
+      repository.openTasks,
+      throwsA(isA<PostgrestApiException>()),
+    );
+  });
+
+  test('runs as a signed-in user', () async {
+    httpClient.stubTable('todos', rows: []);
+    final session = await signInTestUser(supabase.auth);
+
+    await repository.openTasks();
+
+    final request = httpClient.requests.single;
+    expect(request.headers['Authorization'], 'Bearer ${session.accessToken}');
+  });
+}

--- a/packages/supabase_test/lib/internal.dart
+++ b/packages/supabase_test/lib/internal.dart
@@ -1,0 +1,11 @@
+/// Fixtures and mock clients the test suites of the Supabase client packages
+/// themselves run on.
+///
+/// These are published so that the packages of the supabase-flutter monorepo
+/// can share them, and are not part of the supported API of this package:
+/// they change or disappear whenever the internal suites stop needing them.
+/// Everything an app test needs is in `package:supabase_test/supabase_test.dart`.
+library;
+
+export 'src/internal_fixtures.dart';
+export 'src/internal_http_clients.dart';

--- a/packages/supabase_test/lib/src/internal_fixtures.dart
+++ b/packages/supabase_test/lib/src/internal_fixtures.dart
@@ -1,0 +1,46 @@
+import 'dart:convert';
+
+import 'package:meta/meta.dart';
+
+/// User id embedded in the session produced by [getSessionData].
+@visibleForTesting
+const sessionDataUserId = '4d2583da-8de4-49d3-9cd1-37a9a74f55bd';
+
+/// Constructs session data for a given expiration date.
+@visibleForTesting
+({String accessToken, String sessionString}) getSessionData(
+  DateTime expireDateTime,
+) {
+  final expiresAt = expireDateTime.millisecondsSinceEpoch ~/ 1000;
+  final accessTokenMid = base64.encode(
+    utf8.encode(
+      json.encode({
+        'exp': expiresAt,
+        'sub': '1234567890',
+        'role': 'authenticated',
+      }),
+    ),
+  );
+  final accessToken = 'any.$accessTokenMid.any';
+  final sessionString =
+      '{"access_token":"$accessToken","expires_in":'
+      '${expireDateTime.difference(DateTime.now()).inSeconds},"refresh_token":"'
+      '-yeS4omysFs9tpUYBws9Rg","token_type":"bearer","provider_token":null,"pro'
+      'vider_refresh_token":null,"user":{"id":"$sessionDataUserId","app_metadat'
+      'a":{"provider":"email","providers":["email"]},"user_metadata":{"Hello":"'
+      'World"},"aud":"","email":"fake1680338105@email.com","phone":"","created_'
+      'at":"2023-04-01T08:35:05.208586Z","confirmed_at":null,"email_confirmed_a'
+      't":"2023-04-01T08:35:05.220096086Z","phone_confirmed_at":null,"last_sign'
+      '_in_at":"2023-04-01T08:35:05.222755878Z","role":"","updated_at":"2023-04'
+      '-01T08:35:05.226938Z"}}';
+  return (accessToken: accessToken, sessionString: sessionString);
+}
+
+/// Column description of the `todos` fixture table, as the realtime server
+/// reports it in a `postgres_changes` event.
+@visibleForTesting
+const todoColumns = [
+  {'name': 'id', 'type': 'int4', 'type_modifier': 4294967295},
+  {'name': 'task', 'type': 'text', 'type_modifier': 4294967295},
+  {'name': 'status', 'type': 'bool', 'type_modifier': 4294967295},
+];

--- a/packages/supabase_test/lib/src/internal_http_clients.dart
+++ b/packages/supabase_test/lib/src/internal_http_clients.dart
@@ -1,0 +1,72 @@
+// The composed helpers of this package legitimately build on its own
+// test-only primitives outside of a test directory.
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
+import 'dart:async';
+
+import 'package:http/http.dart';
+import 'package:meta/meta.dart';
+
+import 'mock_http_clients.dart';
+
+/// A mock HTTP client that answers every request with the same JSON body.
+@visibleForTesting
+class JsonResponseMockClient extends BaseClient {
+  JsonResponseMockClient({required this.body, this.statusCode = 200});
+
+  /// The body the mocked server encodes and returns for every request.
+  final Object? body;
+
+  final int statusCode;
+
+  Uri? lastUri;
+
+  @override
+  Future<StreamedResponse> send(BaseRequest request) async {
+    lastUri = request.url;
+
+    return jsonStreamedResponse(
+      body,
+      statusCode: statusCode,
+      request: request,
+    );
+  }
+}
+
+/// A mock HTTP client that answers every request with an empty body and the
+/// recognizable status code 420, so a test can assert this client was the
+/// one used.
+@visibleForTesting
+class FailingHttpClient extends BaseClient {
+  @override
+  Future<StreamedResponse> send(BaseRequest request) async {
+    return StreamedResponse(
+      const Stream.empty(),
+      420,
+      request: request,
+    );
+  }
+}
+
+/// Never answers, so only completing [request]'s abort trigger, which
+/// surfaces as a [RequestAbortedException], ends the request.
+///
+/// A request that is not [Abortable] stalls forever.
+@visibleForTesting
+Future<StreamedResponse> stallUntilAborted(BaseRequest request) {
+  final completer = Completer<StreamedResponse>();
+  if (request is Abortable) {
+    final abortTrigger = request.abortTrigger;
+    unawaited(
+      abortTrigger?.then((_) {
+        if (!completer.isCompleted) {
+          completer.completeError(
+            RequestAbortedException(request.url),
+            StackTrace.current,
+          );
+        }
+      }),
+    );
+  }
+  return completer.future;
+}

--- a/packages/supabase_test/lib/src/mock_http_clients.dart
+++ b/packages/supabase_test/lib/src/mock_http_clients.dart
@@ -1,4 +1,3 @@
-import 'dart:async';
 import 'dart:convert';
 
 import 'package:http/http.dart';
@@ -36,66 +35,4 @@ Response jsonResponse(
     statusCode,
     headers: {'content-type': 'application/json; charset=utf-8', ...headers},
   );
-}
-
-/// A mock HTTP client that answers every request with the same JSON body.
-@visibleForTesting
-class JsonResponseMockClient extends BaseClient {
-  JsonResponseMockClient({required this.body, this.statusCode = 200});
-
-  /// The body the mocked server encodes and returns for every request.
-  final Object? body;
-
-  final int statusCode;
-
-  Uri? lastUri;
-
-  @override
-  Future<StreamedResponse> send(BaseRequest request) async {
-    lastUri = request.url;
-
-    return jsonStreamedResponse(
-      body,
-      statusCode: statusCode,
-      request: request,
-    );
-  }
-}
-
-/// A mock HTTP client that answers every request with an empty body and the
-/// recognizable status code 420, so a test can assert this client was the
-/// one used.
-@visibleForTesting
-class FailingHttpClient extends BaseClient {
-  @override
-  Future<StreamedResponse> send(BaseRequest request) async {
-    return StreamedResponse(
-      const Stream.empty(),
-      420,
-      request: request,
-    );
-  }
-}
-
-/// Never answers, so only completing [request]'s abort trigger, which
-/// surfaces as a [RequestAbortedException], ends the request.
-///
-/// A request that is not [Abortable] stalls forever.
-@visibleForTesting
-Future<StreamedResponse> stallUntilAborted(BaseRequest request) {
-  final completer = Completer<StreamedResponse>();
-  if (request is Abortable) {
-    final abortTrigger = request.abortTrigger;
-    unawaited(
-      abortTrigger?.then((_) {
-        if (!completer.isCompleted) {
-          completer.completeError(
-            RequestAbortedException(request.url),
-            StackTrace.current,
-          );
-        }
-      }),
-    );
-  }
-  return completer.future;
 }

--- a/packages/supabase_test/lib/src/realtime_frames.dart
+++ b/packages/supabase_test/lib/src/realtime_frames.dart
@@ -2,15 +2,6 @@ import 'dart:convert';
 
 import 'package:meta/meta.dart';
 
-/// Column description of the `todos` fixture table, as the realtime server
-/// reports it in a `postgres_changes` event.
-@visibleForTesting
-const todoColumns = [
-  {'name': 'id', 'type': 'int4', 'type_modifier': 4294967295},
-  {'name': 'task', 'type': 'text', 'type_modifier': 4294967295},
-  {'name': 'status', 'type': 'bool', 'type_modifier': 4294967295},
-];
-
 /// A protocol 2.0.0 `postgres_changes` text frame, which is a positional
 /// array of `[join_ref, ref, topic, event, payload]`, encoded as JSON.
 @visibleForTesting

--- a/packages/supabase_test/lib/src/session_fixture.dart
+++ b/packages/supabase_test/lib/src/session_fixture.dart
@@ -1,40 +1,4 @@
-import 'dart:convert';
-
 import 'package:meta/meta.dart';
-
-/// User id embedded in the session produced by [getSessionData].
-@visibleForTesting
-const sessionDataUserId = '4d2583da-8de4-49d3-9cd1-37a9a74f55bd';
-
-/// Constructs session data for a given expiration date.
-@visibleForTesting
-({String accessToken, String sessionString}) getSessionData(
-  DateTime expireDateTime,
-) {
-  final expiresAt = expireDateTime.millisecondsSinceEpoch ~/ 1000;
-  final accessTokenMid = base64.encode(
-    utf8.encode(
-      json.encode({
-        'exp': expiresAt,
-        'sub': '1234567890',
-        'role': 'authenticated',
-      }),
-    ),
-  );
-  final accessToken = 'any.$accessTokenMid.any';
-  final sessionString =
-      '{"access_token":"$accessToken","expires_in":'
-      '${expireDateTime.difference(DateTime.now()).inSeconds},"refresh_token":"'
-      '-yeS4omysFs9tpUYBws9Rg","token_type":"bearer","provider_token":null,"pro'
-      'vider_refresh_token":null,"user":{"id":"$sessionDataUserId","app_metadat'
-      'a":{"provider":"email","providers":["email"]},"user_metadata":{"Hello":"'
-      'World"},"aud":"","email":"fake1680338105@email.com","phone":"","created_'
-      'at":"2023-04-01T08:35:05.208586Z","confirmed_at":null,"email_confirmed_a'
-      't":"2023-04-01T08:35:05.220096086Z","phone_confirmed_at":null,"last_sign'
-      '_in_at":"2023-04-01T08:35:05.222755878Z","role":"","updated_at":"2023-04'
-      '-01T08:35:05.226938Z"}}';
-  return (accessToken: accessToken, sessionString: sessionString);
-}
 
 /// Id of the user [testUserJson] describes.
 @visibleForTesting

--- a/packages/supabase_test/lib/supabase_test.dart
+++ b/packages/supabase_test/lib/supabase_test.dart
@@ -1,9 +1,10 @@
 /// Test helpers for apps and packages built on the Supabase clients.
 ///
-/// Holds the mock HTTP clients, JWT builders, auth fixtures and realtime
-/// frames that the test suites of the client packages themselves run on,
-/// published so that apps can test code that talks to Supabase without a
-/// running stack.
+/// Holds the mock HTTP client, JWT builders, auth fixtures and realtime
+/// frames an app needs to test code that talks to Supabase without a running
+/// stack. The test suites of the client packages themselves run on the same
+/// primitives, and keep the fixtures only they need in
+/// `package:supabase_test/internal.dart`.
 ///
 /// Everything here is annotated with `@visibleForTesting`, so the analyzer
 /// warns when a helper leaks outside of test code.


### PR DESCRIPTION
Stacked on #1814; the diff shown here is only this change once that merges.

## What kind of change does this PR introduce?

Chore. Closes SDK-1772.

## What is the current behavior?

`package:supabase_test/supabase_test.dart` exports helpers that only the test suites of this monorepo need: `getSessionData`, `sessionDataUserId`, `todoColumns`, `FailingHttpClient`, `JsonResponseMockClient` and `stallUntilAborted`. `getSessionData` overlaps `testSessionResponseJson` plus `unsignedTestJwt` with a different user id, and `FailingHttpClient` relies on a status-code trick that only makes sense inside the storage and auth suites. The package also has no `example/` directory, which pub.dev scores.

## What is the new behavior?

- Those helpers move to `package:supabase_test/internal.dart`, documented as shared with the monorepo suites and not part of the supported API. The main library only carries what an app test needs.
- The internal suites import the internal library where they use those helpers. No test code changes otherwise.
- `example/supabase_test_example.dart` shows the quick start as a runnable test file: stubbing a table, asserting on the recorded request, an error response and a signed-in user.

## Additional context

`dart analyze packages/` is clean. The `supabase_test` suite and example pass, and the moved-import suites in `postgrest`, `supabase_realtime` and `supabase_auth` that I ran locally pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a complete example demonstrating how to test Supabase repositories, mock HTTP responses, handle database errors, and run authenticated scenarios.

- **Documentation**
  - Updated testing documentation to clarify supported fixtures and testing guidance.
  - Improved descriptions of available testing utilities and their intended use.

- **Tests**
  - Standardized test utilities across Supabase packages.
  - Added shared support for mock responses, failing requests, session data, and realtime fixtures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->