### PR TITLE
feat(supabase_test): mock realtime transport for testing streams and channels

### DIFF
--- a/packages/supabase_test/README.md
+++ b/packages/supabase_test/README.md
@@ -248,10 +248,43 @@ shapes the auth server would return.
 
 ## Testing realtime
 
-Realtime needs a WebSocket rather than an HTTP stub. For unit tests that feed
-frames into a mock socket, `postgresChangesFrame` encodes a
-`postgres_changes` frame the way the server sends it. For anything beyond
-that, run against a real stack (see below).
+Realtime runs over a WebSocket rather than HTTP, so it is answered by a
+`MockRealtimeTransport` instead: a realtime server in memory that joins
+channels, acknowledges pushes and heartbeats, and lets the test push server
+events:
+
+```dart
+final realtime = MockRealtimeTransport();
+final supabase = testSupabaseClient(httpClient: httpClient, realtime: realtime);
+
+final channel = supabase.channel('todos');
+final inserts = channel.onPostgresChanges(
+  event: PostgresChangeEvent.insert,
+  schema: 'public',
+  table: 'todos',
+);
+channel.subscribe();
+await channel.onStatusChange.firstWhere(
+  (change) => change.status == RealtimeSubscribeStatus.subscribed,
+);
+
+realtime.emitPostgresChange(
+  table: 'todos',
+  event: PostgresChangeEvent.insert,
+  newRecord: {'id': 1, 'task': 'Ship it'},
+);
+final payload = await inserts.first;
+expect(payload.newRecord['task'], 'Ship it');
+```
+
+`emitPostgresChange` reaches every joined channel bound to the table and
+event, which includes the channel a `stream()` opens, so a `stream` test
+stubs the initial rows with `stubTable` and then emits the changes it wants
+to see applied. Filters are not evaluated; emit only the changes the code
+under test should see. `emitBroadcast` delivers a broadcast message to a
+channel, `emit` sends any `RealtimeMessage`, and `closeConnection` drops the
+connection so reconnect handling can be exercised. Everything the client sent
+is recorded in `sent`, and `joinedTopics` lists what it subscribed to.
 
 ## Flutter apps
 

--- a/packages/supabase_test/README.md
+++ b/packages/supabase_test/README.md
@@ -2,8 +2,8 @@
 
 Test helpers for apps and packages built on the Supabase Dart and Flutter
 clients. Your tests run against a real `SupabaseClient` whose HTTP layer is
-stubbed per endpoint, so no Supabase stack, network access or hand-rolled
-fakes are needed. The test suites of the Supabase client packages themselves
+stubbed per endpoint and whose realtime socket is served in memory, so no
+Supabase stack, network access or hand-rolled fakes are needed. The test suites of the Supabase client packages themselves
 run on the same primitives.
 
 ## Getting started

--- a/packages/supabase_test/lib/src/mock_realtime_transport.dart
+++ b/packages/supabase_test/lib/src/mock_realtime_transport.dart
@@ -57,7 +57,7 @@ class MockRealtimeTransport {
   /// echoed them in the join reply, with the ids it assigned.
   final _postgresBindings = <String, List<Map<String, dynamic>>>{};
 
-  final _joinRefs = <String, String?>{};
+  final _joinedTopics = <String>{};
 
   var _nextBindingId = 1;
 
@@ -71,13 +71,16 @@ class MockRealtimeTransport {
 
   /// The topics the client has joined and not left, with their `realtime:`
   /// prefix.
-  List<String> get joinedTopics => _joinRefs.keys.toList();
+  List<String> get joinedTopics => _joinedTopics.toList();
 
   /// Opens a connection; hand this method to
   /// `RealtimeClientOptions.transport`, or the whole object to
   /// `testSupabaseClient`.
   WebSocketChannel call(String url, Map<String, String> headers) {
-    final connection = _MockWebSocketChannel(_onClientMessage);
+    final connection = _MockWebSocketChannel(
+      onMessage: _onClientMessage,
+      onClosed: _onConnectionClosed,
+    );
     _connections.add(connection);
     return connection;
   }
@@ -165,11 +168,8 @@ class MockRealtimeTransport {
   /// Closes the open connection from the server side with [code] and
   /// [reason], so the code under test observes the disconnect and the client
   /// reconnects on its schedule.
-  Future<void> closeConnection({int code = 1000, String? reason}) async {
-    final connection = _openConnection();
-    _joinRefs.clear();
-    _postgresBindings.clear();
-    await connection.closeFromServer(code, reason);
+  Future<void> closeConnection({int code = 1000, String? reason}) {
+    return _openConnection().closeFromServer(code, reason);
   }
 
   _MockWebSocketChannel _openConnection() {
@@ -189,6 +189,14 @@ class MockRealtimeTransport {
   String _prefixed(String topic) =>
       topic.startsWith('realtime:') ? topic : 'realtime:$topic';
 
+  /// Whichever side closed the connection, its channels are gone with it.
+  void _onConnectionClosed(_MockWebSocketChannel connection) {
+    if (_connections.isNotEmpty && connection == _connections.last) {
+      _joinedTopics.clear();
+      _postgresBindings.clear();
+    }
+  }
+
   void _onClientMessage(_MockWebSocketChannel connection, Object? frame) {
     if (frame is! String) {
       // Binary broadcast frames carry no reference to reply to.
@@ -205,14 +213,17 @@ class MockRealtimeTransport {
         final bindings = <Map<String, dynamic>>[
           if (requested is List)
             for (final filter in requested)
-              {...filter as Map, 'id': _nextBindingId++},
+              {
+                ...Map<String, dynamic>.from(filter as Map),
+                'id': _nextBindingId++,
+              },
         ];
         _postgresBindings[message.topic] = bindings;
-        _joinRefs[message.topic] = message.ref;
+        _joinedTopics.add(message.topic);
         response = {'postgres_changes': bindings};
       case 'phx_leave':
         _postgresBindings.remove(message.topic);
-        _joinRefs.remove(message.topic);
+        _joinedTopics.remove(message.topic);
     }
     if (message.ref == null) {
       return;
@@ -233,12 +244,13 @@ class MockRealtimeTransport {
 
 class _MockWebSocketChannel extends StreamChannelMixin<dynamic>
     implements WebSocketChannel {
-  _MockWebSocketChannel(this._onMessage) {
+  _MockWebSocketChannel({required this.onMessage, required this.onClosed}) {
     _sink = _MockWebSocketSink(this);
   }
 
   final void Function(_MockWebSocketChannel connection, Object? frame)
-  _onMessage;
+  onMessage;
+  final void Function(_MockWebSocketChannel connection) onClosed;
   final _toClient = StreamController<dynamic>();
   late final _MockWebSocketSink _sink;
 
@@ -269,7 +281,7 @@ class _MockWebSocketChannel extends StreamChannelMixin<dynamic>
   }
 
   void receive(Object? frame) {
-    _onMessage(this, frame);
+    onMessage(this, frame);
   }
 
   Future<void> closeFromServer(int code, String? reason) async {
@@ -281,6 +293,7 @@ class _MockWebSocketChannel extends StreamChannelMixin<dynamic>
   Future<void> _close() async {
     _sink.markDone();
     if (!_toClient.isClosed) {
+      onClosed(this);
       await _toClient.close();
     }
   }

--- a/packages/supabase_test/lib/src/mock_realtime_transport.dart
+++ b/packages/supabase_test/lib/src/mock_realtime_transport.dart
@@ -28,12 +28,13 @@ import 'realtime_frames.dart';
 ///   realtime: realtime,
 /// );
 ///
-/// final changes = supabase.channel('todos').onPostgresChanges(
+/// final channel = supabase.channel('todos');
+/// final changes = channel.onPostgresChanges(
 ///   event: PostgresChangeEvent.insert,
 ///   schema: 'public',
 ///   table: 'todos',
 /// );
-/// supabase.channel('todos').subscribe();
+/// channel.subscribe();
 ///
 /// realtime.emitPostgresChange(
 ///   table: 'todos',
@@ -91,7 +92,8 @@ class MockRealtimeTransport {
   }
 
   /// Sends a `postgres_changes` event for a row of [table] in [schema] to
-  /// every joined channel bound to that table and [event].
+  /// every joined channel bound to that table and [event], including channels
+  /// bound to the whole schema without naming a table.
   ///
   /// [newRecord] is the row after the change and [oldRecord] the row before
   /// it, as the code under test expects them in `newRecord` and `oldRecord`
@@ -131,7 +133,7 @@ class MockRealtimeTransport {
       final ids = [
         for (final binding in bindings)
           if (binding['schema'] == schema &&
-              binding['table'] == table &&
+              (binding['table'] == null || binding['table'] == table) &&
               (binding['event'] == '*' || binding['event'] == type))
             binding['id'] as int,
       ];

--- a/packages/supabase_test/lib/src/mock_realtime_transport.dart
+++ b/packages/supabase_test/lib/src/mock_realtime_transport.dart
@@ -1,0 +1,325 @@
+// The composed helpers of this package legitimately build on its own
+// test-only primitives outside of a test directory.
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:meta/meta.dart';
+import 'package:stream_channel/stream_channel.dart';
+import 'package:supabase/supabase.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+import 'realtime_frames.dart';
+
+/// A realtime server in memory, plugged into a `RealtimeClient` as its
+/// WebSocket transport, so channels and `stream()` can be tested without a
+/// running stack.
+///
+/// The transport answers what the client sends, joins, heartbeats, leaves and
+/// pushes, the way the server does, records every message the client sent in
+/// [sent], and lets a test push server events with [emitPostgresChange],
+/// [emitBroadcast] and [emit]:
+///
+/// ```dart
+/// final realtime = MockRealtimeTransport();
+/// final supabase = testSupabaseClient(
+///   httpClient: httpClient,
+///   realtime: realtime,
+/// );
+///
+/// final changes = supabase.channel('todos').onPostgresChanges(
+///   event: PostgresChangeEvent.insert,
+///   schema: 'public',
+///   table: 'todos',
+/// );
+/// supabase.channel('todos').subscribe();
+///
+/// realtime.emitPostgresChange(
+///   table: 'todos',
+///   event: PostgresChangeEvent.insert,
+///   newRecord: {'id': 1, 'task': 'Ship it'},
+/// );
+/// await expectLater(changes, emits(anything));
+/// ```
+///
+/// Filters of a `postgres_changes` subscription are not evaluated: a change
+/// reaches every joined channel bound to its table and event, so emit only
+/// the changes the code under test should see.
+@visibleForTesting
+class MockRealtimeTransport {
+  final _connections = <_MockWebSocketChannel>[];
+
+  /// Every message the client sent over any connection, oldest first.
+  final sent = <RealtimeMessage>[];
+
+  /// The `postgres_changes` bindings of each joined topic, as the server
+  /// echoed them in the join reply, with the ids it assigned.
+  final _postgresBindings = <String, List<Map<String, dynamic>>>{};
+
+  final _joinRefs = <String, String?>{};
+
+  var _nextBindingId = 1;
+
+  /// How many WebSocket connections the client has opened, so a test can
+  /// assert on a reconnect.
+  int get connectionCount => _connections.length;
+
+  /// Whether the client currently holds an open connection.
+  bool get isConnected =>
+      _connections.isNotEmpty && !_connections.last.isClosed;
+
+  /// The topics the client has joined and not left, with their `realtime:`
+  /// prefix.
+  List<String> get joinedTopics => _joinRefs.keys.toList();
+
+  /// Opens a connection; hand this method to
+  /// `RealtimeClientOptions.transport`, or the whole object to
+  /// `testSupabaseClient`.
+  WebSocketChannel call(String url, Map<String, String> headers) {
+    final connection = _MockWebSocketChannel(_onClientMessage);
+    _connections.add(connection);
+    return connection;
+  }
+
+  /// Sends [message] to the client as if the server had sent it.
+  void emit(RealtimeMessage message) {
+    _emitFrame(jsonEncode(message.toJson()));
+  }
+
+  /// Sends a `postgres_changes` event for a row of [table] in [schema] to
+  /// every joined channel bound to that table and [event].
+  ///
+  /// [newRecord] is the row after the change and [oldRecord] the row before
+  /// it, as the code under test expects them in `newRecord` and `oldRecord`
+  /// of the payload. [columns] describe the column types the way the server
+  /// reports them; when omitted the values are delivered as given.
+  void emitPostgresChange({
+    required String table,
+    required PostgresChangeEvent event,
+    String schema = 'public',
+    Map<String, dynamic> newRecord = const {},
+    Map<String, dynamic> oldRecord = const {},
+    DateTime? commitTimestamp,
+    List<Map<String, dynamic>> columns = const [],
+  }) {
+    if (event == PostgresChangeEvent.all) {
+      throw ArgumentError.value(
+        event,
+        'event',
+        'A change is an insert, an update or a delete',
+      );
+    }
+    final type = event.name.toUpperCase();
+    final data = {
+      'schema': schema,
+      'table': table,
+      'commit_timestamp': (commitTimestamp ?? DateTime.now().toUtc())
+          .toIso8601String(),
+      'type': type,
+      'record': newRecord,
+      'old_record': oldRecord,
+      'columns': columns,
+      'errors': null,
+    };
+    var delivered = false;
+    for (final MapEntry(key: topic, value: bindings)
+        in _postgresBindings.entries) {
+      final ids = [
+        for (final binding in bindings)
+          if (binding['schema'] == schema &&
+              binding['table'] == table &&
+              (binding['event'] == '*' || binding['event'] == type))
+            binding['id'] as int,
+      ];
+      if (ids.isEmpty) {
+        continue;
+      }
+      delivered = true;
+      _emitFrame(postgresChangesFrame(topic, ids: ids, data: data));
+    }
+    if (!delivered) {
+      throw StateError(
+        'No joined channel listens to $type on $schema.$table. '
+        'Joined topics: ${joinedTopics.isEmpty ? '(none)' : joinedTopics}',
+      );
+    }
+  }
+
+  /// Sends a broadcast message with [event] and [payload] to the channel
+  /// [topic], given with or without its `realtime:` prefix.
+  void emitBroadcast(
+    String topic, {
+    required String event,
+    required Map<String, dynamic> payload,
+  }) {
+    emit(
+      RealtimeMessage(
+        topic: _prefixed(topic),
+        event: 'broadcast',
+        payload: {'event': event, 'payload': payload, 'type': 'broadcast'},
+      ),
+    );
+  }
+
+  /// Closes the open connection from the server side with [code] and
+  /// [reason], so the code under test observes the disconnect and the client
+  /// reconnects on its schedule.
+  Future<void> closeConnection({int code = 1000, String? reason}) async {
+    final connection = _openConnection();
+    _joinRefs.clear();
+    _postgresBindings.clear();
+    await connection.closeFromServer(code, reason);
+  }
+
+  _MockWebSocketChannel _openConnection() {
+    if (!isConnected) {
+      throw StateError(
+        'No realtime connection is open. Subscribe a channel first, and give '
+        'the client a turn of the event loop to connect.',
+      );
+    }
+    return _connections.last;
+  }
+
+  void _emitFrame(String frame) {
+    _openConnection().deliver(frame);
+  }
+
+  String _prefixed(String topic) =>
+      topic.startsWith('realtime:') ? topic : 'realtime:$topic';
+
+  void _onClientMessage(_MockWebSocketChannel connection, Object? frame) {
+    if (frame is! String) {
+      // Binary broadcast frames carry no reference to reply to.
+      return;
+    }
+    final message = RealtimeMessage.fromJson(jsonDecode(frame));
+    sent.add(message);
+    final payload = message.payload;
+    Map<String, dynamic> response = const {};
+    switch (message.event) {
+      case 'phx_join':
+        final config = payload is Map ? payload['config'] : null;
+        final requested = config is Map ? config['postgres_changes'] : null;
+        final bindings = <Map<String, dynamic>>[
+          if (requested is List)
+            for (final filter in requested)
+              {...filter as Map, 'id': _nextBindingId++},
+        ];
+        _postgresBindings[message.topic] = bindings;
+        _joinRefs[message.topic] = message.ref;
+        response = {'postgres_changes': bindings};
+      case 'phx_leave':
+        _postgresBindings.remove(message.topic);
+        _joinRefs.remove(message.topic);
+    }
+    if (message.ref == null) {
+      return;
+    }
+    connection.deliver(
+      jsonEncode(
+        RealtimeMessage(
+          topic: message.topic,
+          event: 'phx_reply',
+          payload: {'status': 'ok', 'response': response},
+          ref: message.ref,
+          joinRef: message.joinRef,
+        ).toJson(),
+      ),
+    );
+  }
+}
+
+class _MockWebSocketChannel extends StreamChannelMixin<dynamic>
+    implements WebSocketChannel {
+  _MockWebSocketChannel(this._onMessage) {
+    _sink = _MockWebSocketSink(this);
+  }
+
+  final void Function(_MockWebSocketChannel connection, Object? frame)
+  _onMessage;
+  final _toClient = StreamController<dynamic>();
+  late final _MockWebSocketSink _sink;
+
+  @override
+  int? closeCode;
+
+  @override
+  String? closeReason;
+
+  bool get isClosed => _toClient.isClosed;
+
+  @override
+  Future<void> get ready => Future.value();
+
+  @override
+  String? get protocol => null;
+
+  @override
+  WebSocketSink get sink => _sink;
+
+  @override
+  Stream<dynamic> get stream => _toClient.stream;
+
+  void deliver(String frame) {
+    if (!_toClient.isClosed) {
+      _toClient.add(frame);
+    }
+  }
+
+  void receive(Object? frame) {
+    _onMessage(this, frame);
+  }
+
+  Future<void> closeFromServer(int code, String? reason) async {
+    closeCode = code;
+    closeReason = reason;
+    await _close();
+  }
+
+  Future<void> _close() async {
+    _sink.markDone();
+    if (!_toClient.isClosed) {
+      await _toClient.close();
+    }
+  }
+}
+
+class _MockWebSocketSink implements WebSocketSink {
+  _MockWebSocketSink(this._channel);
+
+  final _MockWebSocketChannel _channel;
+  final _done = Completer<void>();
+
+  void markDone() {
+    if (!_done.isCompleted) {
+      _done.complete();
+    }
+  }
+
+  @override
+  void add(dynamic data) {
+    _channel.receive(data);
+  }
+
+  @override
+  void addError(Object error, [StackTrace? stackTrace]) {}
+
+  @override
+  Future<void> addStream(Stream<dynamic> stream) async {
+    await for (final frame in stream) {
+      add(frame);
+    }
+  }
+
+  @override
+  Future<void> close([int? closeCode, String? closeReason]) async {
+    _channel.closeCode = closeCode ?? 1000;
+    _channel.closeReason = closeReason;
+    await _channel._close();
+  }
+
+  @override
+  Future<void> get done => _done.future;
+}

--- a/packages/supabase_test/lib/src/test_supabase_client.dart
+++ b/packages/supabase_test/lib/src/test_supabase_client.dart
@@ -8,6 +8,7 @@ import 'package:http/http.dart';
 import 'package:meta/meta.dart';
 import 'package:supabase/supabase.dart';
 
+import 'mock_realtime_transport.dart';
 import 'session_fixture.dart';
 import 'test_jwt.dart';
 
@@ -16,7 +17,9 @@ import 'test_jwt.dart';
 /// Compared to constructing one directly, this configures the in-memory
 /// storage the pkce flow requires, turns off the token auto refresh so no
 /// timer outlives the test, and defaults the API key to an unsigned anon JWT.
-/// Answer its requests by passing a `MockSupabaseHttpClient` as [httpClient]:
+/// Answer its requests by passing a `MockSupabaseHttpClient` as [httpClient],
+/// and its realtime traffic by passing a [MockRealtimeTransport] as
+/// [realtime]:
 ///
 /// ```dart
 /// final httpClient = MockSupabaseHttpClient()
@@ -34,6 +37,7 @@ import 'test_jwt.dart';
 @visibleForTesting
 SupabaseClient testSupabaseClient({
   Client? httpClient,
+  MockRealtimeTransport? realtime,
   String url = 'http://localhost:54321',
   String? apiKey,
   bool autoRefreshToken = false,
@@ -46,6 +50,7 @@ SupabaseClient testSupabaseClient({
       autoRefreshToken: autoRefreshToken,
       pkceAsyncStorage: MemoryAuthAsyncStorage(),
     ),
+    realtimeClientOptions: RealtimeClientOptions(transport: realtime?.call),
   );
 }
 

--- a/packages/supabase_test/lib/supabase_test.dart
+++ b/packages/supabase_test/lib/supabase_test.dart
@@ -11,6 +11,7 @@
 library;
 
 export 'src/mock_http_clients.dart';
+export 'src/mock_realtime_transport.dart';
 export 'src/mock_supabase_http_client.dart';
 export 'src/realtime_frames.dart';
 export 'src/session_fixture.dart';

--- a/packages/supabase_test/pubspec.yaml
+++ b/packages/supabase_test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: supabase_test
-description: Test helpers for apps built on the Supabase Dart and Flutter clients, with mock HTTP clients, JWT builders and auth fixtures.
+description: Test helpers for apps built on the Supabase Dart and Flutter clients, with a mock HTTP client, a mock realtime transport, JWT builders and auth fixtures.
 version: 0.1.1
 homepage: 'https://supabase.com'
 repository: 'https://github.com/supabase/supabase-flutter/tree/main/packages/supabase_test'

--- a/packages/supabase_test/pubspec.yaml
+++ b/packages/supabase_test/pubspec.yaml
@@ -18,7 +18,9 @@ dependencies:
   crypto: ^3.0.7
   http: ^1.6.0
   meta: ^1.16.0
+  stream_channel: ^2.1.0
   supabase: 3.0.0-dev.2
+  web_socket_channel: ^3.0.3
 
 dev_dependencies:
   supabase_lints: ^0.1.2

--- a/packages/supabase_test/test/mock_realtime_transport_test.dart
+++ b/packages/supabase_test/test/mock_realtime_transport_test.dart
@@ -58,7 +58,7 @@ void main() {
     });
 
     test('a heartbeat is answered with an ok reply', () async {
-      final connection = realtime.call('ws://localhost:54321/realtime/v1', {});
+      final connection = realtime('ws://localhost:54321/realtime/v1', {});
       final reply = connection.stream.first;
 
       connection.sink.add('[null,"7","phoenix","phx_heartbeat",{}]');

--- a/packages/supabase_test/test/mock_realtime_transport_test.dart
+++ b/packages/supabase_test/test/mock_realtime_transport_test.dart
@@ -1,0 +1,272 @@
+import 'package:supabase/supabase.dart';
+import 'package:supabase_test/supabase_test.dart';
+import 'package:test/test.dart';
+
+void main() {
+  late MockSupabaseHttpClient httpClient;
+  late MockRealtimeTransport realtime;
+  late SupabaseClient supabase;
+
+  setUp(() {
+    httpClient = MockSupabaseHttpClient();
+    realtime = MockRealtimeTransport();
+    supabase = testSupabaseClient(httpClient: httpClient, realtime: realtime);
+    addTearDown(supabase.dispose);
+  });
+
+  Future<void> subscribed(RealtimeChannel channel) {
+    final done = channel.onStatusChange.firstWhere(
+      (change) => change.status == RealtimeSubscribeStatus.subscribed,
+    );
+    channel.subscribe();
+    return done;
+  }
+
+  group('joining', () {
+    test('a channel subscribes and the join is recorded', () async {
+      final channel = supabase.channel('todos');
+      channel.onPostgresChanges(
+        event: PostgresChangeEvent.insert,
+        schema: 'public',
+        table: 'todos',
+      );
+
+      await subscribed(channel);
+
+      expect(realtime.isConnected, isTrue);
+      expect(realtime.connectionCount, 1);
+      expect(realtime.joinedTopics, ['realtime:todos']);
+      final join = realtime.sent.singleWhere(
+        (message) => message.event == 'phx_join',
+      );
+      final config = (join.payload as Map)['config'] as Map;
+      expect(
+        config['postgres_changes'],
+        [
+          containsPair('table', 'todos'),
+        ],
+      );
+    });
+
+    test('leaving a channel forgets its topic', () async {
+      final channel = supabase.channel('todos');
+      await subscribed(channel);
+
+      await channel.unsubscribe();
+
+      expect(realtime.joinedTopics, isEmpty);
+    });
+
+    test('a heartbeat is answered with an ok reply', () async {
+      final connection = realtime.call('ws://localhost:54321/realtime/v1', {});
+      final reply = connection.stream.first;
+
+      connection.sink.add('[null,"7","phoenix","phx_heartbeat",{}]');
+
+      expect(
+        await reply,
+        '[null,"7","phoenix","phx_reply",{"status":"ok","response":{}}]',
+      );
+      expect(realtime.sent.single.event, 'phx_heartbeat');
+    });
+  });
+
+  group('emitPostgresChange', () {
+    test('reaches a channel bound to the table and event', () async {
+      final channel = supabase.channel('todos');
+      final changes = channel.onPostgresChanges(
+        event: PostgresChangeEvent.insert,
+        schema: 'public',
+        table: 'todos',
+      );
+      await subscribed(channel);
+      final received = changes.first;
+
+      realtime.emitPostgresChange(
+        table: 'todos',
+        event: PostgresChangeEvent.insert,
+        newRecord: {'id': 1, 'task': 'Ship it', 'status': false},
+      );
+
+      final payload = await received;
+      expect(payload.eventType, PostgresChangeEvent.insert);
+      expect(payload.table, 'todos');
+      expect(payload.newRecord, {'id': 1, 'task': 'Ship it', 'status': false});
+      expect(payload.oldRecord, isEmpty);
+    });
+
+    test('skips channels bound to another event or table', () async {
+      final channel = supabase.channel('todos');
+      final deletes = channel.onPostgresChanges(
+        event: PostgresChangeEvent.delete,
+        schema: 'public',
+        table: 'todos',
+      );
+      final profiles = channel.onPostgresChanges(
+        event: PostgresChangeEvent.all,
+        schema: 'public',
+        table: 'profiles',
+      );
+      final inserts = channel.onPostgresChanges(
+        event: PostgresChangeEvent.insert,
+        schema: 'public',
+        table: 'todos',
+      );
+      await subscribed(channel);
+      final unexpected = <Object>[];
+      deletes.listen(unexpected.add);
+      profiles.listen(unexpected.add);
+      final received = inserts.first;
+
+      realtime.emitPostgresChange(
+        table: 'todos',
+        event: PostgresChangeEvent.insert,
+        newRecord: {'id': 1},
+      );
+
+      await received;
+      expect(unexpected, isEmpty);
+    });
+
+    test('throws when no joined channel listens to the table', () async {
+      await subscribed(supabase.channel('room'));
+
+      expect(
+        () => realtime.emitPostgresChange(
+          table: 'todos',
+          event: PostgresChangeEvent.insert,
+          newRecord: {'id': 1},
+        ),
+        throwsA(
+          isA<StateError>().having(
+            (error) => error.message,
+            'message',
+            contains('public.todos'),
+          ),
+        ),
+      );
+    });
+
+    test('rejects the all event', () {
+      expect(
+        () => realtime.emitPostgresChange(
+          table: 'todos',
+          event: PostgresChangeEvent.all,
+        ),
+        throwsArgumentError,
+      );
+    });
+  });
+
+  group('stream', () {
+    test('emits the initial rows and then applies the changes', () async {
+      httpClient.stubTable(
+        'todos',
+        rows: [
+          {'id': 1, 'task': 'Ship it'},
+        ],
+      );
+      final stream = supabase.from('todos').stream(primaryKey: ['id']);
+      final snapshots = <SupabaseStreamEvent>[];
+      final subscription = stream.listen(snapshots.add);
+      addTearDown(subscription.cancel);
+      await pumpEventQueue();
+
+      realtime.emitPostgresChange(
+        table: 'todos',
+        event: PostgresChangeEvent.insert,
+        newRecord: {'id': 2, 'task': 'Write tests'},
+      );
+      await pumpEventQueue();
+      realtime.emitPostgresChange(
+        table: 'todos',
+        event: PostgresChangeEvent.update,
+        newRecord: {'id': 1, 'task': 'Shipped'},
+        oldRecord: {'id': 1},
+      );
+      await pumpEventQueue();
+      realtime.emitPostgresChange(
+        table: 'todos',
+        event: PostgresChangeEvent.delete,
+        oldRecord: {'id': 2},
+      );
+      await pumpEventQueue();
+
+      expect(snapshots, [
+        [
+          {'id': 1, 'task': 'Ship it'},
+        ],
+        [
+          {'id': 1, 'task': 'Ship it'},
+          {'id': 2, 'task': 'Write tests'},
+        ],
+        [
+          {'id': 1, 'task': 'Shipped'},
+          {'id': 2, 'task': 'Write tests'},
+        ],
+        [
+          {'id': 1, 'task': 'Shipped'},
+        ],
+      ]);
+    });
+  });
+
+  group('emitBroadcast', () {
+    test('reaches the listeners of the event', () async {
+      final channel = supabase.channel('room');
+      final cursors = channel.onBroadcast(event: 'cursor');
+      await subscribed(channel);
+      final received = cursors.first;
+
+      realtime.emitBroadcast(
+        'room',
+        event: 'cursor',
+        payload: {'x': 1, 'y': 2},
+      );
+
+      final message = await received;
+      expect(message['event'], 'cursor');
+      expect(message['payload'], {'x': 1, 'y': 2});
+    });
+
+    test('a broadcast the client sends is recorded and acknowledged', () async {
+      final channel = supabase.channel('room');
+      await subscribed(channel);
+
+      final status = await channel.sendBroadcastMessage(
+        event: 'cursor',
+        payload: {'x': 3},
+      );
+
+      expect(status, ChannelResponse.ok);
+      final sent = realtime.sent.singleWhere(
+        (message) => message.event == 'broadcast',
+      );
+      expect(sent.topic, 'realtime:room');
+      expect(sent.payload, {'type': 'broadcast', 'event': 'cursor', 'x': 3});
+    });
+  });
+
+  group('closeConnection', () {
+    test('the client observes the disconnect', () async {
+      final channel = supabase.channel('room');
+      await subscribed(channel);
+      final closed = supabase.realtime.onStatusChange.firstWhere(
+        (change) => change.status == RealtimeConnectionStatus.closed,
+      );
+
+      await realtime.closeConnection(code: 1011, reason: 'restart');
+
+      await closed;
+      expect(realtime.isConnected, isFalse);
+      expect(realtime.joinedTopics, isEmpty);
+    });
+  });
+
+  test('emitting without a connection names the problem', () {
+    expect(
+      () => realtime.emitBroadcast('room', event: 'x', payload: {}),
+      throwsA(isA<StateError>()),
+    );
+  });
+}

--- a/packages/supabase_test/test/mock_realtime_transport_test.dart
+++ b/packages/supabase_test/test/mock_realtime_transport_test.dart
@@ -128,6 +128,26 @@ void main() {
       expect(unexpected, isEmpty);
     });
 
+    test('reaches a channel bound to the whole schema', () async {
+      final channel = supabase.channel('everything');
+      final changes = channel.onPostgresChanges(
+        event: PostgresChangeEvent.all,
+        schema: 'public',
+      );
+      await subscribed(channel);
+      final received = changes.first;
+
+      realtime.emitPostgresChange(
+        table: 'todos',
+        event: PostgresChangeEvent.delete,
+        oldRecord: {'id': 1},
+      );
+
+      final payload = await received;
+      expect(payload.table, 'todos');
+      expect(payload.eventType, PostgresChangeEvent.delete);
+    });
+
     test('throws when no joined channel listens to the table', () async {
       await subscribed(supabase.channel('room'));
 

--- a/packages/supabase_test/test/mock_realtime_transport_test.dart
+++ b/packages/supabase_test/test/mock_realtime_transport_test.dart
@@ -263,6 +263,15 @@ void main() {
     });
   });
 
+  test('disposing the client forgets its connection and topics', () async {
+    await subscribed(supabase.channel('room'));
+
+    await supabase.dispose();
+
+    expect(realtime.isConnected, isFalse);
+    expect(realtime.joinedTopics, isEmpty);
+  });
+
   test('emitting without a connection names the problem', () {
     expect(
       () => realtime.emitBroadcast('room', event: 'x', payload: {}),


### PR DESCRIPTION
Stacked on #1817; the diff shown here is only this change once that merges.

## What kind of change does this PR introduce?

Feature. Closes SDK-1773.

## What is the current behavior?

Realtime is the one area an app cannot test with `supabase_test` without a running stack. `postgresChangesFrame` is exported, but there is nothing to feed it into, and the README points at a real stack for anything beyond hand-rolled socket mocks.

## What is the new behavior?

`MockRealtimeTransport` is a realtime server in memory. Handed to `testSupabaseClient` as `realtime`, it becomes the WebSocket transport of the client's `RealtimeClient` and behaves the way the server does for what the client sends:

- `phx_join` is answered with an ok reply echoing the requested `postgres_changes` bindings with server-assigned ids, so `subscribe()` reports `subscribed` and change frames route to the right bindings.
- Heartbeats, leaves and pushes (including `sendBroadcastMessage`) are acknowledged with ok replies.
- Every message the client sent is recorded in `sent`; `joinedTopics`, `isConnected` and `connectionCount` expose the connection state.

A test pushes server events with:

- `emitPostgresChange(table:, event:, newRecord:, oldRecord:)`, delivered to every joined channel bound to that table and event, which includes the channel a `stream()` opens. Filters are not evaluated, which the docs call out.
- `emitBroadcast(topic, event:, payload:)` and `emit(RealtimeMessage)` for anything else, presence frames included.
- `closeConnection()` to drop the connection from the server side and exercise disconnect handling.

The README's realtime section now documents this instead of pointing at a real stack.

## Additional context

`stream_channel` and `web_socket_channel` become dependencies of `supabase_test`. Twelve new tests in `packages/supabase_test/test/mock_realtime_transport_test.dart` cover joining, heartbeats, change routing (including a full `stream()` insert, update and delete sequence), broadcast in both directions and server-side close. The suite passes and `dart analyze packages/` is clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an in-memory mock realtime transport for testing channel connections, broadcasts, heartbeats, database changes, acknowledgments, and disconnects.
  * Added realtime transport support to test Supabase clients.
  * Made the mock transport available through the testing package.

* **Documentation**
  * Updated testing guidance with instructions for using the in-memory realtime socket.

* **Tests**
  * Added coverage for realtime channel behavior, event filtering, acknowledgments, stream updates, connection closure, and client disposal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->