### PR TITLE
feat(supabase_test): match stubs on query parameters

### DIFF
--- a/packages/supabase_test/README.md
+++ b/packages/supabase_test/README.md
@@ -88,6 +88,15 @@ Three rules cover most test setups:
   // First select returns [newTodo], every one after that returns [].
   ```
 
+- **`query` narrows a stub to matching query parameters.** The stub answers
+  only requests whose query carries every entry, so differently filtered
+  reads of one table can receive different rows:
+
+  ```dart
+  httpClient.stubTable('todos', query: {'id': 'eq.1'}, rows: [first]);
+  httpClient.stubTable('todos', query: {'id': 'eq.2'}, rows: [second]);
+  ```
+
 - **An unmatched request throws.** The `StateError` names the request and the
   registered stubs, so a typo in a path surfaces as a failing test with the
   mismatch spelled out instead of a silent wrong answer.

--- a/packages/supabase_test/lib/src/mock_supabase_http_client.dart
+++ b/packages/supabase_test/lib/src/mock_supabase_http_client.dart
@@ -50,12 +50,14 @@ class _Stub {
   _Stub({
     required this.method,
     required this.path,
+    required this.query,
     required this.respond,
     required this.remaining,
   });
 
   final String? method;
   final String? path;
+  final Map<String, String>? query;
   final FutureOr<StreamedResponse> Function(
     BaseRequest request,
     RecordedRequest recorded,
@@ -74,11 +76,26 @@ class _Stub {
     if (path != null && !_pathMatches(request.url.path, path!)) {
       return false;
     }
+    final query = this.query;
+    if (query != null) {
+      final requestQuery = request.url.queryParameters;
+      for (final MapEntry(:key, :value) in query.entries) {
+        if (requestQuery[key] != value) {
+          return false;
+        }
+      }
+    }
     return true;
   }
 
   @override
-  String toString() => '${method ?? '(any method)'} ${path ?? '(any path)'}';
+  String toString() {
+    final query = this.query;
+    final querySuffix = query == null || query.isEmpty
+        ? ''
+        : '?${Uri(queryParameters: query).query}';
+    return '${method ?? '(any method)'} ${path ?? '(any path)'}$querySuffix';
+  }
 }
 
 /// Whether [requestPath] is [stubPath], or ends in [stubPath] at a segment
@@ -159,7 +176,9 @@ class MockSupabaseHttpClient extends BaseClient {
   /// A null [method] or [path] matches any method or path. [path] matches a
   /// request whose URL path is [path] or ends in it, ignoring the query, so a
   /// stub for `/rest/v1/todos` also answers a project served under a path
-  /// prefix. A [Uint8List]
+  /// prefix. [query] narrows the match further to requests whose query
+  /// carries every one of its entries, so two stubs of the same endpoint can
+  /// answer differently filtered queries. A [Uint8List]
   /// body is sent as is with the content type `application/octet-stream`, any
   /// other body is encoded as JSON, and a null [body] produces an empty
   /// response body. [headers] are added to the response, and override the
@@ -170,6 +189,7 @@ class MockSupabaseHttpClient extends BaseClient {
     Object? body, {
     String? method,
     String? path,
+    Map<String, String>? query,
     int statusCode = 200,
     Map<String, String> headers = const {},
     int? times,
@@ -178,6 +198,7 @@ class MockSupabaseHttpClient extends BaseClient {
       _Stub(
         method: method,
         path: path,
+        query: query,
         remaining: times,
         respond: (request, _) => _response(
           body,
@@ -207,17 +228,19 @@ class MockSupabaseHttpClient extends BaseClient {
   /// );
   /// ```
   ///
-  /// [method], [path] and [times] match as they do for [stub].
+  /// [method], [path], [query] and [times] match as they do for [stub].
   void stubHandler(
     StubHandler handler, {
     String? method,
     String? path,
+    Map<String, String>? query,
     int? times,
   }) {
     _stubs.add(
       _Stub(
         method: method,
         path: path,
+        query: query,
         remaining: times,
         respond: (request, recorded) async {
           final response = await handler(recorded);
@@ -239,7 +262,9 @@ class MockSupabaseHttpClient extends BaseClient {
   /// Stubs the PostgREST endpoint `/rest/v1/[table]` that `select`, `insert`,
   /// `update`, `upsert` and `delete` are served through. A null [method]
   /// matches all of them; pass `'GET'` or `'POST'` to answer reads and writes
-  /// differently.
+  /// differently. [query] narrows the stub to queries carrying the given
+  /// PostgREST filters, `{'id': 'eq.1'}` for example, so differently filtered
+  /// reads of one table receive different rows.
   ///
   /// The response is shaped the way PostgREST shapes it for the request: a
   /// query ending in `single()` receives the only row of a one-row list, or
@@ -250,6 +275,7 @@ class MockSupabaseHttpClient extends BaseClient {
     String table, {
     Object? rows,
     String? method,
+    Map<String, String>? query,
     int statusCode = 200,
     int? count,
     int? times,
@@ -258,6 +284,7 @@ class MockSupabaseHttpClient extends BaseClient {
       rows,
       method: method,
       path: '/rest/v1/$table',
+      query: query,
       statusCode: statusCode,
       count: count,
       times: times,
@@ -272,6 +299,7 @@ class MockSupabaseHttpClient extends BaseClient {
   void stubRpc(
     String function, {
     Object? body,
+    Map<String, String>? query,
     int statusCode = 200,
     int? count,
     int? times,
@@ -279,6 +307,7 @@ class MockSupabaseHttpClient extends BaseClient {
     _stubPostgrest(
       body,
       path: '/rest/v1/rpc/$function',
+      query: query,
       statusCode: statusCode,
       count: count,
       times: times,
@@ -291,12 +320,14 @@ class MockSupabaseHttpClient extends BaseClient {
   void stubEdgeFunction(
     String function, {
     Object? body,
+    Map<String, String>? query,
     int statusCode = 200,
     int? times,
   }) {
     stub(
       body,
       path: '/functions/v1/$function',
+      query: query,
       statusCode: statusCode,
       times: times,
     );
@@ -373,6 +404,7 @@ class MockSupabaseHttpClient extends BaseClient {
     required String path,
     required int statusCode,
     String? method,
+    Map<String, String>? query,
     int? count,
     int? times,
   }) {
@@ -380,6 +412,7 @@ class MockSupabaseHttpClient extends BaseClient {
       _Stub(
         method: method,
         path: path,
+        query: query,
         remaining: times,
         respond: (request, _) => _postgrestResponse(
           body,

--- a/packages/supabase_test/test/mock_supabase_http_client_test.dart
+++ b/packages/supabase_test/test/mock_supabase_http_client_test.dart
@@ -573,4 +573,104 @@ void main() {
       expect(response.user?.email, 'fresh@example.com');
     });
   });
+
+  group('query matching', () {
+    test(
+      'differently filtered reads of one table receive different rows',
+      () async {
+        httpClient.stubTable(
+          'todos',
+          query: {'id': 'eq.1'},
+          rows: [
+            {'id': 1, 'task': 'First'},
+          ],
+        );
+        httpClient.stubTable(
+          'todos',
+          query: {'id': 'eq.2'},
+          rows: [
+            {'id': 2, 'task': 'Second'},
+          ],
+        );
+
+        final first = await supabase
+            .from('todos')
+            .select()
+            .eq('id', 1)
+            .single();
+        final second = await supabase
+            .from('todos')
+            .select()
+            .eq('id', 2)
+            .single();
+
+        expect(first['task'], 'First');
+        expect(second['task'], 'Second');
+      },
+    );
+
+    test('a query stub matches a subset of the request query', () async {
+      httpClient.stubTable('todos', query: {'status': 'eq.true'}, rows: []);
+
+      final done = await supabase
+          .from('todos')
+          .select('id, task')
+          .eq('status', true)
+          .order('id');
+
+      expect(done, isEmpty);
+    });
+
+    test('a query stub does not answer a request without the entry', () async {
+      httpClient.stubTable('todos', query: {'status': 'eq.true'}, rows: []);
+
+      await expectLater(
+        () => supabase.from('todos').select(),
+        throwsA(
+          isA<StateError>().having(
+            (error) => error.message,
+            'message',
+            contains('/rest/v1/todos?status=eq.true'),
+          ),
+        ),
+      );
+    });
+
+    test('a broad stub still answers what the narrow one does not', () async {
+      httpClient.stubTable('todos', rows: []);
+      httpClient.stubTable(
+        'todos',
+        query: {'status': 'eq.false'},
+        rows: [
+          {'id': 1},
+        ],
+      );
+
+      final open = await supabase.from('todos').select().eq('status', false);
+      final all = await supabase.from('todos').select();
+
+      expect(open, hasLength(1));
+      expect(all, isEmpty);
+    });
+
+    test('edge function invocations match on their query parameters', () async {
+      httpClient.stubEdgeFunction(
+        'weather',
+        query: {'city': 'Springfield'},
+        body: {'weather': 'sunny'},
+      );
+      httpClient.stubEdgeFunction(
+        'weather',
+        query: {'city': 'Shelbyville'},
+        body: {'weather': 'rain'},
+      );
+
+      final response = await supabase.functions.invoke(
+        'weather',
+        queryParameters: {'city': 'Shelbyville'},
+      );
+
+      expect(response.data, {'weather': 'rain'});
+    });
+  });
 }


### PR DESCRIPTION
Stacked on #1815; the diff shown here is only this change once that merges.

## What kind of change does this PR introduce?

Feature. Closes SDK-1775.

## What is the current behavior?

Stubs match on method and path only. A code path that reads the same table twice with different filters, or invokes one edge function with different query parameters, needs a `stubHandler` to tell the calls apart.

## What is the new behavior?

`stub`, `stubHandler`, `stubTable`, `stubRpc` and `stubEdgeFunction` accept an optional `query` map. A stub with one answers only requests whose query carries every entry, matched as a subset, so the rest of the query (`select`, `order` and so on) does not have to be spelled out:

```dart
httpClient.stubTable('todos', query: {'id': 'eq.1'}, rows: [first]);
httpClient.stubTable('todos', query: {'id': 'eq.2'}, rows: [second]);
```

The latest-stub-wins rule is unchanged, so a broad stub registered in `setUp` still answers whatever a narrower one in the test does not. The "no stub matches" error lists the query of each stub.

## Additional context

Covered by five new tests in `packages/supabase_test/test/mock_supabase_http_client_test.dart`; the suite passes and `dart analyze packages/` is clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added query-parameter matching for mock Supabase HTTP stubs.
  * Supports query matching across table requests, RPCs, edge functions, and custom handlers.
  * Allows different responses based on specific query filters, including partial query matching.

* **Documentation**
  * Updated stubbing guidance with query-matching behavior and examples.

* **Tests**
  * Added coverage for matching, partial matches, missing parameters, fallback stubs, and edge function queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->