### PR TITLE
feat(supabase_flutter): test initialization helper for widget tests

### DIFF
--- a/.sdk-parse-ignore
+++ b/.sdk-parse-ignore
@@ -26,6 +26,11 @@ packages/supabase_typegen/
 # so its public symbols are not capability-matrix symbols.
 packages/supabase_test/
 
+# The testing library of supabase_flutter holds helpers for the tests of an
+# app, not SDK client surface, so its public symbols are not capability-matrix
+# symbols.
+packages/supabase_flutter/lib/testing.dart
+
 # The examples are standalone demo apps, not part of the published SDK, so their
 # public classes are not capability-matrix symbols. Each package also ships its
 # own example app, which the extractor treats as a package of its own because it

--- a/packages/supabase_flutter/lib/testing.dart
+++ b/packages/supabase_flutter/lib/testing.dart
@@ -47,9 +47,9 @@ final String testPublishableKey = _unsignedJwt({
 /// pkce code verifier in memory, turns off the token auto refresh so no timer
 /// outlives the test, disables deep link detection so no platform channel is
 /// touched, and defaults [publishableKey] to [testPublishableKey]. Pass a
-/// `MockSupabaseHttpClient` as [httpClient] to answer the requests, and a
-/// `MockRealtimeTransport` through [realtimeClientOptions] to answer the
-/// realtime traffic.
+/// `MockSupabaseHttpClient` as [httpClient] to answer the requests, and the
+/// `call` method of a `MockRealtimeTransport` as [realtimeTransport] to
+/// answer the realtime traffic.
 ///
 /// Dispose the instance when the test ends, for example with
 /// `addTearDown(supabase.dispose)`, so the next test can initialize again.
@@ -59,7 +59,7 @@ Future<Supabase> initializeTestSupabase({
   String url = 'http://localhost:54321',
   String? publishableKey,
   Map<String, String>? headers,
-  RealtimeClientOptions realtimeClientOptions = const RealtimeClientOptions(),
+  WebSocketTransport? realtimeTransport,
   LocalStorage? localStorage,
   bool autoRefreshToken = false,
 }) {
@@ -68,7 +68,7 @@ Future<Supabase> initializeTestSupabase({
     publishableKey: publishableKey ?? testPublishableKey,
     httpClient: httpClient,
     headers: headers,
-    realtimeClientOptions: realtimeClientOptions,
+    realtimeClientOptions: RealtimeClientOptions(transport: realtimeTransport),
     authOptions: FlutterAuthClientOptions(
       autoRefreshToken: autoRefreshToken,
       localStorage: localStorage ?? const EmptyLocalStorage(),

--- a/packages/supabase_flutter/lib/testing.dart
+++ b/packages/supabase_flutter/lib/testing.dart
@@ -1,0 +1,87 @@
+/// Helpers for the widget and unit tests of an app built on
+/// `supabase_flutter`.
+///
+/// [initializeTestSupabase] initializes [Supabase] the way a test needs it:
+/// in-memory persistence, no token auto refresh, no deep link detection, and
+/// an unsigned test key. Answer the HTTP traffic with a
+/// `MockSupabaseHttpClient` from `package:supabase_test`, and realtime with
+/// its `MockRealtimeTransport`:
+///
+/// ```dart
+/// import 'package:supabase_flutter/testing.dart';
+/// import 'package:supabase_test/supabase_test.dart';
+///
+/// testWidgets('shows the open todos', (tester) async {
+///   final httpClient = MockSupabaseHttpClient()
+///     ..stubTable('todos', rows: [{'id': 1, 'task': 'Ship it'}]);
+///   final supabase = await initializeTestSupabase(httpClient: httpClient);
+///   addTearDown(supabase.dispose);
+///
+///   await tester.pumpWidget(const MyApp());
+///   await tester.pumpAndSettle();
+///
+///   expect(find.text('Ship it'), findsOneWidget);
+/// });
+/// ```
+library;
+
+import 'dart:convert';
+
+import 'package:http/http.dart';
+import 'package:meta/meta.dart';
+
+import 'supabase_flutter.dart';
+
+/// The publishable key [initializeTestSupabase] uses by default: an unsigned
+/// JWT carrying the `anon` role, which the mocked services never verify.
+@visibleForTesting
+final String testPublishableKey = _unsignedJwt({
+  'role': 'anon',
+  'iss': 'supabase_flutter_testing',
+});
+
+/// Initializes [Supabase] for a test and returns the instance.
+///
+/// Compared to [Supabase.initialize], this keeps the session in memory
+/// through [localStorage], which defaults to [EmptyLocalStorage], stores the
+/// pkce code verifier in memory, turns off the token auto refresh so no timer
+/// outlives the test, disables deep link detection so no platform channel is
+/// touched, and defaults [publishableKey] to [testPublishableKey]. Pass a
+/// `MockSupabaseHttpClient` as [httpClient] to answer the requests, and a
+/// `MockRealtimeTransport` through [realtimeClientOptions] to answer the
+/// realtime traffic.
+///
+/// Dispose the instance when the test ends, for example with
+/// `addTearDown(supabase.dispose)`, so the next test can initialize again.
+@visibleForTesting
+Future<Supabase> initializeTestSupabase({
+  Client? httpClient,
+  String url = 'http://localhost:54321',
+  String? publishableKey,
+  Map<String, String>? headers,
+  RealtimeClientOptions realtimeClientOptions = const RealtimeClientOptions(),
+  LocalStorage? localStorage,
+  bool autoRefreshToken = false,
+}) {
+  return Supabase.initialize(
+    url: url,
+    publishableKey: publishableKey ?? testPublishableKey,
+    httpClient: httpClient,
+    headers: headers,
+    realtimeClientOptions: realtimeClientOptions,
+    authOptions: FlutterAuthClientOptions(
+      autoRefreshToken: autoRefreshToken,
+      localStorage: localStorage ?? const EmptyLocalStorage(),
+      pkceAsyncStorage: MemoryAuthAsyncStorage(),
+      detectSessionInUri: false,
+    ),
+  );
+}
+
+String _unsignedJwt(Map<String, dynamic> claims) {
+  final header = base64Url.encode(
+    utf8.encode(jsonEncode({'alg': 'HS256', 'typ': 'JWT'})),
+  );
+  final payload = base64Url.encode(utf8.encode(jsonEncode(claims)));
+  return '$header.$payload.AAAA';
+}

--- a/packages/supabase_flutter/test/testing_test.dart
+++ b/packages/supabase_flutter/test/testing_test.dart
@@ -1,0 +1,72 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:supabase_flutter/testing.dart';
+import 'package:supabase_test/supabase_test.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late MockSupabaseHttpClient httpClient;
+
+  setUp(() {
+    httpClient = MockSupabaseHttpClient();
+  });
+
+  test(
+    'initializes without platform channels and answers from the mock',
+    () async {
+      httpClient.stubTable(
+        'todos',
+        rows: [
+          {'id': 1, 'task': 'Ship it'},
+        ],
+      );
+
+      final supabase = await initializeTestSupabase(httpClient: httpClient);
+      addTearDown(supabase.dispose);
+
+      final todos = await supabase.client.from('todos').select();
+
+      expect(todos, hasLength(1));
+      expect(supabase.client.auth.currentSession, isNull);
+      expect(
+        httpClient.requests.single.headers['apikey'],
+        testPublishableKey,
+      );
+    },
+  );
+
+  test('a signed-in user is not persisted between initializations', () async {
+    final first = await initializeTestSupabase(httpClient: httpClient);
+    await signInTestUser(first.client.auth, userId: 'user-1');
+    expect(first.client.auth.currentUser?.id, 'user-1');
+    await first.dispose();
+
+    final second = await initializeTestSupabase(httpClient: httpClient);
+    addTearDown(second.dispose);
+
+    expect(second.client.auth.currentSession, isNull);
+  });
+
+  test('the publishable key carries the anon role', () {
+    expect(decodeTestJwtClaims(testPublishableKey)['role'], 'anon');
+  });
+
+  test('a custom key, url and headers are passed through', () async {
+    httpClient.stubTable('todos', rows: []);
+
+    final supabase = await initializeTestSupabase(
+      httpClient: httpClient,
+      url: 'https://example.com',
+      publishableKey: 'sb_publishable_test',
+      headers: {'x-app': 'tests'},
+    );
+    addTearDown(supabase.dispose);
+
+    await supabase.client.from('todos').select();
+
+    final request = httpClient.requests.single;
+    expect(request.url.toString(), startsWith('https://example.com/rest/v1/'));
+    expect(request.headers['apikey'], 'sb_publishable_test');
+    expect(request.headers['x-app'], 'tests');
+  });
+}

--- a/packages/supabase_flutter/test/testing_test.dart
+++ b/packages/supabase_flutter/test/testing_test.dart
@@ -47,6 +47,22 @@ void main() {
     expect(second.client.auth.currentSession, isNull);
   });
 
+  test('a realtime transport is wired into the client', () async {
+    final urls = <String>[];
+    final supabase = await initializeTestSupabase(
+      httpClient: httpClient,
+      realtimeTransport: (url, headers) {
+        urls.add(url);
+        throw StateError('no socket in this test');
+      },
+    );
+    addTearDown(supabase.dispose);
+
+    await supabase.client.realtime.connect();
+
+    expect(urls.single, startsWith('ws://localhost:54321/realtime/v1'));
+  });
+
   test('the publishable key carries the anon role', () {
     expect(decodeTestJwtClaims(testPublishableKey)['role'], 'anon');
   });

--- a/packages/supabase_flutter/test/testing_test.dart
+++ b/packages/supabase_flutter/test/testing_test.dart
@@ -58,7 +58,8 @@ void main() {
     );
     addTearDown(supabase.dispose);
 
-    await supabase.client.realtime.connect();
+    supabase.client.channel('room').subscribe();
+    await pumpEventQueue();
 
     expect(urls.single, startsWith('ws://localhost:54321/realtime/v1'));
   });

--- a/packages/supabase_test/README.md
+++ b/packages/supabase_test/README.md
@@ -163,21 +163,15 @@ that, run against a real stack (see below).
 
 ## Flutter apps
 
-Widget tests initialize `supabase_flutter` the same way, with persistence
-pointed at in-memory implementations:
+Widget tests initialize `supabase_flutter` through `initializeTestSupabase`
+from `package:supabase_flutter/testing.dart`, which applies the same test
+defaults as `testSupabaseClient` and takes the same mock HTTP client:
 
 ```dart
-await Supabase.initialize(
-  url: 'http://localhost:54321',
-  publishableKey: unsignedTestJwt({'role': 'anon'}),
-  httpClient: httpClient,
-  authOptions: FlutterAuthClientOptions(
-    localStorage: const EmptyLocalStorage(),
-    pkceAsyncStorage: MemoryAuthAsyncStorage(),
-    autoRefreshToken: false,
-  ),
-);
-addTearDown(Supabase.instance.dispose);
+import 'package:supabase_flutter/testing.dart';
+
+final supabase = await initializeTestSupabase(httpClient: httpClient);
+addTearDown(supabase.dispose);
 ```
 
 ## Testing against a real stack


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature. Closes SDK-1776.

## What is the current behavior?

A widget test has to spell out the full `Supabase.initialize` call with `FlutterAuthClientOptions`, `EmptyLocalStorage`, `MemoryAuthAsyncStorage` and `autoRefreshToken: false` before it can use a mock HTTP client, and has to mock the app links platform channel or turn off deep link detection by hand. `supabase_test` is pure Dart and cannot offer this.

## What is the new behavior?

`package:supabase_flutter/testing.dart` exposes `initializeTestSupabase`, the Flutter counterpart of `testSupabaseClient`:

```dart
final supabase = await initializeTestSupabase(httpClient: httpClient);
addTearDown(supabase.dispose);
```

It initializes `Supabase` with in-memory session storage (`EmptyLocalStorage` unless a `LocalStorage` is passed), in-memory pkce storage, no token auto refresh, no deep link detection so no platform channel is touched, and `testPublishableKey`, an unsigned anon JWT, as the default key. `url`, `publishableKey`, `headers` and `realtimeClientOptions` pass through, so a `MockRealtimeTransport` from `supabase_test` can be wired in.

The library is excluded from the capability-matrix symbol scan the way the other test-only sources are, and the `supabase_test` README points its Flutter section at the helper.

## Additional context

Four tests in `packages/supabase_flutter/test/testing_test.dart` cover initialization without platform channels, the absence of persistence between initializations, the key's claims and pass-through of custom parameters. `flutter test` passes and `dart analyze packages/` is clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `initializeTestSupabase` to simplify setting up Supabase in Flutter app tests.
  * Supports in-memory storage, disabled token refresh and deep-link detection, custom URLs, headers, publishable keys, mock HTTP clients, and realtime transports.
  * Added a test publishable key for local and automated testing.

* **Documentation**
  * Updated Flutter testing guidance to recommend the new initialization helper and its configuration options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->