### PR TITLE
fix(auth): keep pkce code verifiers in memory when no asyncStorage is given

### DIFF
--- a/packages/supabase/lib/src/supabase_client.dart
+++ b/packages/supabase/lib/src/supabase_client.dart
@@ -48,12 +48,12 @@ import 'trace_http_client.dart';
 /// alone, and it can be shared with other clients.
 ///
 /// The pkce flow is used by default and keeps its code verifiers in the
-/// `AuthAsyncStorage` passed to the `pkceAsyncStorage` field of [authOptions].
-/// Pass a persistent implementation whenever the flow can leave the process
-/// before the code comes back, which covers every email link and every
-/// redirect to an OAuth provider. `MemoryAuthAsyncStorage` only suits flows
-/// that start and complete in the same process, such as tests and command line
-/// tools that keep a redirect listener open.
+/// `AuthAsyncStorage` passed to the `pkceAsyncStorage` field of [authOptions],
+/// in memory when none is passed. Pass a persistent implementation whenever
+/// the flow can leave the process before the code comes back, which covers
+/// every email link and every redirect to an OAuth provider. The in-memory
+/// default only suits flows that start and complete in the same process, such
+/// as tests and command line tools that keep a redirect listener open.
 /// {@endtemplate}
 class SupabaseClient {
   /// {@macro supabase_client}

--- a/packages/supabase/lib/src/supabase_client_options.dart
+++ b/packages/supabase/lib/src/supabase_client_options.dart
@@ -50,8 +50,9 @@ class AuthClientOptions {
   /// backoff can squeeze into that window.
   final SupabaseRetryOptions retryOptions;
 
-  /// Storage for the code verifiers of the pkce flow, required when
-  /// [authFlowType] is [AuthFlowType.pkce].
+  /// Storage for the code verifiers of the pkce flow, used when
+  /// [authFlowType] is [AuthFlowType.pkce]. Defaults to a
+  /// [MemoryAuthAsyncStorage].
   ///
   /// A persistent implementation is needed whenever the flow can leave the
   /// process before the code comes back. Email links do so by definition, and
@@ -59,11 +60,11 @@ class AuthClientOptions {
   /// while it waits and the page context is gone after a web redirect.
   /// `supabase_flutter` therefore defaults this to shared preferences.
   ///
-  /// [MemoryAuthAsyncStorage] only suits flows that start and complete in the
-  /// same process, such as tests and command line tools that keep a redirect
-  /// listener open. It is also unfit for a server handling more than one user
-  /// at a time, because the verifier is held under a single key that
-  /// concurrent sign-ins overwrite.
+  /// The default [MemoryAuthAsyncStorage] only suits flows that start and
+  /// complete in the same process, such as tests and command line tools that
+  /// keep a redirect listener open. It is also unfit for a server handling
+  /// more than one user at a time, because the verifiers are held in memory
+  /// shared by every request.
   final AuthAsyncStorage? pkceAsyncStorage;
 
   /// Whether the session is meant to outlive this client.

--- a/packages/supabase/test/client_test.dart
+++ b/packages/supabase/test/client_test.dart
@@ -207,17 +207,17 @@ void main() {
   });
 
   group('auth', () {
-    test('the pkce flow asserts when no pkceAsyncStorage is given', () {
-      expect(
-        () => real.SupabaseClient('http://localhost:1', 'supabaseKey'),
-        throwsA(
-          isA<AssertionError>().having(
-            (error) => error.message,
-            'message',
-            contains('You need to provide asyncStorage to perform pkce flow.'),
-          ),
-        ),
+    test('the pkce flow keeps its verifiers in memory when no '
+        'pkceAsyncStorage is given', () async {
+      final supabase = real.SupabaseClient('http://localhost:1', 'supabaseKey');
+      addTearDown(supabase.dispose);
+
+      final response = await supabase.auth.getOAuthSignInUrl(
+        provider: OAuthProvider.github,
       );
+
+      expect(response.flowId, isNotNull);
+      expect(response.url.queryParameters['code_challenge'], isNotEmpty);
     });
 
     test('the pkce flow works with a MemoryAuthAsyncStorage', () async {

--- a/packages/supabase_auth/lib/src/auth_client.dart
+++ b/packages/supabase_auth/lib/src/auth_client.dart
@@ -45,9 +45,11 @@ class _SessionState {
 ///
 /// [httpClient] custom http client.
 ///
-/// [asyncStorage] local storage to store pkce code verifiers. Required when
-/// using the pkce flow. Pass a [MemoryAuthAsyncStorage] when the verifiers
-/// do not need to outlive the process.
+/// [asyncStorage] local storage to store pkce code verifiers. Defaults to a
+/// [MemoryAuthAsyncStorage], which loses the verifiers when the process exits.
+/// Pass a persistent implementation whenever the flow can leave the process
+/// before the code comes back, such as an email link or an OAuth redirect in
+/// an app.
 ///
 /// [persistSession] whether the session is meant to outlive this client. On
 /// web such a session is kept in sync across the tabs of the same project
@@ -79,18 +81,12 @@ class AuthClient {
     AuthFlowType flowType = AuthFlowType.pkce,
     this.appendPkceFlowIdToRedirects = false,
     this.retryOptions = const SupabaseRetryOptions(count: 8),
-  }) : assert(
-         flowType != AuthFlowType.pkce || asyncStorage != null,
-         'You need to provide asyncStorage to perform pkce flow. Pass a '
-         'MemoryAuthAsyncStorage when the code verifiers do not need to '
-         'outlive the process.',
-       ),
-       _url = url ?? AuthConstants.defaultAuthUrl,
+  }) : _url = url ?? AuthConstants.defaultAuthUrl,
        _headers = {...AuthConstants.defaultHeaders, ...?headers},
        _httpClient = httpClient,
-       _pkceVerifierStore = asyncStorage == null
-           ? null
-           : PKCEVerifierStore(asyncStorage),
+       _pkceVerifierStore = PKCEVerifierStore(
+         asyncStorage ?? MemoryAuthAsyncStorage(),
+       ),
        _persistSession = persistSession,
        _flowType = flowType {
     _autoRefreshToken = autoRefreshToken ?? true;
@@ -170,9 +166,8 @@ class AuthClient {
     sync: true,
   );
 
-  /// Keeps one code verifier per pending pkce flow. Null when no
-  /// [AuthAsyncStorage] was provided, in which case the pkce flow cannot run.
-  final PKCEVerifierStore? _pkceVerifierStore;
+  /// Keeps one code verifier per pending pkce flow.
+  final PKCEVerifierStore _pkceVerifierStore;
 
   /// Whether the reserved `sb_flow_id` query parameter is appended to the
   /// redirect URL of pkce flows, so a callback can be matched to the flow that
@@ -541,11 +536,6 @@ class AuthClient {
     String authCode, {
     String? flowId,
   }) async {
-    assert(
-      _pkceVerifierStore != null,
-      'You need to provide asyncStorage to perform pkce flow.',
-    );
-
     final requestedFlowId = PKCEVerifierStore.validateFlowId(flowId);
     if (flowId != null && requestedFlowId == null) {
       // Told apart from a missing verifier so the message points at the
@@ -556,7 +546,7 @@ class AuthClient {
       );
     }
 
-    final codeVerifierRawString = await _pkceVerifierStore!.retrieve(
+    final codeVerifierRawString = await _pkceVerifierStore.retrieve(
       flowId: requestedFlowId,
     );
     if (codeVerifierRawString == null) {
@@ -605,13 +595,9 @@ class AuthClient {
     if (_flowType != AuthFlowType.pkce) {
       return null;
     }
-    assert(
-      _pkceVerifierStore != null,
-      'You need to provide asyncStorage to perform pkce flow.',
-    );
     final codeVerifier = generatePKCEVerifier();
     final flowId = PKCEVerifierStore.generateFlowId();
-    final evicted = await _pkceVerifierStore!.store(
+    final evicted = await _pkceVerifierStore.store(
       flowId: flowId,
       verifier: storageEventName == null
           ? codeVerifier
@@ -1294,7 +1280,7 @@ class AuthClient {
 
     if (scope != SignOutScope.others) {
       _removeSession();
-      await _pkceVerifierStore?.removeAll();
+      await _pkceVerifierStore.removeAll();
       notifyAllSubscribers(
         AuthChangeEvent.signedOut,
         signOutReason: reason,

--- a/packages/supabase_auth/test/client_test.dart
+++ b/packages/supabase_auth/test/client_test.dart
@@ -968,32 +968,6 @@ void main() {
       },
     );
   });
-
-  group('Constructing a client without an asyncStorage', () {
-    test('asserts when the pkce flow is used', () {
-      expect(
-        () => AuthClient(url: authUrl, headers: {'apikey': anonToken}),
-        throwsA(
-          isA<AssertionError>().having(
-            (error) => error.message,
-            'message',
-            contains('You need to provide asyncStorage to perform pkce flow.'),
-          ),
-        ),
-      );
-    });
-
-    test('is allowed when the implicit flow is used', () {
-      expect(
-        () => AuthClient(
-          url: authUrl,
-          headers: {'apikey': anonToken},
-          flowType: AuthFlowType.implicit,
-        ),
-        returnsNormally,
-      );
-    });
-  });
 }
 
 /// Reads the email-change confirmation link that GoTrue delivered to

--- a/packages/supabase_auth/test/pkce_flow_test.dart
+++ b/packages/supabase_auth/test/pkce_flow_test.dart
@@ -699,4 +699,75 @@ void main() {
       expect(mockClient.lastRedirectTo, isNull);
     });
   });
+
+  group('client without an asyncStorage', () {
+    late PKCETokenMockClient mockClient;
+    late AuthClient client;
+
+    setUp(() {
+      mockClient = PKCETokenMockClient();
+      client = AuthClient(url: 'https://example.com', httpClient: mockClient);
+    });
+
+    tearDown(() => client.dispose());
+
+    test('can be constructed with the default pkce flow', () {
+      expect(
+        () => AuthClient(url: 'https://example.com', httpClient: mockClient),
+        returnsNormally,
+      );
+    });
+
+    test('starts a pkce flow with a code challenge', () async {
+      final response = await client.getOAuthSignInUrl(
+        provider: OAuthProvider.github,
+      );
+
+      expect(response.flowId, isNotNull);
+      expect(response.url.queryParameters['flow_type'], 'pkce');
+      expect(response.url.queryParameters['code_challenge'], isNotEmpty);
+      expect(response.url.queryParameters['code_challenge_method'], 's256');
+    });
+
+    test('exchanges the code with the verifier kept in memory', () async {
+      final response = await client.getOAuthSignInUrl(
+        provider: OAuthProvider.github,
+      );
+
+      await client.exchangeCodeForSession(
+        'my-auth-code',
+        flowId: response.flowId,
+      );
+
+      expect(mockClient.submittedCodeVerifiers, hasLength(1));
+      expect(
+        generatePKCEChallenge(mockClient.submittedCodeVerifiers.single),
+        response.url.queryParameters['code_challenge'],
+      );
+      expect(client.currentSession, isNotNull);
+    });
+
+    test('keeps the verifiers of two clients apart', () async {
+      final other = AuthClient(
+        url: 'https://example.com',
+        httpClient: mockClient,
+      );
+      addTearDown(other.dispose);
+
+      final response = await client.getOAuthSignInUrl(
+        provider: OAuthProvider.github,
+      );
+
+      await expectLater(
+        other.exchangeCodeForSession('my-auth-code', flowId: response.flowId),
+        throwsA(
+          isA<AuthException>().having(
+            (error) => error.message,
+            'message',
+            contains('Code verifier could not be found'),
+          ),
+        ),
+      );
+    });
+  });
 }


### PR DESCRIPTION
Fixes #1319

## Problem

Constructing an `AuthClient` for the pkce flow (the default) without an `asyncStorage` left the verifier store null. A plain `SupabaseClient(url, key)` from the pure Dart `supabase` package does exactly that, so the reporter's script crashed on the first pkce flow:

```
Null check operator used on a null value
#0  GoTrueClient._getUrlForProvider
#1  GoTrueClient.getOAuthSignInUrl
```

With asserts enabled the client could not even be constructed, because the constructor asserted that pkce needs an `asyncStorage`. Both paths reproduce on `main` with the script below, run with and without `--enable-asserts`.

```dart
final supabase = SupabaseClient('http://localhost:54321', 'anon-key');
await supabase.auth.getOAuthSignInUrl(provider: OAuthProvider.github);
```

## Fix

The client now falls back to `MemoryAuthAsyncStorage` when no storage is passed, which is what supabase-js does outside the browser. The verifier store is non-nullable, so the constructor assert, the two method-level asserts and the null checks are gone. `supabase_flutter` is unaffected since it already defaults to shared preferences.

The docs on `AuthClient`, `SupabaseClient` and `AuthClientOptions.pkceAsyncStorage` now describe the in-memory default and when a persistent storage is still required.

## Tests

The assert test in `client_test.dart` is replaced by a group in `pkce_flow_test.dart` that constructs a client without storage, checks the authorize URL carries a code challenge, completes the code exchange against a mocked token endpoint with the matching verifier, and verifies two clients do not share verifiers.