### PR TITLE
feat(supabase_test): match table and rpc stubs on the schema

### DIFF
--- a/packages/supabase_test/README.md
+++ b/packages/supabase_test/README.md
@@ -38,6 +38,11 @@ void main() {
 }
 ```
 
+The typed table API works the same way, since it runs on the same requests:
+`supabase.table(Todos.table).select().where(Todos.id.eq(1)).single()` is
+answered by the same `stubTable`, and typed streams by the same realtime
+transport.
+
 `testSupabaseClient` is a regular `SupabaseClient` wired for tests: it
 configures the in-memory storage the pkce flow requires, turns off the token
 auto refresh so no timer outlives the test, and defaults the API key to an

--- a/packages/supabase_test/README.md
+++ b/packages/supabase_test/README.md
@@ -109,6 +109,11 @@ Three rules cover most test setups:
   httpClient.stubTable('todos', query: {'id': 'eq.2'}, rows: [second]);
   ```
 
+- **`schema` narrows a table or function stub to one schema.** A request
+  made through `schema('archive')` carries the schema in a header, so a stub
+  for the `public` table and one for the `archive` table of the same name can
+  answer differently. A stub without a schema answers every schema.
+
 - **An unmatched request throws.** The `StateError` names the request and the
   registered stubs, so a typo in a path surfaces as a failing test with the
   mismatch spelled out instead of a silent wrong answer.

--- a/packages/supabase_test/lib/src/mock_supabase_http_client.dart
+++ b/packages/supabase_test/lib/src/mock_supabase_http_client.dart
@@ -52,6 +52,7 @@ class _Stub {
     required this.method,
     required this.path,
     required this.query,
+    required this.schema,
     required this.respond,
     required this.remaining,
   });
@@ -59,6 +60,7 @@ class _Stub {
   final String? method;
   final String? path;
   final Map<String, String>? query;
+  final String? schema;
   final FutureOr<StreamedResponse> Function(
     BaseRequest request,
     RecordedRequest recorded,
@@ -86,7 +88,21 @@ class _Stub {
         }
       }
     }
+    if (schema != null && _requestSchema(request) != schema) {
+      return false;
+    }
     return true;
+  }
+
+  /// The schema a PostgREST request addresses: reads carry it in
+  /// `Accept-Profile`, writes in `Content-Profile`, and a request without
+  /// either targets `public`.
+  static String _requestSchema(BaseRequest request) {
+    final method = request.method.toUpperCase();
+    final header = method == 'GET' || method == 'HEAD'
+        ? 'Accept-Profile'
+        : 'Content-Profile';
+    return request.headers[header] ?? 'public';
   }
 
   @override
@@ -95,7 +111,9 @@ class _Stub {
     final querySuffix = query == null || query.isEmpty
         ? ''
         : '?${Uri(queryParameters: query).query}';
-    return '${method ?? '(any method)'} ${path ?? '(any path)'}$querySuffix';
+    final schemaSuffix = schema == null ? '' : ' (schema $schema)';
+    return '${method ?? '(any method)'} ${path ?? '(any path)'}'
+        '$querySuffix$schemaSuffix';
   }
 }
 
@@ -200,6 +218,7 @@ class MockSupabaseHttpClient extends BaseClient {
         method: method,
         path: path,
         query: query,
+        schema: null,
         remaining: times,
         respond: (request, _) => _response(
           body,
@@ -242,6 +261,7 @@ class MockSupabaseHttpClient extends BaseClient {
         method: method,
         path: path,
         query: query,
+        schema: null,
         remaining: times,
         respond: (request, recorded) async {
           final response = await handler(recorded);
@@ -265,7 +285,9 @@ class MockSupabaseHttpClient extends BaseClient {
   /// matches all of them; pass `'GET'` or `'POST'` to answer reads and writes
   /// differently. [query] narrows the stub to queries carrying the given
   /// PostgREST filters, `{'id': 'eq.1'}` for example, so differently filtered
-  /// reads of one table receive different rows.
+  /// reads of one table receive different rows. [schema] narrows it to
+  /// requests addressing that schema, so tables of the same name in different
+  /// schemas receive different rows; a null [schema] matches every schema.
   ///
   /// The response is shaped the way PostgREST shapes it for the request: a
   /// query ending in `single()` receives the only row of a one-row list, or
@@ -277,6 +299,7 @@ class MockSupabaseHttpClient extends BaseClient {
     Object? rows,
     String? method,
     Map<String, String>? query,
+    String? schema,
     int statusCode = 200,
     int? count,
     int? times,
@@ -286,6 +309,7 @@ class MockSupabaseHttpClient extends BaseClient {
       method: method,
       path: '/rest/v1/$table',
       query: query,
+      schema: schema,
       statusCode: statusCode,
       count: count,
       times: times,
@@ -296,11 +320,12 @@ class MockSupabaseHttpClient extends BaseClient {
   /// with [body].
   ///
   /// The response is shaped for `single()` and counts the way [stubTable]
-  /// shapes it.
+  /// shapes it, and [schema] narrows the stub to one schema the same way.
   void stubRpc(
     String function, {
     Object? body,
     Map<String, String>? query,
+    String? schema,
     int statusCode = 200,
     int? count,
     int? times,
@@ -309,6 +334,7 @@ class MockSupabaseHttpClient extends BaseClient {
       body,
       path: '/rest/v1/rpc/$function',
       query: query,
+      schema: schema,
       statusCode: statusCode,
       count: count,
       times: times,
@@ -519,6 +545,7 @@ class MockSupabaseHttpClient extends BaseClient {
     required int statusCode,
     String? method,
     Map<String, String>? query,
+    String? schema,
     int? count,
     int? times,
   }) {
@@ -527,6 +554,7 @@ class MockSupabaseHttpClient extends BaseClient {
         method: method,
         path: path,
         query: query,
+        schema: schema,
         remaining: times,
         respond: (request, _) => _postgrestResponse(
           body,

--- a/packages/supabase_test/test/mock_supabase_http_client_test.dart
+++ b/packages/supabase_test/test/mock_supabase_http_client_test.dart
@@ -769,4 +769,72 @@ void main() {
       });
     });
   });
+
+  group('schema matching', () {
+    test(
+      'tables of the same name in different schemas get their own rows',
+      () async {
+        httpClient.stubTable(
+          'todos',
+          schema: 'public',
+          rows: [
+            {'id': 1, 'task': 'Public'},
+          ],
+        );
+        httpClient.stubTable(
+          'todos',
+          schema: 'archive',
+          rows: [
+            {'id': 2, 'task': 'Archived'},
+          ],
+        );
+
+        final current = await supabase.from('todos').select();
+        final archived = await supabase
+            .schema('archive')
+            .from('todos')
+            .select();
+
+        expect(current.single['task'], 'Public');
+        expect(archived.single['task'], 'Archived');
+      },
+    );
+
+    test('writes are matched on their schema too', () async {
+      httpClient.stubTable('todos', schema: 'archive', method: 'POST');
+
+      await supabase.schema('archive').from('todos').insert({'id': 1});
+
+      await expectLater(
+        () => supabase.from('todos').insert({'id': 1}),
+        throwsA(
+          isA<StateError>().having(
+            (error) => error.message,
+            'message',
+            contains('(schema archive)'),
+          ),
+        ),
+      );
+    });
+
+    test('a stub without a schema answers every schema', () async {
+      httpClient.stubTable('todos', rows: []);
+
+      await supabase.from('todos').select();
+      await supabase.schema('archive').from('todos').select();
+
+      expect(httpClient.requests, hasLength(2));
+    });
+
+    test('stubRpc narrows to a schema', () async {
+      httpClient.stubRpc('total', schema: 'public', body: 1);
+      httpClient.stubRpc('total', schema: 'archive', body: 2);
+
+      final current = await supabase.rpc('total');
+      final archived = await supabase.schema('archive').rpc('total');
+
+      expect(current, 1);
+      expect(archived, 2);
+    });
+  });
 }

--- a/packages/supabase_test/test/typed_api_test.dart
+++ b/packages/supabase_test/test/typed_api_test.dart
@@ -82,9 +82,9 @@ void main() {
   test('single and maybeSingle are shaped for typed rows', () async {
     httpClient.stubTable('todos', rows: []);
 
-    final none = await supabase.table(Todos.table).select().maybeSingle();
+    final Todo? none = await supabase.table(Todos.table).select().maybeSingle();
 
-    expect(none, isNull);
+    expect(none == null, isTrue);
     await expectLater(
       () => supabase.table(Todos.table).select().single(),
       throwsA(

--- a/packages/supabase_test/test/typed_api_test.dart
+++ b/packages/supabase_test/test/typed_api_test.dart
@@ -1,0 +1,170 @@
+// The typed table access API under test is annotated @experimental.
+// ignore_for_file: experimental_member_use
+
+import 'package:supabase/supabase.dart';
+import 'package:supabase_test/supabase_test.dart';
+import 'package:test/test.dart';
+
+extension type const Todo(Map<String, dynamic> _json)
+    implements Map<String, dynamic> {
+  int get id => _json['id'] as int;
+  String get task => _json['task'] as String;
+  bool get status => _json['status'] as bool;
+}
+
+class Todos {
+  static const table = PostgrestTable('todos', Todo.new);
+  static const id = TableColumn<int>('id');
+  static const task = TableColumn<String>('task');
+  static const status = TableColumn<bool>('status');
+}
+
+void main() {
+  late MockSupabaseHttpClient httpClient;
+  late MockRealtimeTransport realtime;
+  late SupabaseClient supabase;
+
+  setUp(() {
+    httpClient = MockSupabaseHttpClient();
+    realtime = MockRealtimeTransport();
+    supabase = testSupabaseClient(httpClient: httpClient, realtime: realtime);
+    addTearDown(supabase.dispose);
+  });
+
+  test('a typed select decodes the stubbed rows', () async {
+    httpClient.stubTable(
+      'todos',
+      rows: [
+        {'id': 1, 'task': 'Ship it', 'status': false},
+      ],
+    );
+
+    final List<Todo> todos = await supabase
+        .table(Todos.table)
+        .select()
+        .where(Todos.status.eq(false));
+
+    expect(todos.single.task, 'Ship it');
+    expect(httpClient.requests.single.queryParameters['status'], 'eq.false');
+  });
+
+  test('typed filters match query stubs', () async {
+    httpClient.stubTable(
+      'todos',
+      query: {'id': 'eq.1'},
+      rows: [
+        {'id': 1, 'task': 'First', 'status': false},
+      ],
+    );
+    httpClient.stubTable(
+      'todos',
+      query: {'id': 'eq.2'},
+      rows: [
+        {'id': 2, 'task': 'Second', 'status': true},
+      ],
+    );
+
+    final first = await supabase
+        .table(Todos.table)
+        .select()
+        .where(Todos.id.eq(1))
+        .single();
+    final second = await supabase
+        .table(Todos.table)
+        .select()
+        .where(Todos.id.eq(2))
+        .single();
+
+    expect(first.task, 'First');
+    expect(second.task, 'Second');
+  });
+
+  test('single and maybeSingle are shaped for typed rows', () async {
+    httpClient.stubTable('todos', rows: []);
+
+    final none = await supabase.table(Todos.table).select().maybeSingle();
+
+    expect(none, isNull);
+    await expectLater(
+      () => supabase.table(Todos.table).select().single(),
+      throwsA(
+        isA<PostgrestApiException>().having(
+          (exception) => exception.errorCode,
+          'errorCode',
+          'PGRST116',
+        ),
+      ),
+    );
+  });
+
+  test('a typed count reads the content-range header', () async {
+    httpClient.stubTable(
+      'todos',
+      rows: [
+        {'id': 1, 'task': 'Ship it', 'status': false},
+      ],
+      count: 3,
+    );
+
+    final total = await supabase.table(Todos.table).count();
+    final page = await supabase
+        .table(Todos.table)
+        .select()
+        .limit(1)
+        .count(CountOption.exact);
+
+    expect(total, 3);
+    expect(page.data.single.id, 1);
+    expect(page.count, 3);
+  });
+
+  test('a typed insert sends the row and returns it through select', () async {
+    httpClient.stubTable(
+      'todos',
+      method: 'POST',
+      statusCode: 201,
+      rows: [
+        {'id': 7, 'task': 'Write tests', 'status': false},
+      ],
+    );
+
+    final Todo inserted = await supabase
+        .table(Todos.table)
+        .insert({'task': 'Write tests', 'status': false})
+        .select()
+        .single();
+
+    expect(inserted.id, 7);
+    expect(httpClient.requests.single.jsonBody, {
+      'task': 'Write tests',
+      'status': false,
+    });
+  });
+
+  test('a typed stream emits typed rows for emitted changes', () async {
+    httpClient.stubTable(
+      'todos',
+      rows: [
+        {'id': 1, 'task': 'Ship it', 'status': false},
+      ],
+    );
+    final snapshots = <List<Todo>>[];
+    final subscription = supabase
+        .table(Todos.table)
+        .stream(primaryKey: [Todos.id])
+        .listen(snapshots.add);
+    addTearDown(subscription.cancel);
+    await pumpEventQueue();
+
+    realtime.emitPostgresChange(
+      table: 'todos',
+      event: PostgresChangeEvent.update,
+      newRecord: {'id': 1, 'task': 'Shipped', 'status': true},
+      oldRecord: {'id': 1},
+    );
+    await pumpEventQueue();
+
+    expect(snapshots.map((rows) => rows.single.task), ['Ship it', 'Shipped']);
+    expect(snapshots.last.single.status, isTrue);
+  });
+}


### PR DESCRIPTION
Stacked on #1818; the diff shown here is only this change once that merges.

## What kind of change does this PR introduce?

Feature. Closes SDK-1777.

## What is the current behavior?

A request made through `supabase.schema('archive').from('todos')` hits the same `/rest/v1/todos` path as the public table, differing only in the `Accept-Profile` header for reads or `Content-Profile` for writes. Stubs match on method, path and query, so a stub cannot be scoped to a schema without a `stubHandler` that inspects the header. The community `mock_supabase_http_client` covered custom schemas, so this was the last gap against its feature list.

## What is the new behavior?

`stubTable` and `stubRpc` accept an optional `schema`. A stub with one answers only requests addressing that schema, with a missing header meaning `public`, so tables or functions of the same name in different schemas receive different responses:

```dart
httpClient.stubTable('todos', schema: 'public', rows: [current]);
httpClient.stubTable('todos', schema: 'archive', rows: [archived]);
```

A stub without a schema keeps answering every schema. The "no stub matches" error names the schema of each stub.

## Additional context

Four new tests in `packages/supabase_test/test/mock_supabase_http_client_test.dart` cover reads, writes, the unscoped default and rpc. The suite passes and `dart analyze packages/` is clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added schema-aware matching for table and RPC test stubs.
  * Schema-specific requests can now match dedicated stubs, while unscoped stubs support requests across schemas.
  * Read and write requests are matched against their selected schema.

* **Documentation**
  * Documented schema-scoped table and RPC stubs in the testing guide.

* **Tests**
  * Added coverage for schema-specific reads, writes, default-schema behavior, and unscoped stubs.
  * Added coverage for typed table queries, inserts, counts, single-row results, and realtime streams.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->