### PR TITLE
feat(supabase_test): storage endpoint shorthands

### DIFF
--- a/packages/supabase_test/README.md
+++ b/packages/supabase_test/README.md
@@ -62,16 +62,28 @@ final httpClient = MockSupabaseHttpClient()
   ..stubSignIn();
 ```
 
-Anything else, storage endpoints for example, is stubbed through the general
-`stub`, which matches on method and URL path. A path matches a request whose
-path is the same or ends in it, so stubs written for `/rest/v1/todos` keep
-working for a project served under a path prefix:
+Storage has shorthands for the calls apps make most, which know the paths
+and the response shapes of the storage API:
+
+```dart
+httpClient
+  ..stubStorageUpload('avatars', 'me.png')
+  ..stubStorageDownload('avatars', 'me.png', bytes: pngBytes)
+  ..stubStorageSignedUrl('avatars', 'me.png')
+  ..stubStorageList('avatars', objects: [storageObjectJson('me.png')])
+  ..stubStorageRemove('avatars', paths: ['me.png']);
+```
+
+Anything else is stubbed through the general `stub`, which matches on method
+and URL path. A path matches a request whose path is the same or ends in it,
+so stubs written for `/rest/v1/todos` keep working for a project served under
+a path prefix:
 
 ```dart
 httpClient.stub(
-  {'Key': 'avatars/me.png'},
-  method: 'POST',
-  path: '/storage/v1/object/avatars/me.png',
+  {'name': 'avatars', 'id': 'avatars', 'public': true},
+  method: 'GET',
+  path: '/storage/v1/bucket/avatars',
 );
 ```
 

--- a/packages/supabase_test/lib/src/mock_supabase_http_client.dart
+++ b/packages/supabase_test/lib/src/mock_supabase_http_client.dart
@@ -12,6 +12,7 @@ import 'package:meta/meta.dart';
 
 import 'mock_http_clients.dart';
 import 'session_fixture.dart';
+import 'storage_fixture.dart';
 import 'test_jwt.dart';
 
 /// A request a [MockSupabaseHttpClient] has answered, with its body already
@@ -383,6 +384,119 @@ class MockSupabaseHttpClient extends BaseClient {
   /// so `getUser` and `updateUser` succeed.
   void stubUser({Map<String, dynamic>? user, int? times}) {
     stub(user ?? testUserJson(), path: '/auth/v1/user', times: times);
+  }
+
+  /// Answers an upload of [path] to [bucket], whether through `upload`,
+  /// `uploadBinary`, `update` or `updateBinary`, with the object key and [id]
+  /// the storage API reports.
+  void stubStorageUpload(
+    String bucket,
+    String path, {
+    String id = 'test-object-id',
+    int statusCode = 200,
+    int? times,
+  }) {
+    final objectPath = _storageObjectPath(bucket, path);
+    for (final method in ['POST', 'PUT']) {
+      stub(
+        {'Key': '$bucket/${_cleanStoragePath(path)}', 'Id': id},
+        method: method,
+        path: '/storage/v1/object/$objectPath',
+        statusCode: statusCode,
+        times: times,
+      );
+    }
+  }
+
+  /// Answers a `download` of [path] from [bucket] with [bytes], whether or
+  /// not an image transformation was requested.
+  void stubStorageDownload(
+    String bucket,
+    String path, {
+    required Uint8List bytes,
+    String contentType = 'application/octet-stream',
+    int statusCode = 200,
+    int? times,
+  }) {
+    final objectPath = _storageObjectPath(bucket, path);
+    for (final endpoint in ['object', 'render/image/authenticated']) {
+      stub(
+        bytes,
+        method: 'GET',
+        path: '/storage/v1/$endpoint/$objectPath',
+        statusCode: statusCode,
+        headers: {'content-type': contentType},
+        times: times,
+      );
+    }
+  }
+
+  /// Answers `createSignedUrl` for [path] in [bucket] with a URL carrying
+  /// [token], so the returned URL is
+  /// `<project>/storage/v1/object/sign/<bucket>/<path>?token=<token>`.
+  void stubStorageSignedUrl(
+    String bucket,
+    String path, {
+    String token = 'test-token',
+    int statusCode = 200,
+    int? times,
+  }) {
+    final objectPath = _storageObjectPath(bucket, path);
+    stub(
+      {'signedURL': '/object/sign/$objectPath?token=$token'},
+      method: 'POST',
+      path: '/storage/v1/object/sign/$objectPath',
+      statusCode: statusCode,
+      times: times,
+    );
+  }
+
+  /// Answers `list` on [bucket] with [objects], each in the JSON shape of a
+  /// `FileObject`, which [storageObjectJson] produces.
+  void stubStorageList(
+    String bucket, {
+    required List<Map<String, dynamic>> objects,
+    int statusCode = 200,
+    int? times,
+  }) {
+    stub(
+      objects,
+      method: 'POST',
+      path: '/storage/v1/object/list/$bucket',
+      statusCode: statusCode,
+      times: times,
+    );
+  }
+
+  /// Answers `remove` on [bucket] with the objects at [paths], as the storage
+  /// API reports the deleted objects.
+  void stubStorageRemove(
+    String bucket, {
+    required List<String> paths,
+    int statusCode = 200,
+    int? times,
+  }) {
+    stub(
+      [
+        for (final path in paths)
+          storageObjectJson(_cleanStoragePath(path), bucketId: bucket),
+      ],
+      method: 'DELETE',
+      path: '/storage/v1/object/$bucket',
+      statusCode: statusCode,
+      times: times,
+    );
+  }
+
+  /// The `<bucket>/<path>` the storage client puts in its URLs, with every
+  /// path segment percent-encoded the way the client encodes it.
+  String _storageObjectPath(String bucket, String path) {
+    final encoded = Uri(pathSegments: _cleanStoragePath(path).split('/')).path;
+    return '$bucket/$encoded';
+  }
+
+  String _cleanStoragePath(String path) {
+    return path.replaceAll(RegExp(r'/+'), '/').replaceAll(RegExp(r'^/|/$'), '');
   }
 
   Map<String, dynamic> _sessionJson({

--- a/packages/supabase_test/lib/src/storage_fixture.dart
+++ b/packages/supabase_test/lib/src/storage_fixture.dart
@@ -1,0 +1,35 @@
+import 'package:meta/meta.dart';
+
+/// The JSON form of a storage object named [name], as the storage API lists
+/// it and as `FileObject.fromJson` reads it.
+@visibleForTesting
+Map<String, dynamic> storageObjectJson(
+  String name, {
+  String id = 'e7b5c1d2-4c7a-4f3e-9c1a-2b3d4e5f6a7b',
+  String bucketId = 'test-bucket',
+  String? owner,
+  Map<String, dynamic>? metadata,
+  DateTime? createdAt,
+  DateTime? updatedAt,
+}) {
+  final created = (createdAt ?? DateTime.utc(2023, 4, 1, 9, 38, 59))
+      .toIso8601String();
+  final updated = (updatedAt ?? DateTime.utc(2023, 4, 1, 9, 38, 59))
+      .toIso8601String();
+  return {
+    'id': id,
+    'name': name,
+    'bucket_id': bucketId,
+    'owner': owner,
+    'created_at': created,
+    'updated_at': updated,
+    'last_accessed_at': updated,
+    'metadata':
+        metadata ??
+        {
+          'size': 1024,
+          'mimetype': 'application/octet-stream',
+          'cacheControl': 'max-age=3600',
+        },
+  };
+}

--- a/packages/supabase_test/lib/supabase_test.dart
+++ b/packages/supabase_test/lib/supabase_test.dart
@@ -14,5 +14,6 @@ export 'src/mock_http_clients.dart';
 export 'src/mock_supabase_http_client.dart';
 export 'src/realtime_frames.dart';
 export 'src/session_fixture.dart';
+export 'src/storage_fixture.dart';
 export 'src/test_jwt.dart';
 export 'src/test_supabase_client.dart';

--- a/packages/supabase_test/test/mock_supabase_http_client_test.dart
+++ b/packages/supabase_test/test/mock_supabase_http_client_test.dart
@@ -673,4 +673,100 @@ void main() {
       expect(response.data, {'weather': 'rain'});
     });
   });
+
+  group('storage shorthands', () {
+    test('stubStorageUpload answers a binary upload and an update', () async {
+      httpClient.stubStorageUpload('avatars', 'me.png', id: 'object-1');
+
+      final uploaded = await supabase.storage
+          .from('avatars')
+          .uploadBinary('me.png', Uint8List.fromList([1, 2, 3]));
+      final updated = await supabase.storage
+          .from('avatars')
+          .updateBinary('me.png', Uint8List.fromList([4, 5, 6]));
+
+      expect(uploaded.fullPath, 'avatars/me.png');
+      expect(uploaded.path, 'me.png');
+      expect(uploaded.id, 'object-1');
+      expect(updated.fullPath, 'avatars/me.png');
+      expect(
+        httpClient.requestsTo('/storage/v1/object/avatars/me.png'),
+        hasLength(2),
+      );
+    });
+
+    test('stubStorageUpload encodes the object path like the client', () async {
+      httpClient.stubStorageUpload('avatars', 'folder/my file.png');
+
+      final response = await supabase.storage
+          .from('avatars')
+          .uploadBinary('folder/my file.png', Uint8List.fromList([1]));
+
+      expect(response.fullPath, 'avatars/folder/my file.png');
+    });
+
+    test('stubStorageDownload answers a download with bytes', () async {
+      httpClient.stubStorageDownload(
+        'avatars',
+        'me.png',
+        bytes: Uint8List.fromList([1, 2, 3]),
+        contentType: 'image/png',
+      );
+
+      final bytes = await supabase.storage.from('avatars').download('me.png');
+      final transformed = await supabase.storage
+          .from('avatars')
+          .download('me.png', transform: const TransformOptions(width: 10));
+
+      expect(bytes, [1, 2, 3]);
+      expect(transformed, [1, 2, 3]);
+    });
+
+    test('stubStorageSignedUrl answers createSignedUrl', () async {
+      httpClient.stubStorageSignedUrl('avatars', 'me.png', token: 'abc');
+
+      final url = await supabase.storage
+          .from('avatars')
+          .createSignedUrl('me.png', 60);
+
+      expect(
+        url,
+        'http://localhost:54321/storage/v1/object/sign/avatars/me.png?token=abc',
+      );
+    });
+
+    test('stubStorageList answers list with file objects', () async {
+      httpClient.stubStorageList(
+        'avatars',
+        objects: [
+          storageObjectJson('me.png'),
+          storageObjectJson('you.png', bucketId: 'avatars'),
+        ],
+      );
+
+      final objects = await supabase.storage.from('avatars').list();
+
+      expect(objects.map((object) => object.name), ['me.png', 'you.png']);
+      expect(objects.last.bucketId, 'avatars');
+      expect(objects.first.metadata?['size'], 1024);
+    });
+
+    test('stubStorageRemove answers remove with the deleted objects', () async {
+      httpClient.stubStorageRemove('avatars', paths: ['me.png', 'you.png']);
+
+      final removed = await supabase.storage.from('avatars').remove([
+        'me.png',
+        'you.png',
+      ]);
+
+      expect(removed.map((object) => object.name), ['me.png', 'you.png']);
+      final request = httpClient
+          .requestsTo('/storage/v1/object/avatars')
+          .single;
+      expect(request.method, 'DELETE');
+      expect(request.jsonBody, {
+        'prefixes': ['me.png', 'you.png'],
+      });
+    });
+  });
 }


### PR DESCRIPTION
Stacked on #1816; the diff shown here is only this change once that merges.

## What kind of change does this PR introduce?

Feature. Closes SDK-1774.

## What is the current behavior?

Every storage call goes through the general `stub` with a hand-typed `/storage/v1/...` path and a hand-typed response body. Getting the object key shape, the signed URL shape or the percent-encoding of the object path right is on the test author.

## What is the new behavior?

`MockSupabaseHttpClient` gains shorthands for the storage calls apps make most, each knowing the path and response shape the storage client expects:

- `stubStorageUpload(bucket, path)` answers `upload`, `uploadBinary`, `update` and `updateBinary` with the object key and id.
- `stubStorageDownload(bucket, path, bytes:)` answers `download`, with or without an image transformation, as bytes with a configurable content type.
- `stubStorageSignedUrl(bucket, path)` answers `createSignedUrl` with a URL carrying a token.
- `stubStorageList(bucket, objects:)` and `stubStorageRemove(bucket, paths:)` answer `list` and `remove` with `FileObject` JSON.
- `storageObjectJson(name)` is the fixture for that JSON.

Object paths are percent-encoded per segment the way the storage client encodes them, so a path with a space matches.

## Additional context

Covered by six new tests in `packages/supabase_test/test/mock_supabase_http_client_test.dart`; the suite passes and `dart analyze packages/` is clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added storage testing helpers for uploads, downloads, signed URLs, bucket listings, and object removal.
  * Added reusable fixtures for generating storage object data.
  * Added support for configuring response bodies, headers, status codes, and invocation limits in storage request stubs.

* **Documentation**
  * Added examples demonstrating storage endpoint shorthand usage and bucket responses.

* **Tests**
  * Added coverage for storage operations, binary data, transformed downloads, encoded paths, metadata, and request verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->