### PR TITLE
fix(realtime): cancel the pending timeout when a push is resent

### DIFF
--- a/packages/supabase_realtime/lib/src/push.dart
+++ b/packages/supabase_realtime/lib/src/push.dart
@@ -53,6 +53,7 @@ class Push {
   void resend(Duration newTimeout) {
     _timeout = newTimeout;
     _cancelRefEvent();
+    _cancelTimeout();
     _ref = '';
     _refEvent = null;
     _receivedResponse = null;

--- a/packages/supabase_realtime/test/socket_test.dart
+++ b/packages/supabase_realtime/test/socket_test.dart
@@ -1260,7 +1260,8 @@ void main() {
         final streamController = StreamController<dynamic>.broadcast();
         final readyCompleter = Completer<void>();
         final capturedMessages = <String>[];
-        final joinSent = Completer<Map<dynamic, dynamic>>();
+        final joinSent = Completer<List<dynamic>>();
+        final subscribed = Completer<void>();
 
         final mockedChannel = MockIOWebSocketChannel();
         final mockedSink = MockWebSocketSink();
@@ -1281,7 +1282,7 @@ void main() {
           final frame = json.decode(raw) as List;
           if (frame[3] == ChannelEvent.join.eventName() &&
               !joinSent.isCompleted) {
-            joinSent.complete(frame[4] as Map);
+            joinSent.complete(frame);
           }
         });
 
@@ -1295,6 +1296,12 @@ void main() {
         );
 
         final channel = socket.channel('realtime:test');
+        channel.onStatusChange.listen((change) {
+          if (change.status == RealtimeSubscribeStatus.subscribed &&
+              !subscribed.isCompleted) {
+            subscribed.complete();
+          }
+        });
         channel.subscribe();
 
         // The join is buffered while the socket is still connecting and the
@@ -1305,13 +1312,25 @@ void main() {
         // Once the connection is ready the token is resolved and the buffered
         // join is re-sent with the token patched into its payload.
         readyCompleter.complete();
-        final joinPayload = await joinSent.future.timeout(
+        final joinFrame = await joinSent.future.timeout(
           const Duration(seconds: 5),
         );
 
         expect(tokenCallbackCalls, greaterThan(0));
         expect(socket.accessToken, token);
-        expect(joinPayload['access_token'], token);
+        expect((joinFrame[4] as Map)['access_token'], token);
+        expect(joinFrame[1], isNotEmpty, reason: 'resent join has no ref');
+
+        streamController.add(
+          json.encode([
+            joinFrame[0],
+            joinFrame[1],
+            joinFrame[2],
+            'phx_reply',
+            {'status': 'ok', 'response': <String, dynamic>{}},
+          ]),
+        );
+        await subscribed.future.timeout(const Duration(seconds: 5));
 
         await socket.disconnect();
         await streamController.close();


### PR DESCRIPTION
## Summary

Fixes #1811.

With an async `customAccessToken`, the client buffers the join while the socket is connecting, resolves the token once the connection is ready and then calls `forceRejoin`, which resends the buffered join. `Push.resend` cleared the reply binding, ref and response but left the old timeout timer alive, so the next `startTimeout` returned early. The resent join went out with an empty ref and no reply handler, and the channel stayed in `joining` with neither a `subscribed` nor a `timedOut` status.

`resend` now cancels the pending timer before sending again.

## Test

The existing "resolves the token and patches buffered join payloads before flushing" test now captures the whole resent join frame, asserts that its ref is non-empty, answers it with a matching `phx_reply` and requires the channel to reach `subscribed`. It fails on `main` with an empty ref and passes with the fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved retry handling by cancelling existing timeout timers before resending.
  - Resent channel joins now retain a valid reference, improving subscription acknowledgement and connection reliability.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->