### PR TITLE
feat(supabase_test): stub failures, stalls, status sequences and text bodies

### DIFF
--- a/packages/supabase_test/README.md
+++ b/packages/supabase_test/README.md
@@ -192,6 +192,34 @@ plain text or binary edge function response is a `Response.bytes` away. A
 `Uint8List` passed as the body of `stub` or `stubEdgeFunction` is sent as
 bytes with the content type `application/octet-stream`.
 
+### Failures, stalls and status sequences
+
+Not every response is a body under a status. `stubError` fails the request
+the way a client fails when the network is gone, `stubStall` never answers
+it, and `stubStatuses` walks it through a sequence of statuses, one per
+request, repeating the last one once they run out:
+
+```dart
+httpClient
+  // The first two requests throw, the ones after them are answered.
+  ..stubError(ClientException('Offline'), times: 2)
+  // Never answered, so only a timeout or an abort ends the request.
+  ..stubStall(path: '/functions/v1/slow')
+  // 503, 503, then 200 for this request and every one after it.
+  ..stubStatuses([503, 503, 200], body: [], path: '/rest/v1/todos');
+```
+
+`stubText` answers with a body that is not JSON, the HTML error page of a
+gateway for example, and carries the reason phrase the client falls back to:
+
+```dart
+httpClient.stubText(
+  '<html><body>502 Bad Gateway</body></html>',
+  statusCode: 502,
+  reasonPhrase: 'Bad Gateway',
+);
+```
+
 A client shared between tests is wiped with `reset`, which forgets the
 registered stubs and the recorded requests.
 
@@ -211,7 +239,15 @@ final insert = httpClient.requestsTo('/rest/v1/todos', method: 'POST').single;
 expect(insert.jsonBody, {'task': 'Write tests'});
 ```
 
-Headers are looked up case-insensitively, as on the request itself.
+Headers are looked up case-insensitively, as on the request itself. For what
+does not survive the wire format, `request` holds the `BaseRequest` the
+client received, so a multipart upload can be asserted on through its
+`files`:
+
+```dart
+final upload = httpClient.requests.single.request as MultipartRequest;
+expect(upload.files.single.contentType.mimeType, 'image/png');
+```
 
 ## Testing auth
 

--- a/packages/supabase_test/lib/src/internal_fixtures.dart
+++ b/packages/supabase_test/lib/src/internal_fixtures.dart
@@ -6,17 +6,19 @@ import 'package:meta/meta.dart';
 @visibleForTesting
 const sessionDataUserId = '4d2583da-8de4-49d3-9cd1-37a9a74f55bd';
 
-/// Constructs session data for a given expiration date.
+/// Constructs session data for a given expiration date, belonging to
+/// [userId].
 @visibleForTesting
 ({String accessToken, String sessionString}) getSessionData(
-  DateTime expireDateTime,
-) {
+  DateTime expireDateTime, {
+  String userId = sessionDataUserId,
+}) {
   final expiresAt = expireDateTime.millisecondsSinceEpoch ~/ 1000;
   final accessTokenMid = base64.encode(
     utf8.encode(
       json.encode({
         'exp': expiresAt,
-        'sub': '1234567890',
+        'sub': userId,
         'role': 'authenticated',
       }),
     ),
@@ -26,7 +28,7 @@ const sessionDataUserId = '4d2583da-8de4-49d3-9cd1-37a9a74f55bd';
       '{"access_token":"$accessToken","expires_in":'
       '${expireDateTime.difference(DateTime.now()).inSeconds},"refresh_token":"'
       '-yeS4omysFs9tpUYBws9Rg","token_type":"bearer","provider_token":null,"pro'
-      'vider_refresh_token":null,"user":{"id":"$sessionDataUserId","app_metadat'
+      'vider_refresh_token":null,"user":{"id":"$userId","app_metadat'
       'a":{"provider":"email","providers":["email"]},"user_metadata":{"Hello":"'
       'World"},"aud":"","email":"fake1680338105@email.com","phone":"","created_'
       'at":"2023-04-01T08:35:05.208586Z","confirmed_at":null,"email_confirmed_a'

--- a/packages/supabase_test/lib/src/mock_supabase_http_client.dart
+++ b/packages/supabase_test/lib/src/mock_supabase_http_client.dart
@@ -5,11 +5,13 @@
 import 'dart:async';
 import 'dart:collection';
 import 'dart:convert';
+import 'dart:math';
 import 'dart:typed_data';
 
 import 'package:http/http.dart';
 import 'package:meta/meta.dart';
 
+import 'internal_http_clients.dart';
 import 'mock_http_clients.dart';
 import 'session_fixture.dart';
 import 'storage_fixture.dart';
@@ -19,7 +21,20 @@ import 'test_jwt.dart';
 /// read, so a test can assert on what the code under test sent.
 @visibleForTesting
 class RecordedRequest {
-  const RecordedRequest._(this.method, this.url, this.headers, this.bodyBytes);
+  const RecordedRequest._(
+    this.request,
+    this.method,
+    this.url,
+    this.headers,
+    this.bodyBytes,
+  );
+
+  /// The request the client received, with its body already read, so
+  /// `finalize` must not be called on it again.
+  ///
+  /// Holds what the typed subclasses carry beyond the wire format, the
+  /// `files` of a [MultipartRequest] for example.
+  final BaseRequest request;
 
   final String method;
   final Uri url;
@@ -55,10 +70,16 @@ class _Stub {
     required this.schema,
     required this.respond,
     required this.remaining,
+    this.bareEndpoint,
   });
 
   final String? method;
   final String? path;
+
+  /// The path this stub also answers when it is matched exactly, so a
+  /// shorthand for `/auth/v1/user` answers the `/user` a bare `AuthClient`
+  /// addresses too.
+  final String? bareEndpoint;
   final Map<String, String>? query;
   final String? schema;
   final FutureOr<StreamedResponse> Function(
@@ -76,7 +97,9 @@ class _Stub {
         method!.toUpperCase() != request.method.toUpperCase()) {
       return false;
     }
-    if (path != null && !_pathMatches(request.url.path, path!)) {
+    if (path != null &&
+        !_pathMatches(request.url.path, path!) &&
+        request.url.path != bareEndpoint) {
       return false;
     }
     final query = this.query;
@@ -153,7 +176,12 @@ const _singleObjectAccept = 'application/vnd.pgrst.object+json';
 /// The latest registered stub that matches a request answers it, so a stub
 /// registered inside a test overrides one registered in `setUp`. A request no
 /// stub matches throws a [StateError] naming the request and the registered
-/// stubs.
+/// stubs. The auth shorthands answer their endpoint both under the
+/// `/auth/v1` prefix and at the root, where a bare `AuthClient` addresses it.
+///
+/// A request can be failed instead of answered with [stubError], stalled
+/// with [stubStall], and driven through a sequence of statuses with
+/// [stubStatuses].
 ///
 /// A response that depends on the request, on the parameters of an `rpc` call
 /// for example, is registered with [stubHandler].
@@ -213,10 +241,32 @@ class MockSupabaseHttpClient extends BaseClient {
     Map<String, String> headers = const {},
     int? times,
   }) {
+    _stub(
+      body,
+      method: method,
+      path: path,
+      query: query,
+      statusCode: statusCode,
+      headers: headers,
+      times: times,
+    );
+  }
+
+  void _stub(
+    Object? body, {
+    String? method,
+    String? path,
+    String? bareEndpoint,
+    Map<String, String>? query,
+    int statusCode = 200,
+    Map<String, String> headers = const {},
+    int? times,
+  }) {
     _stubs.add(
       _Stub(
         method: method,
         path: path,
+        bareEndpoint: bareEndpoint,
         query: query,
         schema: null,
         remaining: times,
@@ -226,6 +276,144 @@ class MockSupabaseHttpClient extends BaseClient {
           statusCode: statusCode,
           headers: headers,
         ),
+      ),
+    );
+  }
+
+  /// Answers requests matching [method] and [path] with [body] as text under
+  /// [contentType] and [reasonPhrase].
+  ///
+  /// Use it for the bodies that are not JSON, the HTML error page a gateway
+  /// returns for example. [method], [path], [query] and [times] match as they
+  /// do for [stub].
+  void stubText(
+    String body, {
+    String? method,
+    String? path,
+    Map<String, String>? query,
+    int statusCode = 200,
+    String contentType = 'text/plain; charset=utf-8',
+    String? reasonPhrase,
+    Map<String, String> headers = const {},
+    int? times,
+  }) {
+    final bytes = utf8.encode(body);
+    _stubs.add(
+      _Stub(
+        method: method,
+        path: path,
+        query: query,
+        schema: null,
+        remaining: times,
+        respond: (request, _) => StreamedResponse(
+          Stream.value(bytes),
+          statusCode,
+          request: request,
+          contentLength: bytes.length,
+          reasonPhrase: reasonPhrase,
+          headers: {'content-type': contentType, ...headers},
+        ),
+      ),
+    );
+  }
+
+  /// Fails requests matching [method] and [path] by throwing [error] instead
+  /// of answering them, the way a client fails when the network is gone.
+  ///
+  /// Pair it with [times] to fail the first requests only, so retry handling
+  /// can be exercised:
+  ///
+  /// ```dart
+  /// httpClient
+  ///   ..stubTable('todos', rows: [])
+  ///   ..stubError(ClientException('Offline'), times: 2);
+  /// // The first two reads throw, every one after that returns no rows.
+  /// ```
+  ///
+  /// [method], [path] and [query] match as they do for [stub].
+  void stubError(
+    Object error, {
+    String? method,
+    String? path,
+    Map<String, String>? query,
+    int? times,
+  }) {
+    _stubs.add(
+      _Stub(
+        method: method,
+        path: path,
+        query: query,
+        schema: null,
+        remaining: times,
+        respond: (_, _) => throw error,
+      ),
+    );
+  }
+
+  /// Never answers requests matching [method] and [path], so only their
+  /// timeout or their abort ends them.
+  ///
+  /// A request that carries no abort trigger stalls forever, so give the
+  /// code under test a timeout. [method], [path], [query] and [times] match
+  /// as they do for [stub].
+  void stubStall({
+    String? method,
+    String? path,
+    Map<String, String>? query,
+    int? times,
+  }) {
+    _stubs.add(
+      _Stub(
+        method: method,
+        path: path,
+        query: query,
+        schema: null,
+        remaining: times,
+        respond: (request, _) => stallUntilAborted(request),
+      ),
+    );
+  }
+
+  /// Answers requests matching [method] and [path] with [statuses] in order,
+  /// one status per request, and repeats the last one once they run out.
+  ///
+  /// Retry handling is driven from failures into a success with it, without
+  /// counting how often the stub was hit:
+  ///
+  /// ```dart
+  /// httpClient.stubStatuses([503, 503, 200], body: []);
+  /// ```
+  ///
+  /// [method], [path] and [query] match as they do for [stub].
+  void stubStatuses(
+    List<int> statuses, {
+    Object? body,
+    String? method,
+    String? path,
+    Map<String, String>? query,
+    Map<String, String> headers = const {},
+  }) {
+    if (statuses.isEmpty) {
+      throw ArgumentError.value(statuses, 'statuses', 'must not be empty');
+    }
+    var answered = 0;
+    _stubs.add(
+      _Stub(
+        method: method,
+        path: path,
+        query: query,
+        schema: null,
+        remaining: null,
+        respond: (request, _) {
+          final statusCode = statuses[min(answered, statuses.length - 1)];
+          answered++;
+          return _response(
+            body,
+            request: request,
+            statusCode: statusCode,
+            headers: headers,
+          );
+        },
       ),
     );
   }
@@ -371,10 +559,11 @@ class MockSupabaseHttpClient extends BaseClient {
     DateTime? expiresAt,
     int? times,
   }) {
-    stub(
+    _stub(
       _sessionJson(user: user, expiresAt: expiresAt),
       method: 'POST',
       path: '/auth/v1/token',
+      bareEndpoint: '/token',
       times: times,
     );
   }
@@ -387,20 +576,22 @@ class MockSupabaseHttpClient extends BaseClient {
     DateTime? expiresAt,
     int? times,
   }) {
-    stub(
+    _stub(
       _sessionJson(user: user, expiresAt: expiresAt),
       method: 'POST',
       path: '/auth/v1/signup',
+      bareEndpoint: '/signup',
       times: times,
     );
   }
 
   /// Answers the logout endpoint, so `signOut` completes.
   void stubSignOut({int? times}) {
-    stub(
+    _stub(
       null,
       method: 'POST',
       path: '/auth/v1/logout',
+      bareEndpoint: '/logout',
       statusCode: 204,
       times: times,
     );
@@ -409,7 +600,12 @@ class MockSupabaseHttpClient extends BaseClient {
   /// Answers the user endpoint with [user], which defaults to [testUserJson],
   /// so `getUser` and `updateUser` succeed.
   void stubUser({Map<String, dynamic>? user, int? times}) {
-    stub(user ?? testUserJson(), path: '/auth/v1/user', times: times);
+    _stub(
+      user ?? testUserJson(),
+      path: '/auth/v1/user',
+      bareEndpoint: '/user',
+      times: times,
+    );
   }
 
   /// Answers an upload of [path] to [bucket], whether through `upload`,
@@ -663,6 +859,7 @@ class MockSupabaseHttpClient extends BaseClient {
       hashCode: (key) => key.toLowerCase().hashCode,
     )..addAll(request.headers);
     final recorded = RecordedRequest._(
+      request,
       request.method,
       request.url,
       UnmodifiableMapView(headers),

--- a/packages/supabase_test/test/mock_supabase_http_client_test.dart
+++ b/packages/supabase_test/test/mock_supabase_http_client_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:typed_data';
 
 import 'package:http/http.dart' as http;
@@ -444,6 +445,132 @@ void main() {
     });
   });
 
+  group('stubError', () {
+    // Retries off, so a failure surfaces on the first request instead of
+    // being ridden out.
+    late SupabaseClient failing;
+
+    setUp(() {
+      failing = SupabaseClient(
+        'http://localhost:54321',
+        'apikey',
+        httpClient: httpClient,
+        authOptions: AuthClientOptions(
+          pkceAsyncStorage: MemoryAuthAsyncStorage(),
+        ),
+        postgrestOptions: const PostgrestClientOptions(
+          retryOptions: SupabaseRetryOptions(enabled: false),
+        ),
+      );
+      addTearDown(failing.dispose);
+    });
+
+    test('throws the error instead of answering the request', () async {
+      httpClient.stubError(http.ClientException('Offline'));
+
+      await expectLater(
+        () => failing.from('todos').select(),
+        throwsA(isA<http.ClientException>()),
+      );
+    });
+
+    test('times limits the failure to the first requests', () async {
+      httpClient
+        ..stubTable('todos', rows: [])
+        ..stubError(http.ClientException('Offline'), times: 1);
+
+      await expectLater(
+        () => failing.from('todos').select(),
+        throwsA(isA<http.ClientException>()),
+      );
+      expect(await failing.from('todos').select(), isEmpty);
+    });
+
+    test('path narrows the failure to one endpoint', () async {
+      httpClient
+        ..stubTable('todos', rows: [])
+        ..stubError(http.ClientException('Offline'), path: '/rest/v1/profiles');
+
+      expect(await failing.from('todos').select(), isEmpty);
+      await expectLater(
+        () => failing.from('profiles').select(),
+        throwsA(isA<http.ClientException>()),
+      );
+    });
+  });
+
+  group('stubStall', () {
+    test('leaves the request unanswered until it times out', () async {
+      httpClient.stubStall();
+      final stalling = SupabaseClient(
+        'http://localhost:54321',
+        'apikey',
+        httpClient: httpClient,
+        authOptions: AuthClientOptions(
+          pkceAsyncStorage: MemoryAuthAsyncStorage(),
+        ),
+        postgrestOptions: const PostgrestClientOptions(
+          requestTimeout: Duration(milliseconds: 50),
+          retryOptions: SupabaseRetryOptions(count: 0),
+        ),
+      );
+      addTearDown(stalling.dispose);
+
+      await expectLater(
+        () => stalling.from('todos').select(),
+        throwsA(isA<TimeoutException>()),
+      );
+      expect(httpClient.requests, hasLength(1));
+    });
+  });
+
+  group('stubStatuses', () {
+    test('answers with one status per request', () async {
+      httpClient.stubStatuses([503, 503, 200], body: []);
+      final url = Uri.parse('http://localhost:54321/rest/v1/todos');
+
+      final statuses = [
+        for (var request = 0; request < 4; request++)
+          (await httpClient.get(url)).statusCode,
+      ];
+
+      expect(statuses, [503, 503, 200, 200]);
+    });
+
+    test('rejects an empty list of statuses', () {
+      expect(() => httpClient.stubStatuses([]), throwsArgumentError);
+    });
+  });
+
+  group('stubText', () {
+    test('answers with the body verbatim under its reason phrase', () async {
+      httpClient.stubText(
+        '<html><body>502 Bad Gateway</body></html>',
+        statusCode: 502,
+        reasonPhrase: 'Bad Gateway',
+      );
+
+      final response = await httpClient.get(
+        Uri.parse('http://localhost:54321/rest/v1/todos'),
+      );
+
+      expect(response.body, '<html><body>502 Bad Gateway</body></html>');
+      expect(response.statusCode, 502);
+      expect(response.reasonPhrase, 'Bad Gateway');
+      expect(response.headers['content-type'], startsWith('text/plain'));
+    });
+
+    test('decodes a non-ASCII body as UTF-8', () async {
+      httpClient.stubText('こんにちは 👋');
+
+      final response = await httpClient.get(
+        Uri.parse('http://localhost:54321/rest/v1/todos'),
+      );
+
+      expect(response.body, 'こんにちは 👋');
+    });
+  });
+
   group('binary bodies', () {
     test('a Uint8List body reaches the caller as bytes', () async {
       httpClient.stubEdgeFunction(
@@ -530,6 +657,27 @@ void main() {
       expect(inserts.single.jsonBody, {'task': 'Write tests'});
     });
 
+    test('request keeps what the client sent beyond the wire format', () async {
+      httpClient.stub(null);
+      final request =
+          http.MultipartRequest(
+              'POST',
+              Uri.parse('http://localhost:54321/storage/v1/object/avatars/me'),
+            )
+            ..files.add(
+              http.MultipartFile.fromString('', 'binary', filename: 'me.png'),
+            );
+
+      await httpClient.send(request);
+
+      final recorded = httpClient.requests.single.request;
+      expect(recorded, isA<http.MultipartRequest>());
+      expect(
+        (recorded as http.MultipartRequest).files.single.filename,
+        'me.png',
+      );
+    });
+
     test('queryParameters exposes the query of the request', () async {
       httpClient.stubTable('todos', rows: []);
 
@@ -562,6 +710,21 @@ void main() {
       expect(supabase.auth.currentSession, isNull);
       final request = httpClient.requestsTo('/auth/v1/logout').single;
       expect(request.method, 'POST');
+    });
+
+    test('a bare AuthClient reaches the same shorthand', () async {
+      httpClient.stubUser(user: testUserJson(email: 'bare@example.com'));
+      final auth = AuthClient(
+        url: 'http://localhost:9999',
+        httpClient: httpClient,
+        asyncStorage: MemoryAuthAsyncStorage(),
+      );
+      addTearDown(auth.dispose);
+
+      final response = await auth.getUser('access-token');
+
+      expect(response.user?.email, 'bare@example.com');
+      expect(httpClient.requests.single.url.path, '/user');
     });
 
     test('stubUser answers getUser', () async {

--- a/packages/supabase_test/test/typed_api_test.dart
+++ b/packages/supabase_test/test/typed_api_test.dart
@@ -14,9 +14,9 @@ extension type const Todo(Map<String, dynamic> _json)
 
 class Todos {
   static const table = PostgrestTable('todos', Todo.new);
-  static const id = TableColumn<int>('id');
-  static const task = TableColumn<String>('task');
-  static const status = TableColumn<bool>('status');
+  static const id = PostgrestColumn<Todo, int>('id');
+  static const task = PostgrestColumn<Todo, String>('task');
+  static const status = PostgrestColumn<Todo, bool>('status');
 }
 
 void main() {


### PR DESCRIPTION
Adds the stubbing pieces that the package suites of this repo still hand-roll a `BaseClient` for. Each one comes from a test that could not be expressed with the current surface.

## What is new

| Helper | Replaces |
|---|---|
| `stubError(error, {times})` | clients that `throw ClientException('Offline')` for the first N requests |
| `stubStall()` | clients that never answer, so a timeout or an abort ends the request |
| `stubStatuses([503, 503, 200])` | clients that walk a retry through a sequence of statuses |
| `stubText(body, {statusCode, contentType, reasonPhrase})` | clients returning a non-JSON body, an HTML gateway error for example |
| `RecordedRequest.request` | assertions on what does not survive the wire format, such as `MultipartRequest.files` |

Two smaller changes in the same vein:

- The auth shorthands (`stubSignIn`, `stubSignUp`, `stubSignOut`, `stubUser`) now answer their endpoint at the root too, where a bare `AuthClient` addresses it, and not only under the `/auth/v1` prefix a `SupabaseClient` uses. The bare path is matched exactly, so a table named `user` is not caught by `stubUser`.
- `getSessionData` in the internal library takes the user the session belongs to, instead of being pinned to one id.

## Also in here

`test/typed_api_test.dart` still used `TableColumn`, which #1796 removed, so `dart analyze` and `dart test` were failing on `main` for this package. It now uses `PostgrestColumn`, which is what the rest of the repo moved to.

## Notes

- Everything is additive except the auth shorthand matching, which widens what those four stubs answer.
- `supabase_test` is in `.sdk-parse-ignore`, so none of the new symbols need registering in `sdk-compliance.yaml`.
- #1827, stacked on this one, moves the package suites onto these helpers and deletes the hand-rolled clients.

## Test plan

- `dart test` in `packages/supabase_test`: 88 pass, with new groups covering each helper.
- `dart test` in `packages/supabase_auth` (549) and `packages/supabase` (170) pass, covering the `getSessionData` and shorthand matching changes.
- `dart analyze` and `dart format` clean.
